### PR TITLE
fix: surface raw_keys in Discord import alert for format debugging

### DIFF
--- a/backend/app/services/discord_notifier.py
+++ b/backend/app/services/discord_notifier.py
@@ -142,6 +142,18 @@ def _post_alert(failure: dict, severity: str) -> None:
             "inline": False,
         })
 
+    # Add raw top-level keys when present — critical for diagnosing
+    # unknown Maxroll data shapes where expected fields are empty.
+    partial = failure.get("partial_data") or {}
+    raw_keys = partial.get("raw_keys")
+    if raw_keys:
+        value = ", ".join(str(k) for k in raw_keys)[:_FIELD_LIMIT]
+        fields.append({
+            "name": "Raw Top-Level Keys",
+            "value": f"`{value}`" if value else "(empty)",
+            "inline": False,
+        })
+
     user_id = failure.get("user_id")
     fields.append({"name": "User", "value": str(user_id) if user_id else "anonymous", "inline": True})
 


### PR DESCRIPTION
The previous commit added raw_keys to partial_data, but the Discord notifier silently dropped them — the "Parsed Data" summary only rendered recognised fields. Without surfacing raw_keys the user has no way to see what Maxroll actually returned unless they can reach the server logs.

Now the Discord alert includes a "Raw Top-Level Keys" field showing every key in the raw payload, comma-separated. When an unknown Maxroll shape causes passives:empty or skills:empty, that field shows exactly which field names we need to add support for.