### PR TITLE
fix(craft-engine): thread seeded rng through full craft action pipeline

### DIFF
--- a/backend/app/engines/craft_engine.py
+++ b/backend/app/engines/craft_engine.py
@@ -74,7 +74,8 @@ def fp_cost(action: str) -> int:
 # ---------------------------------------------------------------------------
 
 def apply_craft_action(item: dict, action: str, affix_name: Optional[str] = None,
-                      target_tier: Optional[int] = None) -> dict:
+                      target_tier: Optional[int] = None,
+                      rng: Optional[random.Random] = None) -> dict:
     """
     Modern Last Epoch craft action pipeline (post-0.8.4).
     Items NEVER fracture. Crafting simply stops when FP runs out.
@@ -87,6 +88,11 @@ def apply_craft_action(item: dict, action: str, affix_name: Optional[str] = None
     5. Check FP remaining
     6. Return result
 
+    Pass an isolated ``rng`` instance for deterministic/seeded simulations.
+    When omitted, falls back to the module-level global random state —
+    preserving the historical behaviour of this function for callers that
+    don't need determinism.
+
     Item structure:
     {
         "forge_potential": int,
@@ -95,7 +101,7 @@ def apply_craft_action(item: dict, action: str, affix_name: Optional[str] = None
     """
     # 1. Validate action — check FP first
     # 2. Roll FP cost
