### PR TITLE
fix: gear import cleanup — body armour lookup, rarity parsing, idol t…

### DIFF
--- a/backend/app/routes/import_route.py
+++ b/backend/app/routes/import_route.py
@@ -534,7 +534,23 @@ def _do_import(url: str, source: str, user_id: str | None):
             error_message="Partial import — some fields could not be mapped.",
             severity="partial",
             missing_fields=warnings,
-            partial_data={"slug": build.slug},
+            partial_data={
+                "slug": build.slug,
+                "character_class": build_data.get("character_class"),
+                "mastery": build_data.get("mastery"),
+                "level": build_data.get("level"),
+                "skills": [s.get("skill_name") for s in build_data.get("skills", [])],
+                "passive_tree": len(build_data.get("passive_tree", [])),
+                "gear": [
+                    {
+                        "slot": g.get("slot"),
+                        "item_name": g.get("item_name"),
+                        "rarity": g.get("rarity"),
+                        "affixes": len(g.get("affixes", [])),
+                    }
+                    for g in build_data.get("gear", [])
+                ],
+            },
         )
 
     imported_fields = []

--- a/backend/app/services/importers/lastepochtools_importer.py
+++ b/backend/app/services/importers/lastepochtools_importer.py
@@ -192,16 +192,29 @@ def _get_affix_map() -> Dict[str, dict]:
 
 # ---------------------------------------------------------------------------
 # Forge slot name → affix registry slot tags (used for slot-validation)
