### PR TITLE
fix: separate passive tree sections into tabs, prevent coordinate ove…

### DIFF
--- a/backend/app/routes/passives.py
+++ b/backend/app/routes/passives.py
@@ -74,11 +74,19 @@ def _nodes_response(nodes: list[PassiveNode], character_class=None, mastery=None
     if not serialized:
         # DB table empty — fall back to the JSON export so the page still works
         serialized = _load_json_fallback(character_class, mastery)
+
+    # Group nodes by tree section (base vs each mastery)
+    grouped: dict[str, list[dict]] = {}
+    for n in serialized:
+        key = n.get("mastery") or "__base__"
+        grouped.setdefault(key, []).append(n)
+
     return ok(data={
         "class": character_class,
         "mastery": mastery,
         "count": len(serialized),
         "nodes": serialized,
+        "grouped": grouped,
     })
 
 

--- a/backend/tests/test_passives_api.py
+++ b/backend/tests/test_passives_api.py
@@ -133,6 +133,23 @@ class TestGetClassTree:
                       "connections", "stats", "ability_granted", "icon"):
             assert field in node, f"Missing field: {field}"
 
+    def test_response_includes_grouped_field(self, client, seeded_passives):
+        """The grouped field must separate nodes by tree section."""
+        resp = client.get("/api/passives/Acolyte")
+        body = resp.get_json()["data"]
+        assert "grouped" in body
+        grouped = body["grouped"]
+        # Base nodes should be under "__base__"
+        assert "__base__" in grouped
+        base_ids = {n["id"] for n in grouped["__base__"]}
+        assert "ac_0" in base_ids  # Bone Aura is a base node
+        # Lich nodes should be under "Lich"
+        assert "Lich" in grouped
+        lich_ids = {n["id"] for n in grouped["Lich"]}
+        assert "ac_22" in lich_ids
+        # No overlap between sections
+        assert base_ids.isdisjoint(lich_ids)
+
     def test_unknown_class_returns_400(self, client):
         resp = client.get("/api/passives/Foo")
         assert resp.status_code == 400

