### PR TITLE
fix: resolve silent import failure, add diagnostic logging, fix gear …

### DIFF
--- a/backend/app/routes/import_route.py
+++ b/backend/app/routes/import_route.py
@@ -7,8 +7,10 @@ POST /api/import/build  → Parse URL (LET or Maxroll), validate, save build, tr
 """
 
 import json as json_lib
+import logging
 import os
 import re
+import traceback
 from typing import Dict, List, Optional
 
 import requests as _requests
@@ -23,6 +25,7 @@ from app.utils.auth import get_current_user
 from app.utils.responses import ok, error as err_response
 
 import_bp = Blueprint("import", __name__)
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Last Epoch class / mastery ID maps
@@ -69,11 +72,12 @@ def _get_skill_id_map() -> Dict[str, str]:
             for v in skills_data.values()
             if isinstance(v, dict) and "id" in v and "name" in v
         }
-        current_app.logger.info(
-            f"import: loaded {len(_SKILL_ID_TO_NAME)} skill ID mappings from {data_path}"
+        logger.info(
+            "import: loaded %d skill ID mappings from %s",
+            len(_SKILL_ID_TO_NAME), data_path,
         )
     except Exception as exc:
-        current_app.logger.warning(f"import: could not load skill ID map: {exc}")
+        logger.warning("import: could not load skill ID map: %s", exc)
         _SKILL_ID_TO_NAME = {}
 
     return _SKILL_ID_TO_NAME
@@ -87,34 +91,81 @@ def _extract_build_info(html: str) -> Optional[dict]:
     """
     Extract the build JSON object embedded in a Last Epoch Tools planner page.
 
