### PR TITLE
fix: correct gear parsing dict iteration and populate partial_data be…

### DIFF
--- a/backend/app/services/importers/lastepochtools_importer.py
+++ b/backend/app/services/importers/lastepochtools_importer.py
@@ -347,11 +347,38 @@ class LastEpochToolsImporter(BaseImporter):
                 "LET importer: unexpected error mapping build code=%s: %s\n%s",
                 code, exc, traceback.format_exc(),
             )
+            # Populate partial_data with whatever we can safely extract from
+            # raw build_info so the Discord alert shows what was parsed
+            # before the failure point.
+            bio = build_info.get("bio", {})
+            try:
+                cls_id = int(bio.get("characterClass", -1))
+            except (ValueError, TypeError):
+                cls_id = -1
+            cls_name = _CLASS_MAP.get(cls_id)
+            mastery_name = None
+            if cls_name:
+                try:
+                    mastery_name = _MASTERY_MAP.get(cls_name, {}).get(
+                        int(bio.get("chosenMastery", 0))
+                    )
+                except (ValueError, TypeError):
+                    pass
+            partial = {
+                "code": code,
+                "character_class": cls_name,
+                "mastery": mastery_name,
+                "level": bio.get("level"),
+                "passive_count": len(build_info.get("charTree", {}).get("selected", {})),
+                "skill_count": len(build_info.get("skillTrees", [])),
+                "gear_attempted": "equipment" in build_info or "gear" in build_info,
+                "error": str(exc),
+            }
             return ImportResult(
                 success=False,
                 source=self.source_name,
                 error_message=f"Failed to map build data: {exc}",
-                partial_data={"code": code, "keys": list(build_info.keys())},
+                partial_data=partial,
             )
 
     def _map(self, build_info: dict, code: str) -> ImportResult:
@@ -431,8 +458,14 @@ class LastEpochToolsImporter(BaseImporter):
         skills.sort(key=lambda s: s["slot"])
         logger.info("LET importer: parsed %d skills", len(skills))
 
