### PR TITLE
fix: unwrap Maxroll profile envelope to reach nested build data

### DIFF
--- a/backend/app/services/importers/maxroll_importer.py
+++ b/backend/app/services/importers/maxroll_importer.py
@@ -128,9 +128,49 @@ def _extract_next_data(html: str) -> Optional[dict]:
         return None
 
 
+# Signals that a dict actually carries build content (not just a label).
+# Used to distinguish a real build payload from a planner *envelope* that
+# happens to carry a top-level `class` field (e.g. Maxroll's profile envelope
+# wraps the real build under `data` alongside metadata like id/date/name).
+_BUILD_CONTENT_KEYS = (
+    "passives", "passiveTree", "passiveNodes", "tree", "passive_tree",
+    "skills", "skillTrees", "abilities", "abilityTree", "skillSpecializations",
+    "equipment", "gear", "items",
+    "level", "mastery", "masteryName",
+    "nodes", "charTree",
+)
+
+
+def _has_class_field(d: dict) -> bool:
+    v = d.get("class", d.get("className", d.get("characterClass")))
+    # Accept 0 (Primalist numeric ID) but reject None/"".
+    return v is not None and v != ""
+
+
 def _is_build_dict(d: dict) -> bool:
-    """Return True if *d* looks like a single-build payload."""
-    return bool(d.get("class") or d.get("className") or d.get("characterClass"))
+    """Return True if *d* looks like a single-build payload.
+
+    Requires both a class signal AND a build-content signal. A bare `class`
+    is insufficient because Maxroll's planner envelope also carries a
+    top-level `class` label while the real build lives under `data`.
+    """
+    if not _has_class_field(d):
+        return False
+    return any(k in d for k in _BUILD_CONTENT_KEYS)
+
+
+def _maybe_decode_json(value):
+    """Return *value* parsed as JSON if it is a string that looks like JSON,
+    otherwise return it unchanged. Maxroll's profile envelopes sometimes
+    store the build payload as a JSON-encoded string under `data`."""
+    if isinstance(value, str):
+        s = value.strip()
+        if s.startswith("{") or s.startswith("["):
+            try:
+                return json.loads(s)
+            except (ValueError, json.JSONDecodeError):
+                return value
+    return value
 
 
 def _unwrap_build_data(payload: dict, variant: int = 0) -> Optional[dict]:
@@ -139,29 +179,46 @@ def _unwrap_build_data(payload: dict, variant: int = 0) -> Optional[dict]:
 
     Maxroll's API has used different envelope formats over time:
       {"data": {...build fields...}}
+      {"data": "<JSON-encoded build>"}
       {"data": [{...build 0...}, {...build 1...}, ...]}
       {"data": {"builds": [{...}, ...]}}
       {"build": {...build fields...}}
       {"plannerData": {...build fields...}}