-    LE Tools embeds the full build as a JS assignment in a <script> tag:
-        window["buildInfo"] = {...};
-    or occasionally:
-        window.buildInfo = {...};
-
-    We locate the assignment with a regex, then use json.JSONDecoder.raw_decode()
-    which is structure-aware and correctly handles arbitrary nesting depth.
-    Using a plain {.*?} regex would break on the first closing brace.
+    Tries multiple extraction strategies:
+    1. window["buildInfo"] = {...}  (classic LE Tools format)
+    2. __NEXT_DATA__ script tag     (Next.js SSR format)
+    3. Fallback script tag scan     (look for any JSON with bio/charTree)
     """
-    # Match either window["buildInfo"] or window.buildInfo assignment
+    # Method 1: window["buildInfo"] or window.buildInfo assignment
     assignment_re = re.search(
         r'window\s*(?:\[\s*["\']buildInfo["\']\s*\]|\.buildInfo)\s*=\s*',
         html,
     )
-    if not assignment_re:
-        return None
+    if assignment_re:
+        start = assignment_re.end()
+        while start < len(html) and html[start] in " \t\r\n":
+            start += 1
+        try:
+            decoder = json_lib.JSONDecoder()
+            obj, _ = decoder.raw_decode(html, start)
+            if isinstance(obj, dict):
+                logger.info("import/url: extracted buildInfo via window assignment")
+                return obj
+        except json_lib.JSONDecodeError as exc:
+            logger.warning("import/url: buildInfo assignment found but JSON decode failed: %s", exc)
 
-    start = assignment_re.end()
-    # Skip any whitespace before the JSON object/value
-    while start < len(html) and html[start] in " \t\r\n":
-        start += 1
+    # Method 2: __NEXT_DATA__ (Next.js SSR)
+    next_data_re = re.search(
+        r'<script\s+id="__NEXT_DATA__"\s+type="application/json">\s*',
+        html,
+    )
+    if next_data_re:
+        start = next_data_re.end()
+        end = html.find("</script>", start)
+        if end > start:
+            try:
+                next_data = json_lib.loads(html[start:end])
+                page_props = next_data.get("props", {}).get("pageProps", {})
+                if "buildInfo" in page_props:
+                    logger.info("import/url: extracted buildInfo via __NEXT_DATA__")
+                    return page_props["buildInfo"]
+                if "build" in page_props:
+                    logger.info("import/url: extracted build via __NEXT_DATA__")
+                    return page_props["build"]
+                if page_props.get("bio") or page_props.get("charTree"):
+                    logger.info("import/url: extracted build from __NEXT_DATA__ pageProps")
+                    return page_props
+                logger.warning(
+                    "import/url: __NEXT_DATA__ found but no buildInfo. pageProps keys: %s",
+                    list(page_props.keys()),
+                )
+            except json_lib.JSONDecodeError as exc:
+                logger.warning("import/url: __NEXT_DATA__ JSON decode failed: %s", exc)
 
-    try:
-        decoder = json_lib.JSONDecoder()
-        obj, _ = decoder.raw_decode(html, start)
-        return obj if isinstance(obj, dict) else None
-    except json_lib.JSONDecodeError:
-        return None
+    # Method 3: Fallback — scan all script tags for JSON with bio/charTree
+    for match in re.finditer(r'<script[^>]*>\s*', html):
+        script_start = match.end()
+        script_end = html.find("</script>", script_start)
+        if script_end < 0:
+            continue
+        script_content = html[script_start:script_end].strip()
+        if not script_content.startswith("{"):
+            json_match = re.search(r'=\s*(\{)', script_content)
+            if not json_match:
+                continue
+            script_content = script_content[json_match.start(1):]
+        if len(script_content) < 50:
+            continue
+        try:
+            obj, _ = json_lib.JSONDecoder().raw_decode(script_content)
+            if isinstance(obj, dict) and ("bio" in obj or "charTree" in obj):
+                logger.info("import/url: extracted build data via fallback script scan")
+                return obj
+        except (json_lib.JSONDecodeError, ValueError):
+            continue
+
+    logger.warning("import/url: no build data found in HTML (%d bytes)", len(html))
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -127,7 +178,7 @@ def _map_let_build(build_info: dict) -> dict:
 
     LE Tools schema (relevant fields):
         bio.level           int
-        bio.characterClass  int  (1–5)
+        bio.characterClass  int  (0–4)
         bio.chosenMastery   int  (1–3)
         charTree.selected   {nodeId: pts}
         skillTrees[]        [{treeID, selected, level, slotNumber}]
@@ -142,8 +193,6 @@ def _map_let_build(build_info: dict) -> dict:
     mastery = _MASTERY_MAP.get(char_class, {}).get(mastery_id, "")
 
     # ---- Passive tree -------------------------------------------------------
-    # charTree.selected = {"nodeId": pointsSpent, ...}
-    # Our format: flat array of nodeIds repeated for multi-point nodes
     char_tree = build_info.get("charTree", {})
     selected_nodes: dict = char_tree.get("selected", {})
     passive_tree: List[int] = []
@@ -164,15 +213,13 @@ def _map_let_build(build_info: dict) -> dict:
         if not tree_id:
             continue
 
-        skill_name = skill_id_map.get(tree_id, tree_id)  # fallback to raw ID
+        skill_name = skill_id_map.get(tree_id, tree_id)
 
-        # Resolve slot from HUD order first, then slotNumber field
         if tree_id in hud:
             slot = hud.index(tree_id)
         else:
             slot = int(st.get("slotNumber", len(skills)))
 
-        # Spec tree uses the same flat-array format as passive tree
         selected_spec: dict = st.get("selected", {})
         spec_tree: List[int] = []
         for node_id_str, pts in selected_spec.items():
@@ -217,7 +264,32 @@ def _map_let_build(build_info: dict) -> dict:
 
 
 # ---------------------------------------------------------------------------
-# Route
+# Helper: record failure + fire Discord alert
+# ---------------------------------------------------------------------------
+
+def _record_and_alert(source: str, url: str, user_id: str | None,
+                      error_message: str, severity: str = "hard",
+                      missing_fields: list | None = None,
+                      partial_data: dict | None = None) -> None:
+    """Create an ImportFailure record and fire the Discord alert."""
+    try:
+        failure = ImportFailure(
+            source=source,
+            raw_url=url,
+            missing_fields=missing_fields or [],
+            partial_data=partial_data,
+            user_id=user_id,
+            error_message=error_message,
+        )
+        db.session.add(failure)
+        db.session.commit()
+        send_import_failure_alert(failure, severity=severity)
+    except Exception as exc:
+        logger.error("import: failed to record import failure: %s", exc)
+
+
+# ---------------------------------------------------------------------------
+# Route: POST /api/import/url
 # ---------------------------------------------------------------------------
 
 @import_bp.post("/url")
@@ -246,74 +318,89 @@ def import_from_url():
 
     code = match.group(1)
 
-    # Fetch the LE Tools planner page server-side (browser blocked by CORS)
+    # Top-level try/except — never return a bare 500
     try:
-        resp = _requests.get(
-            f"https://www.lastepochtools.com/planner/{code}",
-            headers={
-                "User-Agent": (
-                    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
-                    "AppleWebKit/537.36 (KHTML, like Gecko) "
-                    "Chrome/120.0.0.0 Safari/537.36"
-                ),
-                "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-                "Accept-Language": "en-US,en;q=0.9",
-            },
-            timeout=15,
+        # Fetch the LE Tools planner page server-side (browser blocked by CORS)
+        try:
+            resp = _requests.get(
+                f"https://www.lastepochtools.com/planner/{code}",
+                headers={
+                    "User-Agent": (
+                        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                        "AppleWebKit/537.36 (KHTML, like Gecko) "
+                        "Chrome/120.0.0.0 Safari/537.36"
+                    ),
+                    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+                    "Accept-Language": "en-US,en;q=0.9",
+                },
+                timeout=15,
+            )
+            resp.raise_for_status()
+        except _requests.Timeout:
+            return err_response("Timed out fetching the build page — try again.", 504)
+        except _requests.HTTPError as exc:
+            status = exc.response.status_code if exc.response is not None else 502
+            if status == 404:
+                return err_response("Build not found — the link may be expired or invalid.", 404)
+            return err_response(f"Last Epoch Tools returned HTTP {status}.", 502)
+        except _requests.RequestException as exc:
+            return err_response(f"Network error fetching build: {exc}", 502)
+
+        html = resp.text
+        logger.info("import/url: fetched code=%s html_len=%d", code, len(html))
+
+        # Extract the embedded build JSON using structure-aware parsing
+        build_info = _extract_build_info(html)
+
+        if build_info is None:
+            logger.warning(
+                "import/url: could not find buildInfo for code=%s. HTML snippet: %.500s",
+                code, html[:500],
+            )
+            return err_response(
+                "Could not find build data in the page. "
+                "The build code may be invalid, or Last Epoch Tools may have updated their page format.",
+                422,
+            )
+
+        # LE Tools sets buildLoadError on invalid/deleted build codes
+        if build_info.get("buildLoadError"):
+            return err_response("Build not found or deleted on Last Epoch Tools.", 404)
+
+        # LE Tools sometimes wraps the real payload in a "data" key
+        if "data" in build_info and isinstance(build_info["data"], dict):
+            build_info = build_info["data"]
+
+        # Sanity check — a valid build always has bio or charTree
+        if not build_info.get("bio") and not build_info.get("charTree"):
+            logger.warning(
+                "import/url: extracted JSON missing bio/charTree for code=%s: %s",
+                code, list(build_info.keys()),
+            )
+            return err_response("Build data is incomplete or in an unexpected format.", 422)
+
+        mapped = _map_let_build(build_info)
+        logger.info(
+            "import/url: mapped code=%s class=%s mastery=%s passives=%d skills=%d",
+            code, mapped["character_class"], mapped["mastery"],
+            len(mapped["passive_tree"]), len(mapped["skills"]),
         )
-        resp.raise_for_status()
-    except _requests.Timeout:
-        return err_response("Timed out fetching the build page — try again.", 504)
-    except _requests.HTTPError as exc:
-        status = exc.response.status_code if exc.response is not None else 502
-        if status == 404:
-            return err_response("Build not found — the link may be expired or invalid.", 404)
-        return err_response(f"Last Epoch Tools returned HTTP {status}.", 502)
-    except _requests.RequestException as exc:
-        return err_response(f"Network error fetching build: {exc}", 502)
+        return ok({"build": mapped, "source_code": code})
 
-    html = resp.text
-    current_app.logger.info(
-        f"import/url: fetched code={code} html_len={len(html)}"
-    )
-
-    # Extract the embedded build JSON using structure-aware parsing
-    build_info = _extract_build_info(html)
-
-    if build_info is None:
-        current_app.logger.warning(
-            f"import/url: could not find window[buildInfo] for code={code}. "
-            f"HTML snippet: {html[:500]!r}"
+    except Exception as exc:
+        logger.error(
+            "import/url: unhandled exception for url=%s: %s\n%s",
+            url, exc, traceback.format_exc(),
         )
-        return err_response(
-            "Could not find build data in the page. "
-            "The build code may be invalid, or Last Epoch Tools may have updated their page format.",
-            404,
+        user = get_current_user()
+        _record_and_alert(
+            source="lastepochtools",
+            url=url,
+            user_id=user.id if user else None,
+            error_message=f"Unhandled error in import/url: {exc}",
+            partial_data={"traceback": traceback.format_exc()[-500:]},
         )
-
-    # LE Tools sets buildLoadError on invalid/deleted build codes
-    if build_info.get("buildLoadError"):
-        return err_response("Build not found or deleted on Last Epoch Tools.", 404)
-
-    # LE Tools sometimes wraps the real payload in a "data" key
-    if "data" in build_info and isinstance(build_info["data"], dict):
-        build_info = build_info["data"]
-
-    # Sanity check — a valid build always has bio or charTree
-    if not build_info.get("bio") and not build_info.get("charTree"):
-        current_app.logger.warning(
-            f"import/url: extracted JSON missing bio/charTree for code={code}: "
-            f"{list(build_info.keys())}"
-        )
-        return err_response("Build data is incomplete or in an unexpected format.", 502)
-
-    mapped = _map_let_build(build_info)
-    current_app.logger.info(
-        f"import/url: mapped code={code} class={mapped['character_class']} "
-        f"mastery={mapped['mastery']} passive_nodes={len(mapped['passive_tree'])} "
-        f"skills={len(mapped['skills'])}"
-    )
-    return ok({"build": mapped, "source_code": code})
+        return err_response(f"Import failed unexpectedly: {exc}", 422)
 
 
 # ---------------------------------------------------------------------------
@@ -347,6 +434,8 @@ def import_build():
     3. On success — save as a draft build, return slug + summary
     4. On hard failure — log ImportFailure, fire Discord alert, return 422
     5. On partial — save build, log ImportFailure, return 200 with warnings
+
+    NEVER returns 500 — all exceptions are caught, recorded, and returned as 422.
     """
     body = request.get_json(silent=True) or {}
     url: str = body.get("url", "").strip()
