### PR TITLE
fix: strip URL fragments from Maxroll import URLs, fix URL parsing

### DIFF
--- a/backend/app/services/importers/maxroll_importer.py
+++ b/backend/app/services/importers/maxroll_importer.py
@@ -111,27 +111,46 @@ def _extract_next_data(html: str) -> Optional[dict]:
         return None
 
 
-def _unwrap_build_data(payload: dict) -> Optional[dict]:
+def _is_build_dict(d: dict) -> bool:
+    """Return True if *d* looks like a single-build payload."""
+    return bool(d.get("class") or d.get("className") or d.get("characterClass"))
+
+
+def _unwrap_build_data(payload: dict, variant: int = 0) -> Optional[dict]:
     """
     Unwrap the build data from various Maxroll response wrappers.
 
     Maxroll's API has used different envelope formats over time:
       {"data": {...build fields...}}
+      {"data": [{...build 0...}, {...build 1...}, ...]}
+      {"data": {"builds": [{...}, ...]}}
       {"build": {...build fields...}}
       {"plannerData": {...build fields...}}
       {...build fields directly...}
+
+    *variant* is the 0-based index from the URL hash fragment (e.g. #2 → 2).
     """
     # Direct build data (has class or className)
-    if payload.get("class") or payload.get("className") or payload.get("characterClass"):
+    if _is_build_dict(payload):
         return payload
 
     # Nested under a key
     for key in ("data", "build", "plannerData"):
         inner = payload.get(key)
-        if isinstance(inner, dict) and (
-            inner.get("class") or inner.get("className") or inner.get("characterClass")
-        ):
-            return inner
+        if isinstance(inner, dict):
+            # {"data": {"builds": [...]}}
+            builds_list = inner.get("builds")
+            if isinstance(builds_list, list) and builds_list:
+                idx = min(variant, len(builds_list) - 1)
+                if isinstance(builds_list[idx], dict):
+                    return builds_list[idx]
+            if _is_build_dict(inner):
+                return inner
+        # {"data": [{...build...}, ...]}
+        if isinstance(inner, list) and inner:
+            idx = min(variant, len(inner) - 1)
+            if isinstance(inner[idx], dict) and _is_build_dict(inner[idx]):
+                return inner[idx]
 
     return None
 
@@ -154,10 +173,16 @@ class MaxrollImporter(BaseImporter):
             )
 
         code = match.group(1)
-        # Strip hash fragment if present (e.g. #2)
-        code = code.split("#")[0]
 
-        build_data = self._fetch_build_data(code)
+        # Extract variant index from the URL hash fragment (e.g. #2 → variant 2).
+        # The regex already excludes '#' so it won't appear in *code*, but we
+        # still need to pull the fragment from the original URL.
+        variant = 0
+        frag_match = re.search(r"#(\d+)", url)
+        if frag_match:
+            variant = int(frag_match.group(1))
+
+        build_data = self._fetch_build_data(code, variant)
         if build_data is None:
             return ImportResult(
                 success=False,
@@ -170,7 +195,7 @@ class MaxrollImporter(BaseImporter):
 
         return self._map(build_data, code)
 
-    def _fetch_build_data(self, code: str) -> Optional[dict]:
+    def _fetch_build_data(self, code: str, variant: int = 0) -> Optional[dict]:
         """Try multiple strategies to get the build data."""
         headers = {
             "User-Agent": (
@@ -180,6 +205,8 @@ class MaxrollImporter(BaseImporter):
             ),
             "Accept": "application/json, text/html, */*",
             "Accept-Language": "en-US,en;q=0.9",
+            "Referer": "https://maxroll.gg/last-epoch/planner/",
+            "Origin": "https://maxroll.gg",
         }
 
         # Strategy 1: Try API endpoints
@@ -190,7 +217,7 @@ class MaxrollImporter(BaseImporter):
                 if resp.status_code == 200:
                     data = resp.json()
                     if isinstance(data, dict):
-                        unwrapped = _unwrap_build_data(data)
+                        unwrapped = _unwrap_build_data(data, variant)
                         if unwrapped:
                             logger.info("Maxroll: got build data from API %s", api_url)
                             return unwrapped
@@ -205,10 +232,18 @@ class MaxrollImporter(BaseImporter):
                 timeout=15,
             )
             if resp.status_code == 200:
