### PR TITLE
fix: resolve Maxroll mastery-as-class and harden frontend against bad…

### DIFF
--- a/backend/app/services/importers/maxroll_importer.py
+++ b/backend/app/services/importers/maxroll_importer.py
@@ -45,6 +45,16 @@ _MASTERY_MAP: Dict[str, Dict[int, str]] = {
     "Rogue":     {1: "Bladedancer", 2: "Marksman",    3: "Falconer"},
 }
 
+# Reverse lookup: mastery name → base class.
+# Maxroll sometimes stores the mastery name in the `class` field (the
+# current Maxroll planner treats "Bladedancer" etc. as the character's
+# class). We detect this and resolve the real base class.
+_MASTERY_TO_CLASS: Dict[str, str] = {
+    mastery: base
+    for base, masteries in _MASTERY_MAP.items()
+    for mastery in masteries.values()
+}
+
 # Canonical gear slot names (Maxroll may use various formats)
 _SLOT_NORMALISE: Dict[str, str] = {
     "helm": "Helmet",
@@ -326,6 +336,22 @@ class MaxrollImporter(BaseImporter):
             char_class = raw.get("characterClass")
         if isinstance(char_class, int):
             char_class = _CLASS_MAP.get(char_class)
+
+        # Mastery resolution — 0 is not a valid mastery ID so `or` is safe here
+        mastery = raw.get("mastery") or raw.get("masteryName") or ""
+        if isinstance(mastery, int):
+            mastery = _MASTERY_MAP.get(char_class, {}).get(mastery, "")
+
+        # Maxroll frequently stores the mastery name in the `class` field
+        # (e.g. "Bladedancer" instead of "Rogue"). If what we parsed as the
+        # class is actually a known mastery, swap them into the correct slots.
+        if char_class in _MASTERY_TO_CLASS:
+            # If no mastery was set, use the value as the mastery; otherwise
+            # keep the explicit mastery and just correct the base class.
+            if not mastery:
+                mastery = char_class
+            char_class = _MASTERY_TO_CLASS[char_class]
+
         if not char_class:
             return ImportResult(
                 success=False,
@@ -335,10 +361,6 @@ class MaxrollImporter(BaseImporter):
                 build_data={"_raw_keys": list(raw.keys())},
             )
 
-        # Mastery resolution — 0 is not a valid mastery ID so `or` is safe here
-        mastery = raw.get("mastery") or raw.get("masteryName") or ""
-        if isinstance(mastery, int):
-            mastery = _MASTERY_MAP.get(char_class, {}).get(mastery, "")
         if not mastery:
             missing_fields.append("mastery")
 

--- a/backend/tests/test_build_import.py
+++ b/backend/tests/test_build_import.py
@@ -1867,6 +1867,69 @@ class TestMaxrollClassMasteryImport:
         assert result.build_data["character_class"] == "Rogue"
         assert result.build_data["mastery"] == "Falconer"
 
+    def test_mastery_name_in_class_field_resolves_to_base_class(self):
+        """Maxroll stores mastery names (e.g. 'Bladedancer') in the class
+        field. The importer must resolve the real base class and move the
+        mastery name to the mastery slot."""
+        from app.services.importers.maxroll_importer import MaxrollImporter
+        importer = MaxrollImporter()
+        result = importer._map({
+            "class": "Bladedancer",  # actually a Rogue mastery
+            "level": 80,
+            "passives": {},
+            "skills": [],
+        }, "test_bd")
+        assert result.success is True
+        assert result.build_data["character_class"] == "Rogue"
+        assert result.build_data["mastery"] == "Bladedancer"
+
+    def test_mastery_name_in_class_with_explicit_mastery(self):
+        """If `class` is a mastery AND `mastery` is explicit, correct the
+        base class but keep the explicit mastery."""
+        from app.services.importers.maxroll_importer import MaxrollImporter
+        importer = MaxrollImporter()
+        result = importer._map({
+            "class": "Sorcerer",   # Mage mastery
+            "mastery": "Spellblade",  # explicit, takes precedence
+            "level": 80,
+            "passives": {},
+            "skills": [],
+        }, "test_sb")
+        assert result.success is True
+        assert result.build_data["character_class"] == "Mage"
+        assert result.build_data["mastery"] == "Spellblade"
+
+    def test_all_masteries_resolve_to_base_class(self):
+        """Every mastery name in the class field must resolve to its base class."""
+        from app.services.importers.maxroll_importer import MaxrollImporter
+        importer = MaxrollImporter()
+        cases = [
+            ("Beastmaster", "Primalist"),
+            ("Shaman", "Primalist"),
+            ("Druid", "Primalist"),
+            ("Sorcerer", "Mage"),
+            ("Spellblade", "Mage"),
+            ("Runemaster", "Mage"),
+            ("Void Knight", "Sentinel"),
+            ("Forge Guard", "Sentinel"),
+            ("Paladin", "Sentinel"),
+            ("Necromancer", "Acolyte"),
+            ("Lich", "Acolyte"),
+            ("Warlock", "Acolyte"),
+            ("Bladedancer", "Rogue"),
+            ("Marksman", "Rogue"),
+            ("Falconer", "Rogue"),
+        ]
+        for mastery, expected_class in cases:
+            result = importer._map({
+                "class": mastery, "level": 80,
+                "passives": {}, "skills": [],
+            }, "test")
+            assert result.build_data["character_class"] == expected_class, (
+                f"{mastery} should resolve to {expected_class}"
+            )
+            assert result.build_data["mastery"] == mastery
+
     def test_characterClass_field_accepted(self):
         from app.services.importers.maxroll_importer import MaxrollImporter
         importer = MaxrollImporter()

--- a/frontend/src/components/features/build/BuildPlannerPage.tsx
+++ b/frontend/src/components/features/build/BuildPlannerPage.tsx
@@ -306,7 +306,10 @@ function BuildSummary({ build }: { build: Build }) {
   }
 
   const availableSkills = useMemo(
-    () => CLASS_SKILLS[characterClass].filter((s) => !s.mastery || s.mastery === mastery),
+    () =>
+      (CLASS_SKILLS[characterClass] ?? []).filter(
+        (s) => !s.mastery || s.mastery === mastery,
+      ),
     [characterClass, mastery],
   );
   const selectedNames = new Set(draftSkills.map((s) => s.skill_name));
@@ -921,7 +924,7 @@ export default function BuildPlannerPage() {
 
   // Skills available for the selected class, filtered to base + chosen mastery
   const availableSkills = useMemo(() =>
-    CLASS_SKILLS[characterClass].filter(
+    (CLASS_SKILLS[characterClass] ?? []).filter(
       (s) => !s.mastery || s.mastery === mastery
     ),
     [characterClass, mastery]
@@ -940,7 +943,7 @@ export default function BuildPlannerPage() {
     // Drop skills that belong to a different mastery
     setDraftSkills((prev) =>
       prev.filter((ds) => {
-        const def = CLASS_SKILLS[characterClass].find((s) => s.name === ds.skill_name);
+        const def = (CLASS_SKILLS[characterClass] ?? []).find((s) => s.name === ds.skill_name);
         return !def?.mastery || def.mastery === next;
       })
     );


### PR DESCRIPTION
… class

The Maxroll fetch is working now (diagnostic commit confirmed), but the build was being created with character_class="Bladedancer" because Maxroll's planner data stores the mastery name in the `class` field. That crashed the frontend at CLASS_SKILLS[characterClass].filter(...) with "Cannot read properties of undefined (reading 'filter')".

Fixes:
  - Build a reverse _MASTERY_TO_CLASS lookup from the existing mastery map
  - In MaxrollImporter._map(), if the parsed `class` matches a known mastery name, resolve the real base class and move the value into the mastery slot. Preserves an explicit `mastery` field when present.
  - Harden three CLASS_SKILLS[characterClass] lookups in BuildPlannerPage with `?? []` so an unrecognized class can never take down the whole planner UI.

Tests:
  - test_mastery_name_in_class_field_resolves_to_base_class covers the reported Bladedancer case
  - test_mastery_name_in_class_with_explicit_mastery covers the case where both fields are set
  - test_all_masteries_resolve_to_base_class is a parametrised smoke test covering every mastery in the game