### PR TITLE
fix: expand Maxroll field names, flag empty passives/skills, capture …

### DIFF
--- a/backend/app/services/importers/maxroll_importer.py
+++ b/backend/app/services/importers/maxroll_importer.py
@@ -366,8 +366,16 @@ class MaxrollImporter(BaseImporter):
 
         level = int(raw.get("level", 70))
 
-        # Passive tree
-        passives_raw = raw.get("passives") or raw.get("charTree", {}).get("selected", {})
+        # Passive tree — try several candidate keys. Maxroll's planner has
+        # used different names over time; newer exports put them under
+        # `passiveTree`, `tree`, or `passiveNodes` rather than `passives`.
+        passives_raw = (
+            raw.get("passives")
+            or raw.get("passiveTree")
+            or raw.get("passiveNodes")
+            or raw.get("tree")
+            or raw.get("charTree", {}).get("selected", {})
+        )
         passive_tree: List[int] = []
         if isinstance(passives_raw, dict):
             for node_id_str, pts in passives_raw.items():
@@ -379,24 +387,59 @@ class MaxrollImporter(BaseImporter):
             # Some formats use a flat list
             for item in passives_raw:
                 if isinstance(item, dict):
-                    nid = item.get("id") or item.get("nodeId")
-                    pts = item.get("points", 1)
+                    nid = item.get("id") or item.get("nodeId") or item.get("node")
+                    pts = item.get("points") or item.get("pts") or item.get("rank") or 1
                     if nid is not None:
                         try:
                             passive_tree.extend([int(nid)] * max(0, int(pts)))
                         except (ValueError, TypeError):
                             missing_fields.append(f"passive_node:{nid}")
+                elif isinstance(item, (int, str)):
+                    # List of bare node IDs
+                    try:
+                        passive_tree.append(int(item))
+                    except (ValueError, TypeError):
+                        missing_fields.append(f"passive_node:{item}")
 
-        # Skills
-        skills_raw = raw.get("skills") or raw.get("skillTrees") or []
+        # Skills — try several candidate keys
+        skills_raw = (
+            raw.get("skills")
+            or raw.get("skillTrees")
+            or raw.get("abilities")
+            or raw.get("abilityTree")
+            or raw.get("skillSpecializations")
+            or []
+        )
         skills: List[dict] = []
-        for idx, sk in enumerate(skills_raw):
+        if isinstance(skills_raw, list):
+            iterable = enumerate(skills_raw)
+        elif isinstance(skills_raw, dict):
+            # Some formats use {slot: skill_data, ...}
+            iterable = enumerate(skills_raw.values())
+        else:
+            iterable = enumerate([])
+
+        for idx, sk in iterable:
             if isinstance(sk, dict):
-                skill_name = sk.get("name") or sk.get("skill_name") or sk.get("id", "")
+                skill_name = (
+                    sk.get("name")
+                    or sk.get("skill_name")
+                    or sk.get("skillName")
+                    or sk.get("ability")
+                    or sk.get("id", "")
+                )
                 slot = sk.get("slot", idx)
 
-                # Node allocations
-                nodes = sk.get("nodes") or sk.get("selected") or {}
+                # Node allocations — check many candidate keys
+                nodes = (
+                    sk.get("nodes")
+                    or sk.get("selected")
+                    or sk.get("tree")
+                    or sk.get("specTree")
+                    or sk.get("spec_tree")
+                    or sk.get("allocations")
+                    or {}
+                )
                 spec_tree: List[int] = []
                 if isinstance(nodes, dict):
                     for node_id_str, pts in nodes.items():
@@ -404,15 +447,54 @@ class MaxrollImporter(BaseImporter):
                             spec_tree.extend([int(node_id_str)] * max(0, int(pts)))
                         except (ValueError, TypeError):
                             missing_fields.append(f"skill_node:{skill_name}:{node_id_str}")
+                elif isinstance(nodes, list):
+                    for n in nodes:
+                        if isinstance(n, dict):
+                            nid = n.get("id") or n.get("nodeId") or n.get("node")
+                            pts = n.get("points") or n.get("pts") or n.get("rank") or 1
+                            if nid is not None:
+                                try:
+                                    spec_tree.extend([int(nid)] * max(0, int(pts)))
+                                except (ValueError, TypeError):
+                                    missing_fields.append(f"skill_node:{skill_name}:{nid}")
+                        elif isinstance(n, (int, str)):
+                            try:
+                                spec_tree.append(int(n))
+                            except (ValueError, TypeError):
+                                missing_fields.append(f"skill_node:{skill_name}:{n}")
 
                 skills.append({
                     "skill_name": skill_name,
                     "slot": slot,
-                    "points_allocated": int(sk.get("level", 0)),
+                    "points_allocated": int(
+                        sk.get("level") or sk.get("points") or sk.get("points_allocated") or 0
+                    ),
                     "spec_tree": spec_tree,
                 })
 
         skills.sort(key=lambda s: s["slot"])
