### PR TITLE
fix: preserve importer's raw_keys diagnostic in partial-import alert

### DIFF
--- a/backend/app/routes/import_route.py
+++ b/backend/app/routes/import_route.py
@@ -527,6 +527,36 @@ def _do_import(url: str, source: str, user_id: str | None):
     # Track partial imports
     warnings = result.missing_fields
     if warnings:
+        # Build the partial_data payload for the alert. Start with any
+        # diagnostic fields the importer already captured (e.g. raw_keys
+        # from Maxroll's unknown data shapes) so they reach the Discord
+        # notifier. Then add our route-level summary.
+        alert_partial: dict = {}
+        if isinstance(result.partial_data, dict):
+            # Preserve diagnostic fields like raw_keys, but not fields we
+            # rewrite below (to avoid stale/duplicate data).
+            for key, value in result.partial_data.items():
+                if key not in {"character_class", "mastery", "level",
+                               "skills_count", "passives_count",
+                               "gear_count", "missing_count"}:
+                    alert_partial[key] = value
+        alert_partial.update({
+            "slug": build.slug,
+            "character_class": build_data.get("character_class"),
+            "mastery": build_data.get("mastery"),
+            "level": build_data.get("level"),
+            "skills": [s.get("skill_name") for s in build_data.get("skills", [])],
+            "passive_tree": len(build_data.get("passive_tree", [])),
+            "gear": [
+                {
+                    "slot": g.get("slot"),
+                    "item_name": g.get("item_name"),
+                    "rarity": g.get("rarity"),
+                    "affixes": len(g.get("affixes", [])),
+                }
+                for g in build_data.get("gear", [])
+            ],
+        })
         _record_and_alert(
             source=result.source or source,
             url=url,
@@ -534,23 +564,7 @@ def _do_import(url: str, source: str, user_id: str | None):
             error_message="Partial import — some fields could not be mapped.",
             severity="partial",
             missing_fields=warnings,
-            partial_data={
-                "slug": build.slug,
-                "character_class": build_data.get("character_class"),
-                "mastery": build_data.get("mastery"),
-                "level": build_data.get("level"),
-                "skills": [s.get("skill_name") for s in build_data.get("skills", [])],
-                "passive_tree": len(build_data.get("passive_tree", [])),
-                "gear": [
-                    {
-                        "slot": g.get("slot"),
-                        "item_name": g.get("item_name"),
-                        "rarity": g.get("rarity"),
-                        "affixes": len(g.get("affixes", [])),
-                    }
-                    for g in build_data.get("gear", [])
-                ],
-            },
+            partial_data=alert_partial,
         )
 
     imported_fields = []

--- a/backend/tests/test_build_import.py
+++ b/backend/tests/test_build_import.py
@@ -2798,3 +2798,48 @@ class TestMaxrollFullParseFlow:
         mock_alert.assert_called_once()
         call_args = mock_alert.call_args
         assert call_args[1].get("severity") == "partial" or (len(call_args[0]) > 1 and call_args[0][1] == "partial")
+
+    @patch("app.routes.import_route.get_importer")
+    @patch("app.routes.import_route.send_import_failure_alert")
+    def test_partial_import_preserves_raw_keys_in_alert(
+        self, mock_alert, mock_factory, client, db,
+    ):
+        """The ImportFailure record must carry raw_keys from the importer's
+        partial_data through to the Discord notifier so operators can see
+        the actual Maxroll field names."""
+        from app.services.importers.base_importer import ImportResult
+        mock_importer = MagicMock()
+        mock_importer.parse.return_value = ImportResult(
+            success=True,
+            source="maxroll",
+            build_data={
+                "name": "Sparse",
+                "character_class": "Rogue",
+                "mastery": "Bladedancer",
+                "level": 70,
+                "passive_tree": [],
+                "skills": [],
+                "gear": [],
+            },
+            missing_fields=["passives:empty", "skills:empty"],
+            partial_data={
+                "character_class": "Rogue",
+                "mastery": "Bladedancer",
+                "raw_keys": ["class", "mastery", "level", "mysteryField"],
+            },
+        )
+        mock_factory.return_value = mock_importer
+
+        resp = client.post(
+            "/api/import/build",
+            json={"url": "https://maxroll.gg/last-epoch/planner/sparse"},
+            content_type="application/json",
+        )
+
+        assert resp.status_code == 201
+        mock_alert.assert_called_once()
+        # The ImportFailure model instance is the first positional arg.
+        failure = mock_alert.call_args[0][0]
+        assert failure.partial_data is not None
+        assert "raw_keys" in failure.partial_data
+        assert "mysteryField" in failure.partial_data["raw_keys"]


### PR DESCRIPTION
The partial-import path in import_route.py was constructing a fresh partial_data dict and passing it to _record_and_alert, which discarded fields the importer had captured in result.partial_data — most importantly raw_keys, the list of Maxroll's actual top-level JSON keys used to diagnose unknown data shapes.

Start the alert's partial_data from result.partial_data (skipping keys the route rewrites with fresh values) so diagnostic fields like raw_keys reach the Discord notifier, which now renders them as the "Raw Top-Level Keys" embed field.