-# Forge slot name → game baseTypeID (for inferring base type from slot)
-_SLOT_TO_BASE_TYPE_ID: Dict[str, int] = {
-    "helmet": 0, "body_armour": 1, "belt": 2, "boots": 3, "gloves": 4,
-    "weapon1": 5,   # one-handed sword; real ID depends on weapon type
-    "weapon2": 5,
-    "weapon": 5,
-    "off_hand": 14,  # shield
-    "amulet": 20, "ring_1": 21, "ring_2": 21,
-    "relic": 22,
+# Forge slot name → list of possible game baseTypeIDs (ordered by likelihood)
+# Weapons can be many types, so list all weapon baseTypeIDs.
+_SLOT_TO_BASE_TYPE_IDS: Dict[str, List[int]] = {
+    "helmet":      [0],
+    "body_armour": [1],
+    "belt":        [2],
+    "boots":       [3],
+    "gloves":      [4],
+    "weapon1":     [5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 23],  # all weapon types
+    "weapon2":     [5, 6, 7, 8, 9, 10, 11, 18, 19, 17],  # one-hand + shield/catalyst/quiver
+    "weapon":      [5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 23],
+    "off_hand":    [18, 19, 17],  # shield, catalyst, quiver
+    "amulet":      [20],
+    "ring_1":      [21],
+    "ring_2":      [21],
+    "relic":       [22],
+    "idol_altar":  [25, 26, 27, 28, 29, 30, 31, 32, 33],  # all idol sizes
 }
+
+# Equipment-only baseTypeIDs (non-idol, non-blessing, non-lens)
+_EQUIPMENT_BASE_TYPE_IDS = list(range(0, 24))
+# Idol-only baseTypeIDs
+_IDOL_BASE_TYPE_IDS = list(range(25, 34))
 
 
 def _decode_base_item_id(
@@ -218,53 +231,51 @@ def _decode_base_item_id(
     """
     raw = _b64_decode_safe(encoded)
     if raw is None:
+        logger.debug("LET importer: base item ID '%s' failed base64 decode", encoded)
         return None, None, None
 
     varints = _decode_varints(raw)
     subtype_map = _get_item_subtype_map()
 
-    # Infer baseTypeID from slot name
-    base_type_id = _SLOT_TO_BASE_TYPE_ID.get(slot_name)
+    # Infer which baseTypeIDs are valid for this slot
+    slot_base_ids = _SLOT_TO_BASE_TYPE_IDS.get(slot_name)
 
     # Extract candidate subTypeIDs from the varints.
-    # From protobuf analysis: the blob starts with a field tag + value.
-    # The first varint value (after tag parsing) is often a small integer
-    # that could be the subTypeID. We try multiple extraction strategies.
+    # The blob is protobuf-like: first varint is a field tag, second is the value.
     candidates: List[int] = []
 
-    # Strategy 1: parse first field as protobuf (tag byte → field value)
-    if len(raw) >= 2:
-        tag_byte = raw[0]
-        wire_type = tag_byte & 0x07
-        if wire_type == 0 and len(varints) >= 1:
-            # Read the value after the tag — it's varints[0] if we treat
-            # the whole thing as varints, but the tag itself consumes bytes.
-            # Re-decode skipping the tag:
-            tag_varints = _decode_varints(raw)
-            # The tag itself is the first varint; the value is the second
-            if len(tag_varints) >= 2:
-                candidates.append(tag_varints[1])
+    # Strategy 1: protobuf tag → value (second varint is the item subtype)
+    if len(varints) >= 2:
+        candidates.append(varints[1])
 
-    # Strategy 2: plain varints — try each one
+    # Strategy 2: all small varints as additional candidates
     for v in varints:
         if 0 <= v <= 200 and v not in candidates:
             candidates.append(v)
 
-    # Try each candidate as subTypeID with the inferred baseTypeID
-    if base_type_id is not None:
-        for sub_id in candidates:
-            name = subtype_map.get((base_type_id, sub_id))
-            if name:
-                return name, base_type_id, sub_id
+    if not candidates:
+        return None, (slot_base_ids[0] if slot_base_ids else None), None
 
-    # Brute-force: try all (baseTypeID, candidate) combinations
+    # Try each candidate against the slot's known baseTypeIDs (most specific first)
+    if slot_base_ids:
+        for btid in slot_base_ids:
+            for sub_id in candidates:
+                name = subtype_map.get((btid, sub_id))
+                if name:
+                    return name, btid, sub_id
+
+    # Fallback: brute-force scan, but restricted to the correct category.
+    # Idol slots only try idol types; equipment slots only try equipment types.
+    is_idol = slot_name in ("idol_altar",)
+    scan_ids = _IDOL_BASE_TYPE_IDS if is_idol else _EQUIPMENT_BASE_TYPE_IDS
+
     for sub_id in candidates:
-        for btid in range(40):
+        for btid in scan_ids:
             name = subtype_map.get((btid, sub_id))
             if name:
                 return name, btid, sub_id
 
-    return None, base_type_id, None
+    return None, (slot_base_ids[0] if slot_base_ids else None), None
 
 
 def _b64_decode_safe(encoded: str) -> Optional[bytes]:
@@ -927,12 +938,16 @@ class LastEpochToolsImporter(BaseImporter):
             # Rarity — 'ir' field may be an integer, a string integer, or
             # a base64-encoded value. Try all interpretations.
             ir = item_raw.get("ir", item_raw.get("rarity"))
+            logger.debug(
+                "LET importer: %s raw ir=%r type=%s",
+                slot_name, ir, type(ir).__name__,
+            )
             rarity = "normal"
-            if isinstance(ir, int):
+            if isinstance(ir, int) and ir > 0:
                 rarity = _RARITY_MAP.get(ir, f"rarity_{ir}")
             elif isinstance(ir, str):
                 # Try as string integer first ("4" → legendary)
-                if ir.isdigit():
+                if ir.isdigit() and int(ir) > 0:
                     rarity = _RARITY_MAP.get(int(ir), f"rarity_{ir}")
                 elif ir in _RARITY_MAP.values():
                     rarity = ir
@@ -942,7 +957,7 @@ class LastEpochToolsImporter(BaseImporter):
                     if ir_bytes:
                         ir_varints = _decode_varints(ir_bytes)
                         for v in ir_varints:
-                            if v in _RARITY_MAP:
+                            if v in _RARITY_MAP and v > 0:
                                 rarity = _RARITY_MAP[v]
                                 break
 
@@ -961,6 +976,21 @@ class LastEpochToolsImporter(BaseImporter):
                     legendary_potential = 0
             else:
                 legendary_potential = 0
+
+            # Rarity fallback: infer from affix count when ir is 0/missing.
+            # LE Tools may store ir=0 for all items in some format versions,
+            # with the real rarity implicit in the item's affix/unique status.
+            raw_affixes = item_raw.get("affixes", item_raw.get("mods", []))
+            affix_count = len(raw_affixes) if raw_affixes else 0
+            if rarity == "normal" and affix_count > 0:
+                if legendary_potential > 0:
+                    rarity = "legendary"
+                elif affix_count >= 4:
+                    rarity = "exalted"
+                elif affix_count >= 3:
+                    rarity = "rare"
+                elif affix_count >= 1:
+                    rarity = "magic"
 
             # Affixes — LE Tools encodes affix IDs as base64 strings.
             raw_affixes = item_raw.get("affixes", item_raw.get("mods", []))

--- a/backend/tests/test_build_import.py
+++ b/backend/tests/test_build_import.py
@@ -1239,6 +1239,130 @@ class TestBaseItemDecoding:
         assert gear[0]["rarity"] == "legendary"
         assert gear[0].get("legendary_potential") == 2
 
+    @patch("app.services.importers.lastepochtools_importer._requests.get")
+    def test_rarity_inferred_from_affix_count_when_ir_zero(self, mock_get):
+        """When ir=0 (LE Tools default), rarity is inferred from affix count."""
+        html = '''
+        <html><body><script>
+        window["buildInfo"] = {
+            "bio": {"level": 98, "characterClass": 4, "chosenMastery": 1},
+            "charTree": {"selected": {}},
+            "skillTrees": [],
+            "hud": [],
+            "equipment": {
+                "helm": {"id": 1, "affixes": ["a","b","c","d"], "ir": 0, "ur": 1},
+                "body": {"id": 2, "affixes": ["a","b","c","d"], "ir": 0, "ur": 0},
+                "belt": {"id": 3, "affixes": ["a","b","c"], "ir": 0, "ur": 0},
+                "boots": {"id": 4, "affixes": ["a"], "ir": 0, "ur": 0},
+                "gloves": {"id": 5, "affixes": [], "ir": 0, "ur": 0}
+            }
+        };
+        </script></body></html>
+        '''
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.text = html
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        from app.services.importers import LastEpochToolsImporter
+        result = LastEpochToolsImporter().parse("https://www.lastepochtools.com/planner/INFRAR")
+
+        gear = result.build_data["gear"]
+        slots = {g["slot"]: g for g in gear}
+        # ur=1 + 4 affixes → legendary
+        assert slots["helmet"]["rarity"] == "legendary"
+        # 4 affixes, no LP → exalted
+        assert slots["body_armour"]["rarity"] == "exalted"
+        # 3 affixes → rare
+        assert slots["belt"]["rarity"] == "rare"
+        # 1 affix → magic
+        assert slots["boots"]["rarity"] == "magic"
+        # 0 affixes → normal
+        assert slots["gloves"]["rarity"] == "normal"
+
+    @patch("app.services.importers.lastepochtools_importer._requests.get")
+    def test_idol_does_not_resolve_to_ring(self, mock_get):
+        """Idol slots only search idol baseTypeIDs, not rings or other equipment."""
+        html = '''
+        <html><body><script>
+        window["buildInfo"] = {
+            "bio": {"level": 90, "characterClass": 4, "chosenMastery": 1},
+            "charTree": {"selected": {}},
+            "skillTrees": [],
+            "hud": [],
+            "equipment": {
+                "idol_altar": {"id": 1, "affixes": [], "ir": 0, "ur": 0}
+            }
+        };
+        </script></body></html>
+        '''
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.text = html
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        from app.services.importers import LastEpochToolsImporter
+        result = LastEpochToolsImporter().parse("https://www.lastepochtools.com/planner/IDOL")
+
+        gear = result.build_data["gear"]
+        assert len(gear) == 1
+        idol = gear[0]
+        assert idol["slot"] == "idol_altar"
+        # The item_name should NOT be a ring/amulet/weapon name
+        if idol.get("item_name"):
+            name_lower = idol["item_name"].lower()
+            assert "ring" not in name_lower, f"Idol resolved to ring: {idol['item_name']}"
+            assert "amulet" not in name_lower, f"Idol resolved to amulet: {idol['item_name']}"
+
+    @patch("app.routes.import_route.get_importer")
+    @patch("app.routes.import_route.send_import_failure_alert")
+    def test_partial_import_alert_includes_build_data(self, mock_alert, mock_factory, client, db):
+        """Partial import Discord alert partial_data includes class, mastery, gear stats."""
+        from app.services.importers.base_importer import ImportResult
+        mock_importer = MagicMock()
+        mock_importer.parse.return_value = ImportResult(
+            success=True,
+            source="lastepochtools",
+            build_data={
+                "name": "Test Partial",
+                "character_class": "Rogue",
+                "mastery": "Bladedancer",
+                "level": 98,
+                "passive_tree": list(range(50)),
+                "skills": [{"skill_name": "Shurikens"}],
+                "gear": [
+                    {"slot": "helmet", "item_name": "Fiend Cowl", "rarity": "legendary", "affixes": [1,2,3]},
+                    {"slot": "body_armour", "affixes": [1]},
+                ],
+            },
+            missing_fields=["gear_affix:helmet:xyz"],
+        )
+        mock_factory.return_value = mock_importer
+
+        resp = client.post(
+            "/api/import/build",
+            json={"url": "https://www.lastepochtools.com/planner/PARTDATA"},
+            content_type="application/json",
+        )
+
+        assert resp.status_code == 201
+        # Discord alert was fired with partial severity
+        mock_alert.assert_called_once()
+        failure_obj = mock_alert.call_args[0][0]
+        pd = failure_obj.partial_data
+        assert pd is not None
+        assert pd["character_class"] == "Rogue"
+        assert pd["mastery"] == "Bladedancer"
+        assert pd["level"] == 98
+        assert pd["passive_tree"] == 50
+        assert len(pd["skills"]) == 1
+        assert len(pd["gear"]) == 2
+        assert pd["gear"][0]["slot"] == "helmet"
+        assert pd["gear"][0]["item_name"] == "Fiend Cowl"
+        assert pd["gear"][0]["affixes"] == 3
+
 
 # Base64 Affix ID Decoding
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
…ype isolation, partial_data population

Four gear import fixes:

1. Body armour base_id resolution:
   - _SLOT_TO_BASE_TYPE_IDS now maps each slot to a LIST of valid baseTypeIDs (body_armour→[1], weapons→[5-16,23], etc.)
   - Lookup tries slot-specific baseTypeIDs first before fallback scan
   - Undecipherable base64 IDs (truncated/invalid) logged at debug level

2. Rarity always showing "normal":
   - Added affix-count heuristic when ir=0 (LE Tools default): 4+ affixes → exalted, 3 → rare, 1-2 → magic, 0 → normal
   - Legendary potential (ur>0) overrides to legendary
   - Only applies as fallback when ir field is 0 or missing

3. Idol resolving as wrong item type:
   - Idol slots (idol_altar) now only search idol baseTypeIDs (25-33)
   - Equipment slots only search equipment baseTypeIDs (0-23)
   - _IDOL_BASE_TYPE_IDS and _EQUIPMENT_BASE_TYPE_IDS constants prevent cross-contamination in the brute-force fallback

4. partial_data always "No fields parsed":
   - Partial import alerts now populate partial_data with the full build payload: character_class, mastery, level, skills list, passive_tree count, gear slots with item names and affix counts
   - Discord _summarize_partial_data() can now render actual stats

Tests: 67 total (+3 new), 10442 full suite pass
- test_rarity_inferred_from_affix_count_when_ir_zero
- test_idol_does_not_resolve_to_ring
- test_partial_import_alert_includes_build_data