+
+        # Diagnostic — log raw structure when the mapper produced nothing.
+        # This is critical for debugging unknown Maxroll data formats since
+        # the main payload is not captured anywhere else.
+        if not passive_tree and not skills:
+            logger.warning(
+                "Maxroll: mapper produced no passives/skills for code=%s. "
+                "raw top-level keys=%s; sample values=%s",
+                code,
+                list(raw.keys()),
+                {k: type(v).__name__ for k, v in list(raw.items())[:20]},
+            )
+        elif not passive_tree:
+            logger.warning(
+                "Maxroll: no passives mapped for code=%s. raw keys=%s",
+                code, list(raw.keys()),
+            )
+        elif not skills:
+            logger.warning(
+                "Maxroll: no skills mapped for code=%s. raw keys=%s",
+                code, list(raw.keys()),
+            )
 
         # Gear (best-effort mapping)
         gear_raw = raw.get("equipment") or raw.get("gear") or raw.get("items") or []
@@ -480,6 +562,14 @@ class MaxrollImporter(BaseImporter):
                     else:
                         missing_fields.append(f"gear_slot:{slot}")
 
+        # Flag empty passives/skills so the partial import alert captures them.
+        # Without this, a build with 0 passives+skills looks "successful" and
+        # the failure is only visible in the UI.
+        if not passive_tree:
+            missing_fields.append("passives:empty")
+        if not skills:
+            missing_fields.append("skills:empty")
+
         build_data = {
             "name": f"Imported — {char_class} {mastery}".strip(),
             "description": (
@@ -508,6 +598,8 @@ class MaxrollImporter(BaseImporter):
                 "passives_count": len(passive_tree),
                 "gear_count": len(gear),
                 "missing_count": len(missing_fields),
+                # Raw top-level keys — critical for debugging unknown formats
+                "raw_keys": list(raw.keys()),
             } if missing_fields else None,
         )
         return self.validate(result)

--- a/backend/tests/test_build_import.py
+++ b/backend/tests/test_build_import.py
@@ -2065,6 +2065,71 @@ class TestMaxrollSkillsImport:
         assert result.success is True
         assert result.build_data["skills"] == []
 
+    def test_skills_from_abilities_key(self):
+        """Maxroll may use 'abilities' instead of 'skills' as the top-level key."""
+        from app.services.importers.maxroll_importer import MaxrollImporter
+        importer = MaxrollImporter()
+        result = importer._map({
+            "class": "Rogue",
+            "mastery": "Bladedancer",
+            "level": 70,
+            "passives": {"1": 1},
+            "abilities": [
+                {"name": "Shift", "slot": 0, "level": 20, "nodes": {"1": 3}},
+            ],
+        }, "skills_abil")
+        assert result.success is True
+        skills = result.build_data["skills"]
+        assert len(skills) == 1
+        assert skills[0]["skill_name"] == "Shift"
+        assert skills[0]["points_allocated"] == 20
+
+    def test_skills_from_skillName_field(self):
+        """Some formats use skillName instead of name."""
+        from app.services.importers.maxroll_importer import MaxrollImporter
+        importer = MaxrollImporter()
+        result = importer._map({
+            "class": "Mage",
+            "mastery": "Sorcerer",
+            "level": 80,
+            "passives": {"1": 1},
+            "skills": [
+                {"skillName": "Fireball", "slot": 0, "points": 20, "tree": {"5": 2}},
+            ],
+        }, "skills_name")
+        assert result.success is True
+        skills = result.build_data["skills"]
+        assert len(skills) == 1
+        assert skills[0]["skill_name"] == "Fireball"
+        assert skills[0]["points_allocated"] == 20
+        assert len(skills[0]["spec_tree"]) == 2
+
+    def test_skills_with_list_of_nodes(self):
+        """Skill nodes may be a list of {id, points} instead of a dict."""
+        from app.services.importers.maxroll_importer import MaxrollImporter
+        importer = MaxrollImporter()
+        result = importer._map({
+            "class": "Sentinel",
+            "mastery": "Paladin",
+            "level": 80,
+            "passives": {"1": 1},
+            "skills": [
+                {
+                    "name": "Rive",
+                    "slot": 0,
+                    "level": 20,
+                    "nodes": [
+                        {"id": 1, "points": 3},
+                        {"nodeId": 2, "points": 2},
+                        {"node": 3, "points": 1},
+                    ],
+                },
+            ],
+        }, "skills_list")
+        assert result.success is True
+        skills = result.build_data["skills"]
+        assert len(skills[0]["spec_tree"]) == 6  # 3+2+1
+
 
 class TestMaxrollPassivesImport:
     """Passive tree import from dict and list formats."""
@@ -2118,6 +2183,89 @@ class TestMaxrollPassivesImport:
         assert result.success is True
         pt = result.build_data["passive_tree"]
         assert len(pt) == 6  # 4+2