-                build_data = _extract_next_data(resp.text)
-                if build_data:
-                    logger.info("Maxroll: extracted build from __NEXT_DATA__")
-                    return build_data
+                raw = _extract_next_data(resp.text)
+                if raw:
+                    # __NEXT_DATA__ may also wrap multi-variant builds
+                    if isinstance(raw, dict):
+                        unwrapped = _unwrap_build_data(raw, variant)
+                        if unwrapped:
+                            logger.info("Maxroll: extracted build from __NEXT_DATA__")
+                            return unwrapped
+                    # _extract_next_data already returned a valid build dict
+                    if _is_build_dict(raw):
+                        logger.info("Maxroll: extracted build from __NEXT_DATA__")
+                        return raw
         except Exception as exc:
             logger.warning("Maxroll: HTML fetch failed: %s", exc)
 

--- a/backend/tests/test_build_import.py
+++ b/backend/tests/test_build_import.py
@@ -1780,6 +1780,28 @@ class TestMaxrollURLParsing:
         m = URL_PATTERN.search("https://example.com/planner/abc123")
         assert m is None
 
+    def test_extracts_code_excludes_hash_fragment(self):
+        """Regex capture group excludes the # character entirely."""
+        from app.services.importers.maxroll_importer import URL_PATTERN
+        m = URL_PATTERN.search("https://maxroll.gg/last-epoch/planner/29StdI0o#2")
+        assert m is not None
+        assert m.group(1) == "29StdI0o"
+
+    def test_variant_extraction_from_url(self):
+        """parse() correctly extracts variant index from URL hash fragment."""
+        import re
+        url = "https://maxroll.gg/last-epoch/planner/29StdI0o#2"
+        frag_match = re.search(r"#(\d+)", url)
+        assert frag_match is not None
+        assert int(frag_match.group(1)) == 2
+
+    def test_no_variant_defaults_to_zero(self):
+        """URL without hash fragment means variant 0."""
+        import re
+        url = "https://maxroll.gg/last-epoch/planner/29StdI0o"
+        frag_match = re.search(r"#(\d+)", url)
+        assert frag_match is None
+
     def test_no_match_for_wrong_game(self):
         from app.services.importers.maxroll_importer import URL_PATTERN
         m = URL_PATTERN.search("https://maxroll.gg/diablo-4/planner/abc123")
@@ -2152,6 +2174,34 @@ class TestMaxrollUnwrapBuildData:
         payload = {"className": "Acolyte"}
         assert _unwrap_build_data(payload) is payload
 
+    def test_unwrap_data_list_default_variant(self):
+        from app.services.importers.maxroll_importer import _unwrap_build_data
+        b0 = {"class": "Mage", "level": 80}
+        b1 = {"class": "Rogue", "level": 90}
+        payload = {"data": [b0, b1]}
+        assert _unwrap_build_data(payload) is b0
+
+    def test_unwrap_data_list_selects_variant(self):
+        from app.services.importers.maxroll_importer import _unwrap_build_data
+        b0 = {"class": "Mage", "level": 80}
+        b1 = {"class": "Rogue", "level": 90}
+        b2 = {"class": "Sentinel", "level": 100}
+        payload = {"data": [b0, b1, b2]}
+        assert _unwrap_build_data(payload, variant=2) is b2
+
+    def test_unwrap_data_list_clamps_out_of_range(self):
+        from app.services.importers.maxroll_importer import _unwrap_build_data
+        b0 = {"class": "Mage", "level": 80}
+        payload = {"data": [b0]}
+        assert _unwrap_build_data(payload, variant=5) is b0
+
+    def test_unwrap_builds_subkey_selects_variant(self):
+        from app.services.importers.maxroll_importer import _unwrap_build_data
+        b0 = {"class": "Primalist", "level": 70}
+        b1 = {"class": "Acolyte", "level": 85}
+        payload = {"data": {"builds": [b0, b1]}}
+        assert _unwrap_build_data(payload, variant=1) is b1
+
 
 class TestMaxrollPartialImport:
     """Partial imports handle missing data gracefully and populate partial_data."""