-    cost = roll_fp_cost(action)
+    cost = roll_fp_cost(action, rng=rng)
     if item["forge_potential"] < cost:
         log.warning(
             "craft_action.insufficient_fp",
@@ -408,8 +414,12 @@ def compare_strategies(affixes: list, forge_potential: int) -> list:
 
 
 
-def add_affix(item, affix_name, tier):
-    """Add an affix to an item. Returns structured {success, reason} response."""
+def add_affix(item, affix_name, tier, rng: Optional[random.Random] = None):
+    """Add an affix to an item. Returns structured {success, reason} response.
+
+    Pass an isolated ``rng`` instance for deterministic/seeded simulations.
+    When omitted, falls back to the module-level global random state.
+    """
     affix = get_affix_by_name(affix_name)
     if affix is None:
         return {"success": False, "reason": "Affix not found"}
@@ -418,7 +428,7 @@ def add_affix(item, affix_name, tier):
     if not can_add_affix(item, affix_type):
         return {"success": False, "reason": "Slot limit reached"}
 
-    cost = roll_fp_cost("add_affix")
+    cost = roll_fp_cost("add_affix", rng=rng)
     if item["forging_potential"] < cost:
         return {"success": False, "reason": "Not enough FP"}
 
@@ -432,8 +442,12 @@ def add_affix(item, affix_name, tier):
     return {"success": True, "reason": "Affix added"}
 
 
-def upgrade_affix(item, affix_name):
-    """Upgrade an affix tier by 1. Returns structured {success, reason} response."""
+def upgrade_affix(item, affix_name, rng: Optional[random.Random] = None):
+    """Upgrade an affix tier by 1. Returns structured {success, reason} response.
+
+    Pass an isolated ``rng`` instance for deterministic/seeded simulations.
+    When omitted, falls back to the module-level global random state.
+    """
     for affix_list in [item["prefixes"], item["suffixes"]]:
         for affix in affix_list:
             if affix["name"] == affix_name:
@@ -441,7 +455,7 @@ def upgrade_affix(item, affix_name):
                 if is_max_tier(affix_data, affix["tier"]):
                     return {"success": False, "reason": "Already at max tier"}
 
-                cost = roll_fp_cost("upgrade_affix")
+                cost = roll_fp_cost("upgrade_affix", rng=rng)
                 if item["forging_potential"] < cost:
                     return {"success": False, "reason": "Not enough FP"}
 
@@ -452,12 +466,16 @@ def upgrade_affix(item, affix_name):
     return {"success": False, "reason": "Affix not found"}
 
 
-def remove_affix(item, affix_name):
-    """Remove an affix from an item. Returns structured {success, reason} response."""
+def remove_affix(item, affix_name, rng: Optional[random.Random] = None):
+    """Remove an affix from an item. Returns structured {success, reason} response.
+
+    Pass an isolated ``rng`` instance for deterministic/seeded simulations.
+    When omitted, falls back to the module-level global random state.
+    """
     for affix_list in [item["prefixes"], item["suffixes"]]:
         for affix in affix_list:
             if affix["name"] == affix_name:
-                cost = roll_fp_cost("remove_affix")
+                cost = roll_fp_cost("remove_affix", rng=rng)
                 if item["forging_potential"] < cost:
                     return {"success": False, "reason": "Not enough FP"}
 
@@ -468,13 +486,17 @@ def remove_affix(item, affix_name):
     return {"success": False, "reason": "Affix not found"}
 
 
-def unseal_affix(item):
+def unseal_affix(item, rng: Optional[random.Random] = None):
     """Return the sealed affix back to its prefix/suffix slot.
-    Returns structured {success, reason} response."""
+    Returns structured {success, reason} response.
+
+    Pass an isolated ``rng`` instance for deterministic/seeded simulations.
+    When omitted, falls back to the module-level global random state.
+    """
     if item["sealed_affix"] is None:
         return {"success": False, "reason": "No sealed affix"}
 
-    cost = roll_fp_cost("unseal_affix")
+    cost = roll_fp_cost("unseal_affix", rng=rng)
     if item["forging_potential"] < cost:
         return {"success": False, "reason": "Not enough FP"}
 
@@ -491,15 +513,19 @@ def unseal_affix(item):
     return {"success": True, "reason": "Affix unsealed"}
 
 
-def seal_affix(item, affix_name):
-    """Seal an affix (max 1 sealed). Returns structured {success, reason} response."""
+def seal_affix(item, affix_name, rng: Optional[random.Random] = None):
+    """Seal an affix (max 1 sealed). Returns structured {success, reason} response.
+
+    Pass an isolated ``rng`` instance for deterministic/seeded simulations.
+    When omitted, falls back to the module-level global random state.
+    """
     if item["sealed_affix"]:
         return {"success": False, "reason": "Already has sealed affix"}
 
     for affix_list in [item["prefixes"], item["suffixes"]]:
         for affix in affix_list:
             if affix["name"] == affix_name:
-                cost = roll_fp_cost("seal_affix")
+                cost = roll_fp_cost("seal_affix", rng=rng)
                 if item["forging_potential"] < cost:
                     return {"success": False, "reason": "Not enough FP"}
 
@@ -698,9 +724,16 @@ def simulate_craft_attempt(
             "reason": f"Item fractured (probability was {fracture_prob:.1%})",
         }
 
-    # Normalise to pipeline format for apply_craft_action
+    # Normalise to pipeline format for apply_craft_action.
+    # Thread the local rng through so the FP-cost roll inside
+    # apply_craft_action uses this same seeded RNG rather than the global
+    # random module. Without this, the result depends on whatever global
+    # random state preceding code happens to leave behind, and the seed
+    # parameter only controls the fracture check — not the FP roll.
     pipeline_item = _to_pipeline_item(item)
-    result = apply_craft_action(pipeline_item, action, affix_name, target_tier)
+    result = apply_craft_action(
+        pipeline_item, action, affix_name, target_tier, rng=rng,
+    )
     success = result.get("success", False)
     reason  = result.get("reason", result.get("message", ""))
     fp_after = int(pipeline_item.get("forge_potential", fp_before))

--- a/backend/app/engines/fp_engine.py
+++ b/backend/app/engines/fp_engine.py
@@ -93,15 +93,19 @@ def roll_base_fp(item_type: str, rng: Optional[random.Random] = None) -> int:
 # Consume + Log
 # ---------------------------------------------------------------------------
 
-def consume_fp(item: dict, action_type: str) -> dict:
+def consume_fp(item: dict, action_type: str,
+               rng: Optional[random.Random] = None) -> dict:
     """
     Roll an FP cost, validate the item has enough, and deduct it.
+
+    Pass an isolated ``rng`` instance for deterministic/seeded simulations.
+    When omitted, falls back to the module-level global random state.
 
     Returns:
       {"success": True, "cost": int, "remaining_fp": int}
       {"success": False, "reason": str, "cost": int}
     """
-    cost = roll_fp_cost(action_type)
+    cost = roll_fp_cost(action_type, rng=rng)
 
     if item.get("forge_potential", 0) < cost:
         return {
@@ -129,12 +133,16 @@ def log_fp_event(item: dict, action_type: str, cost: int) -> None:
     })
 
 
-def apply_fp(item: dict, action_type: str) -> dict:
+def apply_fp(item: dict, action_type: str,
+             rng: Optional[random.Random] = None) -> dict:
     """
     Main entry point: consume FP, log the event, return result.
     Returns a result dict — caller checks result["success"] before applying craft.
+
+    Pass an isolated ``rng`` instance for deterministic/seeded simulations.
+    When omitted, falls back to the module-level global random state.
     """
-    result = consume_fp(item, action_type)
+    result = consume_fp(item, action_type, rng=rng)
     if result["success"]:
         log_fp_event(item, action_type, result["cost"])
     return result
@@ -144,9 +152,10 @@ def apply_fp(item: dict, action_type: str) -> dict:
 # Session-model helpers (for craft_service which uses SQLAlchemy models)
 # ---------------------------------------------------------------------------
 
-def roll_session_fp_cost(action_type: str) -> int:
+def roll_session_fp_cost(action_type: str,
+                         rng: Optional[random.Random] = None) -> int:
     """Alias for craft_service — same as roll_fp_cost."""
-    return roll_fp_cost(action_type)
+    return roll_fp_cost(action_type, rng=rng)
 
 
 def get_crafting_rules() -> dict:

--- a/backend/tests/test_architecture_determinism.py
+++ b/backend/tests/test_architecture_determinism.py
@@ -427,7 +427,8 @@ class TestCraftEngineProbability:
         assert "item_before" in result
         assert "item_after" in result
 
-    @pytest.mark.xfail(reason="Craft engine uses global random state alongside local RNG — determinism not guaranteed")
+    # Global-RNG leak fixed on fix/craft-engine-rng-determinism — the local
+    # rng is now threaded through apply_craft_action → roll_fp_cost.
     def test_simulate_craft_attempt_is_deterministic_with_seed(self):
         """Same seed + identical input → identical result."""
         from app.engines.craft_engine import simulate_craft_attempt


### PR DESCRIPTION
simulate_craft_attempt created a local rng = random.Random(seed) but only consulted it for the fracture check. Every downstream call into the craft pipeline — apply_craft_action, the module-level add_affix / upgrade_affix / remove_affix / seal_affix / unseal_affix helpers, and via them roll_fp_cost — fell back to the process-global random module. That meant a seeded simulate_craft_attempt call still read whatever global RNG state preceding tests happened to leave behind, and the same seed produced different (success, fp_spent) pairs depending on test ordering.

apply_craft_action, each of the plan-format craft helpers in craft_engine.py, and consume_fp / apply_fp / roll_session_fp_cost in fp_engine.py now accept an optional rng: random.Random | None = None. When supplied, every random draw on that call path uses the provided instance; when omitted, the functions fall back to the global random module so existing non-deterministic callers (craft_service, apply_fp-based tests, UI flows) are unchanged.

simulate_craft_attempt passes its local rng into apply_craft_action, so a seeded call now performs zero reads from the global random module. That removes the test-ordering-dependent flakiness behind the xfail marker on test_simulate_craft_attempt_is_deterministic_with_seed.

Verified with 10 isolated runs of the determinism test, 10 full-suite runs, and 200 direct invocations with adversarially polluted global RNG state between calls — all produce byte-identical results. xfail marker replaced with a comment pointing at this branch.