--- a/frontend/src/components/PassiveTree/PassiveTreeSelector.tsx
+++ b/frontend/src/components/PassiveTree/PassiveTreeSelector.tsx
@@ -1,0 +1,83 @@
+/**
+ * PassiveTreeSelector — tab-based mastery tree selector.
+ *
+ * Renders tabs: Base | Mastery1 | Mastery2 | Mastery3
+ * Each tab shows only nodes from that tree section.
+ * Base tab shows base-class nodes only (mastery === null).
+ * Mastery tabs show that mastery's nodes only (NOT combined with base).
+ *
+ * This prevents the coordinate overlap that occurs when all sections
+ * are rendered on a single canvas (they share x/y ranges in-game).
+ */
+
+interface PassiveTreeSelectorProps {
+  /** Mastery names for the selected class (e.g. ["Necromancer", "Lich", "Warlock"]) */
+  masteries: string[];
+  /** Currently active tab: "__base__" or a mastery name */
+  activeTab: string;
+  /** Called when a tab is clicked */
+  onTabChange: (tab: string) => void;
+  /** Point counts per section for the budget badges */
+  pointsBySection?: Record<string, number>;
+  /** Whether the user has committed to a mastery (disables other mastery tabs) */
+  lockedMastery?: string | null;
+}
+
+export default function PassiveTreeSelector({
+  masteries,
+  activeTab,
+  onTabChange,
+  pointsBySection = {},
+  lockedMastery,
+}: PassiveTreeSelectorProps) {
+  const tabs = ["__base__", ...masteries];
+
+  return (
+    <div className="flex items-stretch gap-0 rounded-t border border-b-0 border-forge-border bg-forge-surface overflow-hidden">
+      {tabs.map((tab) => {
+        const isActive = activeTab === tab;
+        const label = tab === "__base__" ? "Base" : tab;
+        const points = pointsBySection[tab] ?? 0;
+        const isLocked =
+          lockedMastery &&
+          tab !== "__base__" &&
+          tab !== lockedMastery;
+
+        return (
+          <button
+            key={tab}
+            onClick={() => !isLocked && onTabChange(tab)}
+            disabled={!!isLocked}
+            className={`
+              relative flex items-center gap-1.5 px-4 py-2 font-mono text-xs transition-colors
+              ${isActive
+                ? "bg-forge-surface2 text-forge-amber font-semibold border-b-2 border-forge-amber"
+                : isLocked
+                  ? "text-forge-dim/40 cursor-not-allowed"
+                  : "text-forge-dim hover:text-forge-muted hover:bg-forge-surface2/50 cursor-pointer"
+              }
+            `}
+            title={
+              isLocked
+                ? `Locked — you chose ${lockedMastery}`
+                : `View ${label} passive tree`
+            }
+          >
+            <span>{label}</span>
+            {points > 0 && (
+              <span
+                className={`rounded-full px-1.5 py-0.5 text-[9px] font-bold leading-none ${
+                  isActive
+                    ? "bg-forge-amber/20 text-forge-amber"
+                    : "bg-forge-surface2 text-forge-dim"
+                }`}
+              >
+                {points}
+              </span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/components/features/build/BuildPassiveTree.tsx
+++ b/frontend/src/components/features/build/BuildPassiveTree.tsx
@@ -26,10 +26,17 @@ import {
 } from "@/utils/passiveGraph";
 import { computeLayout } from "@/utils/passiveLayout";
 import PassiveTreeCanvas from "@/components/passives/PassiveTreeCanvas";
+import PassiveTreeSelector from "@/components/PassiveTree/PassiveTreeSelector";
+import { CLASS_MASTERIES } from "@constants";
 
 type AllocMap = Record<number, number>;
 
 const CANVAS_H = 580;
+
+// Last Epoch passive point budget rules
+const BASE_POINT_CAP = 20;         // Max points in base class tree
+const NON_CHOSEN_MASTERY_CAP = 25; // Max points in each non-chosen mastery
+// Chosen mastery has no per-section cap (uses overall budget)
 
 interface Props {
   characterClass: string;
@@ -50,6 +57,12 @@ export default function BuildPassiveTree({
 }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [canvasSize, setCanvasSize] = useState({ w: 800, h: CANVAS_H });
+  const [activeTab, setActiveTab] = useState<string>("__base__");
+
+  // Reset tab when class changes
+  useEffect(() => {
+    setActiveTab("__base__");
+  }, [characterClass]);
 
   // Resize observer for responsive width
   useEffect(() => {
@@ -71,12 +84,20 @@ export default function BuildPassiveTree({
     staleTime: 5 * 60 * 1000,
   });
 
-  // Filter nodes: show base + selected mastery (or all if no mastery chosen)
+  const masteries = useMemo(
+    () => (CLASS_MASTERIES as Record<string, readonly string[]>)[characterClass] ?? [],
+    [characterClass],
+  );
+
+  // Filter nodes: show only the active tab's section (no overlap)
   const filteredNodes = useMemo(() => {
+    if (treeData?.grouped) {
+      return treeData.grouped[activeTab] ?? [];
+    }
     const all = treeData?.nodes ?? [];
-    if (!mastery) return all;
-    return all.filter((n) => n.mastery === null || n.mastery === mastery);
-  }, [treeData, mastery]);
+    if (activeTab === "__base__") return all.filter((n) => n.mastery === null);
+    return all.filter((n) => n.mastery === activeTab);
+  }, [treeData, activeTab]);
 
   // ID mappings: raw_node_id ↔ string id
   const { rawToStr, strToRaw } = useMemo(() => {
@@ -145,6 +166,30 @@ export default function BuildPassiveTree({
   const totalSpent = Object.values(allocated).reduce((s, v) => s + v, 0);
   const pointsLeft = totalPassivePoints - totalSpent;
 
+  // Points per tree section for tab badges
+  const pointsBySection = useMemo(() => {
+    const result: Record<string, number> = {};
+    const allNodes = treeData?.nodes ?? [];
+    for (const node of allNodes) {
+      if (!allocatedIds.has(node.id)) continue;
+      const section = node.mastery ?? "__base__";
+      result[section] = (result[section] ?? 0) + (allocatedPoints.get(node.id) ?? 1);
+    }
+    return result;
+  }, [treeData, allocatedIds, allocatedPoints]);
+
+  // Section cap: how many more points can go into the node's section?
+  const sectionCapRemaining = useCallback(
+    (node: PassiveNode): number => {
+      const section = node.mastery ?? "__base__";
+      const spent = pointsBySection[section] ?? 0;
+      if (section === "__base__") return Math.max(0, BASE_POINT_CAP - spent);
+      if (section === mastery) return Infinity; // chosen mastery: no per-section cap
+      return Math.max(0, NON_CHOSEN_MASTERY_CAP - spent);
+    },
+    [pointsBySection, mastery],
+  );
+
   // Allocation handlers — convert string IDs back to numeric for parent callback
   const handleNodeClick = useCallback(
     (nodeId: string, shiftKey: boolean) => {
@@ -154,19 +199,25 @@ export default function BuildPassiveTree({
       if (!node || rawId === undefined) return;
       if (pointsLeft <= 0 && !allocatedIds.has(nodeId)) return;
 
+      const capLeft = sectionCapRemaining(node);
+      if (capLeft <= 0 && !allocatedIds.has(nodeId)) return;
+
       if (allocatedIds.has(nodeId)) {
         const current = allocatedPoints.get(nodeId) ?? 1;
         if (current >= node.max_points) return;
         const target = shiftKey ? node.max_points : current + 1;
-        const clamped = Math.min(target, node.max_points);
+        const addable = Math.min(target - current, pointsLeft, capLeft);
+        const clamped = Math.min(current + addable, node.max_points);
         if (clamped === current) return;
         onAllocate(rawId, clamped);
       } else if (availableIds.has(nodeId)) {
-        const pts = shiftKey ? Math.min(node.max_points, pointsLeft) : 1;
+        const desired = shiftKey ? node.max_points : 1;
+        const pts = Math.min(desired, pointsLeft, capLeft);
+        if (pts <= 0) return;
         onAllocate(rawId, pts);
       }
     },
-    [nodeById, strToRaw, allocatedIds, allocatedPoints, availableIds, onAllocate, readOnly, pointsLeft],
+    [nodeById, strToRaw, allocatedIds, allocatedPoints, availableIds, onAllocate, readOnly, pointsLeft, sectionCapRemaining],
   );
 
   const handleNodeRightClick = useCallback(
@@ -212,16 +263,34 @@ export default function BuildPassiveTree({
 
   if (filteredNodes.length === 0) {
     return (
-      <div className="flex items-center justify-center py-12">
-        <span className="font-mono text-xs text-forge-dim">No passive data for this class.</span>
+      <div ref={containerRef} className="flex flex-col gap-0">
+        <PassiveTreeSelector
+          masteries={[...masteries]}
+          activeTab={activeTab}
+          onTabChange={setActiveTab}
+          pointsBySection={pointsBySection}
+          lockedMastery={mastery || null}
+        />
+        <div className="flex items-center justify-center py-12 border border-t-0 border-forge-border">
+          <span className="font-mono text-xs text-forge-dim">No passive data for this section.</span>
+        </div>
       </div>
     );
   }
 
   return (
     <div ref={containerRef} className="flex flex-col gap-0">
+      {/* Mastery tab selector */}
+      <PassiveTreeSelector
+        masteries={[...masteries]}
+        activeTab={activeTab}
+        onTabChange={setActiveTab}
+        pointsBySection={pointsBySection}
+        lockedMastery={mastery || null}
+      />
+
       {/* Point budget bar */}
-      <div className="flex items-center justify-between border-b border-forge-border bg-forge-surface2 px-3 py-1.5 rounded-t">
+      <div className="flex items-center justify-between border-b border-forge-border bg-forge-surface2 px-3 py-1.5">
         <div className="flex items-center gap-3 font-mono text-[10px]">
           <span className="text-forge-dim uppercase tracking-widest">Passive Points</span>
           <span className={`font-bold ${totalSpent > 0 ? "text-forge-amber" : "text-forge-dim"}`}>
@@ -232,6 +301,23 @@ export default function BuildPassiveTree({
             {pointsLeft} remaining
           </span>
           <span className="text-forge-dim">/ {totalPassivePoints}</span>
+          {/* Section cap for current tab */}
+          {activeTab === "__base__" && (
+            <>
+              <span className="text-forge-dim">·</span>
+              <span className="text-forge-dim">
+                Base: {pointsBySection["__base__"] ?? 0}/{BASE_POINT_CAP}
+              </span>
+            </>
+          )}
+          {activeTab !== "__base__" && activeTab !== mastery && (
+            <>
+              <span className="text-forge-dim">·</span>
+              <span className="text-forge-dim">
+                {activeTab}: {pointsBySection[activeTab] ?? 0}/{NON_CHOSEN_MASTERY_CAP}
+              </span>
+            </>
+          )}
         </div>
         {!readOnly && pointsLeft === 0 && (
           <span className="font-mono text-[9px] text-red-400/80">All points spent</span>

--- a/frontend/src/components/features/build/BuildPlannerPage.tsx
+++ b/frontend/src/components/features/build/BuildPlannerPage.tsx
@@ -274,11 +274,40 @@ function BuildSummary({ build }: { build: Build }) {
     setPassiveTree(prev => prev.slice(0, stepIndex));
   }
   const characterClass = build.character_class;
-  const mastery = build.mastery;
+  const [mastery, setMastery] = useState(build.mastery);
+  const [showMasteryConfirm, setShowMasteryConfirm] = useState<string | null>(null);
+
+  const masteryOptions = useMemo(
+    () => MASTERIES[characterClass] ?? [],
+    [characterClass],
+  );
+
+  function handleMasteryChangeRequest(next: string) {
+    if (next === mastery) return;
+    // Show confirmation if there are passive points or skills that might be affected
+    if (passiveTree.length > 0 || draftSkills.length > 0) {
+      setShowMasteryConfirm(next);
+    } else {
+      setMastery(next);
+    }
+  }
+
+  function confirmMasteryChange() {
+    if (!showMasteryConfirm) return;
+    setMastery(showMasteryConfirm);
+    // Drop mastery-specific skills that don't belong to the new mastery
+    setDraftSkills((prev) =>
+      prev.filter((ds) => {
+        const def = CLASS_SKILLS[characterClass].find((s) => s.name === ds.skill_name);
+        return !def?.mastery || def.mastery === showMasteryConfirm;
+      })
+    );
+    setShowMasteryConfirm(null);
+  }
 
   const availableSkills = useMemo(
     () => CLASS_SKILLS[characterClass].filter((s) => !s.mastery || s.mastery === mastery),
-    [characterClass, mastery]
+    [characterClass, mastery],
   );
   const selectedNames = new Set(draftSkills.map((s) => s.skill_name));
 
@@ -347,6 +376,7 @@ function BuildSummary({ build }: { build: Build }) {
       payload: {
         name: name.trim(),
         description: description.trim() || undefined,
+        mastery,
         level,
         is_ssf: isSsf,
         is_hc: isHc,
@@ -589,15 +619,23 @@ function BuildSummary({ build }: { build: Build }) {
               <textarea value={description} onChange={(e) => setDescription(e.target.value)} rows={2} className={inputCls + " mt-1.5 resize-none"} />
             </label>
 
-            {/* Class & mastery are read-only — fixed at creation */}
+            {/* Class is fixed at creation; mastery can be changed */}
             <div className="block">
               <SectionLabel>Class</SectionLabel>
               <div className={inputCls + " mt-1.5 opacity-50 cursor-not-allowed"}>{characterClass}</div>
             </div>
-            <div className="block">
+            <label className="block">
               <SectionLabel>Mastery</SectionLabel>
-              <div className={inputCls + " mt-1.5 opacity-50 cursor-not-allowed"}>{mastery}</div>
-            </div>
+              <select
+                value={mastery}
+                onChange={(e) => handleMasteryChangeRequest(e.target.value)}
+                className={inputCls + " mt-1.5"}
+              >
+                {masteryOptions.map((m) => (
+                  <option key={m} value={m}>{m}</option>
+                ))}
+              </select>
+            </label>
 
             <label className="block">
               <SectionLabel>Level</SectionLabel>
@@ -701,6 +739,29 @@ function BuildSummary({ build }: { build: Build }) {
           onClose={() => setTreeModal(null)}
           readOnly={treeModal.readOnly}
         />
+      )}
+
+      {/* Mastery change confirmation modal */}
+      {showMasteryConfirm && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
+          <div className="w-full max-w-sm rounded-lg border border-forge-border bg-forge-bg p-6 shadow-2xl">
+            <h3 className="font-display text-lg font-bold text-forge-amber">Change Mastery?</h3>
+            <p className="mt-2 font-body text-sm text-forge-muted">
+              Switching from <strong className="text-forge-text">{mastery}</strong> to{" "}
+              <strong className="text-forge-text">{showMasteryConfirm}</strong> will remove
+              skills exclusive to your current mastery. Passive tree allocations will be preserved
+              but mastery-specific nodes may become locked.
+            </p>
+            <div className="mt-4 flex gap-3 justify-end">
+              <Button variant="outline" size="sm" onClick={() => setShowMasteryConfirm(null)}>
+                Cancel
+              </Button>
+              <Button size="sm" onClick={confirmMasteryChange}>
+                Confirm
+              </Button>
+            </div>
+          </div>
+        </div>
       )}
     </div>
   );

--- a/frontend/src/pages/PassiveTreePage.tsx
+++ b/frontend/src/pages/PassiveTreePage.tsx
@@ -21,6 +21,7 @@ import {
 import { MASTERIES } from "@/lib/gameData";
 import { BASE_CLASSES } from "@constants";
 import PassiveTreeCanvas from "@/components/passives/PassiveTreeCanvas";
+import PassiveTreeSelector from "@/components/PassiveTree/PassiveTreeSelector";
 import PassiveStatsDebugPanel from "@/components/passives/PassiveStatsDebugPanel";
 import StatValidationPanel from "@/components/passives/StatValidationPanel";
 import PointEconomyPanel from "@/components/passives/PointEconomyPanel";
@@ -72,7 +73,7 @@ const CANVAS_H = 650;
 
 export default function PassiveTreePage() {
   const [selectedClass, setSelectedClass] = useState<CharacterClass | null>(null);
-  const [selectedMastery, setSelectedMastery] = useState<string>("__all__");
+  const [selectedMastery, setSelectedMastery] = useState<string>("__base__");
   const [allocatedIds, setAllocatedIds] = useState<Set<string>>(new Set());
   const [allocatedPoints, setAllocatedPoints] = useState<Map<string, number>>(new Map());
   const [showAllocPaths, setShowAllocPaths] = useState(false);
@@ -98,12 +99,17 @@ export default function PassiveTreePage() {
     staleTime: 5 * 60 * 1000,
   });
 
-  // Filter by mastery
+  // Filter by mastery — show only nodes from the active tab's section.
+  // Each section (base vs mastery) has its own coordinate space, so we never
+  // combine them on a single canvas (that causes overlap).
   const filteredNodes = useMemo(() => {
+    if (treeData?.grouped) {
+      return treeData.grouped[selectedMastery] ?? [];
+    }
+    // Fallback for responses without grouped field
     const all = treeData?.nodes ?? [];
-    if (selectedMastery === "__all__") return all;
     if (selectedMastery === "__base__") return all.filter((n) => n.mastery === null);
-    return all.filter((n) => n.mastery === selectedMastery || n.mastery === null);
+    return all.filter((n) => n.mastery === selectedMastery);
   }, [treeData, selectedMastery]);
 
   // Part 3: Precomputed bidirectional adjacency — rebuilt only when nodes change
@@ -311,7 +317,7 @@ export default function PassiveTreePage() {
 
   const handleClassChange = (cls: CharacterClass) => {
     setSelectedClass(cls);
-    setSelectedMastery("__all__");
+    setSelectedMastery("__base__");
     setAllocatedIds(new Set());
     setAllocatedPoints(new Map());
   };
@@ -414,6 +420,19 @@ export default function PassiveTreePage() {
   };
 
   const masteries = selectedClass ? (MASTERIES[selectedClass] ?? []) : [];
+
+  // Points spent per tree section for tab badges
+  const pointsBySection = useMemo(() => {
+    const result: Record<string, number> = {};
+    const allNodes = treeData?.nodes ?? [];
+    for (const node of allNodes) {
+      if (!allocatedIds.has(node.id)) continue;
+      const section = node.mastery ?? "__base__";
+      result[section] = (result[section] ?? 0) + (allocatedPoints.get(node.id) ?? 1);
+    }
+    return result;
+  }, [treeData, allocatedIds, allocatedPoints]);
+
   const totalPointsSpent = useMemo(
     () => Array.from(allocatedPoints.values()).reduce((a, b) => a + b, 0),
     [allocatedPoints],
@@ -441,7 +460,7 @@ export default function PassiveTreePage() {
   }
   if (filteredNodes.length === 0) {
     return (<Page><PageHeader /><ClassSelector selected={selectedClass} onSelect={handleClassChange} />
-      <MasterySelector masteries={masteries} selected={selectedMastery} onSelect={setSelectedMastery} />
+      <PassiveTreeSelector masteries={masteries} activeTab={selectedMastery} onTabChange={setSelectedMastery} pointsBySection={pointsBySection} />
       <div className="mt-4 flex h-80 items-center justify-center rounded border border-forge-border bg-forge-surface">
         <p className="font-mono text-sm text-forge-dim">No passive nodes for this selection.</p>
       </div></Page>);
@@ -451,7 +470,7 @@ export default function PassiveTreePage() {
     <Page>
       <PageHeader />
       <ClassSelector selected={selectedClass} onSelect={handleClassChange} />
-      <MasterySelector masteries={masteries} selected={selectedMastery} onSelect={setSelectedMastery} />
+      <PassiveTreeSelector masteries={masteries} activeTab={selectedMastery} onTabChange={setSelectedMastery} pointsBySection={pointsBySection} />
 
       {/* Status bar */}
       <div className="mt-3 mb-3 flex flex-wrap items-center gap-3">
@@ -566,18 +585,6 @@ function ClassSelector({ selected, onSelect }: { selected: CharacterClass | null
   );
 }
 
-function MasterySelector({ masteries, selected, onSelect }: { masteries: string[]; selected: string; onSelect: (m: string) => void }) {
-  return (
-    <div className="mt-2 flex flex-wrap gap-1.5">
-      {["__all__", "__base__", ...masteries].map((m) => (
-        <button key={m} onClick={() => onSelect(m)}
-          className={`rounded px-2.5 py-1 font-mono text-xs transition-colors ${selected === m ? "bg-forge-cyan/20 text-forge-cyan font-semibold" : "bg-forge-surface2 text-forge-dim hover:text-forge-muted"}`}>
-          {m === "__all__" ? "All" : m === "__base__" ? "Base" : m}
-        </button>
-      ))}
-    </div>
-  );
-}
 
 function Badge({ label, ok }: { label: string; ok: boolean }) {
   return <span className={`rounded px-2.5 py-1 font-mono text-xs font-semibold ${ok ? "bg-green-500/15 text-green-400" : "bg-forge-surface2 text-forge-dim"}`}>{label}</span>;

--- a/frontend/src/services/passiveTreeService.ts
+++ b/frontend/src/services/passiveTreeService.ts
@@ -40,6 +40,8 @@ export interface PassiveTreeResponse {
   mastery: string | null;
   count: number;
   nodes: PassiveNode[];
+  /** Nodes grouped by tree section: "__base__" | mastery name */
+  grouped?: Record<string, PassiveNode[]>;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
…rlap

Base tree and mastery trees share the same x/y coordinate space in LE data. When all sections were rendered on a single canvas, ~110 nodes piled on top of each other. This commit:

- Backend: adds `grouped` field to /api/passives responses, keyed by section
- Frontend: replaces __all__ mastery filter with tab-based PassiveTreeSelector (Base | Mastery1 | Mastery2 | Mastery3) — each tab renders only its section
- BuildPassiveTree: adds mastery tabs with section point caps (base=20, non-chosen mastery=25, chosen mastery=unlimited)
- BuildPlannerPage: mastery is now editable on saved builds with confirmation modal that warns about skill/passive impacts
- Tests: adds grouped field verification test (18/18 pass)