+      {"id": ..., "class": "Rogue", "data": {...real build...}, ...}  (profile envelope)
       {...build fields directly...}
 
     *variant* is the 0-based index from the URL hash fragment (e.g. #2 → 2).
     """
-    # Direct build data (has class or className)
+    # Direct build data (has class + real build content)
     if _is_build_dict(payload):
         return payload
 
-    # Nested under a key
+    # Nested under a wrapper key
     for key in ("data", "build", "plannerData"):
-        inner = payload.get(key)
+        inner = _maybe_decode_json(payload.get(key))
         if isinstance(inner, dict):
             # {"data": {"builds": [...]}}
             builds_list = inner.get("builds")
             if isinstance(builds_list, list) and builds_list:
                 idx = min(variant, len(builds_list) - 1)
                 if isinstance(builds_list[idx], dict):
-                    return builds_list[idx]
-            if _is_build_dict(inner):
+                    # The envelope often has the class label at the top
+                    # level; fall back to it if the inner build lacks one.
+                    candidate = builds_list[idx]
+                    if not _has_class_field(candidate) and _has_class_field(payload):
+                        candidate = {**candidate, "class": payload.get("class")}
+                    return candidate
+            if isinstance(inner, dict) and (
+                _is_build_dict(inner)
+                or any(k in inner for k in _BUILD_CONTENT_KEYS)
+            ):
+                # Envelope fallback: inner has build content but no class —
+                # borrow the class label from the outer envelope. If neither
+                # side has a class, keep looking (don't return a classless dict).
+                if not _has_class_field(inner):
+                    if not _has_class_field(payload):
+                        continue
+                    inner = {**inner, "class": payload.get("class")}
                 return inner
         # {"data": [{...build...}, ...]}
         if isinstance(inner, list) and inner:

--- a/backend/tests/test_build_import.py
+++ b/backend/tests/test_build_import.py
@@ -2382,8 +2382,60 @@ class TestMaxrollUnwrapBuildData:
 
     def test_unwrap_className_detected(self):
         from app.services.importers.maxroll_importer import _unwrap_build_data
-        payload = {"className": "Acolyte"}
+        # `className` must be accompanied by a build-content signal to count
+        # as a real build (otherwise it could be a bare envelope label).
+        payload = {"className": "Acolyte", "level": 85}
         assert _unwrap_build_data(payload) is payload
+
+    def test_unwrap_rejects_envelope_without_build_content(self):
+        """A dict with `class` but no build-content keys is an envelope label,
+        not a build. Must NOT be returned as-is."""
+        from app.services.importers.maxroll_importer import _unwrap_build_data
+        payload = {
+            "id": "abc", "date": "2026", "name": "Cool build",
+            "class": "Rogue",  # display label from the planner profile
+            "public": True, "type": "planner", "tags": [],
+            # no `data`, no build content → nothing to unwrap
+        }
+        assert _unwrap_build_data(payload) is None
+
+    def test_unwrap_profile_envelope_with_nested_data(self):
+        """Maxroll's profile envelope carries top-level metadata and a
+        class label, while the real build lives under `data`."""
+        from app.services.importers.maxroll_importer import _unwrap_build_data
+        inner = {
+            "mastery": "Bladedancer", "level": 95,
+            "passives": {"101": 5},
+            "skills": [{"name": "Shift", "slot": 0, "level": 20, "nodes": {}}],
+        }
+        payload = {
+            "id": "zu5tdn0o", "date": "2026-04-01", "name": "Rogue BD",
+            "class": "Rogue", "data": inner, "public": True, "type": "planner",
+        }
+        result = _unwrap_build_data(payload)
+        assert result is not None
+        # Inner build got the envelope's class merged in (inner lacked one).
+        assert result.get("class") == "Rogue"
+        assert result.get("mastery") == "Bladedancer"
+        assert result.get("passives") == {"101": 5}
+
+    def test_unwrap_profile_envelope_with_jsonstring_data(self):
+        """Some Maxroll envelopes store `data` as a JSON-encoded string."""
+        import json
+        from app.services.importers.maxroll_importer import _unwrap_build_data
+        inner = {
+            "class": "Mage", "mastery": "Sorcerer", "level": 92,
+            "passives": {"7": 3},
+            "skills": [],
+        }
+        payload = {
+            "id": "x1", "name": "Meteor build",
+            "data": json.dumps(inner),
+        }
+        result = _unwrap_build_data(payload)
+        assert result is not None
+        assert result.get("class") == "Mage"
+        assert result.get("level") == 92
 
     def test_unwrap_data_list_default_variant(self):
         from app.services.importers.maxroll_importer import _unwrap_build_data


### PR DESCRIPTION
The Discord diagnostic revealed the real Maxroll payload is a profile envelope: top-level keys id/date/name/class/data/public/folder/mainset/ metadata/tags/etc., with the actual build nested under `data`. The previous _is_build_dict treated the envelope as a build because it had a top-level `class` label, so _unwrap_build_data returned the envelope and _map saw empty passives/skills at the wrong level.

- Tighten _is_build_dict to require a class AND a build-content signal (passives/skills/equipment/level/mastery/etc.), so a bare envelope label no longer qualifies.
- Teach _unwrap_build_data to descend into `data` and inherit the envelope's class when the nested payload lacks one.
- Handle `data` being a JSON-encoded string (another Maxroll pattern).
- Tests: envelope-without-content returns None; profile envelope with nested data unwraps and merges class; JSON-string data is decoded.