### PR TITLE
fix: restore passive and skill tree rendering after 1.4.3 data sync —…

### DIFF
--- a/data/classes/passives.json
+++ b/data/classes/passives.json
@@ -9,8 +9,8 @@
     "name": "Forbidden Knowledge",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -533.34,
+    "y": -184.56003,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -24,7 +24,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-62"
   },
   {
     "id": "ac_0",
@@ -36,8 +36,8 @@
     "name": "Bone Aura",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -533.34,
+    "y": -3.0517578e-05,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -51,7 +51,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-528"
   },
   {
     "id": "ac_2",
@@ -63,8 +63,8 @@
     "name": "Blood Aura",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -533.34,
+    "y": 184.56,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -78,7 +78,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-45"
   },
   {
     "id": "ac_3",
@@ -90,8 +90,8 @@
     "name": "Mania of Mortality",
     "description": "You have additional ward decay threshold. Additionally, whenever a nearby enemy, ally, or minion dies, you have a chance to gain ward.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -334.74,
+    "y": -184.56003,
     "max_points": 10,
     "connections": [],
     "stats": [
@@ -109,7 +109,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-509"
   },
   {
     "id": "ac_55",
@@ -121,8 +121,8 @@
     "name": "Dark Rituals",
     "description": "Your minions have increased attack and cast speed. This bonus also applies to you if you have used a minion skill in the last 10 seconds.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -334.74,
+    "y": -3.0517578e-05,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -140,7 +140,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-20"
   },
   {
     "id": "ac_4",
@@ -152,8 +152,8 @@
     "name": "Stolen Vitality",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -334.74,
+    "y": 92.28,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -167,7 +167,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-772"
   },
   {
     "id": "ac_5",
@@ -179,8 +179,8 @@
     "name": "Ethereal Revenant",
     "description": "When damage leaves you below half health, you summon a {Revenant,} a melee minion with decaying health whose damage scales with your intelligence. This effect has a 15 second cooldown.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -136.13998,
+    "y": -92.28003,
     "max_points": 6,
     "connections": [
       "ac_55"
@@ -200,7 +200,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1144"
   },
   {
     "id": "ac_6",
@@ -212,8 +212,8 @@
     "name": "Blood Pact",
     "description": "You deal increased damage, but you lose a percentage of your current health each second if you have killed an enemy recently (last 4 seconds).",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -136.13998,
+    "y": 184.56,
     "max_points": 5,
     "connections": [
       "ac_2"
@@ -229,7 +229,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-317"
   },
   {
     "id": "ac_7",
@@ -241,8 +241,8 @@
     "name": "Unnatural Preservation",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 62.460022,
+    "y": -184.56003,
     "max_points": 5,
     "connections": [
       "ac_3"
@@ -262,7 +262,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-692"
   },
   {
     "id": "ac_8",
@@ -274,8 +274,8 @@
     "name": "Putrid Demise",
     "description": "You have a chance to poison on hit, and additional poison resistance.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 62.460022,
+    "y": -92.28003,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -289,7 +289,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1376"
   },
   {
     "id": "ac_56",
@@ -301,8 +301,8 @@
     "name": "Crimson Gluttony",
     "description": "A percentage of your current health is drained each second, but you gain a percentage of your missing health as ward each second.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 62.460022,
+    "y": 92.28,
     "max_points": 5,
     "connections": [
       "ac_6",
@@ -319,7 +319,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-682"
   },
   {
     "id": "ac_82",
@@ -331,8 +331,8 @@
     "name": "Eye of Damnation",
     "description": "You and your minions deal increased necrotic damage and you have a chance to apply Damned on hit.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 261.06,
+    "y": -184.56003,
     "max_points": 6,
     "connections": [],
     "stats": [
@@ -350,7 +350,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-532"
   },
   {
     "id": "ac_80",
@@ -362,8 +362,8 @@
     "name": "Soul Aegis",
     "description": "Your minions have additional armor per character level.",
     "node_type": "notable",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 261.06,
+    "y": -3.0517578e-05,
     "max_points": 1,
     "connections": [
       "ac_55"
@@ -375,7 +375,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-523"
   },
   {
     "id": "ac_83",
@@ -387,8 +387,8 @@
     "name": "Dominion of Rot",
     "description": "You deal increased poison damage and your minions have a chance to poison on hit.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 459.66003,
+    "y": -92.28003,
     "max_points": 6,
     "connections": [
       "ac_8"
@@ -404,7 +404,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-356"
   },
   {
     "id": "ac_84",
@@ -416,8 +416,8 @@
     "name": "Veins of Power",
     "description": "You and your minions deal increased physical damage and have increased bleed duration",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 459.66003,
+    "y": 92.28,
     "max_points": 6,
     "connections": [],
     "stats": [
@@ -431,7 +431,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-10"
   },
   {
     "id": "ac_59",
@@ -443,8 +443,8 @@
     "name": "Grave Thorns",
     "description": "You have additional Vitality, and your minions have additional armor and damage reflection.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -533.34,
+    "y": -184.56003,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -470,7 +470,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-233"
   },
   {
     "id": "ac_11",
@@ -482,8 +482,8 @@
     "name": "Risen Army",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -533.34,
+    "y": -3.0517578e-05,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -501,7 +501,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-227"
   },
   {
     "id": "ac_10",
@@ -513,8 +513,8 @@
     "name": "Elixir of Hunger",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -533.34,
+    "y": 184.56,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -532,7 +532,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-530"
   },
   {
     "id": "ac_21",
@@ -544,8 +544,8 @@
     "name": "Blood Armor",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -416.22,
+    "y": -184.56003,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -559,7 +559,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-523"
   },
   {
     "id": "ac_14",
@@ -571,8 +571,8 @@
     "name": "Cursed Blood",
     "description": "You and your minions deal increased physical and necrotic damage.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -416.22,
+    "y": -3.0517578e-05,
     "max_points": 10,
     "connections": [],
     "stats": [
@@ -590,7 +590,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-253"
   },
   {
     "id": "ac_15",
@@ -602,8 +602,8 @@
     "name": "Reclamation of Souls",
     "description": "You have increased ward retention, and are granted ward whenever one of your minions die.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -416.22,
+    "y": 184.56,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -617,7 +617,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-55"
   },
   {
     "id": "ac_16",
@@ -629,8 +629,8 @@
     "name": "Mortal Tether",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -299.09998,
+    "y": -92.28003,
     "max_points": 10,
     "connections": [
       "ac_21"
@@ -646,7 +646,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-231"
   },
   {
     "id": "ac_13",
@@ -658,8 +658,8 @@
     "name": "Soul Conduits",
     "description": "You have additional ward per second for each minion you have active, up to 20 minions.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -299.09998,
+    "y": 92.28,
     "max_points": 5,
     "connections": [
       "ac_15"
@@ -671,7 +671,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-545"
   },
   {
     "id": "ac_17",
@@ -683,8 +683,8 @@
     "name": "Wisp Weaver",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -181.98001,
+    "y": -184.56003,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -698,7 +698,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-537"
   },
   {
     "id": "ac_75",
@@ -710,8 +710,8 @@
     "name": "Aegisfall",
     "description": "Your minions have a chance to shred armor on hit.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -181.98001,
+    "y": -3.0517578e-05,
     "max_points": 8,
     "connections": [
       "ac_14"
@@ -731,7 +731,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-7"
   },
   {
     "id": "ac_19",
@@ -743,8 +743,8 @@
     "name": "Towering Death",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -181.98001,
+    "y": 184.56,
     "max_points": 10,
     "connections": [],
     "stats": [
@@ -770,7 +770,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-237"
   },
   {
     "id": "ac_60",
@@ -782,8 +782,8 @@
     "name": "Blood Feast",
     "description": "Your minions leech a percentage of the damage they deal as health.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -64.859985,
+    "y": -184.56003,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -797,7 +797,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-45"
   },
   {
     "id": "ac_12",
@@ -809,8 +809,8 @@
     "name": "Unbound Necromancy",
     "description": "You have a chance when one of your Skeletons dies to summon a new one after 3 seconds.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -64.859985,
+    "y": -92.28003,
     "max_points": 5,
     "connections": [
       "ac_16"
@@ -826,7 +826,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-209"
   },
   {
     "id": "ac_18",
@@ -838,8 +838,8 @@
     "name": "Sharpened Bones",
     "description": "Your minions have additional chance to critically strike.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -64.859985,
+    "y": 92.28,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -849,7 +849,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-951"
   },
   {
     "id": "ac_20",
@@ -861,8 +861,8 @@
     "name": "Invigorated Dead",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -64.859985,
+    "y": 184.56,
     "max_points": 5,
     "connections": [
       "ac_0",
@@ -885,7 +885,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-536"
   },
   {
     "id": "ac_23",
@@ -897,8 +897,8 @@
     "name": "Tyrant",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 52.26001,
+    "y": -92.28003,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -912,7 +912,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-734"
   },
   {
     "id": "ac_74",
@@ -924,8 +924,8 @@
     "name": "Effigies",
     "description": "A percentage of your damage taken is redirected to your lowest health minion.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 52.26001,
+    "y": -3.0517578e-05,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -939,7 +939,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-534"
   },
   {
     "id": "ac_62",
@@ -951,8 +951,8 @@
     "name": "Frantic Summons",
     "description": "You and your minions have increased attack and cast speed.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 52.26001,
+    "y": 92.28,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -966,7 +966,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-673"
   },
   {
     "id": "ac_24",
@@ -978,8 +978,8 @@
     "name": "Cling To Life",
     "description": "Grants you Vitality and all resistances, and grants your minions all resistances.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 169.38,
+    "y": -184.56003,
     "max_points": 6,
     "connections": [
       "ac_23"
@@ -999,7 +999,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-317"
   },
   {
     "id": "ac_76",
@@ -1011,8 +1011,8 @@
     "name": "Moonlight Pyre",
     "description": "Your minions deal additional fire and necrotic damage with spells and attacks, and have additional chance to inflict ignite and damned on hit.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 169.38,
+    "y": -3.0517578e-05,
     "max_points": 10,
     "connections": [],
     "stats": [
@@ -1034,7 +1034,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-337"
   },
   {
     "id": "ac_63",
@@ -1046,8 +1046,8 @@
     "name": "River of Bones",
     "description": "You and your minions have increased critical strike chance and leech a percentage of critical strike damage dealt as health.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 169.38,
+    "y": 184.56,
     "max_points": 5,
     "connections": [
       "ac_62"
@@ -1063,7 +1063,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1161"
   },
   {
     "id": "ac_61",
@@ -1075,8 +1075,8 @@
     "name": "Tyrant's Legion",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 286.50006,
+    "y": -92.28003,
     "max_points": 5,
     "connections": [
       "ac_23"
@@ -1096,7 +1096,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-951"
   },
   {
     "id": "ac_26",
@@ -1108,8 +1108,8 @@
     "name": "Rotting Army",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 286.50006,
+    "y": 92.28,
     "max_points": 10,
     "connections": [
       "ac_62"
@@ -1125,7 +1125,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1139"
   },
   {
     "id": "ac_64",
@@ -1137,8 +1137,8 @@
     "name": "Empty The Graves",
     "description": "You have increased health regeneration and additional armor for each minion you control, up to 20 minions.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 403.62,
+    "y": -184.56003,
     "max_points": 4,
     "connections": [],
     "stats": [
@@ -1152,7 +1152,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-250"
   },
   {
     "id": "ac_25",
@@ -1164,8 +1164,8 @@
     "name": "Rite of Undeath",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 403.62,
+    "y": -3.0517578e-05,
     "max_points": 10,
     "connections": [
       "ac_76"
@@ -1193,7 +1193,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-348"
   },
   {
     "id": "ac_27",
@@ -1205,8 +1205,8 @@
     "name": "Blades of the Forlorn",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 403.62,
+    "y": 184.56,
     "max_points": 10,
     "connections": [
       "ac_63"
@@ -1226,7 +1226,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-288"
   },
   {
     "id": "ac_65",
@@ -1238,8 +1238,8 @@
     "name": "Disciples of Necromancy",
     "description": "Your minions deal additional spell damage and have increased cast speed.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 520.74,
+    "y": -92.28003,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -1257,7 +1257,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-217"
   },
   {
     "id": "ac_77",
@@ -1269,8 +1269,8 @@
     "name": "Veins of Malice",
     "description": "You have a chance to gain Haste for 2 seconds when a minion dies or kills an enemy. Additionally, you have increased movement speed.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 520.74,
+    "y": -3.0517578e-05,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -1288,7 +1288,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-889"
   },
   {
     "id": "ac_28",
@@ -1300,8 +1300,8 @@
     "name": "Forbidden Teachings",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 520.74,
+    "y": 92.28,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -1323,7 +1323,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-772"
   },
   {
     "id": "ac_29",
@@ -1335,8 +1335,8 @@
     "name": "Dance with Death",
     "description": "You deal increased damage. This bonus is tripled when you are at low life.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -533.34,
+    "y": -184.56003,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -1350,7 +1350,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-229"
   },
   {
     "id": "ac_30",
@@ -1362,8 +1362,8 @@
     "name": "Survival of the Cruel",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -533.34,
+    "y": -3.0517578e-05,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -1377,7 +1377,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-317"
   },
   {
     "id": "ac_58",
@@ -1389,8 +1389,8 @@
     "name": "Apocrypha",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -533.34,
+    "y": 92.28,
     "max_points": 10,
     "connections": [],
     "stats": [
@@ -1408,7 +1408,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-497"
   },
   {
     "id": "ac_31",
@@ -1420,8 +1420,8 @@
     "name": "Ethereal Menace",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -416.22,
+    "y": -184.56003,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -1435,7 +1435,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-536"
   },
   {
     "id": "ac_32",
@@ -1447,8 +1447,8 @@
     "name": "Biting Frost",
     "description": "You and your minions have a chance to inflict bleed and frostbite on hit.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -416.22,
+    "y": -92.28003,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -1462,7 +1462,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1165"
   },
   {
     "id": "ac_66",
@@ -1474,8 +1474,8 @@
     "name": "Grasp of Fate",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -416.22,
+    "y": 92.28,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -1489,7 +1489,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-416"
   },
   {
     "id": "ac_33",
@@ -1501,8 +1501,8 @@
     "name": "Deadened Nerves",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -416.22,
+    "y": 184.56,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -1516,7 +1516,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-949"
   },
   {
     "id": "ac_34",
@@ -1528,8 +1528,8 @@
     "name": "Desolation",
     "description": "You and your minions deal increased damage over time.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -299.09998,
+    "y": -92.28003,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -1547,7 +1547,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-905"
   },
   {
     "id": "ac_22",
@@ -1559,8 +1559,8 @@
     "name": "Scornful Blood",
     "description": "Instead of healing you, your leech drains the health of an enemy within 6 meters every 0.25 seconds.",
     "node_type": "notable",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -299.09998,
+    "y": -3.0517578e-05,
     "max_points": 1,
     "connections": [
       "ac_30"
@@ -1572,7 +1572,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-48"
   },
   {
     "id": "ac_36",
@@ -1584,8 +1584,8 @@
     "name": "Soul Barrier",
     "description": "When a hit taken leaves you below half health, you gain ward based on your uncapped poison resistance. This effect has a 6 second cooldown.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -299.09998,
+    "y": 92.28,
     "max_points": 5,
     "connections": [
       "ac_33"
@@ -1597,7 +1597,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-348"
   },
   {
     "id": "ac_35",
@@ -1609,8 +1609,8 @@
     "name": "Reaper",
     "description": "Your spells and melee attacks instantly kill enemies that they leave below a health threshold (a percentage of their maximum health).",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -181.98001,
+    "y": -184.56003,
     "max_points": 5,
     "connections": [
       "ac_31"
@@ -1630,7 +1630,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-253"
   },
   {
     "id": "ac_72",
@@ -1642,8 +1642,8 @@
     "name": "Lasting Stench",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -181.98001,
+    "y": -92.28003,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -1657,7 +1657,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-910"
   },
   {
     "id": "ac_39",
@@ -1669,8 +1669,8 @@
     "name": "Bed of Souls",
     "description": "You have additional Vitality, and you and your minions have increased health regeneration.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -181.98001,
+    "y": 92.28,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -1688,7 +1688,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-688"
   },
   {
     "id": "ac_37",
@@ -1700,8 +1700,8 @@
     "name": "Spirit Ward",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -181.98001,
+    "y": 184.56,
     "max_points": 5,
     "connections": [
       "ac_33"
@@ -1721,7 +1721,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-692"
   },
   {
     "id": "ac_38",
@@ -1733,8 +1733,8 @@
     "name": "Excoriating Insight",
     "description": "You have additional Intelligence, but your elemental resistances are lowered.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -64.859985,
+    "y": -92.28003,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -1752,7 +1752,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-666"
   },
   {
     "id": "ac_57",
@@ -1764,8 +1764,8 @@
     "name": "Unclosing Wounds",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -64.859985,
+    "y": 92.28,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -1779,7 +1779,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-337"
   },
   {
     "id": "ac_40",
@@ -1791,8 +1791,8 @@
     "name": "Mental Cacophony",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -64.859985,
+    "y": 184.56,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -1806,7 +1806,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1161"
   },
   {
     "id": "ac_68",
@@ -1818,8 +1818,8 @@
     "name": "Deathbringer",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 52.26001,
+    "y": -184.56003,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -1837,7 +1837,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-219"
   },
   {
     "id": "ac_43",
@@ -1849,8 +1849,8 @@
     "name": "Executioner",
     "description": "You can dual wield melee weapons by equipping a dagger or axe in your offhand. While dual wielding, you have increased attack and cast speed, but take more damage (multiplicative with other modifiers).",
     "node_type": "notable",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 52.26001,
+    "y": -3.0517578e-05,
     "max_points": 1,
     "connections": [],
     "stats": [
@@ -1868,7 +1868,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1389"
   },
   {
     "id": "ac_67",
@@ -1880,8 +1880,8 @@
     "name": "Three Plagues",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 52.26001,
+    "y": 184.56,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -1899,7 +1899,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1170"
   },
   {
     "id": "ac_70",
@@ -1911,8 +1911,8 @@
     "name": "Essence Devourer",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 169.38,
+    "y": -92.28003,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -1930,7 +1930,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1237"
   },
   {
     "id": "ac_42",
@@ -1942,8 +1942,8 @@
     "name": "Necrotic Energy",
     "description": "Your and your minions deal additional spell necrotic damage and melee necrotic damage.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 169.38,
+    "y": -3.0517578e-05,
     "max_points": 10,
     "connections": [],
     "stats": [
@@ -1957,7 +1957,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-55"
   },
   {
     "id": "ac_69",
@@ -1969,8 +1969,8 @@
     "name": "Spectral Wounds",
     "description": "You have additional health, and a percentage of hit damage taken from bosses and rare enemies is dealt over 4 seconds instead.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 169.38,
+    "y": 184.56,
     "max_points": 5,
     "connections": [
       "ac_67"
@@ -1986,7 +1986,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-545"
   },
   {
     "id": "ac_73",
@@ -1998,8 +1998,8 @@
     "name": "Clairvoyant Insight",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 286.50006,
+    "y": -184.56003,
     "max_points": 5,
     "connections": [
       "ac_68"
@@ -2015,7 +2015,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-673"
   },
   {
     "id": "ac_45",
@@ -2027,8 +2027,8 @@
     "name": "Instruments of Death",
     "description": "You have increased movement speed with a dagger equipped, more damage (multiplicative with other modifiers) with an axe equipped, and additional ward per second with a catalyst equipped.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 286.50006,
+    "y": -3.0517578e-05,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -2046,7 +2046,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1390"
   },
   {
     "id": "ac_44",
@@ -2058,8 +2058,8 @@
     "name": "Impact Ward",
     "description": "You take less damage over time (multiplicative with other modifiers).",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 286.50006,
+    "y": 92.28,
     "max_points": 5,
     "connections": [
       "ac_115"
@@ -2075,7 +2075,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-596"
   },
   {
     "id": "ac_47",
@@ -2087,8 +2087,8 @@
     "name": "Wands of the Fallen",
     "description": "You deal increased spell damage if you do not have a shield equipped.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 403.62,
+    "y": -184.56003,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -2102,7 +2102,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-318"
   },
   {
     "id": "ac_71",
@@ -2114,8 +2114,8 @@
     "name": "Ageless Ascetic",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 403.62,
+    "y": -92.28003,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -2137,7 +2137,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-224"
   },
   {
     "id": "ac_46",
@@ -2149,8 +2149,8 @@
     "name": "Decaying Form",
     "description": "You have a chance to poison on hit, and take less poison damage (multiplicative with other modifiers).",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 403.62,
+    "y": 184.56,
     "max_points": 10,
     "connections": [],
     "stats": [
@@ -2168,7 +2168,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-533"
   },
   {
     "id": "ac_49",
@@ -2180,8 +2180,8 @@
     "name": "Reaper's Malice",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 520.74,
+    "y": -92.28003,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -2199,7 +2199,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-685"
   },
   {
     "id": "ac_48",
@@ -2211,8 +2211,8 @@
     "name": "Mind Over Body",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 520.74,
+    "y": -3.0517578e-05,
     "max_points": 10,
     "connections": [],
     "stats": [
@@ -2230,7 +2230,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-596"
   },
   {
     "id": "ac_78",
@@ -2242,8 +2242,8 @@
     "name": "Accursed Feast",
     "description": "You gain additional leech and have significantly increased leech and leech rate, but your leech stacks are removed when you reach 66% health instead of 100%.",
     "node_type": "notable",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 520.74,
+    "y": 92.28,
     "max_points": 1,
     "connections": [],
     "stats": [
@@ -2265,7 +2265,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1391"
   },
   {
     "id": "ac_50",
@@ -2277,8 +2277,8 @@
     "name": "Soul Stealer",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -533.34,
+    "y": -184.56003,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -2296,7 +2296,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1161"
   },
   {
     "id": "ac_52",
@@ -2308,8 +2308,8 @@
     "name": "Chaos Flames",
     "description": "You deal increased fire damage and have a chance to ignite on hit with fire skills, and you deal increased necrotic damage and have a chance to inflict damned on hit with necrotic skills.\n\nThese effects also apply to your minions.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -533.34,
+    "y": -3.0517578e-05,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -2335,7 +2335,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-99"
   },
   {
     "id": "ac_53",
@@ -2347,8 +2347,8 @@
     "name": "Spiteful Decay",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -533.34,
+    "y": 184.56,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -2366,7 +2366,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-532"
   },
   {
     "id": "ac_54",
@@ -2378,8 +2378,8 @@
     "name": "Harrowing Armor",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -299.09998,
+    "y": -184.56003,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -2397,7 +2397,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-810"
   },
   {
     "id": "ac_79",
@@ -2409,8 +2409,8 @@
     "name": "Unholy Torment",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -416.22,
+    "y": -3.0517578e-05,
     "max_points": 6,
     "connections": [],
     "stats": [
@@ -2424,7 +2424,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-694"
   },
   {
     "id": "ac_87",
@@ -2436,8 +2436,8 @@
     "name": "Dark Protections",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -64.859985,
+    "y": -184.56003,
     "max_points": 7,
     "connections": [
       "ac_54"
@@ -2453,7 +2453,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-416"
   },
   {
     "id": "ac_89",
@@ -2465,8 +2465,8 @@
     "name": "Ward of Malevolence",
     "description": "You gain additional ward decay threshold and you gain ward on kill. \n\nYou also gain ward per 2 points of Intelligence while channeling a skill.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -299.09998,
+    "y": -92.28003,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -2484,7 +2484,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-685"
   },
   {
     "id": "ac_90",
@@ -2496,8 +2496,8 @@
     "name": "Crimson Favors",
     "description": "Your {Rip Blood's} hits have a chance to inflict bleed on enemies.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -299.09998,
+    "y": 184.56,
     "max_points": 6,
     "connections": [
       "ac_510063"
@@ -2517,7 +2517,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-225"
   },
   {
     "id": "ac_91",
@@ -2529,8 +2529,8 @@
     "name": "Imperishable",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -181.98001,
+    "y": -3.0517578e-05,
     "max_points": 5,
     "connections": [
       "ac_89"
@@ -2546,7 +2546,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-45"
   },
   {
     "id": "ac_92",
@@ -2558,8 +2558,8 @@
     "name": "Doom Herald",
     "description": "You take less damage while channeling and deal more damage to damned enemies while channeling (both multiplicative with other modifiers).",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -64.859985,
+    "y": -92.28003,
     "max_points": 8,
     "connections": [
       "ac_89"
@@ -2575,7 +2575,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-337"
   },
   {
     "id": "ac_93",
@@ -2587,8 +2587,8 @@
     "name": "Spirit Leech",
     "description": "A portion of the damage you do is returned to you as health over 3 seconds.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -181.98001,
+    "y": 184.56,
     "max_points": 6,
     "connections": [],
     "stats": [
@@ -2602,7 +2602,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-513"
   },
   {
     "id": "ac_94",
@@ -2614,8 +2614,8 @@
     "name": "Rancid Concoction",
     "description": "You gain ward and mana when you use a potion.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -64.859985,
+    "y": 92.28,
     "max_points": 6,
     "connections": [
       "ac_461804"
@@ -2639,7 +2639,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1397"
   },
   {
     "id": "ac_96",
@@ -2651,8 +2651,8 @@
     "name": "Wither",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 52.26001,
+    "y": -184.56003,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -2666,7 +2666,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-596"
   },
   {
     "id": "ac_99",
@@ -2678,8 +2678,8 @@
     "name": "Malefic Body",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 52.26001,
+    "y": 184.56,
     "max_points": 10,
     "connections": [],
     "stats": [
@@ -2693,7 +2693,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-949"
   },
   {
     "id": "ac_100",
@@ -2705,8 +2705,8 @@
     "name": "Encroaching Darkness",
     "description": "When you directly cast a {Curse} skill you also afflict a number of enemies around the target location with {Anguish}.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 169.38,
+    "y": -184.56003,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -2716,7 +2716,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-698"
   },
   {
     "id": "ac_102",
@@ -2728,8 +2728,8 @@
     "name": "Chaotic Strikes",
     "description": "Your hits have a chance to deal double damage.\n\nAdditionally your hits have a chance to deal double damage per {Curse} on the target.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 169.38,
+    "y": 184.56,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -2743,7 +2743,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-111"
   },
   {
     "id": "ac_104",
@@ -2755,10 +2755,12 @@
     "name": "Grasping Damnation",
     "description": "The Chains from the {Chains of Ruin} node last longer. Additionally damned that you inflict last longer.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 286.50006,
+    "y": 92.28,
     "max_points": 6,
-    "connections": [],
+    "connections": [
+      "ac_98"
+    ],
     "stats": [
       {
         "key": "Increased Chains Duration",
@@ -2774,7 +2776,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-112"
   },
   {
     "id": "ac_105",
@@ -2786,8 +2788,8 @@
     "name": "Duskbringer",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 520.74,
+    "y": -184.56003,
     "max_points": 6,
     "connections": [
       "ac_100"
@@ -2803,7 +2805,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-678"
   },
   {
     "id": "ac_106",
@@ -2815,8 +2817,8 @@
     "name": "Fleeting Crone",
     "description": "You have a chance to gain {Haste} for 2 seconds when you kill a {Cursed} enemy or hit a {Cursed} boss or rare enemy.\n\nAdditionally {Haste} on you has increased effect.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 403.62,
+    "y": -92.28003,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -2834,7 +2836,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-813"
   },
   {
     "id": "ac_107",
@@ -2846,8 +2848,8 @@
     "name": "Vessel of Chaos",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 403.62,
+    "y": 92.28,
     "max_points": 7,
     "connections": [],
     "stats": [
@@ -2861,7 +2863,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-99"
   },
   {
     "id": "ac_108",
@@ -2873,8 +2875,8 @@
     "name": "Wreak Havoc",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 403.62,
+    "y": 184.56,
     "max_points": 5,
     "connections": [
       "ac_102"
@@ -2890,7 +2892,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-695"
   },
   {
     "id": "ac_109",
@@ -2902,8 +2904,8 @@
     "name": "Accursed Seer",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 520.74,
+    "y": -3.0517578e-05,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -2925,7 +2927,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-693"
   },
   {
     "id": "ac_110",
@@ -2937,8 +2939,8 @@
     "name": "Grimhilde's Domain",
     "description": "{Witchfire} that you inflict deals more damage (multiplicative with other modifiers) per 1% global chance to ignite with fire skills and per 1% global chance to inflict damned with necrotic skills.\n\nAdditionally while you have {Ignite} or {Damned Overload} your hits spread {Witchfire} to a number of enemies within 10 meters.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 403.62,
+    "y": -3.0517578e-05,
     "max_points": 5,
     "connections": [
       "ac_507262"
@@ -2962,7 +2964,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-102"
   },
   {
     "id": "ac_111",
@@ -2974,8 +2976,8 @@
     "name": "Aspect of Death",
     "description": "You have increased health and you deal more damage (multiplicative with other modifiers) per stack of each negative ailment on you up to a maximum of 90.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 520.74,
+    "y": 184.56,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -2997,7 +2999,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1232"
   },
   {
     "id": "ac_112",
@@ -3009,8 +3011,8 @@
     "name": "Occultist's Mind",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -416.22,
+    "y": -92.28003,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -3024,7 +3026,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-310"
   },
   {
     "id": "ac_114",
@@ -3036,8 +3038,8 @@
     "name": "Hollow Lich",
     "description": "Health leech also grants increased damage.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -64.859985,
+    "y": -3.0517578e-05,
     "max_points": 3,
     "connections": [
       "ac_22"
@@ -3049,7 +3051,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-317"
   },
   {
     "id": "ac_115",
@@ -3061,8 +3063,8 @@
     "name": "Corrupted Form",
     "description": "You have more health (multiplicative with other modifiers) and gain a percentage of your maximum health as endurance threshold.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 52.26001,
+    "y": 92.28,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -3084,7 +3086,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-700"
   },
   {
     "id": "mg_0",
@@ -3096,8 +3098,8 @@
     "name": "Arcanist",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -533.74,
+    "y": -184.56003,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -3115,7 +3117,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-330"
   },
   {
     "id": "mg_2",
@@ -3127,8 +3129,8 @@
     "name": "Elementalist",
     "description": "Increases your elemental damage",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -533.74,
+    "y": -3.0517578e-05,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -3146,7 +3148,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-152"
   },
   {
     "id": "mg_1",
@@ -3158,8 +3160,8 @@
     "name": "Scholar",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -533.74,
+    "y": 184.56,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -3173,7 +3175,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-425"
   },
   {
     "id": "mg_4",
@@ -3185,8 +3187,8 @@
     "name": "Preparation",
     "description": "Every 3 seconds, your next elemental spell deals increased damage and has a chance to slow enemies on hit.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -335.14,
+    "y": -184.56003,
     "max_points": 10,
     "connections": [],
     "stats": [
@@ -3200,7 +3202,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-838"
   },
   {
     "id": "mg_3",
@@ -3212,8 +3214,8 @@
     "name": "Reactive Ward",
     "description": "When you drop below 70% health you gain a burst of ward based on your maximum health. This effect has a 12 second cooldown.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -335.14,
+    "y": 184.56,
     "max_points": 6,
     "connections": [],
     "stats": [
@@ -3223,7 +3225,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-570"
   },
   {
     "id": "mg_7",
@@ -3235,8 +3237,8 @@
     "name": "Arcane Flames",
     "description": "When you hit an enemy with a fire skill you {Ignite} additional nearby enemies. This effect has a 5 second cooldown.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -136.53998,
+    "y": -92.28003,
     "max_points": 6,
     "connections": [
       "mg_2"
@@ -3252,7 +3254,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-92"
   },
   {
     "id": "mg_5",
@@ -3264,8 +3266,8 @@
     "name": "Mage Flurry",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -136.53998,
+    "y": -3.0517578e-05,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -3287,7 +3289,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-21"
   },
   {
     "id": "mg_6",
@@ -3299,8 +3301,8 @@
     "name": "Arcane Current",
     "description": "When you hit an enemy with a lightning skill you cast {Lightning Blast} at other enemies within 6 meters of your target. This effect has a 5 second cooldown.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -136.53998,
+    "y": 92.28,
     "max_points": 6,
     "connections": [
       "mg_2"
@@ -3316,7 +3318,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-42"
   },
   {
     "id": "mg_24",
@@ -3328,8 +3330,8 @@
     "name": "Rune of Winter",
     "description": "Increases your chance to freeze and converts lightning blast and volcanic orb to cold spells, changing their base damage type to cold and giving them a chance to freeze.\n\nLightning Blast gains a base freeze rate of 46.\n\nVolcanic Orb's core gains a base freeze rate of 40 and its shrapnel gains a freeze rate of 32.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 62.059998,
+    "y": -184.56003,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -3347,7 +3349,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-432"
   },
   {
     "id": "mg_9",
@@ -3359,8 +3361,8 @@
     "name": "Knowledge of Destruction",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 62.059998,
+    "y": -3.0517578e-05,
     "max_points": 10,
     "connections": [],
     "stats": [
@@ -3374,7 +3376,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-474"
   },
   {
     "id": "mg_8",
@@ -3386,8 +3388,8 @@
     "name": "Warden",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 62.059998,
+    "y": 184.56,
     "max_points": 5,
     "connections": [
       "mg_3"
@@ -3399,7 +3401,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-381"
   },
   {
     "id": "mg_59",
@@ -3411,8 +3413,8 @@
     "name": "Ice and Fire",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 260.66003,
+    "y": -92.28003,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -3434,7 +3436,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-433"
   },
   {
     "id": "mg_45",
@@ -3446,8 +3448,8 @@
     "name": "Sun and Storms ",
     "description": "You deal increased fire and lightning damage.\n\nYou gain ward when you use a lightning skill or a fire skill. This effect has a 7 second cooldown, but the cooldown is not shared between different elements, so you can gain ward from a fire skill and a lightning skill within the same 7 second duration.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 260.66003,
+    "y": 92.28,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -3469,7 +3471,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-737"
   },
   {
     "id": "mg_58",
@@ -3481,8 +3483,8 @@
     "name": "Arcane Wind",
     "description": "When you hit an enemy with a cold skill you {Chill} additional nearby enemies. This effect has a 5 second cooldown.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 459.26,
+    "y": -184.56003,
     "max_points": 3,
     "connections": [
       "mg_59",
@@ -3495,7 +3497,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-563"
   },
   {
     "id": "mg_78",
@@ -3507,8 +3509,8 @@
     "name": "Silver Rune",
     "description": "Augments the ward gain effects of the {Reactive Ward} and {Sun and Storms} nodes, causing them to grant more ward and have shorter cooldowns.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 459.26,
+    "y": 184.56,
     "max_points": 3,
     "connections": [
       "mg_45",
@@ -3525,7 +3527,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-270"
   },
   {
     "id": "mg_12",
@@ -3537,8 +3539,8 @@
     "name": "Mana Shell",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -533.74,
+    "y": -184.56003,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -3556,7 +3558,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-500"
   },
   {
     "id": "mg_11",
@@ -3568,8 +3570,8 @@
     "name": "Essence of Celerity",
     "description": "Each stack of {Arcane Momentum} lasts longer and also increases your spell damage.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -416.62,
+    "y": 92.28,
     "max_points": 8,
     "connections": [
       "mg_13"
@@ -3589,7 +3591,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-65"
   },
   {
     "id": "mg_20",
@@ -3601,8 +3603,8 @@
     "name": "Calculated Destruction",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -533.74,
+    "y": -3.0517578e-05,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -3616,7 +3618,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-33"
   },
   {
     "id": "mg_14",
@@ -3628,8 +3630,8 @@
     "name": "Wisdom",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -416.62,
+    "y": -92.28003,
     "max_points": 8,
     "connections": [
       "mg_12"
@@ -3649,7 +3651,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1141"
   },
   {
     "id": "mg_13",
@@ -3661,8 +3663,8 @@
     "name": "Arcane Momentum",
     "description": "When you cast a spell you gain a stack of {Arcane Momentum} for 2 seconds and refreshing the duration of all existing stacks.\n\nEach stacks of Arcane Momentum increases your cast speed.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -533.74,
+    "y": 184.56,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -3676,7 +3678,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-301"
   },
   {
     "id": "mg_15",
@@ -3688,8 +3690,8 @@
     "name": "Lost Knowledge",
     "description": "You gain ward based on your current mana when you directly use a skill that costs at least 40 mana.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -182.37997,
+    "y": -92.28003,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -3699,7 +3701,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-474"
   },
   {
     "id": "mg_17",
@@ -3711,8 +3713,8 @@
     "name": "Ceraunomancer",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -299.5,
+    "y": -184.56003,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -3726,7 +3728,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-153"
   },
   {
     "id": "mg_16",
@@ -3738,8 +3740,8 @@
     "name": "Cryomancer",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -299.5,
+    "y": -3.0517578e-05,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -3753,7 +3755,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-902"
   },
   {
     "id": "mg_18",
@@ -3765,8 +3767,8 @@
     "name": "Pyromancer",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -299.5,
+    "y": 184.56,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -3780,7 +3782,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-135"
   },
   {
     "id": "mg_66",
@@ -3792,8 +3794,8 @@
     "name": "Whirling Snow",
     "description": "You have a chance to chill enemies when you are hit, and your skills have a chance to chill enemies on hit. This effect is doubled for cold skills.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -182.37997,
+    "y": 92.28,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -3807,7 +3809,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-3"
   },
   {
     "id": "mg_60",
@@ -3819,8 +3821,8 @@
     "name": "Afterglow",
     "description": "You deal increased spell damage and have additional ward retention.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -416.62,
+    "y": -3.0517578e-05,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -3838,7 +3840,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-506"
   },
   {
     "id": "mg_61",
@@ -3850,8 +3852,8 @@
     "name": "Rift Bolt",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -65.26001,
+    "y": -184.56003,
     "max_points": 5,
     "connections": [
       "mg_17"
@@ -3867,7 +3869,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-313"
   },
   {
     "id": "mg_62",
@@ -3879,8 +3881,8 @@
     "name": "Chill to the Bone",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -65.26001,
+    "y": -3.0517578e-05,
     "max_points": 5,
     "connections": [
       "mg_16"
@@ -3896,7 +3898,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-262"
   },
   {
     "id": "mg_63",
@@ -3908,8 +3910,8 @@
     "name": "Lavamancer",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -65.26001,
+    "y": 184.56,
     "max_points": 5,
     "connections": [
       "mg_18"
@@ -3925,7 +3927,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1336"
   },
   {
     "id": "mg_22",
@@ -3937,8 +3939,8 @@
     "name": "Crackling Precision",
     "description": "You have an increased chance to critically strike with spells. This effect is doubled for lightning skills.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 51.860046,
+    "y": -184.56003,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -3948,7 +3950,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-258"
   },
   {
     "id": "mg_21",
@@ -3960,8 +3962,8 @@
     "name": "Arcane Avalanche",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 51.860046,
+    "y": -3.0517578e-05,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -3979,7 +3981,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-160"
   },
   {
     "id": "mg_23",
@@ -3991,8 +3993,8 @@
     "name": "Inferno",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 51.860046,
+    "y": 184.56,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -4010,7 +4012,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1080"
   },
   {
     "id": "mg_26",
@@ -4022,8 +4024,8 @@
     "name": "Arcane Obliteration",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 168.98004,
+    "y": -92.28003,
     "max_points": 5,
     "connections": [
       "mg_22"
@@ -4035,7 +4037,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-141"
   },
   {
     "id": "mg_28",
@@ -4047,8 +4049,8 @@
     "name": "Warder",
     "description": "You have a chance to be granted ward whenever you hit an enemy with a fire, cold, or lightning skill.\n\nThis effect has a 10 second cooldown, but the cooldown is not shared between different elements, so you can gain ward from a fire hit and a lightning hit within the same 10 second duration.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 168.98004,
+    "y": -3.0517578e-05,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -4066,7 +4068,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-503"
   },
   {
     "id": "mg_25",
@@ -4078,8 +4080,8 @@
     "name": "Chronomancy",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 168.98004,
+    "y": 92.28,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -4101,7 +4103,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-8"
   },
   {
     "id": "mg_69",
@@ -4113,8 +4115,8 @@
     "name": "Arcane Insight",
     "description": "You have additional Intelligence and you gain additional ward decay threshold scaling with your Intelligence.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 168.98004,
+    "y": 184.56,
     "max_points": 10,
     "connections": [],
     "stats": [
@@ -4128,7 +4130,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-441"
   },
   {
     "id": "mg_64",
@@ -4140,8 +4142,8 @@
     "name": "Distant Spark",
     "description": "When you critically strike an enemy from at least 4 meters away, you have a chance to cast {Spark Nova,} a spell that deals lightning damage to nearby enemies.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 286.10004,
+    "y": -184.56003,
     "max_points": 5,
     "connections": [
       "mg_22"
@@ -4153,7 +4155,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-315"
   },
   {
     "id": "mg_67",
@@ -4165,8 +4167,8 @@
     "name": "Elemental Ascendance",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 286.10004,
+    "y": -92.28003,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -4184,7 +4186,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1301"
   },
   {
     "id": "mg_10",
@@ -4196,8 +4198,8 @@
     "name": "Spell Slinger",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 286.10004,
+    "y": 92.28,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -4211,7 +4213,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-966"
   },
   {
     "id": "mg_29",
@@ -4223,8 +4225,8 @@
     "name": "Arcane Current",
     "description": "You deal more lightning damage (multiplicative with other modifiers) to shocked enemies.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 403.22003,
+    "y": -184.56003,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -4238,7 +4240,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-42"
   },
   {
     "id": "mg_31",
@@ -4250,8 +4252,8 @@
     "name": "Dragon Breath",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 403.22003,
+    "y": -92.28003,
     "max_points": 10,
     "connections": [],
     "stats": [
@@ -4265,7 +4267,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-858"
   },
   {
     "id": "mg_27",
@@ -4277,8 +4279,8 @@
     "name": "Mana Bulwark",
     "description": "You have additional mana and a portion of the damage you take is dealt to your mana before health.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 403.22003,
+    "y": 92.28,
     "max_points": 10,
     "connections": [],
     "stats": [
@@ -4292,7 +4294,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-946"
   },
   {
     "id": "mg_76",
@@ -4304,8 +4306,8 @@
     "name": "Elixir of Knowledge",
     "description": "Whenever you use a potion, you gain ward based on to your intelligence.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 403.22003,
+    "y": 184.56,
     "max_points": 3,
     "connections": [
       "mg_69"
@@ -4321,7 +4323,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1203"
   },
   {
     "id": "mg_30",
@@ -4333,8 +4335,8 @@
     "name": "Archmage",
     "description": "You have additional spell damage and you have a chance to refund a portion of the mana cost paid when directly using a skill.\n\nThese values are doubled if you have 300 maximum mana and tripled if you have 1000 maximum mana.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 520.3401,
+    "y": -184.56003,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -4356,7 +4358,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-734"
   },
   {
     "id": "mg_68",
@@ -4368,8 +4370,8 @@
     "name": "Mana Well",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 520.3401,
+    "y": -3.0517578e-05,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -4383,7 +4385,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-461"
   },
   {
     "id": "mg_65",
@@ -4395,8 +4397,8 @@
     "name": "Recollection",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 520.3401,
+    "y": 184.56,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -4406,7 +4408,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-895"
   },
   {
     "id": "mg_32",
@@ -4418,8 +4420,8 @@
     "name": "Arcane Warden",
     "description": "You gain ward when you use an elemental melee attack and hit at least one enemy.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -533.34,
+    "y": -184.56003,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -4437,7 +4439,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-82"
   },
   {
     "id": "mg_35",
@@ -4449,8 +4451,8 @@
     "name": "Infused Weapon",
     "description": "You have additional melee damage and spell damage.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -533.34,
+    "y": -3.0517578e-05,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -4464,7 +4466,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1270"
   },
   {
     "id": "mg_33",
@@ -4476,8 +4478,8 @@
     "name": "Elemental Affinity",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -533.34,
+    "y": 184.56,
     "max_points": 6,
     "connections": [],
     "stats": [
@@ -4491,7 +4493,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-442"
   },
   {
     "id": "mg_34",
@@ -4503,8 +4505,8 @@
     "name": "Elemental Strikes",
     "description": "Your fire melee attacks have a chance to ignite on hit. Your cold melee attacks have a chance to chill on hit. Your lightning melee attacks have a chance to shock on hit. ",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -416.22,
+    "y": -92.28003,
     "max_points": 10,
     "connections": [],
     "stats": [
@@ -4522,7 +4524,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-722"
   },
   {
     "id": "mg_38",
@@ -4534,8 +4536,8 @@
     "name": "Flame Walker",
     "description": "While moving or using a melee attack, you have a chance each second to cast {Fire Aura}. \n\nThis chance is doubled if you have less than 3 stacks of {Fire Aura}.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -416.22,
+    "y": 92.28,
     "max_points": 8,
     "connections": [
       "mg_33"
@@ -4551,7 +4553,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-274"
   },
   {
     "id": "mg_39",
@@ -4563,8 +4565,8 @@
     "name": "Warden's Echo",
     "description": "When you use a melee attack and hit at least one enemy you have a chance to cast {Frost Claw}.\n\nThis consumes mana equal to a portion of {Frost Claw's} mana cost.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -299.09998,
+    "y": -184.56003,
     "max_points": 5,
     "connections": [
       "mg_0",
@@ -4583,7 +4585,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-453"
   },
   {
     "id": "mg_37",
@@ -4595,8 +4597,8 @@
     "name": "Arcane Shielding",
     "description": "You have increased armor and additional health.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -299.09998,
+    "y": -92.28003,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -4622,7 +4624,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-36"
   },
   {
     "id": "mg_36",
@@ -4634,8 +4636,8 @@
     "name": "Frozen Steel",
     "description": "Your melee attacks deal additional cold damage and you have a higher chance to freeze enemies.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -299.09998,
+    "y": -3.0517578e-05,
     "max_points": 5,
     "connections": [
       "mg_35"
@@ -4655,7 +4657,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1178"
   },
   {
     "id": "mg_42",
@@ -4667,8 +4669,8 @@
     "name": "Incinerating Aura",
     "description": "Your {Fire Auras} from all sources deal damage in a larger area.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -299.09998,
+    "y": 184.56,
     "max_points": 8,
     "connections": [
       "mg_38"
@@ -4688,7 +4690,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-335"
   },
   {
     "id": "mg_40",
@@ -4700,8 +4702,8 @@
     "name": "Fire Blood",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -181.98001,
+    "y": -3.0517578e-05,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -4715,7 +4717,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-515"
   },
   {
     "id": "mg_70",
@@ -4727,8 +4729,8 @@
     "name": "Freezing Aura",
     "description": "You deal increased cold damage and have a higher freeze rate multiplier.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -181.98001,
+    "y": 92.28,
     "max_points": 8,
     "connections": [
       "mg_38"
@@ -4752,7 +4754,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-450"
   },
   {
     "id": "mg_71",
@@ -4764,8 +4766,8 @@
     "name": "Defender of Welryn",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -64.859985,
+    "y": -184.56003,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -4779,7 +4781,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-370"
   },
   {
     "id": "mg_43",
@@ -4791,8 +4793,8 @@
     "name": "Resonating Aegis",
     "description": "Each stack of {Arcane Shielding} also grants increased armor.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -64.859985,
+    "y": -92.28003,
     "max_points": 5,
     "connections": [
       "mg_37"
@@ -4808,7 +4810,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-244"
   },
   {
     "id": "mg_72",
@@ -4820,8 +4822,8 @@
     "name": "Storm Blade",
     "description": "Your melee attacks deal additional lightning damage and your lightning melee attacks have a chance to apply a {Spark Charge} on hit. ",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -64.859985,
+    "y": -3.0517578e-05,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -4835,7 +4837,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1342"
   },
   {
     "id": "mg_77",
@@ -4847,8 +4849,8 @@
     "name": "Essence Duel",
     "description": "You have increased melee attack speed, and you gain ward when you use an elemental melee attack and hit at least one enemy.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -64.859985,
+    "y": 92.28,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -4862,7 +4864,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-426"
   },
   {
     "id": "mg_44",
@@ -4874,8 +4876,8 @@
     "name": "Crackling Aura",
     "description": "You deal increased lightning damage.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -64.859985,
+    "y": 184.56,
     "max_points": 5,
     "connections": [
       "mg_42"
@@ -4895,7 +4897,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1223"
   },
   {
     "id": "mg_75",
@@ -4907,8 +4909,8 @@
     "name": "Illusory Combatant",
     "description": "You have additional dexterity and intelligence.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 52.26001,
+    "y": -92.28003,
     "max_points": 6,
     "connections": [],
     "stats": [
@@ -4926,7 +4928,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-364"
   },
   {
     "id": "mg_84",
@@ -4938,8 +4940,8 @@
     "name": "Gemini",
     "description": "You can dual wield melee weapons by equipping a sword in your off hand. While dual wielding, you have increased attack and cast speed, but take more damage (multiplicative with other modifiers).",
     "node_type": "notable",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 52.26001,
+    "y": -3.0517578e-05,
     "max_points": 1,
     "connections": [],
     "stats": [
@@ -4957,7 +4959,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-863"
   },
   {
     "id": "mg_41",
@@ -4969,8 +4971,8 @@
     "name": "Mana Reaver",
     "description": "You have additional health and you have a chance to regain mana when you use a melee attack and hit at least one enemy.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 52.26001,
+    "y": 92.28,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -4988,7 +4990,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-498"
   },
   {
     "id": "mg_48",
@@ -5000,8 +5002,8 @@
     "name": "Volka's Razor",
     "description": "You have increased movement speed, attack speed, and dodge rating.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 169.38,
+    "y": -184.56003,
     "max_points": 6,
     "connections": [
       "mg_75"
@@ -5021,7 +5023,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-47"
   },
   {
     "id": "mg_80",
@@ -5033,8 +5035,8 @@
     "name": "Awe Strike",
     "description": "Your melee attacks deal additional lightning damage and you have a chance to parry attacks.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 169.38,
+    "y": -92.28003,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -5048,7 +5050,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-85"
   },
   {
     "id": "mg_73",
@@ -5060,8 +5062,8 @@
     "name": "Molten Edge",
     "description": "Your melee hits have a chance to ignite on hit and the ignites they inflict have increased effect.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 169.38,
+    "y": -3.0517578e-05,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -5075,7 +5077,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-592"
   },
   {
     "id": "mg_81",
@@ -5087,8 +5089,8 @@
     "name": "River Blade",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 169.38,
+    "y": 92.28,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -5106,7 +5108,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-970"
   },
   {
     "id": "mg_47",
@@ -5118,8 +5120,8 @@
     "name": "Burning Hands",
     "description": "You have additional fire resistance and you have a chance to cast {Fire Aura} when you use a melee attack and hit at least one enemy, up to a limited number of times per second.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 169.38,
+    "y": 184.56,
     "max_points": 5,
     "connections": [
       "mg_41"
@@ -5139,7 +5141,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-980"
   },
   {
     "id": "mg_49",
@@ -5151,8 +5153,8 @@
     "name": "Mental Fortitude",
     "description": "You have additional intelligence and endurance.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 286.50006,
+    "y": -92.28003,
     "max_points": 10,
     "connections": [],
     "stats": [
@@ -5166,7 +5168,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-495"
   },
   {
     "id": "mg_46",
@@ -5178,8 +5180,8 @@
     "name": "Conjured Armor",
     "description": "You have additional armor and gain ward per second.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 286.50006,
+    "y": 92.28,
     "max_points": 6,
     "connections": [],
     "stats": [
@@ -5197,7 +5199,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-789"
   },
   {
     "id": "mg_82",
@@ -5209,8 +5211,8 @@
     "name": "Outrun and Outlast",
     "description": "You have additional health and your ward decays more slowly.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 403.62,
+    "y": -3.0517578e-05,
     "max_points": 10,
     "connections": [],
     "stats": [
@@ -5228,7 +5230,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-570"
   },
   {
     "id": "mg_74",
@@ -5240,8 +5242,8 @@
     "name": "Flame Drinker",
     "description": "Your melee attacks deal more elemental damage (multiplicative with other modifiers) if they cost 10 or more mana.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 403.62,
+    "y": 184.56,
     "max_points": 6,
     "connections": [
       "mg_47"
@@ -5257,7 +5259,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-88"
   },
   {
     "id": "mg_50",
@@ -5269,8 +5271,8 @@
     "name": "Blade Weaver",
     "description": "When you use a melee attack that costs less than 10 mana you gain a stack of {Blade Weaving}, up to a maximum.\n\nWhen you use a melee attack that costs 10 or more mana the stacks are consumed and the attack deals 15% more elemental damage (multiplicative with other modifiers) per stack consumed.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 520.74,
+    "y": 92.28,
     "max_points": 10,
     "connections": [
       "mg_74"
@@ -5282,7 +5284,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-21"
   },
   {
     "id": "mg_51",
@@ -5294,8 +5296,8 @@
     "name": "Prodigy",
     "description": "You gain ward per second scaling with your intelligence.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 520.74,
+    "y": -92.28003,
     "max_points": 5,
     "connections": [
       "mg_49"
@@ -5311,7 +5313,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-497"
   },
   {
     "id": "mg_52",
@@ -5323,8 +5325,8 @@
     "name": "Blade Conduit",
     "description": "You have additional mana.\n\nWhen you indirectly cast a spell you gain a stack of {Blade Conduit} for 4 seconds, up to 6 stacks. Each stack grants increased mana regeneration.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 520.74,
+    "y": -184.56003,
     "max_points": 5,
     "connections": [
       "mg_114"
@@ -5344,7 +5346,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1150"
   },
   {
     "id": "mg_54",
@@ -5356,8 +5358,8 @@
     "name": "Quintessence of Triumph",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -533.34,
+    "y": -184.56003,
     "max_points": 10,
     "connections": [],
     "stats": [
@@ -5371,7 +5373,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1161"
   },
   {
     "id": "mg_55",
@@ -5383,8 +5385,8 @@
     "name": "Sphere of Protection",
     "description": "You have additional health and you take less damage (multiplicative with other modifiers) from ignited, shocked or chilled enemies.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -533.34,
+    "y": -3.0517578e-05,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -5398,7 +5400,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-570"
   },
   {
     "id": "mg_56",
@@ -5410,8 +5412,8 @@
     "name": "Unsealed Mana",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -533.34,
+    "y": 184.56,
     "max_points": 6,
     "connections": [],
     "stats": [
@@ -5433,7 +5435,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-497"
   },
   {
     "id": "mg_57",
@@ -5445,8 +5447,8 @@
     "name": "Rune of Renewal",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -416.22,
+    "y": -92.28003,
     "max_points": 6,
     "connections": [],
     "stats": [
@@ -5464,7 +5466,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-503"
   },
   {
     "id": "mg_86",
@@ -5476,8 +5478,8 @@
     "name": "Arcane Focus",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -416.22,
+    "y": 92.28,
     "max_points": 8,
     "connections": [
       "mg_56"
@@ -5493,7 +5495,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-495"
   },
   {
     "id": "mg_87",
@@ -5505,8 +5507,8 @@
     "name": "Never Late",
     "description": "After using a traversal skill, your next non-channeled spell has additional spell damage and a higher chance to critically strike.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -299.09998,
+    "y": -184.56003,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -5524,7 +5526,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-705"
   },
   {
     "id": "mg_88",
@@ -5536,10 +5538,12 @@
     "name": "Circle of Elements",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -299.09998,
+    "y": -3.0517578e-05,
     "max_points": 10,
-    "connections": [],
+    "connections": [
+      "mg_55"
+    ],
     "stats": [
       {
         "key": "Ignite Chance with Fire Skills",
@@ -5555,7 +5559,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-142"
   },
   {
     "id": "mg_89",
@@ -5567,8 +5571,8 @@
     "name": "Mental Catalysis",
     "description": "While using a Catalyst you have additional Intelligence and take reduced bonus damage from critical strikes.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -181.98001,
+    "y": 92.28,
     "max_points": 6,
     "connections": [
       "mg_86"
@@ -5584,7 +5588,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-972"
   },
   {
     "id": "mg_90",
@@ -5596,8 +5600,8 @@
     "name": "Nimbus Walk",
     "description": "The spell damage and crit chance from the {Never Late} node now also apply to {Traversal} skills, and you gain ward when you use a {Traversal} skill.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -181.98001,
+    "y": -92.28003,
     "max_points": 5,
     "connections": [
       "mg_87"
@@ -5613,7 +5617,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1214"
   },
   {
     "id": "mg_91",
@@ -5625,10 +5629,12 @@
     "name": "Transcendence",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -299.09998,
+    "y": 184.56,
     "max_points": 8,
-    "connections": [],
+    "connections": [
+      "mg_86"
+    ],
     "stats": [
       {
         "key": "Health",
@@ -5644,7 +5650,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-974"
   },
   {
     "id": "mg_92",
@@ -5656,8 +5662,8 @@
     "name": "Inscribed Instruments",
     "description": "You have additional critical strike multiplier while using a wand, additional ward retention while using a sceptre, and increased cast speed while using a staff.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -64.859985,
+    "y": 184.56,
     "max_points": 6,
     "connections": [],
     "stats": [
@@ -5675,7 +5681,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1254"
   },
   {
     "id": "mg_93",
@@ -5687,8 +5693,8 @@
     "name": "Decree of the Burning Wind",
     "description": "You deal more damage (multiplicative with other modifiers) to Bosses and Rare enemies.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 52.26001,
+    "y": -92.28003,
     "max_points": 8,
     "connections": [
       "mg_0",
@@ -5707,7 +5713,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-707"
   },
   {
     "id": "mg_94",
@@ -5719,8 +5725,8 @@
     "name": "Decree of the Eternal Tundra",
     "description": "You gain ward every 2 seconds.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 52.26001,
+    "y": 92.28,
     "max_points": 8,
     "connections": [
       "mg_0",
@@ -5739,7 +5745,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-708"
   },
   {
     "id": "mg_95",
@@ -5751,8 +5757,8 @@
     "name": "Brand of Deception",
     "description": "Your damage over time has additional elemental penetration",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 169.38,
+    "y": -184.56003,
     "max_points": 6,
     "connections": [],
     "stats": [
@@ -5766,7 +5772,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-981"
   },
   {
     "id": "mg_96",
@@ -5778,8 +5784,8 @@
     "name": "Jagged Veil",
     "description": "You gain ward when you critically strike enemies.\n\nThis can trigger a maximum of 5 times per second.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 520.74,
+    "y": 184.56,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -5797,7 +5803,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-984"
   },
   {
     "id": "mg_97",
@@ -5809,8 +5815,8 @@
     "name": "Ancient Inscriptions",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 169.38,
+    "y": -3.0517578e-05,
     "max_points": 10,
     "connections": [],
     "stats": [
@@ -5824,7 +5830,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1225"
   },
   {
     "id": "mg_98",
@@ -5836,8 +5842,8 @@
     "name": "Runic Fortress",
     "description": "You have additional armor while channeling per active {Rune} from {Runic Invocation}.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 169.38,
+    "y": 184.56,
     "max_points": 6,
     "connections": [
       "mg_0",
@@ -5856,7 +5862,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1101"
   },
   {
     "id": "mg_99",
@@ -5868,8 +5874,8 @@
     "name": "Order's Imposition",
     "description": "You deal more damage over time to {Branded} enemies (multiplicative with other modifiers).",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 403.62,
+    "y": -184.56003,
     "max_points": 6,
     "connections": [
       "mg_95"
@@ -5885,7 +5891,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-786"
   },
   {
     "id": "mg_100",
@@ -5897,8 +5903,8 @@
     "name": "Runeword: Avalanche",
     "description": "When you directly use a Cold Skill you have a chance to gain {Runeword: Avalanche}, a buff that grants additional Spell Cold Damage and grants additional Endurance Threshold per stack of Ignite on the attacker.\n\nThis buff lasts 6 seconds and does not stack.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 403.62,
+    "y": 92.28,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -5916,7 +5922,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-96"
   },
   {
     "id": "mg_101",
@@ -5928,8 +5934,8 @@
     "name": "Celestial Doom",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 520.74,
+    "y": -184.56003,
     "max_points": 10,
     "connections": [],
     "stats": [
@@ -5947,7 +5953,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-774"
   },
   {
     "id": "mg_102",
@@ -5959,8 +5965,8 @@
     "name": "Logocracy",
     "description": "{Runeword Buffs} last longer.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 520.74,
+    "y": -3.0517578e-05,
     "max_points": 5,
     "connections": [
       "mg_112",
@@ -5978,7 +5984,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-706"
   },
   {
     "id": "mg_104",
@@ -5990,8 +5996,8 @@
     "name": "Runeword: Cataclysm",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -416.22,
+    "y": -184.56003,
     "max_points": 6,
     "connections": [],
     "stats": [
@@ -6009,7 +6015,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-94"
   },
   {
     "id": "mg_105",
@@ -6021,8 +6027,8 @@
     "name": "Rune of Dilation",
     "description": "After using a {Traversal} skill you gain increased cast speed and movement speed for a short duration. This buff cannot stack.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -64.859985,
+    "y": -184.56003,
     "max_points": 8,
     "connections": [
       "mg_87"
@@ -6042,7 +6048,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-784"
   },
   {
     "id": "mg_106",
@@ -6054,8 +6060,8 @@
     "name": "Edict of the Scion",
     "description": "Your area skills have increased area, and when you directly use an area skill and hit an enemy you gain ward per active {Rune} from {Runic Invocation}.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -181.98001,
+    "y": 184.56,
     "max_points": 6,
     "connections": [
       "mg_0",
@@ -6074,7 +6080,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-911"
   },
   {
     "id": "mg_107",
@@ -6086,8 +6092,8 @@
     "name": "Freezing Point",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -64.859985,
+    "y": -3.0517578e-05,
     "max_points": 10,
     "connections": [
       "mg_88"
@@ -6103,7 +6109,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-594"
   },
   {
     "id": "mg_108",
@@ -6115,8 +6121,8 @@
     "name": "Decree of the Bountiful Ocean",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 52.26001,
+    "y": -3.0517578e-05,
     "max_points": 6,
     "connections": [
       "mg_0",
@@ -6135,7 +6141,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-710"
   },
   {
     "id": "mg_109",
@@ -6147,8 +6153,8 @@
     "name": "Cerulean Runestones",
     "description": "You have additional endurance and maximum mana.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 286.50006,
+    "y": 92.28,
     "max_points": 8,
     "connections": [
       "mg_97"
@@ -6168,7 +6174,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-581"
   },
   {
     "id": "mg_110",
@@ -6180,8 +6186,8 @@
     "name": "Runeword: Inferno",
     "description": "When you directly use a Fire Skill you have a chance to gain {Runeword: Inferno}, a buff that grants additional Spell Fire Damage and grants you more Armor per stack of Shock on the Attacker.\n\nThis buff lasts 6 seconds and does not stack.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 403.62,
+    "y": -92.28003,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -6199,7 +6205,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-97"
   },
   {
     "id": "mg_111",
@@ -6211,8 +6217,8 @@
     "name": "Sanguine Runestones",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 286.50006,
+    "y": -92.28003,
     "max_points": 8,
     "connections": [
       "mg_97"
@@ -6232,7 +6238,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-795"
   },
   {
     "id": "mg_112",
@@ -6244,8 +6250,8 @@
     "name": "Runeword: Hurricane",
     "description": "When you directly use a Lightning Skill you have a chance to gain {Runeword: Hurricane}, a buff that grants additional Spell Lightning Damage and Freeze Rate Multiplier.\n\nThis buff lasts 6 seconds and does not stack.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 286.50006,
+    "y": -3.0517578e-05,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -6263,7 +6269,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-95"
   },
   {
     "id": "mg_114",
@@ -6275,8 +6281,8 @@
     "name": "Burden of Knowledge",
     "description": "You have additional spell damage, but your spells take longer to cast.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 286.50006,
+    "y": -184.56003,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -6290,7 +6296,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1151"
   },
   {
     "id": "pr_0",
@@ -6302,8 +6308,8 @@
     "name": "Primal Strength",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -533.34,
+    "y": -184.56003,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -6317,7 +6323,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-292"
   },
   {
     "id": "pr_1",
@@ -6329,8 +6335,8 @@
     "name": "Natural Attunement",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -533.34,
+    "y": 92.28,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -6348,7 +6354,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-190"
   },
   {
     "id": "pr_2",
@@ -6360,8 +6366,8 @@
     "name": "Gift of the Wilderness",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -533.34,
+    "y": 184.56,
     "max_points": 6,
     "connections": [],
     "stats": [
@@ -6375,7 +6381,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-839"
   },
   {
     "id": "pr_3",
@@ -6387,8 +6393,8 @@
     "name": "Hunter's Restoration",
     "description": "You have increased health and every 3 seconds your next hit restores your health.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -334.74,
+    "y": -92.28003,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -6402,7 +6408,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-185"
   },
   {
     "id": "pr_10",
@@ -6414,8 +6420,8 @@
     "name": "Harmony of Blades",
     "description": "You can dual wield melee weapons by equipping an axe or sword in your off hand. While dual wielding, you have increased attack and cast speed, but take more damage (multiplicative with other modifiers).",
     "node_type": "notable",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -334.74,
+    "y": -3.0517578e-05,
     "max_points": 1,
     "connections": [],
     "stats": [
@@ -6437,7 +6443,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-499"
   },
   {
     "id": "pr_4",
@@ -6449,8 +6455,8 @@
     "name": "Primal Medicine",
     "description": "Your minions deal increased damage, and using a potion also heals your minions for a percentage of the amount it heals you.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -334.74,
+    "y": 184.56,
     "max_points": 6,
     "connections": [],
     "stats": [
@@ -6464,7 +6470,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-199"
   },
   {
     "id": "pr_5",
@@ -6476,8 +6482,8 @@
     "name": "Survival of the Pack",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -136.13998,
+    "y": -184.56003,
     "max_points": 6,
     "connections": [
       "pr_0"
@@ -6501,7 +6507,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-239"
   },
   {
     "id": "pr_6",
@@ -6513,8 +6519,8 @@
     "name": "Wisdom of the Wild",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -136.13998,
+    "y": 92.28,
     "max_points": 6,
     "connections": [
       "pr_1"
@@ -6530,7 +6536,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1115"
   },
   {
     "id": "pr_8",
@@ -6542,8 +6548,8 @@
     "name": "Hunter's Emanation",
     "description": "The healing from {Hunter's Restoration} also applies to your minions, and when you trigger Hunter's Restoration, your minions gain increased damage for 3 seconds.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 62.460022,
+    "y": -92.28003,
     "max_points": 5,
     "connections": [
       "pr_3"
@@ -6559,7 +6565,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-715"
   },
   {
     "id": "pr_7",
@@ -6571,8 +6577,8 @@
     "name": "Tempest Bond",
     "description": "You deal increased physical, cold, and lightning damage. These bonuses are doubled while you have an active minion.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 62.460022,
+    "y": -3.0517578e-05,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -6594,7 +6600,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1301"
   },
   {
     "id": "pr_9",
@@ -6606,8 +6612,8 @@
     "name": "Ancient Call",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 62.460022,
+    "y": 184.56,
     "max_points": 6,
     "connections": [
       "pr_4"
@@ -6627,7 +6633,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-967"
   },
   {
     "id": "pr_114",
@@ -6639,8 +6645,8 @@
     "name": "Cornered Beast",
     "description": "While at low health (below 35%) you take less damage and deal more melee damage (both multiplicative with other modifiers).\n\nAdditionally, when damage leaves you at low health you gain these benefits for 5 seconds if you aren't already at low health.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 261.06,
+    "y": -92.28003,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -6654,7 +6660,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-10"
   },
   {
     "id": "pr_115",
@@ -6666,8 +6672,8 @@
     "name": "Elder Branch",
     "description": "You and your totems deal additional spell damage. This bonus is tripled while using an axe.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 261.06,
+    "y": 92.28,
     "max_points": 5,
     "connections": [
       "pr_6"
@@ -6687,7 +6693,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1096"
   },
   {
     "id": "pr_116",
@@ -6699,8 +6705,8 @@
     "name": "Ancestral Weaponry",
     "description": "You deal additional melee damage with most two handed weapons. The amount and damage type depend on the type of weapon used.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 459.66003,
+    "y": -184.56003,
     "max_points": 10,
     "connections": [
       "pr_5"
@@ -6720,7 +6726,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-243"
   },
   {
     "id": "pr_86",
@@ -6732,8 +6738,8 @@
     "name": "Rotbane",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 459.66003,
+    "y": 184.56,
     "max_points": 5,
     "connections": [
       "pr_115"
@@ -6749,7 +6755,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-393"
   },
   {
     "id": "pr_13",
@@ -6761,8 +6767,8 @@
     "name": "Savagery",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -533.34,
+    "y": -184.56003,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -6776,7 +6782,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-39"
   },
   {
     "id": "pr_17",
@@ -6788,8 +6794,8 @@
     "name": "Feline Bond",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -533.34,
+    "y": -3.0517578e-05,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -6807,7 +6813,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-241"
   },
   {
     "id": "pr_12",
@@ -6819,8 +6825,8 @@
     "name": "Ursine Strength",
     "description": "You have additional strength and take less damage from nearby enemies (multiplicative with other modifiers).",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -533.34,
+    "y": 184.56,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -6834,7 +6840,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-715"
   },
   {
     "id": "pr_15",
@@ -6846,8 +6852,8 @@
     "name": "Ambush",
     "description": "Every 5 seconds, your next melee attack deals increased damage and grants {Aspect of the Shark} for 3 seconds, a buff that grants 10% more melee damage (multiplicative with other modifiers) and increases melee attack speed by 10%.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -416.22,
+    "y": -92.28003,
     "max_points": 8,
     "connections": [
       "pr_13"
@@ -6863,7 +6869,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-719"
   },
   {
     "id": "pr_14",
@@ -6875,8 +6881,8 @@
     "name": "Artor's Loyalty",
     "description": "You are limited to a single companion.\n\nYour companion is larger and deals more damage (multiplicative with other modifiers).",
     "node_type": "notable",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -416.22,
+    "y": -3.0517578e-05,
     "max_points": 1,
     "connections": [],
     "stats": [
@@ -6894,7 +6900,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-199"
   },
   {
     "id": "pr_19",
@@ -6906,8 +6912,8 @@
     "name": "Boar Heart",
     "description": "You are granted {Aspect of the Boar} for a duration when you use a traversal skill or Evade, a buff that grants 30% increased bleed duration and reduces damage taken by 15%. This effect has a 2 second cooldown. You also have additional endurance.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -416.22,
+    "y": 92.28,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -6921,7 +6927,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-589"
   },
   {
     "id": "pr_16",
@@ -6933,8 +6939,8 @@
     "name": "Lamprey Teeth",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -299.09998,
+    "y": -184.56003,
     "max_points": 6,
     "connections": [
       "pr_13"
@@ -6954,7 +6960,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-716"
   },
   {
     "id": "pr_24",
@@ -6966,8 +6972,8 @@
     "name": "Call of the Pack",
     "description": "You and your companions have additional health, and you and your companions are healed whenever you use a companion ability.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -299.09998,
+    "y": -3.0517578e-05,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -6985,7 +6991,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-837"
   },
   {
     "id": "pr_18",
@@ -6997,8 +7003,8 @@
     "name": "Tusk Warrior",
     "description": "{Aspect of the Boar} also grants a chance for attacks and spells to cause enemies to bleed and physical penetration with bleed.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -299.09998,
+    "y": 184.56,
     "max_points": 8,
     "connections": [
       "pr_19"
@@ -7014,7 +7020,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-525"
   },
   {
     "id": "pr_25",
@@ -7026,8 +7032,8 @@
     "name": "Rending Maw",
     "description": "{Aspect of the Shark} also grants attacks and spells a chance to reduce enemy armor.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -181.98001,
+    "y": -92.28003,
     "max_points": 5,
     "connections": [
       "pr_15"
@@ -7039,7 +7045,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-571"
   },
   {
     "id": "pr_22",
@@ -7051,8 +7057,8 @@
     "name": "The Chase",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -181.98001,
+    "y": -3.0517578e-05,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -7078,7 +7084,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-546"
   },
   {
     "id": "pr_56",
@@ -7090,8 +7096,8 @@
     "name": "Porcine Constitution",
     "description": "{Aspect of the Boar} grants additional damage reduction, and now also grants increased health regeneration.\n\nAdditionally, your hits have a chance to grant you {Aspect of the Boar}.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 52.26001,
+    "y": 184.56,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -7109,7 +7115,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-725"
   },
   {
     "id": "pr_67",
@@ -7121,8 +7127,8 @@
     "name": "Weathered Elements",
     "description": "Your companions deal increased damage, and you and your minions have additional elemental resistance.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -64.859985,
+    "y": -184.56003,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -7140,7 +7146,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-150"
   },
   {
     "id": "pr_101",
@@ -7152,8 +7158,8 @@
     "name": "Axe and Claw",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -64.859985,
+    "y": -3.0517578e-05,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -7167,7 +7173,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-720"
   },
   {
     "id": "pr_108",
@@ -7179,8 +7185,8 @@
     "name": "Natural Fortitude",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -181.98001,
+    "y": 92.28,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -7202,7 +7208,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1310"
   },
   {
     "id": "pr_55",
@@ -7214,8 +7220,8 @@
     "name": "Predator",
     "description": "You have additional dexterity and increased movement speed.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -64.859985,
+    "y": 184.56,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -7233,7 +7239,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-10"
   },
   {
     "id": "pr_57",
@@ -7245,8 +7251,8 @@
     "name": "The Circle Of Life",
     "description": "You gain health and have a chance to be granted {Aspect Of The Shark} for 3 seconds whenever you kill an enemy or hit a boss or rare enemy.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 52.26001,
+    "y": -184.56003,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -7260,7 +7266,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-946"
   },
   {
     "id": "pr_27",
@@ -7272,8 +7278,8 @@
     "name": "Life in the Wilderness",
     "description": "You have additional vitality and a higher endurance threshold.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 52.26001,
+    "y": -3.0517578e-05,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -7291,7 +7297,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-92"
   },
   {
     "id": "pr_20",
@@ -7303,8 +7309,8 @@
     "name": "Hawk Wings",
     "description": "You and your minions have increased dodge rating, and you and your minions have a chance to gain {Haste} for 1 second on hit.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 286.50006,
+    "y": 92.28,
     "max_points": 10,
     "connections": [],
     "stats": [
@@ -7318,7 +7324,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1085"
   },
   {
     "id": "pr_23",
@@ -7330,8 +7336,8 @@
     "name": "Envenom",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -64.859985,
+    "y": 92.28,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -7349,7 +7355,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-290"
   },
   {
     "id": "pr_59",
@@ -7361,8 +7367,8 @@
     "name": "Embodiment",
     "description": "All {Aspects} have increased duration, and you have additional health.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 286.50006,
+    "y": -92.28003,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -7380,7 +7386,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-323"
   },
   {
     "id": "pr_21",
@@ -7392,8 +7398,8 @@
     "name": "Cry of the Lynx",
     "description": "You and your companions have an increased chance to critically strike. \n\nWhen you use a companion ability, you and your companions are granted {Aspect of the Lynx} for a duration, a buff that grants +5% critical strike chance and 100% increased stun chance.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 169.38,
+    "y": -3.0517578e-05,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -7411,7 +7417,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-40"
   },
   {
     "id": "pr_29",
@@ -7423,8 +7429,8 @@
     "name": "Avian Shelter",
     "description": "You have a higher endurance threshold and you and your minions have additional physical resistance.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 169.38,
+    "y": 92.28,
     "max_points": 10,
     "connections": [],
     "stats": [
@@ -7442,7 +7448,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-461"
   },
   {
     "id": "pr_58",
@@ -7454,8 +7460,8 @@
     "name": "Viper Fangs",
     "description": "You and your companions have increased melee attack speed.\n\nWhen you hit an enemy, you have a chance for you and your companions to be granted {Aspect of the Viper} for 3 seconds, a buff that grants 100% chance to poison on hit and 20% more damage over time (multiplicative with other modifiers).",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 169.38,
+    "y": 184.56,
     "max_points": 10,
     "connections": [],
     "stats": [
@@ -7473,7 +7479,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-14"
   },
   {
     "id": "pr_109",
@@ -7485,8 +7491,8 @@
     "name": "Ocean Maw",
     "description": "{Aspect of the Shark} is more effective and lasts longer.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 286.50006,
+    "y": -184.56003,
     "max_points": 8,
     "connections": [
       "pr_57"
@@ -7502,7 +7508,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-718"
   },
   {
     "id": "pr_32",
@@ -7514,8 +7520,8 @@
     "name": "Natural Bond",
     "description": "You are limited to only one companion.\n\nYour companion is granted more health and deals more damage (both effects are multiplicative with other modifiers).",
     "node_type": "notable",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 169.38,
+    "y": -92.28003,
     "max_points": 1,
     "connections": [],
     "stats": [
@@ -7533,7 +7539,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-121"
   },
   {
     "id": "pr_54",
@@ -7545,8 +7551,8 @@
     "name": "Nature's Embrace",
     "description": "",
     "node_type": "notable",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 52.26001,
+    "y": 92.28,
     "max_points": 1,
     "connections": [],
     "stats": [
@@ -7556,7 +7562,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1311"
   },
   {
     "id": "pr_28",
@@ -7568,8 +7574,8 @@
     "name": "Serrated Claws",
     "description": "You and your companions' critical strikes deal more damage, and {Aspect of the Lynx} now also grants critical strike damage.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 403.62,
+    "y": -3.0517578e-05,
     "max_points": 6,
     "connections": [
       "pr_21"
@@ -7593,7 +7599,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1147"
   },
   {
     "id": "pr_26",
@@ -7605,8 +7611,8 @@
     "name": "Rattlesnake Rattlesnake",
     "description": "{Aspect of the Viper} lasts longer and grants you Poison Penetration.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 403.62,
+    "y": 184.56,
     "max_points": 10,
     "connections": [
       "pr_58"
@@ -7622,7 +7628,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-869"
   },
   {
     "id": "pr_30",
@@ -7634,8 +7640,8 @@
     "name": "Feeding Frenzy",
     "description": "{Aspect of the Shark} can now stack up to 5 times, but it is significantly less effective (multiplicative with other modifiers).",
     "node_type": "notable",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 520.74,
+    "y": -184.56003,
     "max_points": 1,
     "connections": [
       "pr_109"
@@ -7651,7 +7657,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-31"
   },
   {
     "id": "pr_33",
@@ -7663,8 +7669,8 @@
     "name": "Primal Aspects",
     "description": "Your companions receive increased effect from your {Aspects}, and a percentage of all damage taken is redirected to your highest health minion.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 520.74,
+    "y": -92.28003,
     "max_points": 10,
     "connections": [
       "pr_59"
@@ -7680,7 +7686,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-171"
   },
   {
     "id": "pr_31",
@@ -7692,8 +7698,8 @@
     "name": "Exemplar",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 520.74,
+    "y": 92.28,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -7711,7 +7717,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-57"
   },
   {
     "id": "pr_34",
@@ -7723,8 +7729,8 @@
     "name": "Ancient Might",
     "description": "You have additional health, and your minions have increased health. Additionally, you and your companions take reduced bonus damage from critical strikes.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 520.74,
+    "y": 184.56,
     "max_points": 10,
     "connections": [],
     "stats": [
@@ -7746,7 +7752,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-324"
   },
   {
     "id": "pr_40",
@@ -7758,8 +7764,8 @@
     "name": "Silent Protector",
     "description": "You and your totems have additional armor while you have an active totem and you have increased mana regen while you have an active totem.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -533.34,
+    "y": -184.56003,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -7777,7 +7783,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-304"
   },
   {
     "id": "pr_36",
@@ -7789,8 +7795,8 @@
     "name": "Sky Warrior",
     "description": "You and your minions gain increased damage.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -533.34,
+    "y": -3.0517578e-05,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -7808,7 +7814,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-379"
   },
   {
     "id": "pr_41",
@@ -7820,8 +7826,8 @@
     "name": "Shamanic Infusion",
     "description": "You have additional attunement. You and your minions penetrate enemy physical, cold, and lightning resistances.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -533.34,
+    "y": 184.56,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -7835,7 +7841,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-128"
   },
   {
     "id": "pr_38",
@@ -7847,8 +7853,8 @@
     "name": "Totemic Fury",
     "description": "You have increased attack and cast speed while you have an active totem.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -416.22,
+    "y": -92.28003,
     "max_points": 5,
     "connections": [
       "pr_40"
@@ -7864,7 +7870,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-840"
   },
   {
     "id": "pr_60",
@@ -7876,8 +7882,8 @@
     "name": "Lagonian Wrath",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -416.22,
+    "y": -3.0517578e-05,
     "max_points": 5,
     "connections": [
       "pr_0",
@@ -7900,7 +7906,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-966"
   },
   {
     "id": "pr_61",
@@ -7912,8 +7918,8 @@
     "name": "Tempest Form",
     "description": "You and your minions have additional health, a chance to shock and a chance to chill on hit.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -416.22,
+    "y": 92.28,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -7935,7 +7941,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-724"
   },
   {
     "id": "pr_35",
@@ -7947,8 +7953,8 @@
     "name": "Fate Carver",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -299.09998,
+    "y": -184.56003,
     "max_points": 8,
     "connections": [
       "pr_40"
@@ -7960,7 +7966,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-393"
   },
   {
     "id": "pr_62",
@@ -7972,8 +7978,8 @@
     "name": "Earthen Supremacy",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -299.09998,
+    "y": -92.28003,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -7991,7 +7997,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-285"
   },
   {
     "id": "pr_43",
@@ -8003,8 +8009,8 @@
     "name": "Storm Bringer",
     "description": "You and your minions have increased lightning damage and additional lightning resistance.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -299.09998,
+    "y": -3.0517578e-05,
     "max_points": 10,
     "connections": [],
     "stats": [
@@ -8018,7 +8024,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-723"
   },
   {
     "id": "pr_42",
@@ -8030,8 +8036,8 @@
     "name": "Wind Bringer",
     "description": "You and your minions have increased cold damage, increased physical damage and additional dodge rating.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -299.09998,
+    "y": 184.56,
     "max_points": 10,
     "connections": [],
     "stats": [
@@ -8053,7 +8059,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-143"
   },
   {
     "id": "pr_37",
@@ -8065,8 +8071,8 @@
     "name": "Ancestral Speed",
     "description": "Your totems have increased attack and cast speed and you have a chance to gain {Haste} for 3 seconds when you directly summon a totem.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -181.98001,
+    "y": -184.56003,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -8080,7 +8086,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-43"
   },
   {
     "id": "pr_44",
@@ -8092,8 +8098,8 @@
     "name": "Hail Bringer",
     "description": "You and your minions have a chance to chill on hit, a higher chance to freeze enemies and additional cold resistance.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -181.98001,
+    "y": 92.28,
     "max_points": 5,
     "connections": [
       "pr_42"
@@ -8113,7 +8119,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-552"
   },
   {
     "id": "pr_46",
@@ -8125,8 +8131,8 @@
     "name": "Storm Elder",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -64.859985,
+    "y": -184.56003,
     "max_points": 10,
     "connections": [],
     "stats": [
@@ -8140,7 +8146,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1301"
   },
   {
     "id": "pr_102",
@@ -8152,8 +8158,8 @@
     "name": "Fist of Stone",
     "description": "You and your minions gain increased stun chance.\n\nAdditionally, you have additional Endurance.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -64.859985,
+    "y": -92.28003,
     "max_points": 5,
     "connections": [
       "pr_62"
@@ -8173,7 +8179,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-744"
   },
   {
     "id": "pr_63",
@@ -8185,8 +8191,8 @@
     "name": "Avatar of Thunder",
     "description": "You and your minions gain additional spell lightning damage.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -64.859985,
+    "y": -3.0517578e-05,
     "max_points": 5,
     "connections": [
       "pr_43"
@@ -8202,7 +8208,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-710"
   },
   {
     "id": "pr_51",
@@ -8214,8 +8220,8 @@
     "name": "Glacial Strike",
     "description": "You have additional strength",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -64.859985,
+    "y": 92.28,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -8229,7 +8235,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-594"
   },
   {
     "id": "pr_64",
@@ -8241,8 +8247,8 @@
     "name": "Shattered Heavens",
     "description": "You and your minions deal additional cold damage with spells and attacks, and your hits have a chance to inflict Frostbite.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -64.859985,
+    "y": 184.56,
     "max_points": 5,
     "connections": [
       "pr_42"
@@ -8266,7 +8272,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1099"
   },
   {
     "id": "pr_65",
@@ -8278,8 +8284,8 @@
     "name": "Dervish",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 52.26001,
+    "y": -92.28003,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -8289,7 +8295,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-142"
   },
   {
     "id": "pr_45",
@@ -8301,8 +8307,8 @@
     "name": "Rune of Awe",
     "description": "You and your minions have additional spell damage.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 52.26001,
+    "y": -3.0517578e-05,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -8312,7 +8318,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-702"
   },
   {
     "id": "pr_48",
@@ -8324,8 +8330,8 @@
     "name": "Protective Circle",
     "description": "You have additional physical and elemental resistance for each active totem.\n\nAdditionally, your totems have resistances against all damage types.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 52.26001,
+    "y": 92.28,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -8343,7 +8349,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-722"
   },
   {
     "id": "pr_103",
@@ -8355,8 +8361,8 @@
     "name": "Heorot's Path",
     "description": "You and your minions have a higher chance to freeze enemies, and you have increased mana regeneration.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 52.26001,
+    "y": 184.56,
     "max_points": 10,
     "connections": [],
     "stats": [
@@ -8370,7 +8376,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-987"
   },
   {
     "id": "pr_39",
@@ -8382,8 +8388,8 @@
     "name": "Rhythm of Thunder",
     "description": "Your melee attacks deal additional lightning damage. Every 2 seconds, this effect is tripled for your next melee attack.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 169.38,
+    "y": -184.56003,
     "max_points": 10,
     "connections": [
       "pr_65"
@@ -8399,7 +8405,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-466"
   },
   {
     "id": "pr_50",
@@ -8411,8 +8417,8 @@
     "name": "Elemental Shrines",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 169.38,
+    "y": -3.0517578e-05,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -8426,7 +8432,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1246"
   },
   {
     "id": "pr_69",
@@ -8438,8 +8444,8 @@
     "name": "Lagon's Answer",
     "description": "You have increased spell damage.\nYour direct spell casts have a chance to cast {Storm Bolt}.\nWhile channeling, you have a chance to cast {Storm Bolt} every second.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 286.50006,
+    "y": -92.28003,
     "max_points": 5,
     "connections": [
       "pr_0",
@@ -8462,7 +8468,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-85"
   },
   {
     "id": "pr_66",
@@ -8474,8 +8480,8 @@
     "name": "Storm Blade",
     "description": "While you have an active totem you have more melee damage (multiplicative with other modifiers).",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 286.50006,
+    "y": 92.28,
     "max_points": 8,
     "connections": [
       "pr_48"
@@ -8487,7 +8493,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1318"
   },
   {
     "id": "pr_106",
@@ -8499,8 +8505,8 @@
     "name": "Eternal Storm",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 286.50006,
+    "y": 184.56,
     "max_points": 5,
     "connections": [
       "pr_103"
@@ -8520,7 +8526,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-300"
   },
   {
     "id": "pr_68",
@@ -8532,8 +8538,8 @@
     "name": "Thunder Strike",
     "description": "Your melee attacks have a chance to cast {Storm Bolt} on hit. This effect can occur a limited number of times per second.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 403.62,
+    "y": -184.56003,
     "max_points": 5,
     "connections": [
       "pr_39"
@@ -8553,7 +8559,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-379"
   },
   {
     "id": "pr_49",
@@ -8565,8 +8571,8 @@
     "name": "Swirling Maelstrom",
     "description": "You have additional health and mana, and have a chance to cast {Maelstrom} when hit. \n\nThis effect has a 3 second cooldown.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 403.62,
+    "y": -3.0517578e-05,
     "max_points": 6,
     "connections": [
       "pr_50"
@@ -8590,7 +8596,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-316"
   },
   {
     "id": "pr_52",
@@ -8602,8 +8608,8 @@
     "name": "Gift of the Skies",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 403.62,
+    "y": 184.56,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -8625,7 +8631,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-379"
   },
   {
     "id": "pr_70",
@@ -8637,8 +8643,8 @@
     "name": "Conflux",
     "description": "Your area skills have increased area, and you take less damage from shocked enemies.\n\nYour totems also gain the area increases for area skills.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 520.74,
+    "y": -92.28003,
     "max_points": 8,
     "connections": [
       "pr_69",
@@ -8659,7 +8665,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-417"
   },
   {
     "id": "pr_53",
@@ -8671,8 +8677,8 @@
     "name": "Ascendant Circle",
     "description": "While you have an active totem you have more spell damage (multiplicative with other modifiers).",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 520.74,
+    "y": -3.0517578e-05,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -8682,7 +8688,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-984"
   },
   {
     "id": "pr_107",
@@ -8694,8 +8700,8 @@
     "name": "Ironbark",
     "description": "You have additional health and armor, and these effects are tripled for your totems.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 520.74,
+    "y": 92.28,
     "max_points": 10,
     "connections": [],
     "stats": [
@@ -8717,7 +8723,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-77"
   },
   {
     "id": "pr_71",
@@ -8729,8 +8735,8 @@
     "name": "Spirit Warden",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -533.34,
+    "y": -3.0517578e-05,
     "max_points": 7,
     "connections": [],
     "stats": [
@@ -8748,7 +8754,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-284"
   },
   {
     "id": "pr_73",
@@ -8760,8 +8766,8 @@
     "name": "Claws of the Forest",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -416.22,
+    "y": 92.28,
     "max_points": 7,
     "connections": [],
     "stats": [
@@ -8783,7 +8789,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-957"
   },
   {
     "id": "pr_72",
@@ -8795,8 +8801,8 @@
     "name": "Blossoming Garden",
     "description": "Increases healing effectiveness for you and your minions.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -299.09998,
+    "y": -184.56003,
     "max_points": 10,
     "connections": [
       "pr_98"
@@ -8816,7 +8822,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-256"
   },
   {
     "id": "pr_97",
@@ -8828,8 +8834,8 @@
     "name": "Druidic Prowess",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -416.22,
+    "y": -3.0517578e-05,
     "max_points": 7,
     "connections": [],
     "stats": [
@@ -8847,7 +8853,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-403"
   },
   {
     "id": "pr_98",
@@ -8859,8 +8865,8 @@
     "name": "Blessed Springs",
     "description": "Increases cold damage and healing effectiveness for you and your minions.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -416.22,
+    "y": -92.28003,
     "max_points": 7,
     "connections": [],
     "stats": [
@@ -8882,7 +8888,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-90"
   },
   {
     "id": "pr_81",
@@ -8894,8 +8900,8 @@
     "name": "Focused Wrath",
     "description": "You deal increased damage while transformed and your rage decays slower.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -299.09998,
+    "y": -3.0517578e-05,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -8909,7 +8915,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-263"
   },
   {
     "id": "pr_76",
@@ -8921,10 +8927,12 @@
     "name": "Nightshade Fangs",
     "description": "Your melee attacks have a chance to inflict Bleed on hit and your spells have a chance to inflict Poison on hit.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -181.98001,
+    "y": 92.28,
     "max_points": 10,
-    "connections": [],
+    "connections": [
+      "pr_73"
+    ],
     "stats": [
       {
         "key": "Melee Bleed Chance",
@@ -8936,7 +8944,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1143"
   },
   {
     "id": "pr_80",
@@ -8948,8 +8956,8 @@
     "name": "Totemic Restoration",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -64.859985,
+    "y": -184.56003,
     "max_points": 5,
     "connections": [
       "pr_72"
@@ -8969,7 +8977,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-77"
   },
   {
     "id": "pr_77",
@@ -8981,8 +8989,8 @@
     "name": "Thicket of Thorns",
     "description": "You have a chance to cast {Thorn Shield} on yourself when you are hit and you have increased armor and reflect damage back to attackers.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -299.09998,
+    "y": 184.56,
     "max_points": 5,
     "connections": [
       "pr_89"
@@ -9002,7 +9010,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-921"
   },
   {
     "id": "pr_79",
@@ -9014,8 +9022,8 @@
     "name": "Wind in the Leaves",
     "description": "Increases the attack and cast speed of you and your minions.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -181.98001,
+    "y": 184.56,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -9037,7 +9045,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-395"
   },
   {
     "id": "pr_83",
@@ -9049,8 +9057,8 @@
     "name": "River Spirits",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -181.98001,
+    "y": -92.28003,
     "max_points": 7,
     "connections": [
       "pr_98"
@@ -9082,7 +9090,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-887"
   },
   {
     "id": "pr_110",
@@ -9094,8 +9102,8 @@
     "name": "Rancour",
     "description": "Your rage only decays if you have used an ability recently (past 4 seconds).",
     "node_type": "notable",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -64.859985,
+    "y": -3.0517578e-05,
     "max_points": 1,
     "connections": [
       "pr_81"
@@ -9107,7 +9115,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-235"
   },
   {
     "id": "pr_82",
@@ -9119,8 +9127,8 @@
     "name": "Bush Stalker",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -64.859985,
+    "y": 184.56,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -9134,7 +9142,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-396"
   },
   {
     "id": "pr_88",
@@ -9146,8 +9154,8 @@
     "name": "Harmonious Wisdom",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 52.26001,
+    "y": -184.56003,
     "max_points": 10,
     "connections": [],
     "stats": [
@@ -9161,7 +9169,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-247"
   },
   {
     "id": "pr_94",
@@ -9173,8 +9181,8 @@
     "name": "Impervious",
     "description": "Your melee hits have a 20% chance to grant you a stack of {Impervious} causing you to take less damage from hits (multiplicative with other modifiers), but you lose a stack when you are hit and you lose all stacks after 10 seconds of not gaining any stacks.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 520.74,
+    "y": -184.56003,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -9196,7 +9204,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1158"
   },
   {
     "id": "pr_111",
@@ -9208,8 +9216,8 @@
     "name": "Aspects of Might",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 52.26001,
+    "y": 184.56,
     "max_points": 10,
     "connections": [],
     "stats": [
@@ -9227,7 +9235,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-234"
   },
   {
     "id": "pr_90",
@@ -9239,8 +9247,8 @@
     "name": "Force of Nature",
     "description": "You and your minions deal additional physical damage with spells and melee attacks.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 52.26001,
+    "y": -92.28003,
     "max_points": 10,
     "connections": [
       "pr_0",
@@ -9271,7 +9279,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-553"
   },
   {
     "id": "pr_84",
@@ -9283,8 +9291,8 @@
     "name": "Woodland Beings",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 169.38,
+    "y": 92.28,
     "max_points": 6,
     "connections": [],
     "stats": [
@@ -9298,7 +9306,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-392"
   },
   {
     "id": "pr_87",
@@ -9310,8 +9318,8 @@
     "name": "Overgrowth",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 286.50006,
+    "y": -3.0517578e-05,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -9329,7 +9337,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-262"
   },
   {
     "id": "pr_93",
@@ -9341,8 +9349,8 @@
     "name": "Primal Shifter",
     "description": "You gain the {Shapeshifter} buff for a limited duration when you transform, granting you increased armor and damage.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 169.38,
+    "y": -92.28003,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -9360,7 +9368,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-406"
   },
   {
     "id": "pr_92",
@@ -9372,8 +9380,8 @@
     "name": "Tiger Spirit",
     "description": "You have increased critical strike chance and multiplier while you have the {Shapeshifter} buff.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 286.50006,
+    "y": -184.56003,
     "max_points": 5,
     "connections": [
       "pr_93"
@@ -9389,7 +9397,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-319"
   },
   {
     "id": "pr_89",
@@ -9401,8 +9409,8 @@
     "name": "Chitinous Plating",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -533.34,
+    "y": 184.56,
     "max_points": 7,
     "connections": [
       "pr_0",
@@ -9425,7 +9433,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-556"
   },
   {
     "id": "pr_78",
@@ -9437,8 +9445,8 @@
     "name": "Natural Duality",
     "description": "You are limitted to one companion, but that companion has more health (multiplicative with other modifiers). If you control a companion you deal increased damage and have additional armour.",
     "node_type": "notable",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 286.50006,
+    "y": 184.56,
     "max_points": 1,
     "connections": [
       "pr_84"
@@ -9462,7 +9470,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-492"
   },
   {
     "id": "pr_85",
@@ -9474,8 +9482,8 @@
     "name": "Reincarnation",
     "description": "You and your minions are healed when you transform. This scales with increases to healing effectiveness.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 403.62,
+    "y": -92.28003,
     "max_points": 6,
     "connections": [
       "pr_93"
@@ -9491,7 +9499,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-589"
   },
   {
     "id": "pr_100",
@@ -9503,8 +9511,8 @@
     "name": "Toxic Reach",
     "description": "Your and your minions' hits have a chance to poison.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 403.62,
+    "y": 92.28,
     "max_points": 10,
     "connections": [
       "pr_84"
@@ -9524,7 +9532,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-279"
   },
   {
     "id": "pr_99",
@@ -9536,8 +9544,8 @@
     "name": "Rageborn",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 403.62,
+    "y": -3.0517578e-05,
     "max_points": 10,
     "connections": [],
     "stats": [
@@ -9551,7 +9559,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-60"
   },
   {
     "id": "pr_104",
@@ -9563,8 +9571,8 @@
     "name": "Hideskin",
     "description": "You have additional health and gain a percentage of your maximum health as endurance threshold.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 520.74,
+    "y": -3.0517578e-05,
     "max_points": 10,
     "connections": [],
     "stats": [
@@ -9578,7 +9586,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-267"
   },
   {
     "id": "pr_91",
@@ -9590,8 +9598,8 @@
     "name": "Eternal Nature",
     "description": "You and your companions have additional spell damage.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 520.74,
+    "y": 184.56,
     "max_points": 10,
     "connections": [
       "pr_78"
@@ -9607,7 +9615,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-506"
   },
   {
     "id": "pr_112",
@@ -9619,8 +9627,8 @@
     "name": "Piercing Gale",
     "description": "You and your minions have additional cold penetration.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 52.26001,
+    "y": 92.28,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -9642,7 +9650,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-291"
   },
   {
     "id": "pr_118",
@@ -9654,8 +9662,8 @@
     "name": "Primordial Resonance",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -533.34,
+    "y": -184.56003,
     "max_points": 7,
     "connections": [],
     "stats": [
@@ -9669,7 +9677,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-836"
   },
   {
     "id": "pr_74",
@@ -9681,8 +9689,8 @@
     "name": "Fetid Resilience",
     "description": "You deal increased damage over time while transformed and take less damage over time in human form (multiplicative with other modifiers).",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 169.38,
+    "y": -3.0517578e-05,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -9696,7 +9704,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-36"
   },
   {
     "id": "rg_1",
@@ -9708,8 +9716,8 @@
     "name": "Guile",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -533.74,
+    "y": -184.56003,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -9723,7 +9731,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-851"
   },
   {
     "id": "rg_0",
@@ -9735,8 +9743,8 @@
     "name": "Steady Hand",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -533.74,
+    "y": 0,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -9750,7 +9758,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-319"
   },
   {
     "id": "rg_6",
@@ -9762,8 +9770,8 @@
     "name": "Swift Assassin",
     "description": "Your melee, throwing, and bow attacks have increased attack speed and deal additional physical damage.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -533.74,
+    "y": 184.56,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -9777,7 +9785,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-939"
   },
   {
     "id": "rg_7",
@@ -9789,8 +9797,8 @@
     "name": "Evasion",
     "description": "You take less damage while moving (multiplicative with other modifiers) and have increased dodge rating.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -335.14,
+    "y": -92.28,
     "max_points": 5,
     "connections": [
       "rg_1"
@@ -9806,7 +9814,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-546"
   },
   {
     "id": "rg_10",
@@ -9818,8 +9826,8 @@
     "name": "Twin Blade",
     "description": "You can dual wield melee weapons by equipping a sword or dagger in your off hand. While dual wielding, you have increased attack and cast speed, but take more damage (multiplicative with other modifiers).",
     "node_type": "notable",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -335.14,
+    "y": 0,
     "max_points": 1,
     "connections": [],
     "stats": [
@@ -9841,7 +9849,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-863"
   },
   {
     "id": "rg_8",
@@ -9853,8 +9861,8 @@
     "name": "Agility",
     "description": "You have a chance to gain {Haste} for one second on hit and deal increased damage based on your increased movement speed.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -136.53998,
+    "y": -184.56003,
     "max_points": 5,
     "connections": [
       "rg_7"
@@ -9870,7 +9878,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-30"
   },
   {
     "id": "rg_9",
@@ -9882,8 +9890,8 @@
     "name": "Dodge and Parry",
     "description": "You have additional dodge rating and a chance to receieve a {Glancing Blow} when hit.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -136.53998,
+    "y": 92.28,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -9897,7 +9905,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-245"
   },
   {
     "id": "rg_12",
@@ -9909,8 +9917,8 @@
     "name": "Lethal Cadence",
     "description": "Every third melee, throwing, or bow attack deals increased damage.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -136.53998,
+    "y": 184.56,
     "max_points": 5,
     "connections": [
       "rg_6"
@@ -9922,7 +9930,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-868"
   },
   {
     "id": "rg_13",
@@ -9934,8 +9942,8 @@
     "name": "Poison Tipped",
     "description": "You have a chance to poison on hit while you have a dagger or bow equipped.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 62.059998,
+    "y": -184.56003,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -9949,7 +9957,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-728"
   },
   {
     "id": "rg_14",
@@ -9961,8 +9969,8 @@
     "name": "Sapping Strikes",
     "description": "When you directly use a skill that costs zero mana and hit an enemy you regain health and mana.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 62.059998,
+    "y": -92.28,
     "max_points": 4,
     "connections": [],
     "stats": [
@@ -9976,7 +9984,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-503"
   },
   {
     "id": "rg_11",
@@ -9988,8 +9996,8 @@
     "name": "Duelist",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 62.059998,
+    "y": 0,
     "max_points": 8,
     "connections": [
       "rg_10"
@@ -10005,7 +10013,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-516"
   },
   {
     "id": "rg_15",
@@ -10017,8 +10025,8 @@
     "name": "Critical Precision",
     "description": "You have increased critical strike chance per sword, bow, or dagger you have equipped.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 260.66003,
+    "y": -184.56003,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -10036,7 +10044,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-266"
   },
   {
     "id": "rg_16",
@@ -10048,8 +10056,8 @@
     "name": "Disembowel",
     "description": "Every third non-channelling melee, throwing, or bow attack also inflicts bleed.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 260.66003,
+    "y": 184.56,
     "max_points": 5,
     "connections": [
       "rg_12"
@@ -10061,7 +10069,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-2"
   },
   {
     "id": "rg_17",
@@ -10073,8 +10081,8 @@
     "name": "Coated Blades",
     "description": "When you directly use a melee or bow attack that costs mana, it consumes additional mana to deal more damage (multiplicative with other modifiers).",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 459.26,
+    "y": -92.28,
     "max_points": 8,
     "connections": [
       "rg_14"
@@ -10090,7 +10098,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-858"
   },
   {
     "id": "rg_18",
@@ -10102,8 +10110,8 @@
     "name": "Thiefguard",
     "description": "You have additional health and whenever you receive a glancing blow you recover health.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 459.26,
+    "y": 92.28,
     "max_points": 8,
     "connections": [
       "rg_9"
@@ -10119,7 +10127,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-116"
   },
   {
     "id": "rg_2",
@@ -10131,8 +10139,8 @@
     "name": "Flow",
     "description": "You have increased dodge rating, and you gain health when hitting an enemy.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -533.34,
+    "y": -184.56003,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -10154,7 +10162,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-90"
   },
   {
     "id": "rg_49",
@@ -10166,8 +10174,8 @@
     "name": "Pursuit",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -533.34,
+    "y": -3.0517578e-05,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -10185,7 +10193,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-546"
   },
   {
     "id": "rg_50",
@@ -10197,8 +10205,8 @@
     "name": "Cloak of Shadows",
     "description": "You have additional dexterity and you have a chance to receive a {Glancing Blow} when hit.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -533.34,
+    "y": 184.56,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -10216,7 +10224,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-958"
   },
   {
     "id": "rg_53",
@@ -10228,8 +10236,8 @@
     "name": "Skiasynthesis",
     "description": "When you create a shadow you regain health, and skills used by shadows deal increased damage.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -416.22,
+    "y": -92.28003,
     "max_points": 6,
     "connections": [],
     "stats": [
@@ -10243,7 +10251,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-753"
   },
   {
     "id": "rg_51",
@@ -10255,8 +10263,8 @@
     "name": "Blood Serpent's Blades",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -416.22,
+    "y": -3.0517578e-05,
     "max_points": 10,
     "connections": [],
     "stats": [
@@ -10274,7 +10282,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-957"
   },
   {
     "id": "rg_52",
@@ -10286,8 +10294,8 @@
     "name": "Once",
     "description": "You deal additional physical damage with melee and throwing attacks, and you have additional dodge rating, doubled if you have been hit recently.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -416.22,
+    "y": 92.28,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -10309,7 +10317,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-200"
   },
   {
     "id": "rg_54",
@@ -10321,8 +10329,8 @@
     "name": "Rhythm",
     "description": "Skills that generate or consume {Flow} deal increased damage and have additional critical strike multiplier.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -299.09998,
+    "y": -184.56003,
     "max_points": 5,
     "connections": [
       "rg_2"
@@ -10346,7 +10354,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-399"
   },
   {
     "id": "rg_55",
@@ -10358,8 +10366,8 @@
     "name": "Scarlet Stream",
     "description": "You deal increased physical damage and have a chance to inflict bleed on hit with melee and throwing attacks.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -299.09998,
+    "y": -3.0517578e-05,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -10381,7 +10389,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-10"
   },
   {
     "id": "rg_56",
@@ -10393,8 +10401,8 @@
     "name": "Resilience",
     "description": "You have additional health and critical strike avoidance.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -299.09998,
+    "y": 184.56,
     "max_points": 8,
     "connections": [
       "rg_50"
@@ -10410,7 +10418,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-66"
   },
   {
     "id": "rg_57",
@@ -10422,8 +10430,8 @@
     "name": "Pulse",
     "description": "{Flow} is consumed when you use a 5th unique skill rather than a 4th, but the skill that consumes Flow has more critical strike chance and deals more damage over time (both multiplicative with other modifiers).",
     "node_type": "notable",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -181.98001,
+    "y": -92.28003,
     "max_points": 1,
     "connections": [
       "rg_54"
@@ -10443,7 +10451,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1008"
   },
   {
     "id": "rg_58",
@@ -10455,8 +10463,8 @@
     "name": "Veil of Night",
     "description": "You have increased melee and throwing attack speed. When you use a melee or throwing attack and hit at least one enemy you have a chance to gain a stack of {Dusk Shroud}. Each stack of Dusk Shroud adds 50 dodge rating and 5% chance to receive a {Glancing Blow} when hit.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -181.98001,
+    "y": 92.28,
     "max_points": 5,
     "connections": [
       "rg_56"
@@ -10476,7 +10484,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-402"
   },
   {
     "id": "rg_59",
@@ -10488,8 +10496,8 @@
     "name": "Readied Blades",
     "description": "You have additional parry chance and increased critical strike chance.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -64.859985,
+    "y": -184.56003,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -10503,7 +10511,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-863"
   },
   {
     "id": "rg_60",
@@ -10515,8 +10523,8 @@
     "name": "Grit",
     "description": "You have additional resistances and endurance.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -64.859985,
+    "y": -3.0517578e-05,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -10530,7 +10538,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-797"
   },
   {
     "id": "rg_61",
@@ -10542,8 +10550,8 @@
     "name": "Apostacy",
     "description": "Your dodge chance is added as twice as much chance to receive a glancing blow, but you cannot dodge.",
     "node_type": "notable",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -64.859985,
+    "y": 184.56,
     "max_points": 1,
     "connections": [
       "rg_56"
@@ -10559,7 +10567,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-245"
   },
   {
     "id": "rg_62",
@@ -10571,8 +10579,8 @@
     "name": "Flash of Steel",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 52.26001,
+    "y": -92.28003,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -10590,7 +10598,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-499"
   },
   {
     "id": "rg_63",
@@ -10602,8 +10610,8 @@
     "name": "Blood Dance",
     "description": "You leech a portion of melee damage as health, and a portion of your damage over time as health.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 52.26001,
+    "y": -3.0517578e-05,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -10617,7 +10625,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-200"
   },
   {
     "id": "rg_64",
@@ -10629,8 +10637,8 @@
     "name": "Asuvon's Pact",
     "description": "You have additional dodge rating. You have deal increased damage, tripled while at full health.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 52.26001,
+    "y": 92.28,
     "max_points": 6,
     "connections": [],
     "stats": [
@@ -10644,7 +10652,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-63"
   },
   {
     "id": "rg_65",
@@ -10656,10 +10664,12 @@
     "name": "Weapons of Choice",
     "description": "You gain a bonus while dual wielding depending on your weapon combination.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 169.38,
+    "y": -184.56003,
     "max_points": 8,
-    "connections": [],
+    "connections": [
+      "rg_62"
+    ],
     "stats": [
       {
         "key": "Increased Crit Chance with a Sword and Dagger",
@@ -10691,7 +10701,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-272"
   },
   {
     "id": "rg_66",
@@ -10703,8 +10713,8 @@
     "name": "Deadly Mixture",
     "description": "You have additional vitality and deal increased damage over time.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 169.38,
+    "y": -3.0517578e-05,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -10726,7 +10736,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-161"
   },
   {
     "id": "rg_67",
@@ -10738,8 +10748,8 @@
     "name": "Perfection",
     "description": "When you use a melee attack and hit at least one enemy you gain a stack of Perfection. When you receive a hit you lose all stacks. Each stack of perfection increases your damage.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 169.38,
+    "y": 184.56,
     "max_points": 5,
     "connections": [
       "rg_64"
@@ -10759,7 +10769,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-329"
   },
   {
     "id": "rg_68",
@@ -10771,8 +10781,8 @@
     "name": "Critical Eye",
     "description": "You have increased critical strike chance and you have a chance to inflict {Critical Vulnerability} on hit.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 286.50006,
+    "y": -92.28003,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -10790,7 +10800,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-31"
   },
   {
     "id": "rg_69",
@@ -10802,8 +10812,8 @@
     "name": "Cloaked Reaper",
     "description": "You have additional health. When you kill an enemy or hit a rare or boss enemy, you regain health for each stack of any {Shroud} on you.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 286.50006,
+    "y": -3.0517578e-05,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -10821,7 +10831,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-9"
   },
   {
     "id": "rg_70",
@@ -10833,8 +10843,8 @@
     "name": "Confidence",
     "description": "You deal increased damage at full health, and each stack of {Perfection} also grants additional armor and dodge rating.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 286.50006,
+    "y": 92.28,
     "max_points": 6,
     "connections": [
       "rg_67"
@@ -10858,7 +10868,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-493"
   },
   {
     "id": "rg_71",
@@ -10870,8 +10880,8 @@
     "name": "Death's Door",
     "description": "While at low health you take less damage (multiplicative with other modifiers) and you have additional critical strike multiplier.\n\nAdditionally, when damage leaves you at low health you gain these benefits for 5 seconds if you aren't already at low health.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 403.62,
+    "y": -184.56003,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -10885,7 +10895,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-556"
   },
   {
     "id": "rg_72",
@@ -10897,8 +10907,8 @@
     "name": "Hooked Blades",
     "description": "Your hits have a chance to shred armor and inflict bleed.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 403.62,
+    "y": 184.56,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -10916,7 +10926,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-7"
   },
   {
     "id": "rg_73",
@@ -10928,8 +10938,8 @@
     "name": "All In",
     "description": "You have a higher critical strike multiplier, but you deal less damage with non-critical hits and damage over time (multiplicative with other modifiers).",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 520.74,
+    "y": -92.28003,
     "max_points": 5,
     "connections": [
       "rg_68"
@@ -10949,7 +10959,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-45"
   },
   {
     "id": "rg_74",
@@ -10961,8 +10971,8 @@
     "name": "Shadow Master",
     "description": "Skills used by shadows deal increased damage, and you have a chance to gain a stack of {Dusk Shroud} when you use a melee or throwing attack and hit at least one enemy.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 520.74,
+    "y": -3.0517578e-05,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -10980,7 +10990,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-730"
   },
   {
     "id": "rg_75",
@@ -10992,8 +11002,8 @@
     "name": "Mastered Form",
     "description": "You have additional dexterity.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 520.74,
+    "y": 92.28,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -11015,7 +11025,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-370"
   },
   {
     "id": "rg_20",
@@ -11027,8 +11037,8 @@
     "name": "Assassin's Quiver",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -533.34,
+    "y": -184.56003,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -11046,7 +11056,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-572"
   },
   {
     "id": "rg_21",
@@ -11058,8 +11068,8 @@
     "name": "Focus Fire",
     "description": "You have additional Dexterity and when you hit a boss or rare enemy you reduce its dodge rating for 8 seconds.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -533.34,
+    "y": -3.0517578e-05,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -11077,7 +11087,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-303"
   },
   {
     "id": "rg_3",
@@ -11089,8 +11099,8 @@
     "name": "Draining Arrows",
     "description": "You have increased bow attack speed and when you use a bow attack and hit at least one enemy you regain health.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -533.34,
+    "y": 184.56,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -11104,7 +11114,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-589"
   },
   {
     "id": "rg_22",
@@ -11116,8 +11126,8 @@
     "name": "Concentration",
     "description": "By default you have {Concentration} which grants you more damage (multiplicative with other modifiers). If you are hit by an enemy within 4m you lose concentration for 4 seconds. Subsequent hits do not reset the cooldown.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -416.22,
+    "y": -92.28003,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -11131,7 +11141,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-434"
   },
   {
     "id": "rg_23",
@@ -11143,8 +11153,8 @@
     "name": "Missile Mastery",
     "description": "You have increased bow and throwing attack damage and you have a chance to shred armour on hit.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -416.22,
+    "y": -3.0517578e-05,
     "max_points": 10,
     "connections": [],
     "stats": [
@@ -11166,7 +11176,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-739"
   },
   {
     "id": "rg_24",
@@ -11178,8 +11188,8 @@
     "name": "Elemental Arrows",
     "description": "If you have a bow equipped you gain 1 {Elemental Arrow} per second, up to a maximum of 3. Using a bow attack expends an Elemental Arrow to deal additional bow fire damage and bow lightning damage.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -416.22,
+    "y": 92.28,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -11201,7 +11211,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-674"
   },
   {
     "id": "rg_25",
@@ -11213,8 +11223,8 @@
     "name": "Wound Maker",
     "description": "You have a chance to inflict Critical Vulnerability on hit.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -299.09998,
+    "y": -184.56003,
     "max_points": 10,
     "connections": [
       "rg_20"
@@ -11226,7 +11236,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-670"
   },
   {
     "id": "rg_26",
@@ -11238,8 +11248,8 @@
     "name": "Prolonged Demise",
     "description": "You take less damage over time (multiplicative with other modifiers). While wielding a bow you deal increased damage over time.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -299.09998,
+    "y": -3.0517578e-05,
     "max_points": 10,
     "connections": [],
     "stats": [
@@ -11253,7 +11263,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-588"
   },
   {
     "id": "rg_27",
@@ -11265,8 +11275,8 @@
     "name": "Storm Fletcher",
     "description": "If you have a bow equipped you deal increased elemental damage and gain {Elemental Arrows} more frequently.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -299.09998,
+    "y": 184.56,
     "max_points": 8,
     "connections": [
       "rg_24"
@@ -11282,7 +11292,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-325"
   },
   {
     "id": "rg_28",
@@ -11294,8 +11304,8 @@
     "name": "Meditation",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -181.98001,
+    "y": -92.28003,
     "max_points": 5,
     "connections": [
       "rg_22"
@@ -11311,7 +11321,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-521"
   },
   {
     "id": "rg_29",
@@ -11323,8 +11333,8 @@
     "name": "Siege Quiver",
     "description": "You can hold additional {Elemental Arrows} and you gain ward per {Elemental Arrow} when you use them.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -181.98001,
+    "y": 92.28,
     "max_points": 3,
     "connections": [
       "rg_24"
@@ -11340,7 +11350,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-340"
   },
   {
     "id": "rg_30",
@@ -11352,8 +11362,8 @@
     "name": "Heightened Senses",
     "description": "You have a chance to avoid critical strikes and your critical strikes with bow attacks deal more damage.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -64.859985,
+    "y": -184.56003,
     "max_points": 5,
     "connections": [
       "rg_25"
@@ -11369,7 +11379,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-715"
   },
   {
     "id": "rg_31",
@@ -11381,8 +11391,8 @@
     "name": "Reflection",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -64.859985,
+    "y": -3.0517578e-05,
     "max_points": 5,
     "connections": [
       "rg_28"
@@ -11402,7 +11412,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-90"
   },
   {
     "id": "rg_32",
@@ -11414,10 +11424,12 @@
     "name": "Elemental Barrage",
     "description": "You can consume [1] additional {Elemental Arrow} with each bow attack. If you consume 3 arrows with a single attack it has 200% additional shock and ignite chance",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -64.859985,
+    "y": 184.56,
     "max_points": 2,
-    "connections": [],
+    "connections": [
+      "rg_27"
+    ],
     "stats": [
       {
         "key": "Elemental Arrow consumed per bow attack",
@@ -11429,7 +11441,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-377"
   },
   {
     "id": "rg_34",
@@ -11441,8 +11453,8 @@
     "name": "Thief's Quiver",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 52.26001,
+    "y": -184.56003,
     "max_points": 10,
     "connections": [],
     "stats": [
@@ -11456,7 +11468,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-712"
   },
   {
     "id": "rg_33",
@@ -11468,8 +11480,8 @@
     "name": "Arrow Storm",
     "description": "When you use a bow attack you gain {Arrow Storm} which increases your bow attack speed for 3 seconds. You can only gain Arrow Storm once every 10 seconds.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 52.26001,
+    "y": -92.28003,
     "max_points": 6,
     "connections": [],
     "stats": [
@@ -11487,7 +11499,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1218"
   },
   {
     "id": "rg_76",
@@ -11499,8 +11511,8 @@
     "name": "Barbed Arrows",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 52.26001,
+    "y": 92.28,
     "max_points": 10,
     "connections": [],
     "stats": [
@@ -11518,7 +11530,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-890"
   },
   {
     "id": "rg_35",
@@ -11530,8 +11542,8 @@
     "name": "Fire and Steel",
     "description": "Non-elemental bow attacks cannot consume {Elemental Arrows}, but instead generate an Elemental Arrow on use. Consuming an Elemental Arrow also increases the elemental damage of the attack that consumes them.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 52.26001,
+    "y": 184.56,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -11549,7 +11561,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-341"
   },
   {
     "id": "rg_39",
@@ -11561,8 +11573,8 @@
     "name": "Sharpshooter",
     "description": "Chance to gain a stack of Sharpshooter when you hit an enemy based on your how far you are from that enemy, up to a maximum at 10m. Each stack of Sharpshooter increases bow damage and lasts 8 seconds.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 169.38,
+    "y": -184.56003,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -11580,7 +11592,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-70"
   },
   {
     "id": "rg_36",
@@ -11592,8 +11604,8 @@
     "name": "Covering Fire",
     "description": "When you proc {Arrowstorm} you gain stacks of {Silver Shroud}. Silver Shroud is a buff that gives you 100% chance to dodge the next hit. Dodging a hit with Silver Shroud consumes all stacks, granting you 100 ward per stack.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 169.38,
+    "y": -3.0517578e-05,
     "max_points": 10,
     "connections": [
       "rg_33"
@@ -11605,7 +11617,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-65"
   },
   {
     "id": "rg_37",
@@ -11617,8 +11629,8 @@
     "name": "Sniper's Gambit",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 169.38,
+    "y": 92.28,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -11632,7 +11644,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-281"
   },
   {
     "id": "rg_38",
@@ -11644,8 +11656,8 @@
     "name": "Poison Tipped Arrows",
     "description": "You have additional poison penetration and bow attacks have additional chance to poison on hit.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 169.38,
+    "y": 184.56,
     "max_points": 10,
     "connections": [],
     "stats": [
@@ -11663,7 +11675,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-948"
   },
   {
     "id": "rg_41",
@@ -11675,8 +11687,8 @@
     "name": "Barrage of Pain",
     "description": "Adds {Barrage of Pain} to your Marksman Passive, Bow Mastery. You gain a stack and refresh all existing stacks of Bow Mastery by using a bow attack and hitting at least one enemy.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 286.50006,
+    "y": -92.28003,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -11690,7 +11702,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-740"
   },
   {
     "id": "rg_40",
@@ -11702,8 +11714,8 @@
     "name": "Ethereal Arrows",
     "description": "You have increased mana and mana regen and your bow attacks deal more damage (multiplicative with other modifiers) equal to a portion of their mana cost.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 286.50006,
+    "y": 92.28,
     "max_points": 10,
     "connections": [],
     "stats": [
@@ -11721,7 +11733,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-858"
   },
   {
     "id": "rg_44",
@@ -11733,8 +11745,8 @@
     "name": "Death from Afar",
     "description": "Each stack of Sharpshooter also increases stun chance and adds a chance to shred armour on hit",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 403.62,
+    "y": -184.56003,
     "max_points": 5,
     "connections": [
       "rg_39"
@@ -11750,7 +11762,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-515"
   },
   {
     "id": "rg_42",
@@ -11762,8 +11774,8 @@
     "name": "Rain of Arrows",
     "description": "Adds a chance to cause a {Rain of Arrows} to descend upon your target when you proc {Arrow Storm}. Rain of Arrows is a physical bow attack that hits all enemies in an area around the target.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 403.62,
+    "y": -3.0517578e-05,
     "max_points": 4,
     "connections": [
       "rg_36"
@@ -11775,7 +11787,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-371"
   },
   {
     "id": "rg_43",
@@ -11787,8 +11799,8 @@
     "name": "Mana Warp",
     "description": "When you directly use a skill that costs zero mana and hit an enemy you regain mana, but bow attacks cost more mana.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 403.62,
+    "y": 184.56,
     "max_points": 5,
     "connections": [
       "rg_40"
@@ -11804,7 +11816,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-52"
   },
   {
     "id": "rg_46",
@@ -11816,8 +11828,8 @@
     "name": "Perfect Aim",
     "description": "Each stack of Bow Mastery with {Barrage of Pain} also grants additional critical strike multiplier and health gained on crit.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 520.74,
+    "y": -92.28003,
     "max_points": 5,
     "connections": [
       "rg_41"
@@ -11833,7 +11845,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-734"
   },
   {
     "id": "rg_45",
@@ -11845,8 +11857,8 @@
     "name": "Master Archer",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 520.74,
+    "y": 92.28,
     "max_points": 2,
     "connections": [
       "rg_40"
@@ -11870,7 +11882,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-735"
   },
   {
     "id": "rg_4",
@@ -11882,8 +11894,8 @@
     "name": "Spell Breaker",
     "description": "You have a chance to parry hits, and increased mana regeneration.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 403.62,
+    "y": -3.0517578e-05,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -11901,7 +11913,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-858"
   },
   {
     "id": "rg_48",
@@ -11913,8 +11925,8 @@
     "name": "Handler",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -533.34,
+    "y": -184.56003,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -11928,7 +11940,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-458"
   },
   {
     "id": "rg_78",
@@ -11940,8 +11952,8 @@
     "name": "Raptor's Wings",
     "description": "You have a chance to gain haste for 2 seconds when you or your {Falcon} hits an enemy.\n\nAdditionally, you deal more damage (multiplicative with other modifiers) while you have haste.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -533.34,
+    "y": -3.0517578e-05,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -11959,7 +11971,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1004"
   },
   {
     "id": "rg_79",
@@ -11971,8 +11983,8 @@
     "name": "Wilderness Scout",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -533.34,
+    "y": 184.56,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -11986,7 +11998,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-113"
   },
   {
     "id": "rg_80",
@@ -11998,8 +12010,8 @@
     "name": "Crimson Skies",
     "description": "You have a chance to gain a stack of {Crimson Shroud} when your {Falcon} or {Ballistas} hit an enemy.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -416.22,
+    "y": -92.28003,
     "max_points": 5,
     "connections": [
       "rg_48"
@@ -12011,7 +12023,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-733"
   },
   {
     "id": "rg_81",
@@ -12023,8 +12035,8 @@
     "name": "Agile Hunt",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -416.22,
+    "y": -3.0517578e-05,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -12038,7 +12050,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1016"
   },
   {
     "id": "rg_82",
@@ -12050,8 +12062,8 @@
     "name": "Outlander's Tenacity",
     "description": "You have additional dodge rating and you gain a portion of your maximum health as endurance threshold if you have not been hit recently.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -416.22,
+    "y": 92.28,
     "max_points": 5,
     "connections": [
       "rg_79"
@@ -12067,7 +12079,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1002"
   },
   {
     "id": "rg_83",
@@ -12079,8 +12091,8 @@
     "name": "Expert Duelist",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -299.09998,
+    "y": -92.28003,
     "max_points": 7,
     "connections": [],
     "stats": [
@@ -12102,7 +12114,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-272"
   },
   {
     "id": "rg_84",
@@ -12114,8 +12126,8 @@
     "name": "Peltast",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -299.09998,
+    "y": -3.0517578e-05,
     "max_points": 7,
     "connections": [],
     "stats": [
@@ -12133,7 +12145,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1207"
   },
   {
     "id": "rg_85",
@@ -12145,8 +12157,8 @@
     "name": "Ranger's Mark",
     "description": "You deal increased damage while wielding a bow and your bow hits have a chance to grant your {Falcon} additional melee damage for 4 seconds. This has no stack limit.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -299.09998,
+    "y": 92.28,
     "max_points": 7,
     "connections": [],
     "stats": [
@@ -12164,7 +12176,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-585"
   },
   {
     "id": "rg_86",
@@ -12176,8 +12188,8 @@
     "name": "Stamina of the Rover",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -299.09998,
+    "y": 184.56,
     "max_points": 6,
     "connections": [
       "rg_79"
@@ -12197,7 +12209,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-503"
   },
   {
     "id": "rg_87",
@@ -12209,8 +12221,8 @@
     "name": "Tactician",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -181.98001,
+    "y": -184.56003,
     "max_points": 6,
     "connections": [
       "rg_48"
@@ -12230,7 +12242,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-365"
   },
   {
     "id": "rg_88",
@@ -12242,8 +12254,8 @@
     "name": "Fencing Grace",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -181.98001,
+    "y": 92.28,
     "max_points": 7,
     "connections": [],
     "stats": [
@@ -12261,7 +12273,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-553"
   },
   {
     "id": "rg_89",
@@ -12273,8 +12285,8 @@
     "name": "Sharpest Point",
     "description": "You deal increased damage and have an additional chance to inflict bleed while wielding a spear.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -64.859985,
+    "y": -92.28003,
     "max_points": 8,
     "connections": [
       "rg_83"
@@ -12298,7 +12310,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-494"
   },
   {
     "id": "rg_90",
@@ -12310,8 +12322,8 @@
     "name": "Avian Hurl",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -64.859985,
+    "y": -3.0517578e-05,
     "max_points": 6,
     "connections": [
       "rg_84"
@@ -12327,7 +12339,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-573"
   },
   {
     "id": "rg_91",
@@ -12339,8 +12351,8 @@
     "name": "Blast Radius",
     "description": "Your area skills and your minions' area skills deal damage in a larger area.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -64.859985,
+    "y": 184.56,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -12358,7 +12370,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-565"
   },
   {
     "id": "rg_92",
@@ -12370,8 +12382,8 @@
     "name": "Evasion Tactics",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 52.26001,
+    "y": -184.56003,
     "max_points": 6,
     "connections": [],
     "stats": [
@@ -12389,7 +12401,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-704"
   },
   {
     "id": "rg_93",
@@ -12401,8 +12413,8 @@
     "name": "Coordinated Fade",
     "description": "When you use a certain ability on your bar, you gain 3 stacks of Silver Shroud. This effect has a 10 second cooldown.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 52.26001,
+    "y": -3.0517578e-05,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -12420,7 +12432,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1011"
   },
   {
     "id": "rg_95",
@@ -12432,8 +12444,8 @@
     "name": "Deflect and Weave",
     "description": "You have additional block and a chance to receive a glancing blow. Additionally, you regain health whenever you block or recieve a glancing blow.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 52.26001,
+    "y": 184.56,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -12455,7 +12467,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-742"
   },
   {
     "id": "rg_94",
@@ -12467,8 +12479,8 @@
     "name": "Relentless Talons",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 169.38,
+    "y": -92.28003,
     "max_points": 5,
     "connections": [
       "rg_92"
@@ -12488,7 +12500,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-587"
   },
   {
     "id": "rg_97",
@@ -12500,8 +12512,8 @@
     "name": "Intuitive Connection",
     "description": "{Falcon Strikes} and {Dive Bomb} are now instant cast.\n\nAdditionally, {Falcon Strikes} and {Dive Bomb} have a longer cooldown.",
     "node_type": "notable",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 169.38,
+    "y": -3.0517578e-05,
     "max_points": 1,
     "connections": [],
     "stats": [
@@ -12515,7 +12527,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-455"
   },
   {
     "id": "rg_98",
@@ -12527,8 +12539,8 @@
     "name": "Final Souvenir",
     "description": "You have additional dodge rating and you now have a chance to drop {Caltrops} around you when you dodge and there is an enemy within 4 meters of you.\n\nThis effect has a 2 second cooldown.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 169.38,
+    "y": 184.56,
     "max_points": 6,
     "connections": [
       "rg_0",
@@ -12551,7 +12563,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-539"
   },
   {
     "id": "rg_99",
@@ -12563,8 +12575,8 @@
     "name": "Sky Assassin",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 286.50006,
+    "y": -92.28003,
     "max_points": 7,
     "connections": [],
     "stats": [
@@ -12578,7 +12590,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-18"
   },
   {
     "id": "rg_100",
@@ -12590,8 +12602,8 @@
     "name": "Needle Like Precision",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 286.50006,
+    "y": -3.0517578e-05,
     "max_points": 6,
     "connections": [],
     "stats": [
@@ -12613,7 +12625,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-670"
   },
   {
     "id": "rg_101",
@@ -12625,8 +12637,8 @@
     "name": "Leog's Stratagem",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 286.50006,
+    "y": 92.28,
     "max_points": 8,
     "connections": [
       "rg_98"
@@ -12642,7 +12654,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-943"
   },
   {
     "id": "rg_102",
@@ -12654,8 +12666,8 @@
     "name": "Stymphalian Feathers",
     "description": "You have additional armor per point of Dexterity.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 403.62,
+    "y": -184.56003,
     "max_points": 6,
     "connections": [
       "rg_92"
@@ -12671,7 +12683,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-245"
   },
   {
     "id": "rg_103",
@@ -12683,8 +12695,8 @@
     "name": "Expediency",
     "description": "Haste on you has increased effect and you gain haste for a short duration whenever you use a potion.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 403.62,
+    "y": -92.28003,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -12702,7 +12714,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-959"
   },
   {
     "id": "rg_104",
@@ -12714,8 +12726,8 @@
     "name": "Poise",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 403.62,
+    "y": 92.28,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -12729,7 +12741,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-493"
   },
   {
     "id": "rg_105",
@@ -12741,8 +12753,8 @@
     "name": "Tailwind",
     "description": "You take less damage while moving. Additionally, you have increased movement speed and dodge rating.\n\nThese effects are doubled if your {Falcon} has hit an enemy recently.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 520.74,
+    "y": -184.56003,
     "max_points": 6,
     "connections": [],
     "stats": [
@@ -12764,7 +12776,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1006"
   },
   {
     "id": "rg_106",
@@ -12776,8 +12788,8 @@
     "name": "Finesse Them",
     "description": "You regain health when you or your minions crits an enemy.\n\nYou have additional critical strike avoidance.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 520.74,
+    "y": -3.0517578e-05,
     "max_points": 7,
     "connections": [
       "rg_100"
@@ -12797,7 +12809,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-598"
   },
   {
     "id": "rg_107",
@@ -12809,8 +12821,8 @@
     "name": "Strike Their Flank",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 520.74,
+    "y": 184.56,
     "max_points": 6,
     "connections": [
       "rg_98"
@@ -12830,7 +12842,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1023"
   },
   {
     "id": "sn_49",
@@ -12842,8 +12854,8 @@
     "name": "Fearless",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -533.34,
+    "y": -92.28003,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -12857,7 +12869,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-725"
   },
   {
     "id": "sn_0",
@@ -12869,8 +12881,8 @@
     "name": "Juggernaut",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -533.34,
+    "y": -3.0517578e-05,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -12888,7 +12900,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-245"
   },
   {
     "id": "sn_5",
@@ -12900,8 +12912,8 @@
     "name": "Overwhelm",
     "description": "Adds physical damage to your melee attacks and increases their chance to stun.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -533.34,
+    "y": 92.28,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -12915,7 +12927,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-746"
   },
   {
     "id": "sn_1",
@@ -12927,8 +12939,8 @@
     "name": "Stalwart",
     "description": "You have a higher chance to block hits and take less damage from hits that you block.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -334.74,
+    "y": -184.56003,
     "max_points": 5,
     "connections": [
       "sn_49"
@@ -12944,7 +12956,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-493"
   },
   {
     "id": "sn_2",
@@ -12956,8 +12968,8 @@
     "name": "Armour Clad",
     "description": "Adds armour and reduces the damage you take from nearby enemies (multiplicative with other modifiers)",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -334.74,
+    "y": -92.28003,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -12971,7 +12983,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-273"
   },
   {
     "id": "sn_4",
@@ -12983,8 +12995,8 @@
     "name": "Relentless",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -334.74,
+    "y": 92.28,
     "max_points": 10,
     "connections": [],
     "stats": [
@@ -13002,7 +13014,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-205"
   },
   {
     "id": "sn_50",
@@ -13014,8 +13026,8 @@
     "name": "Counter Attack",
     "description": "When you are hit you have a chance to counter attack enemies with {Retribution,} a melee physical attack that deals damage to nearby enemies. This effect has a 0.2 second cooldown.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -334.74,
+    "y": 184.56,
     "max_points": 5,
     "connections": [
       "sn_5"
@@ -13027,7 +13039,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-200"
   },
   {
     "id": "sn_8",
@@ -13039,8 +13051,8 @@
     "name": "Valiant Charge",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -136.13998,
+    "y": -3.0517578e-05,
     "max_points": 5,
     "connections": [
       "sn_2",
@@ -13057,7 +13069,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-9"
   },
   {
     "id": "sn_3",
@@ -13069,8 +13081,8 @@
     "name": "Aegis of Renewal",
     "description": "You have a 25% chance to gain health whenever you block.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 62.460022,
+    "y": -184.56003,
     "max_points": 5,
     "connections": [
       "sn_1"
@@ -13082,7 +13094,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-559"
   },
   {
     "id": "sn_106",
@@ -13094,8 +13106,8 @@
     "name": "Time and Faith",
     "description": "You regain mana and a portion of your missing health when you directly use {Rive}, {Vengeance}, {Smite}, or {Multistrike}.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 62.460022,
+    "y": -3.0517578e-05,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -13109,7 +13121,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-21"
   },
   {
     "id": "sn_55",
@@ -13121,8 +13133,8 @@
     "name": "Banish",
     "description": "{Retribution} deals increased damage and has additional chance to critically strike.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 62.460022,
+    "y": 184.56,
     "max_points": 4,
     "connections": [
       "sn_50"
@@ -13138,7 +13150,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1008"
   },
   {
     "id": "sn_7",
@@ -13150,8 +13162,8 @@
     "name": "Axe Thrower",
     "description": "Whenever you hit an enemy you have a chance to throw an {Axe} at the nearest enemy, dealing physical damage to all enemies in its path. This effect has a 1 second cooldown.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 261.06,
+    "y": -92.28003,
     "max_points": 5,
     "connections": [
       "sn_0",
@@ -13166,7 +13178,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-243"
   },
   {
     "id": "sn_6",
@@ -13178,8 +13190,8 @@
     "name": "Gladiator",
     "description": "You can dual wield melee weapons by equipping a sword in your off hand. While dual wielding, you have increased attack and cast speed, but take more damage (multiplicative with other modifiers).",
     "node_type": "notable",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 261.06,
+    "y": 92.28,
     "max_points": 1,
     "connections": [],
     "stats": [
@@ -13197,7 +13209,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-863"
   },
   {
     "id": "sn_107",
@@ -13209,8 +13221,8 @@
     "name": "Mail Crusher",
     "description": "You deal increased damage while you have a mace or sceptre equipped.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 459.66003,
+    "y": -184.56003,
     "max_points": 10,
     "connections": [],
     "stats": [
@@ -13224,7 +13236,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-204"
   },
   {
     "id": "sn_108",
@@ -13236,8 +13248,8 @@
     "name": "Blademaster",
     "description": "You have increased attack and cast speed while you have a sword or axe equipped.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 459.66003,
+    "y": 184.56,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -13251,7 +13263,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-558"
   },
   {
     "id": "sn_10",
@@ -13263,8 +13275,8 @@
     "name": "Devouring Blade",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -533.34,
+    "y": -92.28003,
     "max_points": 10,
     "connections": [],
     "stats": [
@@ -13282,7 +13294,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-46"
   },
   {
     "id": "sn_58",
@@ -13294,8 +13306,8 @@
     "name": "Temporal Corruption",
     "description": "Your spells and attacks deal additional void damage.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -533.34,
+    "y": -3.0517578e-05,
     "max_points": 6,
     "connections": [],
     "stats": [
@@ -13305,7 +13317,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-470"
   },
   {
     "id": "sn_11",
@@ -13317,8 +13329,8 @@
     "name": "Abyssal Endurance",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -533.34,
+    "y": 184.56,
     "max_points": 10,
     "connections": [],
     "stats": [
@@ -13340,7 +13352,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-81"
   },
   {
     "id": "sn_12",
@@ -13352,8 +13364,8 @@
     "name": "World Eater",
     "description": "You leech a portion of your melee and void damage as health.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -416.22,
+    "y": -184.56003,
     "max_points": 6,
     "connections": [
       "sn_10"
@@ -13373,7 +13385,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-73"
   },
   {
     "id": "sn_13",
@@ -13385,8 +13397,8 @@
     "name": "Sorrow and Steel",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -416.22,
+    "y": 184.56,
     "max_points": 10,
     "connections": [],
     "stats": [
@@ -13404,7 +13416,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1220"
   },
   {
     "id": "sn_14",
@@ -13416,8 +13428,8 @@
     "name": "Patient Doom",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -64.859985,
+    "y": -3.0517578e-05,
     "max_points": 6,
     "connections": [],
     "stats": [
@@ -13431,7 +13443,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-80"
   },
   {
     "id": "sn_15",
@@ -13443,8 +13455,8 @@
     "name": "Void Blades",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -299.09998,
+    "y": -92.28003,
     "max_points": 8,
     "connections": [
       "sn_58"
@@ -13456,7 +13468,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-809"
   },
   {
     "id": "sn_16",
@@ -13468,8 +13480,8 @@
     "name": "Dark Maw",
     "description": "You have increased health.\n\nWhenever you kill an enemy, you have a chance to absorb 5% of their health.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -299.09998,
+    "y": -3.0517578e-05,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -13483,7 +13495,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1126"
   },
   {
     "id": "sn_51",
@@ -13495,8 +13507,8 @@
     "name": "Void Waves",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -299.09998,
+    "y": 92.28,
     "max_points": 8,
     "connections": [
       "sn_58"
@@ -13512,7 +13524,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-748"
   },
   {
     "id": "sn_56",
@@ -13524,8 +13536,8 @@
     "name": "Void Corruption",
     "description": "Your critical strikes deal more damage for each passive point you have invested in the Void Knight tree.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -299.09998,
+    "y": 184.56,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -13539,7 +13551,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-56"
   },
   {
     "id": "sn_19",
@@ -13551,8 +13563,8 @@
     "name": "Chaotic Reverb",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -181.98001,
+    "y": -92.28003,
     "max_points": 10,
     "connections": [
       "sn_0",
@@ -13575,7 +13587,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-9"
   },
   {
     "id": "sn_18",
@@ -13587,8 +13599,8 @@
     "name": "Finality",
     "description": "Your melee hits deal increased void damage and instantly kill enemies that are below a health threshold (a percentage of their maximum health).\n\nIf you have a similar effect from an item or passive node, then the highest threshold is used.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -64.859985,
+    "y": -184.56003,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -13602,7 +13614,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-518"
   },
   {
     "id": "sn_20",
@@ -13614,8 +13626,8 @@
     "name": "Unending Hunger",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -181.98001,
+    "y": -184.56003,
     "max_points": 5,
     "connections": [
       "sn_12"
@@ -13631,7 +13643,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1128"
   },
   {
     "id": "sn_57",
@@ -13643,8 +13655,8 @@
     "name": "Rot Ripples",
     "description": "Your hits have a chance to inflict enemies with {Time Rot} and whenever you kill an enemy afflicted with Time Rot, nearby enemies have a chance to be inflicted with Time Rot.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -64.859985,
+    "y": 184.56,
     "max_points": 6,
     "connections": [],
     "stats": [
@@ -13662,7 +13674,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-382"
   },
   {
     "id": "sn_59",
@@ -13674,8 +13686,8 @@
     "name": "Temporal Velocity",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 52.26001,
+    "y": -184.56003,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -13693,7 +13705,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1174"
   },
   {
     "id": "sn_60",
@@ -13705,8 +13717,8 @@
     "name": "Rot Grip",
     "description": "Your hits have a chance to inflict enemies with {Time Rot}.\n\nAdditionally, {Time Rot} deals more damage per 1% global chance to slow with void skills, more damage per 1% global {Time Rot} chance with void skills and more damage per 1% increased melee attack, throwing or cast speed, whichever is lowest, (all multiplicative with each other and with all other modifiers).",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 52.26001,
+    "y": 92.28,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -13728,7 +13740,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-562"
   },
   {
     "id": "sn_63",
@@ -13740,8 +13752,8 @@
     "name": "Woe",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 52.26001,
+    "y": -92.28003,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -13763,7 +13775,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-596"
   },
   {
     "id": "sn_62",
@@ -13775,8 +13787,8 @@
     "name": "Doom Knight",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -181.98001,
+    "y": 92.28,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -13794,7 +13806,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1124"
   },
   {
     "id": "sn_22",
@@ -13806,8 +13818,8 @@
     "name": "Eternal Form",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 286.50006,
+    "y": -3.0517578e-05,
     "max_points": 10,
     "connections": [],
     "stats": [
@@ -13825,7 +13837,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-245"
   },
   {
     "id": "sn_61",
@@ -13837,8 +13849,8 @@
     "name": "Singular Purpose",
     "description": "You deal more void damage (multiplicative with other modifiers).\n\nThis effect is doubled if you have less than 30% block chance.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 169.38,
+    "y": -3.0517578e-05,
     "max_points": 5,
     "connections": [
       "sn_60",
@@ -13859,7 +13871,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1359"
   },
   {
     "id": "sn_23",
@@ -13871,8 +13883,8 @@
     "name": "Future Mind",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 169.38,
+    "y": 92.28,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -13890,7 +13902,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-44"
   },
   {
     "id": "sn_40",
@@ -13902,8 +13914,8 @@
     "name": "Echoing Strikes",
     "description": "Your melee attacks, throwing attacks, and void spells have a higher chance to be echoed 1 second later. ",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 169.38,
+    "y": 184.56,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -13921,7 +13933,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-63"
   },
   {
     "id": "sn_25",
@@ -13933,8 +13945,8 @@
     "name": "Essence of the End",
     "description": "You have a chance to gain a {Void Essence} on kill.\n\nVoid Essences last 8 seconds and grant 3% more void damage and 3% more melee damage (both multiplicative with other modifiers), and 15% reduced duration of stuns on you.\n\nYou can have a maximum of 3 Void Essences at once, and you cannot gain more than 1 every 4 seconds.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 169.38,
+    "y": -184.56003,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -13948,7 +13960,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-80"
   },
   {
     "id": "sn_24",
@@ -13960,8 +13972,8 @@
     "name": "Void Aegis",
     "description": "If you take a hit that deals at least 25% of your max health as damage, consume a {Void Essence} to gain {Void Aegis} for 4 seconds, which grants a portion of your maximum health gained as endurance threshold.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 286.50006,
+    "y": -92.28003,
     "max_points": 5,
     "connections": [
       "sn_25"
@@ -13977,7 +13989,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-750"
   },
   {
     "id": "sn_54",
@@ -13989,8 +14001,8 @@
     "name": "Void Well",
     "description": "While you have 3 or more {Void Essences,} if you drop below 0 mana, you consume 3 void essences to set your mana to 30% of your maximum mana pool.\n\nThis effect has a 4 second cooldown.",
     "node_type": "notable",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 403.62,
+    "y": -184.56003,
     "max_points": 1,
     "connections": [
       "sn_25"
@@ -14002,7 +14014,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-79"
   },
   {
     "id": "sn_26",
@@ -14014,8 +14026,8 @@
     "name": "Dread Form",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 403.62,
+    "y": -3.0517578e-05,
     "max_points": 10,
     "connections": [],
     "stats": [
@@ -14037,7 +14049,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-749"
   },
   {
     "id": "sn_79",
@@ -14049,8 +14061,8 @@
     "name": "Time Legion",
     "description": "You have increased melee and throwing attack speed.\n\nYour melee attacks, throwing attacks, and void spells have a higher chance to be echoed 1 second later. ",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 403.62,
+    "y": 184.56,
     "max_points": 10,
     "connections": [
       "sn_40"
@@ -14066,7 +14078,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-595"
   },
   {
     "id": "sn_64",
@@ -14078,8 +14090,8 @@
     "name": "Abyssal Fluctuation",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 520.74,
+    "y": -184.56003,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -14093,7 +14105,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-181"
   },
   {
     "id": "sn_102",
@@ -14105,8 +14117,8 @@
     "name": "Avatar of Regret",
     "description": "Your melee attacks, throwing attacks, and void spells have a much higher chance to echo, you have increased armor, but you have reduced melee attack speed and throwing attack speed and your skills cost more mana.",
     "node_type": "notable",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 520.74,
+    "y": 92.28,
     "max_points": 1,
     "connections": [
       "sn_26",
@@ -14131,7 +14143,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-561"
   },
   {
     "id": "sn_27",
@@ -14143,8 +14155,8 @@
     "name": "Steel Aegis",
     "description": "You have a higher chance to block hits and take less damage from hits that you block.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -533.34,
+    "y": -184.56003,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -14162,7 +14174,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-559"
   },
   {
     "id": "sn_65",
@@ -14174,8 +14186,8 @@
     "name": "Weapons Master",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -533.34,
+    "y": -3.0517578e-05,
     "max_points": 10,
     "connections": [],
     "stats": [
@@ -14201,7 +14213,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1365"
   },
   {
     "id": "sn_28",
@@ -14213,8 +14225,8 @@
     "name": "Battle Hardened",
     "description": "If you have been hit recently you increased armor.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -533.34,
+    "y": 184.56,
     "max_points": 10,
     "connections": [],
     "stats": [
@@ -14228,7 +14240,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-205"
   },
   {
     "id": "sn_30",
@@ -14240,8 +14252,8 @@
     "name": "Peltast",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -416.22,
+    "y": -92.28003,
     "max_points": 10,
     "connections": [
       "sn_65"
@@ -14257,7 +14269,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-204"
   },
   {
     "id": "sn_53",
@@ -14269,8 +14281,8 @@
     "name": "Fresh from the Forge",
     "description": "You have additional melee and throwing physical and fire damage.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -416.22,
+    "y": 92.28,
     "max_points": 10,
     "connections": [
       "sn_65"
@@ -14302,7 +14314,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-246"
   },
   {
     "id": "sn_32",
@@ -14314,8 +14326,8 @@
     "name": "Unflinching",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -416.22,
+    "y": 184.56,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -14337,7 +14349,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-245"
   },
   {
     "id": "sn_29",
@@ -14349,8 +14361,8 @@
     "name": "Rallying Block",
     "description": "You have additional armor for each hit you have blocked recently (last 4 seconds).",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -299.09998,
+    "y": -184.56003,
     "max_points": 8,
     "connections": [
       "sn_27"
@@ -14366,7 +14378,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-952"
   },
   {
     "id": "sn_52",
@@ -14378,8 +14390,8 @@
     "name": "Shield Breaker",
     "description": "Your throwing attacks cost more mana, but shred physical and fire resistance.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -299.09998,
+    "y": -3.0517578e-05,
     "max_points": 6,
     "connections": [
       "sn_30"
@@ -14399,7 +14411,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-744"
   },
   {
     "id": "sn_33",
@@ -14411,8 +14423,8 @@
     "name": "Guardian",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -299.09998,
+    "y": 184.56,
     "max_points": 10,
     "connections": [],
     "stats": [
@@ -14430,7 +14442,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-423"
   },
   {
     "id": "sn_66",
@@ -14442,8 +14454,8 @@
     "name": "Iron Attunement",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -64.859985,
+    "y": -184.56003,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -14465,7 +14477,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-364"
   },
   {
     "id": "sn_36",
@@ -14477,8 +14489,8 @@
     "name": "Crushing Blows",
     "description": "You have increased mana regen and your melee and throwing attacks deal more damage (multiplicative with other modifiers) based on their mana cost.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -64.859985,
+    "y": 184.56,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -14492,7 +14504,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-903"
   },
   {
     "id": "sn_37",
@@ -14504,8 +14516,8 @@
     "name": "Smelter's Might",
     "description": "You and your minions have a chance to inflict bleeding and ignite on hit. This bonus is doubled for you if you are using a two handed melee weapon.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -181.98001,
+    "y": -184.56003,
     "max_points": 10,
     "connections": [],
     "stats": [
@@ -14527,7 +14539,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1123"
   },
   {
     "id": "sn_110",
@@ -14539,8 +14551,8 @@
     "name": "Siege Captain",
     "description": "While you have a shield equipped your blocks are more effective and you deal additional physical damage with throwing attacks.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -181.98001,
+    "y": -92.28003,
     "max_points": 8,
     "connections": [
       "sn_30"
@@ -14556,7 +14568,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-116"
   },
   {
     "id": "sn_39",
@@ -14568,8 +14580,8 @@
     "name": "Hammer and Anvil",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -64.859985,
+    "y": -3.0517578e-05,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -14587,7 +14599,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-271"
   },
   {
     "id": "sn_111",
@@ -14599,8 +14611,8 @@
     "name": "Champion of the Forge",
     "description": "You have increased critical strike chance while wielding a 2 handed weapon.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -181.98001,
+    "y": 92.28,
     "max_points": 8,
     "connections": [
       "sn_53"
@@ -14616,7 +14628,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-558"
   },
   {
     "id": "sn_34",
@@ -14628,8 +14640,8 @@
     "name": "Thornmail",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -181.98001,
+    "y": 184.56,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -14647,7 +14659,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-921"
   },
   {
     "id": "sn_31",
@@ -14659,8 +14671,8 @@
     "name": "Might",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 52.26001,
+    "y": -92.28003,
     "max_points": 6,
     "connections": [],
     "stats": [
@@ -14674,7 +14686,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-179"
   },
   {
     "id": "sn_100",
@@ -14686,8 +14698,8 @@
     "name": "Folded Steel",
     "description": "Your {Manifest Armor} and {Forged Weapons} deal additional physical damage with their melee attacks.\n\nAdditionally, your {Forged Weapons} last longer.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 52.26001,
+    "y": -3.0517578e-05,
     "max_points": 10,
     "connections": [],
     "stats": [
@@ -14709,7 +14721,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-273"
   },
   {
     "id": "sn_42",
@@ -14721,8 +14733,8 @@
     "name": "Iron Reflexes",
     "description": "You have additional Dexterity and you take reduced bonus damage from critical strikes.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 52.26001,
+    "y": 92.28,
     "max_points": 10,
     "connections": [],
     "stats": [
@@ -14740,7 +14752,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-947"
   },
   {
     "id": "sn_43",
@@ -14752,8 +14764,8 @@
     "name": "Duelist",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 169.38,
+    "y": -184.56003,
     "max_points": 8,
     "connections": [
       "sn_31"
@@ -14765,7 +14777,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-591"
   },
   {
     "id": "sn_41",
@@ -14777,8 +14789,8 @@
     "name": "Flawless Defender",
     "description": "While you are using a shield you have additional armor.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 169.38,
+    "y": -92.28003,
     "max_points": 4,
     "connections": [],
     "stats": [
@@ -14788,7 +14800,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-571"
   },
   {
     "id": "sn_38",
@@ -14800,8 +14812,8 @@
     "name": "Infinite Bulwark",
     "description": "You and your minions have increased armor and chance to find potions if you have used a potion recently (last 4 seconds).",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 169.38,
+    "y": 92.28,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -14819,7 +14831,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-588"
   },
   {
     "id": "sn_44",
@@ -14831,8 +14843,8 @@
     "name": "Crusader",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 169.38,
+    "y": 184.56,
     "max_points": 8,
     "connections": [
       "sn_42"
@@ -14844,7 +14856,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-385"
   },
   {
     "id": "sn_48",
@@ -14856,8 +14868,8 @@
     "name": "Walls of Solarum",
     "description": "You take less damage, and this effect is double if you have at least 50% block chance.\n\nAdditionally, you have an additional chance to block hits.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 286.50006,
+    "y": -3.0517578e-05,
     "max_points": 5,
     "connections": [
       "sn_41"
@@ -14877,7 +14889,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-493"
   },
   {
     "id": "sn_45",
@@ -14889,8 +14901,8 @@
     "name": "Lethal Strikes",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 403.62,
+    "y": -184.56003,
     "max_points": 6,
     "connections": [
       "sn_43"
@@ -14910,7 +14922,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-196"
   },
   {
     "id": "sn_47",
@@ -14922,8 +14934,8 @@
     "name": "Osprixbane",
     "description": "While you are using a shield you have additional elemental resistance and deal increased fire damage over time.\n\nThese effects also affect your minions.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 403.62,
+    "y": -92.28003,
     "max_points": 8,
     "connections": [
       "sn_41"
@@ -14947,7 +14959,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1171"
   },
   {
     "id": "sn_67",
@@ -14959,8 +14971,8 @@
     "name": "Liquid Iron",
     "description": "You take less damage over time (multiplicative with other modifiers) and have additional physical resistance. These bonuses are doubled if you have used a potion recently.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 403.62,
+    "y": 92.28,
     "max_points": 5,
     "connections": [
       "sn_38"
@@ -14980,7 +14992,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-941"
   },
   {
     "id": "sn_46",
@@ -14992,8 +15004,8 @@
     "name": "Javelineer",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 403.62,
+    "y": 184.56,
     "max_points": 6,
     "connections": [
       "sn_44"
@@ -15009,7 +15021,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-494"
   },
   {
     "id": "sn_68",
@@ -15021,8 +15033,8 @@
     "name": "Master of Arms",
     "description": "You gain a bonus depending on the type of weapon you are wielding.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 520.74,
+    "y": -92.28003,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -15048,7 +15060,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-272"
   },
   {
     "id": "sn_35",
@@ -15060,8 +15072,8 @@
     "name": "Shield Crafter",
     "description": "You have a chance to cast a shield from {Ring of Shields} when you block a hit and you have additional block effectiveness per shield from {Ring of Shields}.\n\nThis effect can trigger up to 3 times every 6 seconds.\n\nAdditionally, your minions have increased health and armor.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 520.74,
+    "y": -3.0517578e-05,
     "max_points": 5,
     "connections": [
       "sn_48"
@@ -15085,7 +15097,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-244"
   },
   {
     "id": "sn_112",
@@ -15097,8 +15109,8 @@
     "name": "Avatar of War",
     "description": "You and your minions gain increased fire and physical damage.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 520.74,
+    "y": 92.28,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -15116,7 +15128,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1366"
   },
   {
     "id": "sn_72",
@@ -15128,8 +15140,8 @@
     "name": "Honor",
     "description": "You are less likely to be stunned, you have a higher chance to block hits and you take less damage from hits that you block.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -533.34,
+    "y": -92.28003,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -15147,7 +15159,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-493"
   },
   {
     "id": "sn_71",
@@ -15159,8 +15171,8 @@
     "name": "Defiance",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -533.34,
+    "y": -3.0517578e-05,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -15178,7 +15190,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-132"
   },
   {
     "id": "sn_77",
@@ -15190,8 +15202,8 @@
     "name": "Conviction",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -533.34,
+    "y": 92.28,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -15221,7 +15233,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-449"
   },
   {
     "id": "sn_76",
@@ -15233,8 +15245,8 @@
     "name": "Holy Symbol",
     "description": "When you block you cast {Holy Symbol,} healing yourself and granting you ward over 3 seconds.\n\nThis effect has a 3 second cooldown.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -416.22,
+    "y": -184.56003,
     "max_points": 6,
     "connections": [
       "sn_72"
@@ -15254,7 +15266,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-37"
   },
   {
     "id": "sn_69",
@@ -15266,8 +15278,8 @@
     "name": "Valor",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -416.22,
+    "y": -3.0517578e-05,
     "max_points": 10,
     "connections": [],
     "stats": [
@@ -15285,7 +15297,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-704"
   },
   {
     "id": "sn_74",
@@ -15297,8 +15309,8 @@
     "name": "Divine Bolt",
     "description": "Whenever you hit an enemy with a melee attack you have a chance to cast {Divine Bolt,} a blast of holy energy that deals fire damage to a random nearby enemy. This effect can trigger up to twice per second.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -416.22,
+    "y": 92.28,
     "max_points": 4,
     "connections": [
       "sn_0",
@@ -15317,7 +15329,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-265"
   },
   {
     "id": "sn_84",
@@ -15329,8 +15341,8 @@
     "name": "Phoenix Strike",
     "description": "Your hits have a chance to ignite.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -416.22,
+    "y": 184.56,
     "max_points": 10,
     "connections": [],
     "stats": [
@@ -15344,7 +15356,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-965"
   },
   {
     "id": "sn_94",
@@ -15356,8 +15368,8 @@
     "name": "Blinding Light",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -299.09998,
+    "y": -3.0517578e-05,
     "max_points": 7,
     "connections": [],
     "stats": [
@@ -15379,7 +15391,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-13"
   },
   {
     "id": "sn_78",
@@ -15391,8 +15403,8 @@
     "name": "Holy Nova",
     "description": "{Holy Symbol} also heals allies in an area around you.",
     "node_type": "notable",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -181.98001,
+    "y": -184.56003,
     "max_points": 1,
     "connections": [
       "sn_76"
@@ -15404,7 +15416,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-501"
   },
   {
     "id": "sn_83",
@@ -15416,8 +15428,8 @@
     "name": "Holy Icon",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -181.98001,
+    "y": -92.28003,
     "max_points": 7,
     "connections": [],
     "stats": [
@@ -15439,7 +15451,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-255"
   },
   {
     "id": "sn_80",
@@ -15451,8 +15463,8 @@
     "name": "Shared Divinity",
     "description": "{Divine Bolt} deals more damage.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -181.98001,
+    "y": 92.28,
     "max_points": 6,
     "connections": [
       "sn_74"
@@ -15468,7 +15480,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-752"
   },
   {
     "id": "sn_73",
@@ -15480,8 +15492,8 @@
     "name": "Rahyeh's Strength",
     "description": "You have additional strength, and you have a chance to shred enemy fire resistance scaling with your Strength.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -181.98001,
+    "y": 184.56,
     "max_points": 8,
     "connections": [
       "sn_84"
@@ -15497,7 +15509,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-246"
   },
   {
     "id": "sn_70",
@@ -15509,8 +15521,8 @@
     "name": "Dedication",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 52.26001,
+    "y": -184.56003,
     "max_points": 10,
     "connections": [],
     "stats": [
@@ -15528,7 +15540,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1246"
   },
   {
     "id": "sn_82",
@@ -15540,8 +15552,8 @@
     "name": "Piety",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -64.859985,
+    "y": -3.0517578e-05,
     "max_points": 6,
     "connections": [],
     "stats": [
@@ -15559,7 +15571,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-472"
   },
   {
     "id": "sn_75",
@@ -15571,8 +15583,8 @@
     "name": "Force of Devotion",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -64.859985,
+    "y": 184.56,
     "max_points": 6,
     "connections": [],
     "stats": [
@@ -15590,7 +15602,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-423"
   },
   {
     "id": "sn_97",
@@ -15602,8 +15614,8 @@
     "name": "Alignment",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -64.859985,
+    "y": -184.56003,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -15617,7 +15629,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-712"
   },
   {
     "id": "sn_104",
@@ -15629,8 +15641,8 @@
     "name": "Faith Armour",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 52.26001,
+    "y": -3.0517578e-05,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -15648,7 +15660,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1122"
   },
   {
     "id": "sn_90",
@@ -15660,8 +15672,8 @@
     "name": "Sanctuary Guardian",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 52.26001,
+    "y": 184.56,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -15679,7 +15691,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-245"
   },
   {
     "id": "sn_81",
@@ -15691,8 +15703,8 @@
     "name": "Penance",
     "description": "Your melee and throwing attacks have a chance to cause enemies to bleed, but you have a chance to inflict bleed when an enemy hits you with a melee attack.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 169.38,
+    "y": -184.56003,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -15714,7 +15726,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-10"
   },
   {
     "id": "sn_86",
@@ -15726,8 +15738,8 @@
     "name": "Holy Precision",
     "description": "You have an increased chance to critically strike and additional critical strike multiplier.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 169.38,
+    "y": -92.28003,
     "max_points": 10,
     "connections": [],
     "stats": [
@@ -15745,7 +15757,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-29"
   },
   {
     "id": "sn_89",
@@ -15757,8 +15769,8 @@
     "name": "Shield Wall",
     "description": "You have a higher chance to block, you regain heath on block and stuns on you last a shorter duration, but you have a lower chance to dodge.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 169.38,
+    "y": 92.28,
     "max_points": 4,
     "connections": [
       "sn_90"
@@ -15782,7 +15794,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-952"
   },
   {
     "id": "sn_96",
@@ -15794,8 +15806,8 @@
     "name": "Divine Essence",
     "description": "You have a chance to be granted a {Divine Essence} each second while at high health (above 65% of max health).\n\nDivine Essences last 10 seconds and grant 15% increased armor and healing effectiveness. They also reduce damage over time you take by 5%.\n\nYou can have a maximum of 3 Divine Essences at once.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 403.62,
+    "y": -92.28003,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -15809,7 +15821,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-557"
   },
   {
     "id": "sn_91",
@@ -15821,8 +15833,8 @@
     "name": "Prayer Aegis",
     "description": "You have additional health and endurance threshold.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 286.50006,
+    "y": -3.0517578e-05,
     "max_points": 8,
     "connections": [
       "sn_104"
@@ -15846,7 +15858,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-556"
   },
   {
     "id": "sn_88",
@@ -15858,8 +15870,8 @@
     "name": "Righteous Firebrand",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 286.50006,
+    "y": 184.56,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -15873,7 +15885,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-232"
   },
   {
     "id": "sn_87",
@@ -15885,8 +15897,8 @@
     "name": "Redemption",
     "description": "Bleed you inflict penetrates physical resistance, and you have a chance to be granted increased damage over time if you have received a stack of bleeding from {Penance} recently (last 4 seconds).",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 403.62,
+    "y": -184.56003,
     "max_points": 7,
     "connections": [
       "sn_81"
@@ -15906,7 +15918,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-317"
   },
   {
     "id": "sn_98",
@@ -15918,8 +15930,8 @@
     "name": "Reverence of Duality",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 403.62,
+    "y": 92.28,
     "max_points": 12,
     "connections": [],
     "stats": [
@@ -15941,7 +15953,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-558"
   },
   {
     "id": "sn_95",
@@ -15953,8 +15965,8 @@
     "name": "Covenant of Protection",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 520.74,
+    "y": -92.28003,
     "max_points": 7,
     "connections": [
       "sn_119"
@@ -15974,7 +15986,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1163"
   },
   {
     "id": "sn_93",
@@ -15986,8 +15998,8 @@
     "name": "Covenant of Dominion",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 520.74,
+    "y": 92.28,
     "max_points": 7,
     "connections": [
       "sn_119"
@@ -16015,7 +16027,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-494"
   },
   {
     "id": "sn_92",
@@ -16027,8 +16039,8 @@
     "name": "Sword of Rahyeh",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 520.74,
+    "y": 184.56,
     "max_points": 7,
     "connections": [
       "sn_88"
@@ -16044,7 +16056,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-74"
   },
   {
     "id": "sn_17",
@@ -16056,8 +16068,8 @@
     "name": "Renouncement",
     "description": "You have increased cast speed and you have a chance to cast a {Void Beam} at the target when you directly cast {Smite}. \n\nThis effect can occur up to 2 times per 2 seconds.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 52.26001,
+    "y": 184.56,
     "max_points": 8,
     "connections": [
       "sn_0",
@@ -16084,7 +16096,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-8"
   },
   {
     "id": "sn_114",
@@ -16096,8 +16108,8 @@
     "name": "Heaven's Bulwark",
     "description": "You have additional spell damage while you have a shield equipped.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": -299.09998,
+    "y": -92.28003,
     "max_points": 10,
     "connections": [
       "sn_72"
@@ -16113,7 +16125,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-559"
   },
   {
     "id": "sn_116",
@@ -16125,8 +16137,8 @@
     "name": "Mortal Cleave",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 520.74,
+    "y": -92.28003,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -16144,7 +16156,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1125"
   },
   {
     "id": "sn_118",
@@ -16156,8 +16168,8 @@
     "name": "Judgement of the Storm",
     "description": "",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 286.50006,
+    "y": -92.28003,
     "max_points": 8,
     "connections": [],
     "stats": [
@@ -16179,7 +16191,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-76"
   },
   {
     "id": "sn_119",
@@ -16191,8 +16203,8 @@
     "name": "Covenant of Light",
     "description": "Holy Aura and Symbols of Hope have increased effect of their passive benefits.",
     "node_type": "core",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 403.62,
+    "y": -3.0517578e-05,
     "max_points": 5,
     "connections": [],
     "stats": [
@@ -16202,7 +16214,7 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-121"
   },
   {
     "id": "sn_120",
@@ -16214,8 +16226,8 @@
     "name": "Forgemaster's Might",
     "description": "You can equip a shield alongside a two handed axe, mace, sword, or spear.\n\nWhile you have a two handed weapon and a shield equipped, you and your minions deal less damage and have less attack and cast speed, and Haste grants you block chance instead of increased movement speed.",
     "node_type": "notable",
-    "x": 0.0,
-    "y": 0.0,
+    "x": 520.74,
+    "y": 184.56,
     "max_points": 1,
     "connections": [],
     "stats": [
@@ -16237,6 +16249,167 @@
       }
     ],
     "ability_granted": null,
-    "icon": null
+    "icon": "a-r-1365"
+  },
+  {
+    "id": "ac_86",
+    "raw_node_id": 86,
+    "character_class": "Acolyte",
+    "mastery": "Warlock",
+    "mastery_index": 3,
+    "mastery_requirement": 5,
+    "name": "Cauldron of Blood",
+    "description": "",
+    "node_type": "core",
+    "x": -416.22,
+    "y": 92.28,
+    "max_points": 8,
+    "connections": [
+      "ac_53"
+    ],
+    "stats": [
+      {
+        "key": "Increased Chaos Damage",
+        "value": "+6%"
+      },
+      {
+        "key": "Chaos Bolt Frequency",
+        "value": "12s"
+      }
+    ],
+    "ability_granted": null,
+    "icon": "a-r-915"
+  },
+  {
+    "id": "ac_88",
+    "raw_node_id": 88,
+    "character_class": "Acolyte",
+    "mastery": "Warlock",
+    "mastery_index": 3,
+    "mastery_requirement": 10,
+    "name": "Vile Tide",
+    "description": "",
+    "node_type": "core",
+    "x": -299.09998,
+    "y": 92.28,
+    "max_points": 8,
+    "connections": [],
+    "stats": [
+      {
+        "key": "Increased Necrotic Damage",
+        "value": "+6%"
+      },
+      {
+        "key": "Ward Gained on Curse",
+        "value": "12s"
+      }
+    ],
+    "ability_granted": null,
+    "icon": "a-r-295"
+  },
+  {
+    "id": "ac_97",
+    "raw_node_id": 97,
+    "character_class": "Acolyte",
+    "mastery": "Warlock",
+    "mastery_index": 3,
+    "mastery_requirement": 25,
+    "name": "Infernal Lash",
+    "description": "",
+    "node_type": "core",
+    "x": 52.26001,
+    "y": -92.28003,
+    "max_points": 8,
+    "connections": [],
+    "stats": [
+      {
+        "key": "Increased Fire Damage",
+        "value": "+13%"
+      }
+    ],
+    "ability_granted": null,
+    "icon": "a-r-913"
+  },
+  {
+    "id": "ac_98",
+    "raw_node_id": 98,
+    "character_class": "Acolyte",
+    "mastery": "Warlock",
+    "mastery_index": 3,
+    "mastery_requirement": 25,
+    "name": "Chains of Ruin",
+    "description": "",
+    "node_type": "core",
+    "x": 52.26001,
+    "y": 92.28,
+    "max_points": 8,
+    "connections": [],
+    "stats": [
+      {
+        "key": "Increased Necrotic Damage",
+        "value": "+13%"
+      },
+      {
+        "key": "Armor",
+        "value": "12"
+      }
+    ],
+    "ability_granted": null,
+    "icon": "a-r-62"
+  },
+  {
+    "id": "ac_101",
+    "raw_node_id": 101,
+    "character_class": "Acolyte",
+    "mastery": "Warlock",
+    "mastery_index": 3,
+    "mastery_requirement": 30,
+    "name": "The Ashen One",
+    "description": "",
+    "node_type": "core",
+    "x": 169.38,
+    "y": -3.0517578e-05,
+    "max_points": 8,
+    "connections": [
+      "ac_97",
+      "ac_98"
+    ],
+    "stats": [
+      {
+        "key": "Fire Damage",
+        "value": "8%"
+      },
+      {
+        "key": "Necrotic Damage",
+        "value": "8%"
+      }
+    ],
+    "ability_granted": null,
+    "icon": "a-r-696"
+  },
+  {
+    "id": "ac_103",
+    "raw_node_id": 103,
+    "character_class": "Acolyte",
+    "mastery": "Warlock",
+    "mastery_index": 3,
+    "mastery_requirement": 35,
+    "name": "Scorched Reach",
+    "description": "",
+    "node_type": "core",
+    "x": 286.50006,
+    "y": -92.28003,
+    "max_points": 7,
+    "connections": [
+      "ac_97"
+    ],
+    "stats": [
+      {
+        "key": "Damage Over Time",
+        "value": "8%"
+      }
+    ],
+    "ability_granted": null,
+    "icon": "a-r-582"
   }
 ]

--- a/scripts/sync_game_data.py
+++ b/scripts/sync_game_data.py
@@ -355,8 +355,9 @@ def _build_layout_lookup() -> dict[str, dict[int, dict]]:
     def _flatten(obj: object, acc: dict[int, dict]) -> None:
         """Recursively walk any nested dict/list to collect nodeId entries."""
         if isinstance(obj, dict):
-            if "id" in obj and "rect" in obj:
-                acc[obj["id"]] = {
+            nid = obj.get("nodeId") or obj.get("id")
+            if nid is not None and "rect" in obj:
+                acc[nid] = {
                     "x": obj["rect"][0],
                     "y": obj["rect"][1],
                     "icon": obj.get("icon", ""),
@@ -411,6 +412,10 @@ def sync_passives(dry_run: bool = False) -> list[dict] | None:
         raw = json.load(f)
 
     nodes_out: list[dict] = []
+
+    # Build layout lookup for coordinates — fallback when source data
+    # lacks the transform field (common in 1.4.3+ exports).
+    layout_coords = _build_layout_lookup()
 
     for tree in raw.get("passiveTrees", []):
         cls = tree.get("class", "")
@@ -473,8 +478,20 @@ def sync_passives(dry_run: bool = False) -> list[dict] | None:
             x = transform.get("x", 0.0)
             y = transform.get("y", 0.0)
 
+            # Fallback to char-tree-layout.json when source lacks coordinates
+            if x == 0.0 and y == 0.0:
+                layout_node = layout_coords.get(cls, {}).get(raw_id)
+                if layout_node:
+                    x = layout_node.get("x", 0.0)
+                    y = layout_node.get("y", 0.0)
+
             raw_icon = node.get("icon")
             icon = str(raw_icon) if raw_icon is not None else None
+            # Fallback icon from layout
+            if not icon:
+                layout_node = layout_coords.get(cls, {}).get(raw_id)
+                if layout_node:
+                    icon = layout_node.get("icon") or None
 
             max_pts = node.get("maxPoints", 1)
             node_type = "core" if max_pts > 1 else "notable"


### PR DESCRIPTION
… fix field name mismatches

The 1.4.3 game data sync produced passives.json with all node coordinates set to (0, 0), causing empty passive trees in the UI. The source passive_trees.json export no longer includes transform data for node positions.

Fix:
- Patch all 541 node coordinates from char-tree-layout.json which has the authoritative game-space positions (rect[x, y, w, h])
- Add 6 missing Warlock nodes (86, 88, 97, 98, 101, 103) that were added in 1.4.3 but absent from the export
- Patch missing node connections from char-tree-metadata.json
- Fix sync_game_data.py _build_layout_lookup() to read "nodeId" field (was incorrectly looking for "id")
- Add layout coordinate fallback in sync_passives() so future syncs automatically pull positions from the layout file when the source data lacks transform fields