### PR TITLE
fix(import): populate gear in /api/import/url preview (1K-1, #155)

### DIFF
--- a/backend/app/routes/import_route.py
+++ b/backend/app/routes/import_route.py
@@ -237,6 +237,19 @@ def _map_let_build(build_info: dict) -> dict:
 
     skills.sort(key=lambda s: s["slot"])
 
+    # ---- Gear ---------------------------------------------------------------
+    # Delegate to the full importer's gear parser so the preview endpoint
+    # produces the same gear payload as /api/import/build. The method does
+    # not use instance state, so a fresh instance is safe.
+    from app.services.importers import LastEpochToolsImporter
+    gear_missing: List[str] = []
+    try:
+        gear = LastEpochToolsImporter()._parse_gear(build_info, gear_missing)
+    except Exception as exc:
+        logger.warning("import/url: gear parse failed: %s", exc)
+        gear = []
+        gear_missing.append(f"gear_parse_error:{exc}")
+
     return {
         "name": f"Imported — {char_class} {mastery}".strip(),
         "description": (
@@ -248,17 +261,15 @@ def _map_let_build(build_info: dict) -> dict:
         "level": level,
         "passive_tree": passive_tree,
         "skills": skills,
-        "gear": [],
+        "gear": gear,
         "_import_meta": {
             "source": "lastepochtools",
             "char_class_id": char_class_id,
             "mastery_id": mastery_id,
             "skill_count": len(skills),
             "passive_nodes": len(selected_nodes),
-            "gear_note": (
-                "Gear not imported — Last Epoch Tools item IDs "
-                "require a separate database lookup"
-            ),
+            "gear_count": len(gear),
+            "gear_missing_fields": gear_missing,
         },
     }
 

--- a/backend/tests/test_build_import.py
+++ b/backend/tests/test_build_import.py
@@ -3633,3 +3633,66 @@ class TestMaxrollFullParseFlow:
         assert failure.partial_data is not None
         assert "raw_keys" in failure.partial_data
         assert "mysteryField" in failure.partial_data["raw_keys"]
+
+
+# ---------------------------------------------------------------------------
+# /api/import/url preview mapper — regression tests for issue #155
+# (Gear was hardcoded to [] in _map_let_build; now delegates to the full
+#  importer's gear parser.)
+# ---------------------------------------------------------------------------
+
+class TestMapLetBuildGear:
+    def test_preview_mapper_populates_gear(self):
+        """_map_let_build returns parsed gear, not an empty list (issue #155)."""
+        from app.routes.import_route import _map_let_build
+
+        build_info = {
+            "bio": {"level": 90, "characterClass": 4, "chosenMastery": 1},
+            "charTree": {"selected": {}},
+            "skillTrees": [],
+            "hud": [],
+            "equipment": {
+                "helm": {"id": 5, "affixes": [], "ir": 0, "ur": 0},
+                "weapon": {"id": 10, "affixes": [], "ir": 0, "ur": 0},
+                "belt": {"id": 7, "affixes": [], "ir": 0, "ur": 0},
+            },
+        }
+
+        mapped = _map_let_build(build_info)
+
+        assert isinstance(mapped["gear"], list)
+        assert len(mapped["gear"]) == 3
+        slots = [g["slot"] for g in mapped["gear"]]
+        assert "helmet" in slots
+        assert "weapon" in slots
+        assert "belt" in slots
+        assert mapped["_import_meta"]["gear_count"] == 3
+
+    def test_preview_mapper_no_equipment(self):
+        """Build with no equipment data returns empty gear cleanly."""
+        from app.routes.import_route import _map_let_build
+
+        build_info = {
+            "bio": {"level": 70, "characterClass": 0, "chosenMastery": 1},
+            "charTree": {"selected": {}},
+            "skillTrees": [],
+            "hud": [],
+        }
+
+        mapped = _map_let_build(build_info)
+
+        assert mapped["gear"] == []
+        assert mapped["_import_meta"]["gear_count"] == 0
+
+    def test_preview_mapper_meta_no_stale_gear_note(self):
+        """The outdated 'gear_note' key must not leak into the response."""
+        from app.routes.import_route import _map_let_build
+
+        mapped = _map_let_build({
+            "bio": {"level": 70, "characterClass": 0, "chosenMastery": 1},
+            "charTree": {"selected": {}},
+            "skillTrees": [],
+            "hud": [],
+        })
+
+        assert "gear_note" not in mapped["_import_meta"]

--- a/docs/TheForge MasterPlan v2 - Master Plan.csv
+++ b/docs/TheForge MasterPlan v2 - Master Plan.csv
@@ -81,7 +81,7 @@ THE FORGE — MASTER DEVELOPMENT PLAN,,,,,,,,
 20,Phase 1,1I-2,Test Necromancer skeleton DPS — count × per-minion DPS,QA,HIGH,Not Started,FALSE,Skeleton DPS × active count should approximate total in-game output
 21,Phase 1,1J-1,"Add corrupted attribute stats (Brutality, Madness) to BuildStats schema",Engine,MEDIUM,Not Started,FALSE,"Season 4: Rune of Corruption can convert STR → Brutality, INT → Madness. New stat types"
 22,Phase 1,1J-2,Model Brutality and Madness stat effects in damage pipeline,Engine,MEDIUM,Not Started,FALSE,"Brutality: 0.02% more melee dmg per mana cost, reduced health leech. Madness: crit multi + penalty"
-23,Phase 1,1K-1,Fix gear import from Last Epoch Tools (#155),Import,CRITICAL,Not Started,FALSE,Gear slots empty after LET import. Highest-visibility broken feature. Fix before any public sharing
+23,Phase 1,1K-1,Fix gear import from Last Epoch Tools (#155),Import,CRITICAL,Complete,TRUE,Gear slots empty after LET import. Highest-visibility broken feature. Fix before any public sharing
 24,Phase 1,1K-2,Verify Maxroll import coverage across 10+ builds,Import,HIGH,Not Started,FALSE,Document any missing field patterns. Fix edge cases in maxroll_importer.py
 25,Phase 1,1K-3,Verify idol data imports correctly from LET and Maxroll,Import,HIGH,Not Started,FALSE,Idols are a separate gear system. Confirm importers capture idol affixes into idol slots
 26,Phase 1,1K-4,Verify blessing data imports correctly from LET,Import,HIGH,Not Started,FALSE,LET stores blessings in build exports. Confirm our importer captures them


### PR DESCRIPTION
The LET preview endpoint hardcoded gear to [], so the UI showed an empty gear panel even though the full /api/import/build endpoint already parses gear correctly. _map_let_build now delegates to LastEpochToolsImporter._parse_gear so both endpoints return the same gear payload. Drops the stale "gear_note" hint in _import_meta and adds gear_count / gear_missing_fields. Three regression tests cover populated, empty, and no-stale-note cases.

Mark 1K-1 Complete in the master plan CSV.