+
+    def test_passives_from_passiveTree_key(self):
+        """Maxroll may use 'passiveTree' instead of 'passives'."""
+        from app.services.importers.maxroll_importer import MaxrollImporter
+        importer = MaxrollImporter()
+        result = importer._map({
+            "class": "Mage",
+            "mastery": "Sorcerer",
+            "level": 80,
+            "passiveTree": {"1": 3, "2": 5},
+            "skills": [{"name": "X", "slot": 0, "level": 1, "nodes": {}}],
+        }, "pt_alt")
+        assert result.success is True
+        assert len(result.build_data["passive_tree"]) == 8
+
+    def test_passives_from_bare_id_list(self):
+        """Passives may be encoded as a flat list of node IDs."""
+        from app.services.importers.maxroll_importer import MaxrollImporter
+        importer = MaxrollImporter()
+        result = importer._map({
+            "class": "Acolyte",
+            "mastery": "Lich",
+            "level": 75,
+            "passiveNodes": [10, 10, 20, 30, 30, 30],
+            "skills": [{"name": "X", "slot": 0, "level": 1, "nodes": {}}],
+        }, "pt_bare")
+        assert result.success is True
+        pt = result.build_data["passive_tree"]
+        assert pt.count(10) == 2
+        assert pt.count(20) == 1
+        assert pt.count(30) == 3
+
+
+class TestMaxrollMissingDataDiagnostics:
+    """Empty passives/skills should be flagged so partial-import alerts fire."""
+
+    def test_empty_passives_flagged_as_missing(self):
+        from app.services.importers.maxroll_importer import MaxrollImporter
+        importer = MaxrollImporter()
+        result = importer._map({
+            "class": "Mage",
+            "mastery": "Sorcerer",
+            "level": 80,
+            "passives": {},
+            "skills": [{"name": "X", "slot": 0, "level": 1, "nodes": {}}],
+        }, "empty_pt")
+        assert result.success is True
+        assert "passives:empty" in result.missing_fields
+
+    def test_empty_skills_flagged_as_missing(self):
+        from app.services.importers.maxroll_importer import MaxrollImporter
+        importer = MaxrollImporter()
+        result = importer._map({
+            "class": "Mage",
+            "mastery": "Sorcerer",
+            "level": 80,
+            "passives": {"1": 3},
+            "skills": [],
+        }, "empty_sk")
+        assert result.success is True
+        assert "skills:empty" in result.missing_fields
+
+    def test_partial_data_includes_raw_keys_for_debugging(self):
+        """partial_data must include raw top-level keys so Discord alerts
+        can be used to diagnose unknown Maxroll data shapes."""
+        from app.services.importers.maxroll_importer import MaxrollImporter
+        importer = MaxrollImporter()
+        result = importer._map({
+            "class": "Mage",
+            "mastery": "Sorcerer",
+            "level": 80,
+            "passives": {},
+            "skills": [],
+            # simulate unknown field names Maxroll might actually be using
+            "someUnknownField": "xyz",
+            "anotherField": 42,
+        }, "unknown_shape")
+        assert result.success is True
+        assert result.partial_data is not None
+        assert "raw_keys" in result.partial_data
+        raw_keys = result.partial_data["raw_keys"]
+        assert "someUnknownField" in raw_keys
+        assert "anotherField" in raw_keys
 
 
 class TestMaxrollGearSlotNormalisation:


### PR DESCRIPTION
…raw keys

After the class/mastery fix, the import correctly identified the class as Rogue Bladedancer but imported 0 passives and 0 skills. The raw Maxroll data uses field names we weren't checking.

Changes:
  - Passives: now try passives, passiveTree, passiveNodes, tree, and charTree.selected. Accept flat lists of bare node IDs in addition to the existing dict and {id, points} formats.
  - Skills: now try skills, skillTrees, abilities, abilityTree, and skillSpecializations. Accept list-of-nodes inside each skill (not just dict). Accept skillName/ability as alternatives to name. Accept points/points_allocated as alternatives to level. Accept specTree, spec_tree, allocations as alternatives to nodes.
  - Flag passives:empty and skills:empty in missing_fields so the partial-import Discord alert fires — previously, builds with 0 passives/skills were silently "successful" and the failure was only visible in the UI.
  - Include raw top-level keys in partial_data so the Discord alert shows what fields Maxroll is actually using, making the next unknown-shape diagnosable without server log access.
  - Log a warning with the raw structure when the mapper produces no passives/skills — the key diagnostic for tracking down format drift.

Tests:
  - test_skills_from_abilities_key, test_skills_from_skillName_field, test_skills_with_list_of_nodes — alternate skill shapes
  - test_passives_from_passiveTree_key, test_passives_from_bare_id_list — alternate passive shapes
  - TestMaxrollMissingDataDiagnostics — covers the empty-flag behaviour and raw_keys capture