@@ -362,40 +451,51 @@ def import_build():
     except ValueError as exc:
         return err_response(str(exc), 400)
 
+    # Top-level try/except — catch ANY unhandled error, record it, alert, return 422
+    try:
+        return _do_import(url, source, user_id)
+    except Exception as exc:
+        logger.error(
+            "import/build: unhandled exception for url=%s: %s\n%s",
+            url, exc, traceback.format_exc(),
+        )
+        _record_and_alert(
+            source=source,
+            url=url,
+            user_id=user_id,
+            error_message=f"Unhandled error: {exc}\n{traceback.format_exc()[-500:]}",
+            partial_data={"traceback": traceback.format_exc()[-500:]},
+        )
+        return err_response(f"Import failed unexpectedly: {exc}", 422)
+
+
+def _do_import(url: str, source: str, user_id: str | None):
+    """Inner import logic — separated so the top-level handler can catch everything."""
+
     # Run importer
     try:
         importer = get_importer(url)
         result: ImportResult = importer.parse(url)
     except Exception as exc:
-        current_app.logger.exception("import/build: unexpected error parsing %s", url)
-        # Log failure
-        failure = ImportFailure(
+        logger.exception("import/build: error during parse for %s", url)
+        _record_and_alert(
             source=source,
-            raw_url=url,
-            missing_fields=[],
-            partial_data=None,
+            url=url,
             user_id=user_id,
-            error_message=f"Unexpected error: {exc}",
+            error_message=f"Importer crashed: {exc}",
         )
-        db.session.add(failure)
-        db.session.commit()
-        send_import_failure_alert(failure, severity="hard")
-        return err_response(f"Import failed: {exc}", 500)
+        return err_response(f"Import failed: {exc}", 422)
 
     # Hard failure — class/mastery unmappable
     if not result.success:
-        failure = ImportFailure(
+        _record_and_alert(
             source=result.source or source,
-            raw_url=url,
+            url=url,
+            user_id=user_id,
+            error_message=result.error_message or "Unknown parse failure",
             missing_fields=result.missing_fields,
             partial_data=result.build_data,
-            user_id=user_id,
-            error_message=result.error_message,
         )
-        db.session.add(failure)
-        db.session.commit()
-        send_import_failure_alert(failure, severity="hard")
-
         return err_response(
             result.error_message or "Import failed — could not parse the build.",
             422,
@@ -403,29 +503,39 @@ def import_build():
 
     # Success (possibly partial)
     build_data = result.build_data
+    if not build_data:
+        _record_and_alert(
+            source=source, url=url, user_id=user_id,
+            error_message="Importer returned success=True but build_data is None",
+        )
+        return err_response("Import returned no data despite reporting success.", 422)
+
     # Force draft (not public) for imported builds
     build_data["is_public"] = False
 
     try:
         build = build_service.create_build(build_data, user_id=user_id)
     except Exception as exc:
-        current_app.logger.exception("import/build: failed to save build from %s", url)
-        return err_response(f"Build parsed but could not be saved: {exc}", 500)
+        logger.exception("import/build: failed to save build from %s", url)
+        _record_and_alert(
+            source=source, url=url, user_id=user_id,
+            error_message=f"Build parsed but save failed: {exc}",
+            partial_data={"build_data_keys": list(build_data.keys())},
+        )
+        return err_response(f"Build parsed but could not be saved: {exc}", 422)
 
     # Track partial imports
     warnings = result.missing_fields
     if warnings:
-        failure = ImportFailure(
+        _record_and_alert(
             source=result.source or source,
-            raw_url=url,
-            missing_fields=warnings,
-            partial_data={"slug": build.slug},
+            url=url,
             user_id=user_id,
             error_message="Partial import — some fields could not be mapped.",
+            severity="partial",
+            missing_fields=warnings,
+            partial_data={"slug": build.slug},
         )
-        db.session.add(failure)
-        db.session.commit()
-        send_import_failure_alert(failure, severity="partial")
 
     imported_fields = []
     if build_data.get("character_class"):

--- a/backend/app/services/importers/base_importer.py
+++ b/backend/app/services/importers/base_importer.py
@@ -88,6 +88,7 @@ class ImportResult:
     source: str = ""
     missing_fields: list = field(default_factory=list)
     error_message: Optional[str] = None
+    partial_data: Optional[dict] = None
 
 
 class BaseImporter(ABC):

--- a/backend/app/services/importers/lastepochtools_importer.py
+++ b/backend/app/services/importers/lastepochtools_importer.py
@@ -11,12 +11,14 @@ Schema (relevant fields):
     charTree.selected   {nodeId: pts}
     skillTrees[]        [{treeID, selected, level, slotNumber}]
     hud                 [treeID × 5]  — HUD slot order
+    equipment[]         [{baseTypeID, affixes: [{affixID, tier}], ...}]
 """
 
 import json
 import logging
 import os
 import re
+import traceback
 from typing import Dict, List, Optional
 
 import requests as _requests
@@ -42,8 +44,36 @@ _MASTERY_MAP: Dict[str, Dict[int, str]] = {
     "Rogue":     {1: "Bladedancer", 2: "Marksman",    3: "Falconer"},
 }
 
+# LE Tools equipment slot indices → slot names
+_EQUIP_SLOT_MAP: Dict[int, str] = {
+    0: "helmet",
+    1: "body_armour",
+    2: "belt",
+    3: "boots",
+    4: "gloves",
+    5: "weapon",
+    6: "off_hand",
+    7: "amulet",
+    8: "ring_1",
+    9: "ring_2",
+    10: "relic",
+}
+
 # Skill tree ID → display name (loaded lazily)
 _SKILL_ID_TO_NAME: Optional[Dict[str, str]] = None
+
+# Base item type ID → base item info (loaded lazily)
+_BASE_ITEM_MAP: Optional[Dict[int, dict]] = None
+
+# Affix ID → affix info (loaded lazily)
+_AFFIX_MAP: Optional[Dict[str, dict]] = None
+
+
+def _project_root() -> str:
+    """Return project root (4 levels up from this file)."""
+    return os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(
+        os.path.dirname(os.path.abspath(__file__))
+    ))))
 
 
 def _get_skill_id_map() -> Dict[str, str]:
@@ -52,10 +82,7 @@ def _get_skill_id_map() -> Dict[str, str]:
         return _SKILL_ID_TO_NAME
 
     try:
-        root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(
-            os.path.dirname(os.path.abspath(__file__))
-        ))))
-        path = os.path.join(root, "data", "classes", "skills_metadata.json")
+        path = os.path.join(_project_root(), "data", "classes", "skills_metadata.json")
         with open(path) as f:
             skills_data = json.load(f)
         _SKILL_ID_TO_NAME = {
@@ -71,29 +98,135 @@ def _get_skill_id_map() -> Dict[str, str]:
     return _SKILL_ID_TO_NAME
 
 
+def _get_base_item_map() -> Dict[int, dict]:
+    """Load base item data keyed by LE Tools integer type ID."""
+    global _BASE_ITEM_MAP
+    if _BASE_ITEM_MAP is not None:
+        return _BASE_ITEM_MAP
+
+    _BASE_ITEM_MAP = {}
+    try:
+        path = os.path.join(_project_root(), "data", "items", "base_items.json")
+        with open(path) as f:
+            data = json.load(f)
+        # base_items.json is {slot_name: [items...]} — flatten
+        idx = 0
+        for slot_name, items in data.items():
+            for item in items:
+                item["_slot"] = slot_name
+                _BASE_ITEM_MAP[idx] = item
+                idx += 1
+        logger.info("LET importer: loaded %d base item entries", len(_BASE_ITEM_MAP))
+    except Exception as exc:
+        logger.warning("LET importer: could not load base item map: %s", exc)
+
+    return _BASE_ITEM_MAP
+
+
+def _get_affix_map() -> Dict[str, dict]:
+    """Load affix data keyed by affix ID string."""
+    global _AFFIX_MAP
+    if _AFFIX_MAP is not None:
+        return _AFFIX_MAP
+
+    _AFFIX_MAP = {}
+    try:
+        path = os.path.join(_project_root(), "data", "items", "affixes.json")
+        with open(path) as f:
+            affixes = json.load(f)
+        for affix in affixes:
+            affix_id = affix.get("affix_id") or affix.get("id")
+            if affix_id is not None:
+                _AFFIX_MAP[str(affix_id)] = affix
+        logger.info("LET importer: loaded %d affix entries", len(_AFFIX_MAP))
+    except Exception as exc:
+        logger.warning("LET importer: could not load affix map: %s", exc)
+
+    return _AFFIX_MAP
+
+
 # URL pattern for Last Epoch Tools planner links
 URL_PATTERN = re.compile(r"lastepochtools\.com/planner/([A-Za-z0-9_\-]+)")
 
 
 def _extract_build_info(html: str) -> Optional[dict]:
     """Extract the embedded build JSON from LE Tools HTML."""
+    # Method 1: window["buildInfo"] = {...} or window.buildInfo = {...}
     assignment_re = re.search(
         r'window\s*(?:\[\s*["\']buildInfo["\']\s*\]|\.buildInfo)\s*=\s*',
         html,
     )
-    if not assignment_re:
-        return None
+    if assignment_re:
+        start = assignment_re.end()
+        while start < len(html) and html[start] in " \t\r\n":
+            start += 1
+        try:
+            decoder = json.JSONDecoder()
+            obj, _ = decoder.raw_decode(html, start)
+            if isinstance(obj, dict):
+                logger.info("LET importer: extracted buildInfo via window assignment")
+                return obj
+        except json.JSONDecodeError as exc:
+            logger.warning("LET importer: found buildInfo assignment but JSON decode failed: %s", exc)
 
-    start = assignment_re.end()
-    while start < len(html) and html[start] in " \t\r\n":
-        start += 1
+    # Method 2: Look for __NEXT_DATA__ (Next.js SSR pages embed data here)
+    next_data_re = re.search(
+        r'<script\s+id="__NEXT_DATA__"\s+type="application/json">\s*',
+        html,
+    )
+    if next_data_re:
+        start = next_data_re.end()
+        end = html.find("</script>", start)
+        if end > start:
+            try:
+                next_data = json.loads(html[start:end])
+                # Navigate to props.pageProps.buildInfo or similar
+                page_props = next_data.get("props", {}).get("pageProps", {})
+                if "buildInfo" in page_props:
+                    logger.info("LET importer: extracted buildInfo via __NEXT_DATA__")
+                    return page_props["buildInfo"]
+                if "build" in page_props:
+                    logger.info("LET importer: extracted build data via __NEXT_DATA__.props.pageProps.build")
+                    return page_props["build"]
+                # Return entire pageProps if it has bio/charTree
+                if page_props.get("bio") or page_props.get("charTree"):
+                    logger.info("LET importer: extracted build data from __NEXT_DATA__ pageProps")
+                    return page_props
+                logger.warning(
+                    "LET importer: found __NEXT_DATA__ but no buildInfo. Keys: %s, pageProps keys: %s",
+                    list(next_data.keys()),
+                    list(page_props.keys()),
+                )
+            except json.JSONDecodeError as exc:
+                logger.warning("LET importer: __NEXT_DATA__ JSON decode failed: %s", exc)
 
-    try:
-        decoder = json.JSONDecoder()
-        obj, _ = decoder.raw_decode(html, start)
-        return obj if isinstance(obj, dict) else None
-    except json.JSONDecodeError:
-        return None
+    # Method 3: Look for any large JSON object in script tags that has bio/charTree keys
+    for match in re.finditer(r'<script[^>]*>\s*', html):
+        script_start = match.end()
+        script_end = html.find("</script>", script_start)
+        if script_end < 0:
+            continue
+        script_content = html[script_start:script_end].strip()
+        # Look for JSON-like content starting with {
+        if not script_content.startswith("{"):
+            # Try after an assignment like var x =
+            json_match = re.search(r'=\s*(\{)', script_content)
+            if not json_match:
+                continue
+            json_start = json_match.start(1)
+            script_content = script_content[json_start:]
+        if len(script_content) < 50:
+            continue
+        try:
+            obj, _ = json.JSONDecoder().raw_decode(script_content)
+            if isinstance(obj, dict) and ("bio" in obj or "charTree" in obj):
+                logger.info("LET importer: extracted build data from script tag via fallback scan")
+                return obj
+        except (json.JSONDecodeError, ValueError):
+            continue
+
+    logger.warning("LET importer: no build data found in HTML (%d bytes)", len(html))
+    return None
 
 
 class LastEpochToolsImporter(BaseImporter):
@@ -109,6 +242,7 @@ class LastEpochToolsImporter(BaseImporter):
             )
 
         code = match.group(1)
+        logger.info("LET importer: starting import for code=%s", code)
 
         # Fetch the page server-side
         try:
@@ -126,6 +260,10 @@ class LastEpochToolsImporter(BaseImporter):
                 timeout=15,
             )
             resp.raise_for_status()
+            logger.info(
+                "LET importer: fetched page for code=%s status=%d len=%d",
+                code, resp.status_code, len(resp.text),
+            )
         except _requests.Timeout:
             return ImportResult(
                 success=False, source=self.source_name,
@@ -133,6 +271,7 @@ class LastEpochToolsImporter(BaseImporter):
             )
         except _requests.HTTPError as exc:
             status = exc.response.status_code if exc.response is not None else 502
+            logger.warning("LET importer: HTTP %d for code=%s", status, code)
             if status == 404:
                 return ImportResult(
                     success=False, source=self.source_name,
@@ -143,6 +282,7 @@ class LastEpochToolsImporter(BaseImporter):
                 error_message=f"Last Epoch Tools returned HTTP {status}.",
             )
         except _requests.RequestException as exc:
+            logger.warning("LET importer: network error for code=%s: %s", code, exc)
             return ImportResult(
                 success=False, source=self.source_name,
                 error_message=f"Network error fetching build: {exc}",
@@ -152,15 +292,23 @@ class LastEpochToolsImporter(BaseImporter):
         build_info = _extract_build_info(html)
 
         if build_info is None:
+            # Log a snippet for debugging
+            logger.warning(
+                "LET importer: no buildInfo found for code=%s. "
+                "HTML snippet (first 500 chars): %s",
+                code, html[:500],
+            )
             return ImportResult(
                 success=False, source=self.source_name,
                 error_message=(
                     "Could not find build data in the page. "
                     "The build code may be invalid, or Last Epoch Tools may have updated their format."
                 ),
+                partial_data={"html_length": len(html), "code": code},
             )
 
         if build_info.get("buildLoadError"):
+            logger.info("LET importer: buildLoadError flag set for code=%s", code)
             return ImportResult(
                 success=False, source=self.source_name,
                 error_message="Build not found or deleted on Last Epoch Tools.",
@@ -169,14 +317,42 @@ class LastEpochToolsImporter(BaseImporter):
         # LE Tools sometimes wraps the payload in "data"
         if "data" in build_info and isinstance(build_info["data"], dict):
             build_info = build_info["data"]
+            logger.info("LET importer: unwrapped 'data' key for code=%s", code)
 
         if not build_info.get("bio") and not build_info.get("charTree"):
+            logger.warning(
+                "LET importer: extracted JSON missing bio/charTree for code=%s: keys=%s",
+                code, list(build_info.keys()),
+            )
             return ImportResult(
                 success=False, source=self.source_name,
                 error_message="Build data is incomplete or in an unexpected format.",
+                partial_data={"keys": list(build_info.keys()), "code": code},
             )
 
-        return self._map(build_info, code)
+        logger.info(
+            "LET importer: extracted build data for code=%s, top-level keys=%s",
+            code, list(build_info.keys()),
+        )
+
+        try:
+            result = self._map(build_info, code)
+            logger.info(
+                "LET importer: mapping complete for code=%s success=%s missing=%d",
+                code, result.success, len(result.missing_fields),
+            )
+            return result
+        except Exception as exc:
+            logger.error(
+                "LET importer: unexpected error mapping build code=%s: %s\n%s",
+                code, exc, traceback.format_exc(),
+            )
+            return ImportResult(
+                success=False,
+                source=self.source_name,
+                error_message=f"Failed to map build data: {exc}",
+                partial_data={"code": code, "keys": list(build_info.keys())},
+            )
 
     def _map(self, build_info: dict, code: str) -> ImportResult:
         """Map LE Tools JSON to Forge build payload."""
@@ -199,6 +375,11 @@ class LastEpochToolsImporter(BaseImporter):
         if not mastery:
             missing_fields.append("mastery")
 
+        logger.info(
+            "LET importer: bio parsed — class=%s (id=%d) mastery=%s (id=%d) level=%d",
+            char_class, char_class_id, mastery or "UNKNOWN", mastery_id, level,
+        )
+
         # Passive tree
         char_tree = build_info.get("charTree", {})
         selected_nodes: dict = char_tree.get("selected", {})
@@ -208,6 +389,7 @@ class LastEpochToolsImporter(BaseImporter):
                 passive_tree.extend([int(node_id_str)] * max(0, int(pts)))
             except (ValueError, TypeError):
                 missing_fields.append(f"passive_node:{node_id_str}")
+        logger.info("LET importer: parsed %d passive nodes (%d total points)", len(selected_nodes), len(passive_tree))
 
         # Skills
         skill_id_map = _get_skill_id_map()
@@ -247,6 +429,11 @@ class LastEpochToolsImporter(BaseImporter):
             })
 
         skills.sort(key=lambda s: s["slot"])
+        logger.info("LET importer: parsed %d skills", len(skills))
+
+        # Gear
+        gear = self._parse_gear(build_info, missing_fields)
+        logger.info("LET importer: parsed %d gear items", len(gear))
 
         build_data = {
             "name": f"Imported — {char_class} {mastery}".strip(),
@@ -259,7 +446,7 @@ class LastEpochToolsImporter(BaseImporter):
             "level": level,
             "passive_tree": passive_tree,
             "skills": skills,
-            "gear": [],
+            "gear": gear,
             "_source_code": code,
         }
 
@@ -270,3 +457,92 @@ class LastEpochToolsImporter(BaseImporter):
             missing_fields=missing_fields,
         )
         return self.validate(result)
+
+    def _parse_gear(self, build_info: dict, missing_fields: List[str]) -> list:
+        """
+        Parse gear from LE Tools equipment data.
+
+        LE Tools uses several possible keys: "equipment", "gear", "items".
+        Each entry has baseTypeID (int), affixes (list of {affixID, tier}),
+        and a slot index.
+        """
+        raw_equipment = (
+            build_info.get("equipment")
+            or build_info.get("gear")
+            or build_info.get("items")
+            or []
+        )
+
+        if not raw_equipment:
+            logger.info("LET importer: no gear/equipment data in build")
+            return []
+
+        logger.info(
+            "LET importer: raw equipment entries=%d, sample keys=%s",
+            len(raw_equipment),
+            list(raw_equipment[0].keys()) if raw_equipment and isinstance(raw_equipment[0], dict) else "N/A",
+        )
+
+        base_item_map = _get_base_item_map()
+        affix_map = _get_affix_map()
+        gear: list = []
+
+        for idx, item_raw in enumerate(raw_equipment):
+            if not isinstance(item_raw, dict):
+                continue
+
+            # Determine slot
+            slot_idx = item_raw.get("equipmentSlot", item_raw.get("slot", idx))
+            slot_name = _EQUIP_SLOT_MAP.get(int(slot_idx), f"slot_{slot_idx}")
+
+            # Base type
+            base_type_id = item_raw.get("baseTypeID", item_raw.get("baseType", item_raw.get("base_type_id")))
+            base_item_name = None
+            if base_type_id is not None:
+                base_info = base_item_map.get(int(base_type_id))
+                if base_info:
+                    base_item_name = base_info.get("name")
+                else:
+                    missing_fields.append(f"gear_base_type:{slot_name}:{base_type_id}")
+
+            # Affixes
+            raw_affixes = item_raw.get("affixes", item_raw.get("mods", []))
+            parsed_affixes = []
+            for affix_raw in (raw_affixes or []):
+                if not isinstance(affix_raw, dict):
+                    continue
+                affix_id = str(affix_raw.get("affixID", affix_raw.get("id", "")))
+                tier = affix_raw.get("tier", affix_raw.get("t", 0))
+                affix_info = affix_map.get(affix_id) if affix_id else None
+                parsed_affixes.append({
+                    "id": affix_id,
+                    "name": affix_info["name"] if affix_info else None,
+                    "tier": tier,
+                    "_raw": affix_raw if not affix_info else None,
+                })
+                if not affix_info and affix_id:
+                    missing_fields.append(f"gear_affix:{slot_name}:{affix_id}")
+
+            # Implicit stats
+            implicit_value = item_raw.get("implicitValue", item_raw.get("implicit"))
+
+            gear_entry = {
+                "slot": slot_name,
+                "base_type_id": base_type_id,
+                "item_name": base_item_name,
+                "affixes": parsed_affixes,
+                "implicit": implicit_value,
+                "rarity": item_raw.get("rarity", "normal"),
+                "_raw": item_raw if not base_item_name else None,
+            }
+
+            # Clean up None _raw entries
+            if gear_entry["_raw"] is None:
+                del gear_entry["_raw"]
+            for affix in gear_entry["affixes"]:
+                if affix.get("_raw") is None:
+                    affix.pop("_raw", None)
+
+            gear.append(gear_entry)
+
+        return gear

--- a/backend/tests/test_build_import.py
+++ b/backend/tests/test_build_import.py
@@ -720,3 +720,209 @@ class TestBaseImporterValidation:
         )
         validated = DummyImporter().validate(result)
         assert any("class:FakeClass" in f for f in validated.missing_fields)
+
+
+# ---------------------------------------------------------------------------
+# Import Route Never Returns 500
+# ---------------------------------------------------------------------------
+
+class TestImportNever500:
+    """Verify the import route never returns 500 — always 422, 400, or 2xx."""
+
+    @patch("app.routes.import_route.get_importer")
+    @patch("app.routes.import_route.send_import_failure_alert")
+    def test_importer_crash_returns_422_not_500(self, mock_alert, mock_factory, client, db):
+        """When the importer raises an unexpected exception, route returns 422 not 500."""
+        mock_importer = MagicMock()
+        mock_importer.parse.side_effect = RuntimeError("Unexpected crash in parser")
+        mock_factory.return_value = mock_importer
+
+        resp = client.post(
+            "/api/import/build",
+            json={"url": "https://www.lastepochtools.com/planner/CRASH"},
+            content_type="application/json",
+        )
+
+        assert resp.status_code == 422
+        body = resp.get_json()
+        assert any("crash" in e["message"].lower() for e in body["errors"])
+
+    @patch("app.routes.import_route.get_importer")
+    @patch("app.routes.import_route.build_service")
+    @patch("app.routes.import_route.send_import_failure_alert")
+    def test_save_failure_returns_422_not_500(self, mock_alert, mock_bs, mock_factory, client, db):
+        """When build save fails, route returns 422 not 500."""
+        from app.services.importers.base_importer import ImportResult
+        mock_importer = MagicMock()
+        mock_importer.parse.return_value = ImportResult(
+            success=True,
+            source="lastepochtools",
+            build_data={
+                "name": "Test", "character_class": "Mage", "mastery": "Sorcerer",
+                "level": 80, "passive_tree": [], "skills": [], "gear": [],
+            },
+        )
+        mock_factory.return_value = mock_importer
+        mock_bs.create_build.side_effect = Exception("DB constraint violation")
+
+        resp = client.post(
+            "/api/import/build",
+            json={"url": "https://www.lastepochtools.com/planner/SAVEFAIL"},
+            content_type="application/json",
+        )
+
+        assert resp.status_code == 422
+        body = resp.get_json()
+        assert any("could not be saved" in e["message"].lower() for e in body["errors"])
+
+    @patch("app.routes.import_route.get_importer")
+    @patch("app.routes.import_route.send_import_failure_alert")
+    def test_importer_crash_fires_discord_alert(self, mock_alert, mock_factory, client, db):
+        """Crashes in the importer still fire a Discord alert."""
+        mock_importer = MagicMock()
+        mock_importer.parse.side_effect = ValueError("Something broke")
+        mock_factory.return_value = mock_importer
+
+        client.post(
+            "/api/import/build",
+            json={"url": "https://www.lastepochtools.com/planner/CRASH2"},
+            content_type="application/json",
+        )
+
+        mock_alert.assert_called_once()
+
+    @patch("app.routes.import_route.get_importer")
+    @patch("app.routes.import_route.send_import_failure_alert")
+    def test_null_build_data_returns_422(self, mock_alert, mock_factory, client, db):
+        """When importer returns success=True but build_data=None, returns 422."""
+        from app.services.importers.base_importer import ImportResult
+        mock_importer = MagicMock()
+        mock_importer.parse.return_value = ImportResult(
+            success=True,
+            source="lastepochtools",
+            build_data=None,
+        )
+        mock_factory.return_value = mock_importer
+
+        resp = client.post(
+            "/api/import/build",
+            json={"url": "https://www.lastepochtools.com/planner/NULLDATA"},
+            content_type="application/json",
+        )
+
+        assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Gear Parsing
+# ---------------------------------------------------------------------------
+
+class TestGearParsing:
+    @patch("app.services.importers.lastepochtools_importer._requests.get")
+    def test_parses_equipment_from_build(self, mock_get):
+        """When build has equipment data, it gets parsed to gear array."""
+        html = '''
+        <html><body><script>
+        window["buildInfo"] = {
+            "bio": {"level": 90, "characterClass": 4, "chosenMastery": 1},
+            "charTree": {"selected": {}},
+            "skillTrees": [],
+            "hud": [],
+            "equipment": [
+                {"equipmentSlot": 0, "baseTypeID": 5, "affixes": [{"affixID": "42", "tier": 3}]},
+                {"equipmentSlot": 5, "baseTypeID": 10}
+            ]
+        };
+        </script></body></html>
+        '''
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.text = html
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        from app.services.importers import LastEpochToolsImporter
+        result = LastEpochToolsImporter().parse("https://www.lastepochtools.com/planner/GEAR1")
+
+        assert result.success is True
+        gear = result.build_data["gear"]
+        assert len(gear) == 2
+        assert gear[0]["slot"] == "helmet"
+        assert gear[1]["slot"] == "weapon"
+
+    @patch("app.services.importers.lastepochtools_importer._requests.get")
+    def test_no_equipment_returns_empty_gear(self, mock_get):
+        """Build without equipment data returns empty gear list."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.text = _LET_HTML
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        from app.services.importers import LastEpochToolsImporter
+        result = LastEpochToolsImporter().parse("https://www.lastepochtools.com/planner/NOGEAR")
+
+        assert result.success is True
+        assert result.build_data["gear"] == []
+
+
+# ---------------------------------------------------------------------------
+# Extraction Strategies
+# ---------------------------------------------------------------------------
+
+class TestExtractionStrategies:
+    @patch("app.services.importers.lastepochtools_importer._requests.get")
+    def test_extracts_from_next_data(self, mock_get):
+        """Extraction works when data is in __NEXT_DATA__ script tag."""
+        html = '''
+        <html><body>
+        <script id="__NEXT_DATA__" type="application/json">
+        {"props": {"pageProps": {"buildInfo": {
+            "bio": {"level": 80, "characterClass": 1, "chosenMastery": 1},
+            "charTree": {"selected": {"5": 3}},
+            "skillTrees": [],
+            "hud": []
+        }}}}
+        </script>
+        </body></html>
+        '''
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.text = html
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        from app.services.importers import LastEpochToolsImporter
+        result = LastEpochToolsImporter().parse("https://www.lastepochtools.com/planner/NEXT")
+
+        assert result.success is True
+        assert result.build_data["character_class"] == "Mage"
+
+    @patch("app.services.importers.lastepochtools_importer._requests.get")
+    def test_mapping_crash_returns_failure_not_exception(self, mock_get):
+        """If _map() throws, parse() returns ImportResult(success=False) not an exception."""
+        # Build info has invalid data that will cause mapping to fail
+        html = '''
+        <html><body><script>
+        window["buildInfo"] = {
+            "bio": {"level": "not_a_number", "characterClass": "invalid", "chosenMastery": "bad"},
+            "charTree": {"selected": {}},
+            "skillTrees": [],
+            "hud": []
+        };
+        </script></body></html>
+        '''
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.text = html
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        from app.services.importers import LastEpochToolsImporter
+        from app.services.importers.base_importer import ImportResult as IR
+        result = LastEpochToolsImporter().parse("https://www.lastepochtools.com/planner/BAD")
+
+        # Should return a result, not raise an exception
+        assert isinstance(result, IR)
+        assert result.success is False
+        assert result.error_message is not None


### PR DESCRIPTION
…parsing and Discord alerts

Root cause: multiple error paths in the import system returned 500 or let exceptions propagate to the global error handler, producing an opaque "Internal server error" with no diagnostic information.

Changes:

Importer (lastepochtools_importer.py):
- Add INFO-level logging at every major step (fetch, extract, parse bio, parse skills, parse passives, parse gear, map complete)
- Wrap _map() in try/except so mapping crashes return ImportResult(success=False) instead of propagating as unhandled exceptions
- Add 3 extraction strategies: window["buildInfo"], __NEXT_DATA__ (Next.js), and fallback script tag scan — handles format changes gracefully
- Implement full gear parsing: equipment slot mapping, base item name lookup from data/items/base_items.json, affix resolution from data/items/affixes.json
- Unmappable gear base types and affixes go to missing_fields with raw data

Base importer:
- Add partial_data field to ImportResult dataclass for diagnostic context

Import route (import_route.py):
- NEVER return 500 — all error paths now return 422 with descriptive messages
- Add top-level try/except around both endpoints that catches ANY unhandled exception, records an ImportFailure, fires Discord alert, returns 422
- Extract _record_and_alert() helper to DRY failure tracking
- Handle edge case: importer returns success=True with build_data=None

Tests (test_build_import.py — 44 total, +8 new):
- TestImportNever500: verify crash→422, save failure→422, crash fires alert, null build_data→422
- TestGearParsing: equipment parsed to gear array, no equipment→empty
- TestExtractionStrategies: __NEXT_DATA__ extraction, mapping crash→failure