-        # Gear
-        gear = self._parse_gear(build_info, missing_fields)
+        # Gear — wrapped so a crash here still returns what was parsed above
+        try:
+            gear = self._parse_gear(build_info, missing_fields)
+        except Exception as exc:
+            logger.error("LET importer: gear parsing failed: %s", exc)
+            missing_fields.append(f"gear_parse_error:{exc}")
+            gear = []
+
         logger.info("LET importer: parsed %d gear items", len(gear))
 
         build_data = {
@@ -463,37 +496,82 @@ class LastEpochToolsImporter(BaseImporter):
         Parse gear from LE Tools equipment data.
 
         LE Tools uses several possible keys: "equipment", "gear", "items".
-        Each entry has baseTypeID (int), affixes (list of {affixID, tier}),
-        and a slot index.
+        The value can be:
+          - A list of item dicts (each with equipmentSlot / slot index)
+          - A dict keyed by slot name or slot ID string (e.g. {"0": {...}, "helm": {...}})
         """
         raw_equipment = (
             build_info.get("equipment")
             or build_info.get("gear")
             or build_info.get("items")
-            or []
         )
 
         if not raw_equipment:
             logger.info("LET importer: no gear/equipment data in build")
             return []
 
+        # Normalise to a list of (slot_key, item_dict) pairs regardless of shape
+        items_iter: List[tuple] = []
+        if isinstance(raw_equipment, list):
+            items_iter = [(idx, v) for idx, v in enumerate(raw_equipment)]
+            sample = raw_equipment[0] if raw_equipment else None
+        elif isinstance(raw_equipment, dict):
+            items_iter = list(raw_equipment.items())
+            sample = next(iter(raw_equipment.values()), None) if raw_equipment else None
+        else:
+            logger.warning(
+                "LET importer: unexpected equipment type %s, skipping gear",
+                type(raw_equipment).__name__,
+            )
+            return []
+
         logger.info(
-            "LET importer: raw equipment entries=%d, sample keys=%s",
-            len(raw_equipment),
-            list(raw_equipment[0].keys()) if raw_equipment and isinstance(raw_equipment[0], dict) else "N/A",
+            "LET importer: raw equipment type=%s entries=%d sample_keys=%s",
+            type(raw_equipment).__name__,
+            len(items_iter),
+            list(sample.keys()) if isinstance(sample, dict) else "N/A",
         )
 
         base_item_map = _get_base_item_map()
         affix_map = _get_affix_map()
         gear: list = []
 
-        for idx, item_raw in enumerate(raw_equipment):
+        # LE Tools slot name → Forge slot name (covers both string-keyed dicts
+        # and explicit slot fields inside item dicts)
+        _LET_SLOT_ALIASES: Dict[str, str] = {
+            "helm": "helmet", "helmet": "helmet", "head": "helmet",
+            "body": "body_armour", "body_armour": "body_armour",
+            "chest": "body_armour", "bodyArmour": "body_armour",
+            "belt": "belt", "waist": "belt",
+            "boots": "boots", "feet": "boots",
+            "gloves": "gloves", "hands": "gloves",
+            "weapon": "weapon", "mainHand": "weapon",
+            "offHand": "off_hand", "off_hand": "off_hand", "shield": "off_hand",
+            "amulet": "amulet", "neck": "amulet",
+            "ring1": "ring_1", "ring_1": "ring_1", "leftRing": "ring_1",
+            "ring2": "ring_2", "ring_2": "ring_2", "rightRing": "ring_2",
+            "relic": "relic",
+        }
+
+        for slot_key, item_raw in items_iter:
             if not isinstance(item_raw, dict):
                 continue
 
-            # Determine slot
-            slot_idx = item_raw.get("equipmentSlot", item_raw.get("slot", idx))
-            slot_name = _EQUIP_SLOT_MAP.get(int(slot_idx), f"slot_{slot_idx}")
+            # Determine slot — try the item's own field first, then the dict key,
+            # then fall back to the numeric index via _EQUIP_SLOT_MAP
+            explicit_slot = item_raw.get("equipmentSlot", item_raw.get("slot"))
+            if explicit_slot is not None:
+                try:
+                    slot_name = _EQUIP_SLOT_MAP.get(int(explicit_slot), f"slot_{explicit_slot}")
+                except (ValueError, TypeError):
+                    slot_name = _LET_SLOT_ALIASES.get(str(explicit_slot), str(explicit_slot))
+            elif isinstance(slot_key, str) and not slot_key.isdigit():
+                slot_name = _LET_SLOT_ALIASES.get(slot_key, slot_key)
+            else:
+                try:
+                    slot_name = _EQUIP_SLOT_MAP.get(int(slot_key), f"slot_{slot_key}")
+                except (ValueError, TypeError):
+                    slot_name = f"slot_{slot_key}"
 
             # Base type
             base_type_id = item_raw.get("baseTypeID", item_raw.get("baseType", item_raw.get("base_type_id")))

--- a/backend/tests/test_build_import.py
+++ b/backend/tests/test_build_import.py
@@ -851,6 +851,41 @@ class TestGearParsing:
         assert gear[1]["slot"] == "weapon"
 
     @patch("app.services.importers.lastepochtools_importer._requests.get")
+    def test_parses_dict_keyed_equipment(self, mock_get):
+        """When equipment is a dict keyed by slot name/ID, it still parses."""
+        html = '''
+        <html><body><script>
+        window["buildInfo"] = {
+            "bio": {"level": 90, "characterClass": 4, "chosenMastery": 1},
+            "charTree": {"selected": {}},
+            "skillTrees": [],
+            "hud": [],
+            "equipment": {
+                "helm": {"baseTypeID": 5, "affixes": [{"affixID": "42", "tier": 3}]},
+                "weapon": {"baseTypeID": 10},
+                "3": {"baseTypeID": 7}
+            }
+        };
+        </script></body></html>
+        '''
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.text = html
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        from app.services.importers import LastEpochToolsImporter
+        result = LastEpochToolsImporter().parse("https://www.lastepochtools.com/planner/DICTGEAR")
+
+        assert result.success is True
+        gear = result.build_data["gear"]
+        assert len(gear) == 3
+        slots = [g["slot"] for g in gear]
+        assert "helmet" in slots   # "helm" → "helmet" via alias
+        assert "weapon" in slots
+        assert "boots" in slots    # "3" → boots via _EQUIP_SLOT_MAP
+
+    @patch("app.services.importers.lastepochtools_importer._requests.get")
     def test_no_equipment_returns_empty_gear(self, mock_get):
         """Build without equipment data returns empty gear list."""
         mock_resp = MagicMock()
@@ -926,3 +961,34 @@ class TestExtractionStrategies:
         assert isinstance(result, IR)
         assert result.success is False
         assert result.error_message is not None
+
+    @patch("app.services.importers.lastepochtools_importer._requests.get")
+    def test_mapping_crash_populates_partial_data(self, mock_get):
+        """When _map() crashes, partial_data still contains class/mastery/counts."""
+        html = '''
+        <html><body><script>
+        window["buildInfo"] = {
+            "bio": {"level": 85, "characterClass": 3, "chosenMastery": 2},
+            "charTree": {"selected": {"10": 5, "20": 3}},
+            "skillTrees": [{"treeID": "x", "selected": {}, "level": 1}],
+            "hud": [],
+            "equipment": "THIS_WILL_CAUSE_A_TYPE_ERROR"
+        };
+        </script></body></html>
+        '''
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.text = html
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        from app.services.importers import LastEpochToolsImporter
+        result = LastEpochToolsImporter().parse("https://www.lastepochtools.com/planner/PARTIAL_CRASH")
+
+        # Should succeed — gear parsing handles the invalid type gracefully
+        # and returns empty gear list (no crash propagation)
+        assert result.success is True
+        assert result.build_data["character_class"] == "Acolyte"
+        assert result.build_data["mastery"] == "Lich"
+        assert result.build_data["gear"] == []
+        assert len(result.build_data["passive_tree"]) == 8  # 5+3


### PR DESCRIPTION
…fore gear step

_parse_gear() crashed with KeyError: 0 when raw_equipment was a dict (keyed by slot name or slot ID) instead of a list. The code assumed integer indexing with raw_equipment[0].

Changes:
- Normalise equipment to (key, value) pairs regardless of whether the input is a list, dict-by-slot-name, or dict-by-slot-ID
- Add _LET_SLOT_ALIASES mapping to translate LE Tools slot names (helm, body, mainHand, etc.) to Forge slot names
- Handle numeric string keys ("3") via _EQUIP_SLOT_MAP fallback
- Gracefully skip non-dict/list equipment types with a warning log
- Wrap gear parsing in its own try/except inside _map() so a gear crash still returns the successfully parsed class/mastery/skills
- Populate partial_data in the parse() crash handler with whatever was extractable from raw build_info (class, mastery, level, passive count, skill count) so Discord alerts show useful context
- Guard all int() casts in crash handler with try/except for malformed bio data

Tests (+2 new, 46 total):
- test_parses_dict_keyed_equipment: dict with "helm"/"weapon"/"3" keys
- test_mapping_crash_populates_partial_data: invalid equipment type handled gracefully, passives/skills still parsed