@@ -2396,6 +2446,59 @@ class TestMaxrollFullParseFlow:
         assert result.success is True
         assert result.build_data["character_class"] == "Rogue"
         assert result.build_data["mastery"] == "Falconer"
+
+    @patch("app.services.importers.maxroll_importer._requests.get")
+    def test_parse_with_hash_variant_selects_correct_build(self, mock_get):
+        """URL #2 selects the third build from a multi-variant planner."""
+        api_data = {
+            "data": [
+                {"class": "Mage", "mastery": "Sorcerer", "level": 80,
+                 "passives": {}, "skills": [], "equipment": []},
+                {"class": "Rogue", "mastery": "Bladedancer", "level": 85,
+                 "passives": {}, "skills": [], "equipment": []},
+                {"class": "Sentinel", "mastery": "Paladin", "level": 90,
+                 "passives": {}, "skills": [], "equipment": []},
+            ]
+        }
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = api_data
+        mock_get.return_value = mock_resp
+
+        from app.services.importers import MaxrollImporter
+        result = MaxrollImporter().parse(
+            "https://maxroll.gg/last-epoch/planner/29StdI0o#2"
+        )
+
+        assert result.success is True
+        assert result.build_data["character_class"] == "Sentinel"
+        assert result.build_data["mastery"] == "Paladin"
+        assert result.build_data["level"] == 90
+
+    @patch("app.services.importers.maxroll_importer._requests.get")
+    def test_parse_without_hash_selects_first_build(self, mock_get):
+        """URL without hash fragment selects the first build (variant 0)."""
+        api_data = {
+            "data": [
+                {"class": "Acolyte", "mastery": "Lich", "level": 75,
+                 "passives": {}, "skills": [], "equipment": []},
+                {"class": "Primalist", "mastery": "Druid", "level": 95,
+                 "passives": {}, "skills": [], "equipment": []},
+            ]
+        }
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = api_data
+        mock_get.return_value = mock_resp
+
+        from app.services.importers import MaxrollImporter
+        result = MaxrollImporter().parse(
+            "https://maxroll.gg/last-epoch/planner/29StdI0o"
+        )
+
+        assert result.success is True
+        assert result.build_data["character_class"] == "Acolyte"
+        assert result.build_data["mastery"] == "Lich"
 
     @patch("app.services.importers.maxroll_importer._requests.get")
     def test_all_fetch_strategies_fail_returns_error(self, mock_get):


### PR DESCRIPTION
The Maxroll import failed for URLs like /planner/29StdI0o#2 because the #N fragment was being discarded entirely. That fragment selects a specific build variant from multi-variant planners, and the importer didn't handle array-wrapped responses.

Changes:
  - parse() now extracts the variant index from the URL hash fragment and threads it through _fetch_build_data -> _unwrap_build_data
  - _unwrap_build_data() accepts a variant index and handles three new response shapes: {"data": [build0, build1, ...]} {"data": {"builds": [build0, build1, ...]}} Falls back to clamped index when variant is out of range.
  - HTML __NEXT_DATA__ fallback also unwraps with variant awareness
  - Added Referer/Origin headers so the API treats requests as legitimate
  - Added tests for fragment-based variant selection and multi-build unwrapping