### PR TITLE
feat(skills): add base damage schema fields to skills_metadata.json (0G-1)

### DIFF
--- a/backend/app/game_data/game_data_loader.py
+++ b/backend/app/game_data/game_data_loader.py
@@ -132,6 +132,25 @@ def get_all_skills_metadata() -> dict:
     return _pipeline().skills_metadata
 
 
+def get_skill_base_damage(skill_name: str) -> dict | None:
+    """
+    Returns the 0G-1 base-damage payload for a skill, or None when the
+    skill is unknown or its damage fields are not yet populated.
+
+    Shape: {base_damage_min, base_damage_max, damage_scaling_stat, attack_type}
+    Any field can be None independently of the others until 0G-2..0G-6
+    finish populating values per class.
+    """
+    meta = _pipeline().skills_metadata.get(skill_name)
+    if not meta:
+        return None
+    fields = ("base_damage_min", "base_damage_max",
+              "damage_scaling_stat", "attack_type")
+    if all(meta.get(f) is None for f in fields):
+        return None
+    return {f: meta.get(f) for f in fields}
+
+
 # ---------------------------------------------------------------------------
 # Enemy profiles
 # ---------------------------------------------------------------------------

--- a/backend/app/game_data/pipeline.py
+++ b/backend/app/game_data/pipeline.py
@@ -118,7 +118,7 @@ class GameDataPipeline:
         self._cache["enemies"]        = self._load_enemies(self._version)
         self._cache["skills"]         = self._load_skills(self._version)
         self._cache["classes"]        = self._load_classes()
-        self._cache["skills_meta"]    = self._load_optional("skills_meta", {})
+        self._cache["skills_meta"]    = self._load_skills_metadata()
         self._cache["uniques"]        = self._load_optional("uniques", {})
         self._cache["rarities"]       = self._load_optional("rarities", [])
         self._cache["damage_types"]   = self._load_optional("damage_types", [])
@@ -263,6 +263,95 @@ class GameDataPipeline:
     def _load_optional(self, key: str, default):
         raw = _load_json(key)
         return raw if raw is not None else default
+
+    def _load_skills_metadata(self) -> dict:
+        """
+        Load skills_metadata.json, drop meta-keys (``_schema``, ``_meta``),
+        and validate the Phase-0 0G-1 damage fields whenever they are
+        populated. Missing values are allowed (user fills them in 0G-2..0G-6);
+        malformed values raise at startup so bad data cannot reach the engine.
+        """
+        raw = _load_json("skills_meta")
+        if raw is None:
+            return {}
+        if not isinstance(raw, dict):
+            raise RuntimeError(
+                "pipeline: skills_metadata.json must be a JSON object"
+            )
+
+        skills = {k: v for k, v in raw.items() if not k.startswith("_")}
+        populated = 0
+        missing_any = 0
+        for name, entry in skills.items():
+            if not isinstance(entry, dict):
+                raise RuntimeError(
+                    f"pipeline: skills_metadata.json[{name!r}] must be an object"
+                )
+            self._validate_skill_damage_fields(name, entry)
+            if all(
+                entry.get(f) is not None
+                for f in ("base_damage_min", "base_damage_max",
+                          "damage_scaling_stat", "attack_type")
+            ):
+                populated += 1
+            elif any(
+                f not in entry
+                for f in ("base_damage_min", "base_damage_max",
+                          "damage_scaling_stat", "attack_type")
+            ):
+                missing_any += 1
+
+        log.info(
+            "pipeline.skills_metadata.loaded",
+            total=len(skills),
+            populated_0g=populated,
+            unpopulated_0g=len(skills) - populated,
+            entries_missing_any_0g_field=missing_any,
+        )
+        return skills
+
+    _ALLOWED_ATTACK_TYPES = {
+        "melee", "ranged", "throwing", "spell",
+        "channeled", "dot", "minion", "aura", "utility",
+    }
+    _ALLOWED_SCALING_STATS = {
+        "strength", "intelligence", "dexterity",
+        "vitality", "attunement", "none",
+    }
+
+    def _validate_skill_damage_fields(self, name: str, entry: dict) -> None:
+        """
+        Per-entry check for the 0G-1 fields. Null values are fine.
+        Any populated value must match its declared type / enum.
+        """
+        dmin = entry.get("base_damage_min")
+        dmax = entry.get("base_damage_max")
+        if dmin is not None and not isinstance(dmin, (int, float)):
+            raise RuntimeError(
+                f"skills_metadata[{name!r}].base_damage_min must be numeric or null"
+            )
+        if dmax is not None and not isinstance(dmax, (int, float)):
+            raise RuntimeError(
+                f"skills_metadata[{name!r}].base_damage_max must be numeric or null"
+            )
+        if dmin is not None and dmax is not None and dmin > dmax:
+            raise RuntimeError(
+                f"skills_metadata[{name!r}]: base_damage_min > base_damage_max"
+            )
+
+        scaling = entry.get("damage_scaling_stat")
+        if scaling is not None and scaling not in self._ALLOWED_SCALING_STATS:
+            raise RuntimeError(
+                f"skills_metadata[{name!r}].damage_scaling_stat={scaling!r} "
+                f"not in {sorted(self._ALLOWED_SCALING_STATS)}"
+            )
+
+        atype = entry.get("attack_type")
+        if atype is not None and atype not in self._ALLOWED_ATTACK_TYPES:
+            raise RuntimeError(
+                f"skills_metadata[{name!r}].attack_type={atype!r} "
+                f"not in {sorted(self._ALLOWED_ATTACK_TYPES)}"
+            )
 
     def _detect_version(self) -> str:
         raw = _load_json("affixes")

--- a/backend/tests/test_skills_metadata_schema.py
+++ b/backend/tests/test_skills_metadata_schema.py
@@ -1,0 +1,165 @@
+"""
+Phase 0 · 0G-1 — Schema tests for skills_metadata.json.
+
+The 0G-1 task adds four fields to every skill entry:
+    base_damage_min, base_damage_max, damage_scaling_stat, attack_type
+
+Values stay null until the per-class population tasks (0G-2..0G-6).
+These tests lock the contract so that:
+  - the data file keeps the new fields present on every skill,
+  - the pipeline strips the ``_schema`` meta key before exposing data,
+  - populated values that violate the enum/type raise at load time,
+  - the ``get_skill_base_damage`` accessor returns the expected shape.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from app.game_data.game_data_loader import (
+    get_all_skills_metadata,
+    get_skill_base_damage,
+)
+from app.game_data.pipeline import GameDataPipeline
+
+
+_SKILLS_META_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "data" / "classes" / "skills_metadata.json"
+)
+
+_NEW_FIELDS = (
+    "base_damage_min",
+    "base_damage_max",
+    "damage_scaling_stat",
+    "attack_type",
+)
+
+
+class TestSkillsMetadataFile:
+    def test_every_skill_has_new_fields(self):
+        raw = json.loads(_SKILLS_META_PATH.read_text())
+        skills = {k: v for k, v in raw.items() if not k.startswith("_")}
+        assert skills, "expected at least one skill entry"
+        missing = {
+            name: [f for f in _NEW_FIELDS if f not in entry]
+            for name, entry in skills.items()
+            if any(f not in entry for f in _NEW_FIELDS)
+        }
+        assert not missing, f"skills missing 0G-1 fields: {missing}"
+
+    def test_schema_block_declares_expected_fields(self):
+        raw = json.loads(_SKILLS_META_PATH.read_text())
+        assert "_schema" in raw, "expected self-describing _schema block"
+        fields = raw["_schema"].get("fields", {})
+        for f in _NEW_FIELDS:
+            assert f in fields, f"_schema.fields missing {f!r}"
+
+
+class TestPipelineStripsMetaKeys:
+    def test_schema_key_is_not_exposed_to_consumers(self):
+        meta = get_all_skills_metadata()
+        assert "_schema" not in meta
+        # Sanity: we still get real skills.
+        assert len(meta) > 0
+
+
+class TestPipelineValidation:
+    def _base_skill(self, **overrides) -> dict:
+        entry = {
+            "id": "t",
+            "name": "Test",
+            "description": "",
+            "lore": "",
+            "class": "",
+            "base_damage_min": None,
+            "base_damage_max": None,
+            "damage_scaling_stat": None,
+            "attack_type": None,
+        }
+        entry.update(overrides)
+        return entry
+
+    def test_rejects_non_numeric_base_damage_min(self):
+        p = GameDataPipeline()
+        with pytest.raises(RuntimeError, match="base_damage_min"):
+            p._validate_skill_damage_fields(
+                "Bad", self._base_skill(base_damage_min="42")
+            )
+
+    def test_rejects_min_greater_than_max(self):
+        p = GameDataPipeline()
+        with pytest.raises(RuntimeError, match="base_damage_min > base_damage_max"):
+            p._validate_skill_damage_fields(
+                "Bad",
+                self._base_skill(base_damage_min=100, base_damage_max=10),
+            )
+
+    def test_rejects_unknown_attack_type(self):
+        p = GameDataPipeline()
+        with pytest.raises(RuntimeError, match="attack_type"):
+            p._validate_skill_damage_fields(
+                "Bad", self._base_skill(attack_type="lollygag")
+            )
+
+    def test_rejects_unknown_scaling_stat(self):
+        p = GameDataPipeline()
+        with pytest.raises(RuntimeError, match="damage_scaling_stat"):
+            p._validate_skill_damage_fields(
+                "Bad", self._base_skill(damage_scaling_stat="charisma")
+            )
+
+    def test_all_null_fields_are_valid(self):
+        p = GameDataPipeline()
+        p._validate_skill_damage_fields("Blank", self._base_skill())
+
+    def test_populated_fields_pass_validation(self):
+        p = GameDataPipeline()
+        p._validate_skill_damage_fields(
+            "Ok",
+            self._base_skill(
+                base_damage_min=10,
+                base_damage_max=20,
+                damage_scaling_stat="strength",
+                attack_type="melee",
+            ),
+        )
+
+
+class TestAccessor:
+    def test_returns_none_for_unknown_skill(self):
+        assert get_skill_base_damage("Definitely Not A Skill 🦑") is None
+
+    def test_returns_none_when_all_fields_null(self):
+        # Every real skill currently has null 0G-1 fields (user populates in
+        # later tasks); so any live skill key should return None.
+        meta = get_all_skills_metadata()
+        a_skill = next(iter(meta))
+        assert get_skill_base_damage(a_skill) is None
+
+    def test_returns_shape_when_any_field_populated(self, monkeypatch):
+        # Surgically overwrite one skill's fields in the live pipeline cache
+        # so we exercise the populated-path without mutating on-disk data.
+        meta = get_all_skills_metadata()
+        target = next(iter(meta))
+        original = dict(meta[target])
+        meta[target].update({
+            "base_damage_min": 50,
+            "base_damage_max": 75,
+            "damage_scaling_stat": "intelligence",
+            "attack_type": "spell",
+        })
+        try:
+            payload = get_skill_base_damage(target)
+            assert payload == {
+                "base_damage_min": 50,
+                "base_damage_max": 75,
+                "damage_scaling_stat": "intelligence",
+                "attack_type": "spell",
+            }
+        finally:
+            meta[target].clear()
+            meta[target].update(original)

--- a/data/classes/skills_metadata.json
+++ b/data/classes/skills_metadata.json
@@ -1,1129 +1,1837 @@
 {
+  "_schema": {
+    "_comment": "Field contract for each skill entry. Phase 0 task 0G-1 adds base_damage_min/max, damage_scaling_stat, attack_type. Values populated per class in 0G-2..0G-6.",
+    "fields": {
+      "id": {
+        "type": "string",
+        "source": "LET treeID"
+      },
+      "name": {
+        "type": "string"
+      },
+      "description": {
+        "type": "string"
+      },
+      "lore": {
+        "type": "string"
+      },
+      "class": {
+        "type": "string",
+        "enum": [
+          "",
+          "Sentinel",
+          "Mage",
+          "Acolyte",
+          "Primalist",
+          "Rogue"
+        ]
+      },
+      "base_damage_min": {
+        "type": "number|null",
+        "notes": "Minimum tooltip damage at skill level 1, before any scaling"
+      },
+      "base_damage_max": {
+        "type": "number|null",
+        "notes": "Maximum tooltip damage at skill level 1"
+      },
+      "damage_scaling_stat": {
+        "type": "string|null",
+        "enum": [
+          null,
+          "strength",
+          "intelligence",
+          "dexterity",
+          "vitality",
+          "attunement",
+          "none"
+        ]
+      },
+      "attack_type": {
+        "type": "string|null",
+        "enum": [
+          null,
+          "melee",
+          "ranged",
+          "throwing",
+          "spell",
+          "channeled",
+          "dot",
+          "minion",
+          "aura",
+          "utility"
+        ]
+      }
+    }
+  },
   "Abyssal Echoes": {
     "id": "ab0lh",
     "name": "Abyssal Echoes",
     "description": "A nova that echoes from up to 8 enemies it reaches and applies abyssal decay. Enemies with abyssal decay take void damage over time for 5 seconds, if they take a hit all the damage from abyssal decay is dealt to them immediately.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Acid Flask": {
     "id": "aacfl",
     "name": "Acid Flask",
     "description": "Throw a flask of acid that explodes dealing physical damage on impact, poisoning enemies and reducing their armor.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Aerial Assault": {
     "id": "aa989",
     "name": "Aerial Assault",
     "description": "You leap towards the target and your {Falcon} dives to catch you and momentarily carry you further, before it flies up and unleashes a {Wing Burst} at the target location.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Anomaly": {
     "id": "an0mz",
     "name": "Anomaly",
     "description": "Brings enemies that were sent forward back to your time.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Arcane Ascendance": {
     "id": "arcas",
     "name": "Arcane Ascendance",
     "description": "",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Armblade Slash": {
     "id": "abs2",
     "name": "Armblade Slash",
     "description": "Slash enemies in front of you with a fast combo ability.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Assemble Abomination": {
     "id": "aa710",
     "name": "Assemble Abomination",
     "description": "Hold ability key to channel to absorb your Wraiths, Summoned Skeletons, Skeletal Mages, Golems, and Volatile Zombies in an area. When you release, summon a single hulking abomination with added health and more damage per minion absorbed.\n\nThe abomination remembers the minions absorbed to create it and will rapidly devour those minions to restore 10% of its maximum health.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Aura Of Decay": {
     "id": "ad0ry",
     "name": "Aura Of Decay",
     "description": "Toggles Aura of Decay, which poisons you every second, and leaves a trail of decay. Enemies near you or in the trail are poisoned four times a second, and your chance to poison on hit applies to each of these instances at 100% effectiveness.\n\nWhile Aura of Decay is active you take 30% less poison damage. Additionally, you take 50% less damage from your own Aura of Decay.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Avalanche": {
     "id": "av75ch",
     "name": "Avalanche",
     "description": "Summon the might of winter and pummel your foes in ice and snow, unleashing a large boulder at the target followed by 10 smaller boulders around the area over 2 seconds.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Ballista": {
     "id": "ba1574",
     "name": "Ballista",
     "description": "Summons a ballista that fires bolts at nearby enemies.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Banner Rush": {
     "id": "br8s7",
     "name": "Banner Rush",
     "description": "Dash to your Banner. Cannot be used without a target.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Black Hole": {
     "id": "bh2",
     "name": "Black Hole",
     "description": "",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Bladestorm": {
     "id": "bl5st",
     "name": "Bladestorm",
     "description": "",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Bone Curse": {
     "id": "bc53",
     "name": "Bone Curse",
     "description": "Apply a curse to enemies in an area for 8 seconds that causes physical damage when hit. The damage is tripled if you inflicted the hit yourself.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Chaos Bolts": {
     "id": "ch4bo",
     "name": "Chaos Bolts",
     "description": "A barrage of chaotic projectiles which land in an area around the target. The explosions deal necrotic and fire damage in a small area.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Chthonic Fissure": {
     "id": "ch0fs",
     "name": "Chthonic Fissure",
     "description": "Opens an infernal fissure in the ground, dealing fire damage over time to enemies on top of it, as well as releasing {Spirits} from the fissure that seek nearby enemies. These spirits inflict enemies with {Torment}, a {Curse} that slows and deals necrotic damage over time.\n\nMax 1 active fissure.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Cinder Strike": {
     "id": "cinss",
     "name": "Cinder Strike",
     "description": "Melee or bow combo with three attacks. The first attack also creates a fiery explosion, damaging nearby enemies.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Create Shadow": {
     "id": "en6",
     "name": "Create Shadow",
     "description": "Create a Shadow of yourself that persists for up to 5 seconds and will imitate your next Shadow Cascade, Shurikens, Umbral Blades, or Acid Flask.\nUp to 3 Shadows can be active at once.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Dancing Strikes": {
     "id": "dacn37",
     "name": "Dancing Strikes",
     "description": "Requires dual wielding.\n\nA series of fast dash attacks. Dancing Strikes' movement does not scale with attack speed, but it gains increased cooldown recovery speed and more damage equal to 50% of your total increased melee attack speed.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Dark Quiver": {
     "id": "dqv5",
     "name": "Dark Quiver",
     "description": "Requires a bow.\n\nSummons 7 Black Arrows that rain from the sky over 4 seconds, granting 100% increased damage to your next bow attack when retrieved.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Death Seal": {
     "id": "ds34i",
     "name": "Death Seal",
     "description": "Releases a Wave of Death dealing damage based on how long Death Seal has been actve and your current percent missing health.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Decoy": {
     "id": "deeco",
     "name": "Decoy",
     "description": "Throw a device to create a Decoy that taunts enemies around it for 2.5 seconds before exploding.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Detonate Decoy": {
     "id": "",
     "name": "Detonate Decoy",
     "description": "Detonate your decoys instantly.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Detonating Arrow": {
     "id": "detar",
     "name": "Detonating Arrow",
     "description": "Requires a bow.\n\nFires an arrow that embeds itself in a target then explodes after 0.6 seconds.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Devouring Orb": {
     "id": "do5vr",
     "name": "Devouring Orb",
     "description": "Creates a devouring orb at the target location for 10 seconds that deals void damage over time to nearby enemies, and casts a void rift whenever something dies nearby, hitting nearby enemies to deal void damage.\n\nEach successive rift has 12% more damage and area of effect, capped at an increase of 120%.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Disintegrate": {
     "id": "dig5",
     "name": "Disintegrate",
     "description": "",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Dive": {
     "id": "sbsw7",
     "name": "Dive",
     "description": "Dash a short fixed distance in the target direction dealing damage to all enemies in your path.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Dive Bomb": {
     "id": "db992",
     "name": "Dive Bomb",
     "description": "Your {Falcon} ascends high into the sky then dive bombs the target location at high speed, dealing a high amount of physical damage to enemies in the area.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Drain Life": {
     "id": "dl73",
     "name": "Drain Life",
     "description": "Channelled spell that targets up to 3 enemies around the target location, dealing necrotic damage over time and leeching 30% of that damage back as health.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Dread Shade": {
     "id": "ds4d3",
     "name": "Dread Shade",
     "description": "Your minion's health is drained for 3% of its max health per second for each second the shade has been active, but it and your minions around it deal +10 necrotic damage with spells and attacks and have 50% increased necrotic damage.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Earthquake": {
     "id": "eq5s",
     "name": "Earthquake",
     "description": "Slam the ground with your weapon damaging enemies in a large area and creating 2 to 4 aftershocks nearby.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Enchant Weapon": {
     "id": "sb44eQ",
     "name": "Enchant Weapon",
     "description": "",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Entangling Roots": {
     "id": "er6no",
     "name": "Entangling Roots",
     "description": "Call forth a wave of roots that grows outwards in a wide cone in front of you. The wave deals physical damage and roots enemies it hits for 1.5 seconds. Rooted enemies take physical damage over time until they are freed.\n\nAdded spell damage applies at 100% to the initial hit and 200% per second to the damage over time.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Erasing Strike": {
     "id": "es6ai",
     "name": "Erasing Strike",
     "description": "A melee attack that hits all enemies in a large area in front of you. Enemies killed by the hit are erased from existence, replaced by void rifts.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Eterra's Blessing": {
     "id": "eb5656",
     "name": "Eterra's Blessing",
     "description": "The nearest allied target is healed for 100 health. If the target is one of your minions then the healing is tripled and the minion is energised for 4 seconds, increasing its size by 20% and its damage by 100%.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Evade": {
     "id": "werebearevade1",
     "name": "Evade",
     "description": "Rapidly move a short distance forwards.\n\nEvading does not grant damage immunity or prevent abilities from hitting you.\n\nEvade gains 0.5% Increased Cooldown Recovery Speed per Character level.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Explosive Trap": {
     "id": "ex4tp",
     "name": "Explosive Trap",
     "description": "Throws a trap that explodes when triggered, dealing throwing fire damage. Traps take 0.4 seconds to arm and explode when enemies walk over them or after 30s. \n\nYou can have a maximum of 6 active traps at a time.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Falcon Strikes": {
     "id": "aa32a",
     "name": "Falcon Strikes",
     "description": "Your Falcon rapidly strike enemies within the target area.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Falconry": {
     "id": "falc0",
     "name": "Falconry",
     "description": "Passive:\nSummons a {Falcon} that fights with you.\n\nActive:\n{Falcon Strikes}: The {Falcon} rapidly hits many enemies in the target area. \n",
     "lore": "The Dune Falcon is one of the most deadly hunters in all of Eterra. What it lacks in size it makes up in speed, precision, and intelligence. Fierce and independent, the Dune Falcon is known to maim those who attempt to train it. Only those it recognizes as an equal can hope to gain its trust and be accepted as a hunting partner.",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Familiar Rage": {
     "id": "fs11",
     "name": "Familiar Rage",
     "description": "",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Firebrand": {
     "id": "f1b4d",
     "name": "Firebrand",
     "description": "",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Flame Reave": {
     "id": "fr11mv",
     "name": "Flame Reave",
     "description": "",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Flame Rush": {
     "id": "fl71ds",
     "name": "Flame Rush",
     "description": "",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Flame Ward": {
     "id": "fw3d",
     "name": "Flame Ward",
     "description": "",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Flay": {
     "id": "fl44",
     "name": "Flay",
     "description": "Spirit Step up to 3 meters towards an enemy if not within range, then perform a narrow rending slash.\nEach enemy killed by the melee attack will release a Blood Eruption, a spell dealing physical damage in an area.\nEnemies can be hit by both Flay and all Blood Eruptions that occur.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Flurry": {
     "id": "flur3",
     "name": "Flurry",
     "description": "A bow or melee attack that performs 3 rapid strikes. The last strike can be cancelled by moving.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Focus": {
     "id": "vm53dx",
     "name": "Focus",
     "description": "",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Forge Strike": {
     "id": "fs3e3",
     "name": "Forge Strike",
     "description": "A melee attack that hits all enemies in an area in front of you.\n\n25% chance on hit to summon a Forged Weapon which lasts for 20 seconds and is affected by the stats and attack rate of your weapon. You can control up to 6 Forged Weapons at once.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Frigid Tempest": {
     "id": "fi9",
     "name": "Frigid Tempest",
     "description": "Conjures a spear of frost that pierces enemies.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Frost Claw": {
     "id": "frc87w",
     "name": "Frost Claw",
     "description": "",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Frost Wall": {
     "id": "fr4wl",
     "name": "Frost Wall",
     "description": "",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Fury Leap": {
     "id": "fl13",
     "name": "Fury Leap",
     "description": "Leap to the target location, dealing damage to nearby enemies when you hit the ground.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Gathering Storm": {
     "id": "ga2st",
     "name": "Gathering Storm",
     "description": "Strike at your enemy with a mighty lightning powered storm. When you use Gathering Storm and hit at least one enemy, you gain a {Storm Stack}. Every second you expend a Storm Stack to cause a {Storm Bolt} to strike a nearby enemy. This interval is reduced by 2% for every stack you currently have.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Ghostflame": {
     "id": "gh0fl",
     "name": "Ghostflame",
     "description": "Channel to releases a continuous jet of horrid flames in front of you dealing fire and necrotic damage over time.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Glacier": {
     "id": "gl14",
     "name": "Glacier",
     "description": "",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Glyph of Dominion": {
     "id": "gy2dm",
     "name": "Glyph of Dominion",
     "description": "",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Hail of Arrows": {
     "id": "exvol8",
     "name": "Hail of Arrows",
     "description": "Requires a bow.\n\nLaunch a hail of arrows into the sky that rain down on the target location over 3.5 seconds.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Hammer Throw": {
     "id": "ht16aw",
     "name": "Hammer Throw",
     "description": "Throws a hammer that returns to you after a short delay.\n\nAdded Throwing Damage is applied to each hit at 110% effectiveness.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Harvest": {
     "id": "ha84",
     "name": "Harvest",
     "description": "A melee attack that hits all enemies in an area in front of you, dealing double damage to those that are Cursed.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Healing Hands": {
     "id": "hh7pa3",
     "name": "Healing Hands",
     "description": "Heals all allies in a target area for 50 health and applies a lingering warmth which heals 80 health over the next 3 seconds. The lingering warmth cannot stack on the same target.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Heartseeker": {
     "id": "htsk5",
     "name": "Heartseeker",
     "description": "Requires a bow.\n\nShoot an arrow that seeks the heart of a nearby target, passing harmlessly through other enemies. Whenever it hits its target it has a chance to continue through it and {Recurve} to strike it again. \n\nSubsequent {Recurve} chance is multiplied by 0.8 each time the arrow {Recurves}. If the target dies, it will choose a new target.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Holy Aura": {
     "id": "ah443",
     "name": "Holy Aura",
     "description": "You and nearby allies passively gain 30% increased damage and +15% additional elemental resistance. Activating Holy Aura doubles the stat bonuses for 4 seconds.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Human Form": {
     "id": "wbthf",
     "name": "Human Form",
     "description": "Return back to human form, returning your original stats and abilities.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Hungering Souls": {
     "id": "hs18gu",
     "name": "Hungering Souls",
     "description": "Calls forth five hungering souls that seeks out enemies, on hit they deal necrotic damage and then possesses the target.\n\nPossessed enemies take necrotic damage over time for 1.5 seconds. Enemies cannot be possessed by multiple souls at once.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Ice Barrage": {
     "id": "ib5g3",
     "name": "Ice Barrage",
     "description": "",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Ice Ward": {
     "id": "is58",
     "name": "Ice Ward",
     "description": "",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Infernal Shade": {
     "id": "is40",
     "name": "Infernal Shade",
     "description": "Target enemy and all nearby enemies take fire damage per second. Each enemy can only have one Infernal Shade attached at a time. Expires after 5 seconds. Max 4 active shades.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Javelin": {
     "id": "javeli",
     "name": "Javelin",
     "description": "Hurl a javelin that pierces through every enemy in its path.\n\nIf you have a spear equipped added melee damage from the spear applies to Javelin as added throwing damage at 50% of its normal value. Added melee damage from other sources has no effect.\n\nAdded throwing damage applies at 250% effectiveness.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Judgement": {
     "id": "pa67ju",
     "name": "Judgement",
     "description": "A powerful melee attack that leaves an area of {Consecrated Ground} for 4 seconds.\n\nAllies on the {Consecrated Ground} are healed for 50 health each second.\n\nEnemies on Consecrate Ground take fire damage over time that scales with spell damage. Consecrate Ground gains 1 spell damage per 5% increased healing effectiveness.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Lethal Mirage": {
     "id": "mira59",
     "name": "Lethal Mirage",
     "description": "Become immune for a duration and rapidly strike nearby targets with 6 mirages.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Lightning Blast": {
     "id": "lb23il",
     "name": "Lightning Blast",
     "description": "",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Lunge": {
     "id": "lu25ng",
     "name": "Lunge",
     "description": "Dash to a nearby enemy and strike it with your weapon. Cannot be used without a target. Costs more mana the further away the target is.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Maelstrom": {
     "id": "mas54",
     "name": "Maelstrom",
     "description": "Surrounds you with a freezing Maelstrom that deals cold damage over time to nearby enemies.\n\nCan be cast repeatedly to create multiple maelstroms at once. Each Maelstrom lasts 7 seconds.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Mana Strike": {
     "id": "ms26",
     "name": "Mana Strike",
     "description": "",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Manifest Armor": {
     "id": "ma6hdr",
     "name": "Manifest Armor",
     "description": "Manifests an animated set of heavy armor, which attacks slowly.\n\nStats granted by your body armor, helmet, gloves and boots also apply to your Manifest Armor.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Mark For Death": {
     "id": "md26kh",
     "name": "Mark For Death",
     "description": "",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Marrow Shards": {
     "id": "bp2nk",
     "name": "Marrow Shards",
     "description": "Fires sharpened bones from your body. The bones pierce through enemies inflicting physical damage. Instead of mana, this spell costs 9% of your current health.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Maul": {
     "id": "wbra",
     "name": "Maul",
     "description": "Jump forward a short distance and slam into the ground dealing damage to nearby enemies.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Multishot": {
     "id": "mush9",
     "name": "Multishot",
     "description": "Requires a bow.\n\nA bow attack that fires a cone of 5 arrows in the target direction. Aiming the cursor further from your character reduces the spread.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Multistrike": {
     "id": "multis",
     "name": "Multistrike",
     "description": "A melee attack that grants a stack of {Armament} if you hit at least one enemy.\n\nArmament stacks up to 2 times and each stack lasts 3 seconds.\n\nEach stack of {Armament} causes an additional sword to strike a nearby enemy when you use Multistrike.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Net": {
     "id": "ne01t",
     "name": "Net",
     "description": "Leaps backwards and throws a net which snares enemies and deals physical damage. Netted bosses and rare enemies have 35% less movement speed, and other enemies are immobilized.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Profane Veil": {
     "id": "pr5fm",
     "name": "Profane Veil",
     "description": "Channel to conceal yourself within a Profane Veil that deals necrotic damage over time to enemies around you. While concealed you dodge every Hit, but you can still take damage from damage over time effects, such as ailments, and you move more slowly.\n\nLast for up to 2 seconds (also ends when you release the key). Cooldown does not recover during use.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Puncture": {
     "id": "pun22",
     "name": "Puncture",
     "description": "An extended melee stab or piercing bow attack that has a 30% chance to inflict bleed on hit. Bleeds inflicted by puncture have 30% increased duration.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Rampage": {
     "id": "ch2ge",
     "name": "Rampage",
     "description": "Charge towards a target location dealing damage and knocking back enemies in your path.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Reap": {
     "id": "rf1azz",
     "name": "Reap",
     "description": "Dash a short distance in the target direction using your scythes to strike all enemies in your path. Restores 15 health for each enemy hit.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Rebuke": {
     "id": "re82ke",
     "name": "Rebuke",
     "description": "Hold ability key to channel for up to 2 seconds. You take 80% less damage while channelling.\n\nWhen you stop channelling the barrier breaks dealing physical damage to all nearby enemies. This deals 20 additional physical damage for each hit you received while channelling.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Ring Of Shields": {
     "id": "rs31hi",
     "name": "Ring Of Shields",
     "description": "Manifests a ring of shields around you.\n\nEach shield has 75 base health and lasts up to 10 seconds. Shields draw enemy aggression and block projectiles.\n\nStats on your equipped shield also apply to the shields created by Ring of Shields",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Rip Blood": {
     "id": "rb31pl",
     "name": "Rip Blood",
     "description": "Rips blood out of a target enemy dealing physical damage to it. An orb of the blood is drawn back to you, restoring 5 health when it reaches you.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Riposte": {
     "id": "ln24",
     "name": "Riposte",
     "description": "",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Rive": {
     "id": "sndr1-",
     "name": "Rive",
     "description": "A combo of three melee attacks. Every third consecutive attack with Rive slashes in a full circle around the character, dealing double damage.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Roar": {
     "id": "wb45ro",
     "name": "Roar",
     "description": "Unleash a thunderous roar which knocks enemies back and stuns them for 1.5 seconds. Rares and bosses are stunned for half as long.. All effects from your Warcry Skill Tree are applied to Roar.\n\n20% of remaining cooldown recovered whenever you stun (or freeze if Warcry is converted to cold) an enemy, including with Roar itself. This effect can occur a maximum of two times each second.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Runebolt": {
     "id": "fb8fe",
     "name": "Runebolt",
     "description": "",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Runic Invocation": {
     "id": "rn7iv",
     "name": "Runic Invocation",
     "description": "",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Sacrifice": {
     "id": "sf31rc",
     "name": "Sacrifice",
     "description": "Rips apart an allied minion, dealing physical damage to enemies around it.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Serpent Strike": {
     "id": "st31et",
     "name": "Serpent Strike",
     "description": "Requires a spear.\n\nA melee attack with 140% poison chance.\n\nPoisons inflicted by serpent strike last 40% longer.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Shadow Cascade": {
     "id": "dagg3",
     "name": "Shadow Cascade",
     "description": "Requires dual wielding.\n\nA circular attack that's also used by your shadow clones.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Shadow Rend": {
     "id": "sh4re",
     "name": "Shadow Rend",
     "description": "",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Shatter Strike": {
     "id": "ss3tre",
     "name": "Shatter Strike",
     "description": "",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Shield Bash": {
     "id": "sb4h",
     "name": "Shield Bash",
     "description": "Requires a shield.\n\nA melee directional attack that stuns enemies for 1 second. 100% increased stun duration against non-boss enemies.\n\n1.5% more damage per 1% block chance (up to 150%, multiplicative with other modifiers).\n\n20% of remaining cooldown recovered whenever you stun an enemy, including with Shield Bash itself. This effect can occur a maximum of two times each second.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Shield Rush": {
     "id": "sr31hu",
     "name": "Shield Rush",
     "description": "Requires a shield.\n\nCharge through enemies in the target direction until you release the ability key. You hit enemies in your path and in a wider area at the end of the movement. You do not regenerate mana while rushing.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Shield Throw": {
     "id": "st31io",
     "name": "Shield Throw",
     "description": "Throws a shield at a target enemy. The shield ricochets to up to 2 additional targets before returning to you.\n\nYou cannot throw a new shield until the current shield has returned to you.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Shift": {
     "id": "shiif",
     "name": "Shift",
     "description": "Dash a short fixed distance in the target direction.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Shocking Impact": {
     "id": "me27",
     "name": "Shocking Impact",
     "description": "Call a meteor from the sky that deals a large amount of damage upon landing. Added damage is applied at five times its normal value.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Shurikens": {
     "id": "srk21",
     "name": "Shurikens",
     "description": "Throw 3 shurikens in a cone.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Smelter's Wrath": {
     "id": "st4th",
     "name": "Smelter's Wrath",
     "description": "Channel to charge a powerful frontal cone attack, dealing fire and physical damage to all enemies hit. Charging for longer increases its range and power. 2 second maximum charge time.\n\nYour armor is doubled while channelling Smelter's Wrath.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Smite": {
     "id": "sm87r4",
     "name": "Smite",
     "description": "Smites a target enemy with a bolt of holy fire that descends from the sky, healing allies around the target for 60 health. If you are in the area you are also healed.\n\nCannot be used without a target.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Smoke Bomb": {
     "id": "smbmb",
     "name": "Smoke Bomb",
     "description": "Drop a Smoke Bomb at your feet that blinds enemies and grants you haste while you remain inside it. The Smoke Bomb grows in size over its duration. Lasts 4 seconds.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Snap Freeze": {
     "id": "sw31a",
     "name": "Snap Freeze",
     "description": "",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Soul Feast": {
     "id": "fe8at",
     "name": "Soul Feast",
     "description": "Feasts on the souls of {Cursed} enemies, dealing necrotic damage to them, and drawing fragments of their souls back to you. The soul fragments each grant 3 ward when they reach you.\n\nFeasts on up to 13 enemies, prioritising those closest to you.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Spirit Plague": {
     "id": "sp5g2",
     "name": "Spirit Plague",
     "description": "Curses a target with a powerful necrotic damage over time effect which lasts 3 seconds. Spreads to a single nearby target on target death.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Spirit Thorns": {
     "id": "tb47",
     "name": "Spirit Thorns",
     "description": "Releases a burst of thorns towards enemies in the target direction. Thorns deal physical damage on hit and multiple thorns can hit the same target.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Spriggan Form": {
     "id": "sf5rd",
     "name": "Spriggan Form",
     "description": "Transform into a forest spriggan, increasing your spell casting capabilities, and gaining 4 new abilities.\n\nYour mana is replaced with Rage while in spriggan form. When your Rage reaches 0 you automatically transform back into your human form. Your starting Rage is equal to your maximum mana. Rage slowly decays over time at a constant rate.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Static": {
     "id": "st47ic",
     "name": "Static",
     "description": "",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Static Orb": {
     "id": "so35a",
     "name": "Static Orb",
     "description": "",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Summon Bear": {
     "id": "be36ar",
     "name": "Summon Bear",
     "description": "Summons a primal bear that follows you into combat. When its health drops to 0 it is downed, and you can stand near it to revive it.\n\nThe bear counts as a companion. You can have a maximum of two companions at once by default.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Summon Bone Golem": {
     "id": "bg36nl",
     "name": "Summon Bone Golem",
     "description": "Summons a bone golem, which attacks slowly, but has a 15% chance to retaliate with Bone Shatter when hit.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Summon Cryomancer": {
     "id": "sc3r",
     "name": "Summon Cryomancer",
     "description": "Summons a skeleton mage to assist you. You are limited to 2 mages at a time.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Summon Death Knight": {
     "id": "sdk3",
     "name": "Summon Death Knight",
     "description": "Summons a Skeleton Death Knight to assist you.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Summon Forged Weapon": {
     "id": "sw44on",
     "name": "Summon Forged Weapon",
     "description": "Summons a Forged Weapon which lasts for 20 seconds and is affected by the stats and attack rate of your weapon. You can control up to 6 Forged Weapons at once.\n\nForged Weapons have 220 based health.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Summon Frenzy Totem": {
     "id": "sf37",
     "name": "Summon Frenzy Totem",
     "description": "Summons a totem that grants Frenzy to all nearby allies. Frenzy increases attack and cast speed by 20%.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Summon Healing Totem": {
     "id": "sht54dd",
     "name": "Summon Healing Totem",
     "description": "Summons a totem that heals nearby allies. Healing totems have 100 base health and last 6 seconds.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Summon Hive": {
     "id": "sh1v3",
     "name": "Summon Hive",
     "description": "Summons a Hive that releases Locusts while enemies are nearby. You can have a maximum of three Hives by default and each Hive contains 12 Locusts.\n\nYou are limited to 12 active Locusts and each Locust lasts up to 12 seconds.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Summon Pyromancer": {
     "id": "pr6y",
     "name": "Summon Pyromancer",
     "description": "Summons a skeleton mage to assist you. You are limited to 2 mages at a time.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Summon Raptor": {
     "id": "srtor",
     "name": "Summon Raptor",
     "description": "Summons a primal raptor that ferociously attacks your enemies. When its health drops to 0 it is downed, and you can stand near it to revive it.\n\nThe raptor counts as a companion. You can have a maximum of two companions at once by default.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Summon Sabertooth": {
     "id": "sa36oh",
     "name": "Summon Sabertooth",
     "description": "Summons a primal sabertooth cat that leaps into combat. When its health drops to 0 it is downed, and you can stand near it to revive it.\n\nThe sabertooth cat counts as a companion. You can have a maximum of two companions at once by default.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Summon Scorpion": {
     "id": "sc36pi",
     "name": "Summon Scorpion",
     "description": "Summons a scorpion that follows you into combat. Its attacks with its tails inflict a long lasting poison. When its health drops to 0 it is downed, and you can stand near it to revive it.\n\nThe scorpion counts as a companion. You can have a maximum of two companions at once by default.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Summon Skeletal Mage": {
     "id": "sm4g",
     "name": "Summon Skeletal Mage",
     "description": "Summons a Skeletal Mage to assist you. You are limited to 2 Skeletal Mages at a time.\nSkeletal Mages cast Dread Bolt, which has 150% added damage effectiveness and has a 50% chance to apply Damned on hit.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Summon Skeleton": {
     "id": "ss37kl",
     "name": "Summon Skeleton",
     "description": "Summons a skeleton warrior or skeleton archer to guard you. You are limited to 3 skeletons at a time.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Summon Skeleton Rogue": {
     "id": "sr5t",
     "name": "Summon Skeleton Rogue",
     "description": "Summon a primal wolf to guard you and attack your enemies",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Summon Spriggan": {
     "id": "sp38",
     "name": "Summon Spriggan",
     "description": "Summon a spriggan that casts spells to attack your enemies and has a passive Healing Aura that restores 10 health per second. When its health drops to 0 it is downed, and you can stand near it to revive it.\n\nThe spriggan counts as a companion. You can have a maximum of two companions at once by default.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Summon Squirrel": {
     "id": "sps5l",
     "name": "Summon Squirrel",
     "description": "Summons a primal wolf that follows you into combat. When its health drops to 0 it is downed, and you can stand near it to revive it.\n\nThe wolf counts as a companion. You can have a maximum of two companions at once by default.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Summon Storm Crows": {
     "id": "ssc50",
     "name": "Summon Storm Crows",
     "description": "Summons Storm Crows up to your companion limit. The Storm Crow casts spells from a distance. When its health drops to 0 it is downed, and you can stand near it to revive it.\n\nThe Storm Crow counts as a companion. You can have a maximum of two companions at once by default.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Summon Storm Totem": {
     "id": "st38ml",
     "name": "Summon Storm Totem",
     "description": "Summons a totem that casts lightning storms around nearby enemies.\n\nStorm totems last 8 seconds, and you cannot control more than 1 at once.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Summon Thorn Totem": {
     "id": "th39",
     "name": "Summon Thorn Totem",
     "description": "Summons a totem that fires thorns at nearby enemies. You can have a maximum of two thorn totems by default.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Summon Vine": {
     "id": "vi41a",
     "name": "Summon Vine",
     "description": "Summons 1 poisonous vine.\n\nVines are melee minions that inflict poison on hit. You can have up to 12 vines.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Summon Vines": {
     "id": "vi41",
     "name": "Summon Vines",
     "description": "Summon 3 poisonous vines for 8 seconds.\n\nEach vine has 50 base health.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Summon Volatile Zombie": {
     "id": "svz81",
     "name": "Summon Volatile Zombie",
     "description": "Summons a Volatile Zombie which trudges towards the nearest enemy. When it reaches an enemy or dies, it explodes dealing physical and fire damage to surrounding enemies.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Summon Wolf": {
     "id": "wo42",
     "name": "Summon Wolf",
     "description": "Summons a primal wolf that follows you into combat. When its health drops to 0 it is downed, and you can stand near it to revive it.\n\nWhile you have your maximum number of wolves, the ability is replaced with {Howl}.\n\nThe wolf counts as a companion. You can have a maximum of two companions at once by default.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Summon Wraith": {
     "id": "sw42ih",
     "name": "Summon Wraith",
     "description": "Summons a wraith that rapidly fades from this world, but will seek and attack your foes while it remains.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Surge": {
     "id": "su5g3",
     "name": "Surge",
     "description": "",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Swarm Strike": {
     "id": "sbsa4",
     "name": "Swarm Strike",
     "description": "A circular attack which deals damage to all nearby enemies, then gathers nearby locusts to create a Swarm around you which deals damage over time to nearby enemies.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Swarmblade Form": {
     "id": "sbf4m",
     "name": "Swarmblade Form",
     "description": "Transform into an agile Swarmblade, increasing your melee capabilities, and gaining 4 new abilities.\n\nYour mana is replaced with Rage while in swarmblade form. When your Rage reaches 0 you automatically transform back into your human form. Your starting Rage is equal to your maximum mana. Rage slowly decays over time at a constant rate.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Swipe": {
     "id": "sw43",
     "name": "Swipe",
     "description": "A melee attack that hits all enemies in an area in front of you. Unaffected by weapon range.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Symbols of Hope": {
     "id": "si4lgl",
     "name": "Symbols of Hope",
     "description": "Every 2 seconds, summons a symbol that orbits you, causing you and your allies' attacks and spells to deal 3 additional fire damage and increasing health regeneration by 20%.\n\nActivate to consume the symbols, granting 100 ward and 5% less damage taken per symbol for 3 seconds.\n\nYou can have up to 3 symbols at a time.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Synchronized Strike": {
     "id": "sync5",
     "name": "Synchronized Strike",
     "description": "Requires a melee weapon.\n\nJump forward and strike in an area in front of you while shadows appear and simultaneously strike on either side of you.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Teleport": {
     "id": "fl45",
     "name": "Teleport",
     "description": "Teleport to target location.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Tempest Strike": {
     "id": "ts85i",
     "name": "Tempest Strike",
     "description": "A melee combo attack that cycles through a cold strike, a physical strike, and a lightning strike that trigger elemental {Tempest} spells of the same damage type if the strikes hit at least one enemy.\n\nCold strike: Triggers a {Frigid Tempest}, which is a cold projectile that pierces through enemies.\nPhysical strike: Triggers a {Wind Tempest}, which is a small twister that lasts a short duration dealing physical damage per over time.\nLightning strike: Triggers a {Thunder Tempest}, which is an expanding storm of lightning bolts.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Thorn Shield": {
     "id": "ts48",
     "name": "Thorn Shield",
     "description": "Form a protective barrier of thorns around yourself or an ally that grants 30 armor and reflects 50 damage to attackers. When the shield expires, a burst of thorns shoots out and damages all nearby enemies.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Tornado": {
     "id": "to50",
     "name": "Tornado",
     "description": "Conjures a tornado that moves at random, pulling in nearby enemies and dealing physical damage to them.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Transplant": {
     "id": "ts50pl",
     "name": "Transplant",
     "description": "Creates a new body for you at the target location, then detonates your old body to deal physical damage to enemies around it.\n\nInstead of mana, this spell costs 13% of your current health.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Umbral Blades": {
     "id": "na28",
     "name": "Umbral Blades",
     "description": "Recall all Umbral Blades to you, hitting enemies along the way.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Upheaval": {
     "id": "uph41",
     "name": "Upheaval",
     "description": "Sunders the ground in a line in front of you, dealing damage to enemies along the path.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Vengeance": {
     "id": "gs15de",
     "name": "Vengeance",
     "description": "A melee attack that also prepares you to riposte incoming hits.\n\nIf vengeance successfully hits an enemy and you take a hit in the next 2 seconds you will riposte, taking 25% less damage and striking at a nearby enemy.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Void Cleave": {
     "id": "v01cv",
     "name": "Void Cleave",
     "description": "Requires a 2-handed sword or axe.\n\nA melee attack that hits all enemies in an area in front of you. Can be echoed by Void Knights. Unaffected by weapon range.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Volatile Reversal": {
     "id": "vr53sl",
     "name": "Volatile Reversal",
     "description": "A combo ability that jumps forwards in time to a target location and performs a melee attack on arrival. Recast within 3 seconds to jump backwards in time to your original location and perform a melee attack on arrival.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Volcanic Orb": {
     "id": "vo54",
     "name": "Volcanic Orb",
     "description": "",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Wandering Spirits": {
     "id": "ws54hm",
     "name": "Wandering Spirits",
     "description": "Reveals wandering spirits around you for 6 seconds. The spirits wander at random dealing necrotic damage over time to enemies they pass through.\n\n4 spirits are revealed immediately after casting the skill and 17 more are revealed over the next 6 seconds.\n\nThe spirits individually last up to 4 seconds, but all remaining spirits fade once the reveal duration ends.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Warcry": {
     "id": "wc57",
     "name": "Warcry",
     "description": "Unleash a mighty roar that knocks back nearby enemies and stuns them for 1.5 seconds. Rares and bosses are stunned for half as long.\n\n20% of remaining cooldown recovered whenever you stun (or freeze if Warcry is converted to cold) an enemy, including with Warcry itself. This effect can occur a maximum of two times each second.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Warpath": {
     "id": "va53st",
     "name": "Warpath",
     "description": "Spin towards the mouse while you hold down the ability key, striking nearby enemies as you move.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Wave of Death": {
     "id": "dsw43",
     "name": "Wave of Death",
     "description": "Releases a Wave of Death dealing damage based on how long Death Seal has been actve and your current percent missing health.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   },
   "Werebear Form": {
     "id": "wb8fo",
     "name": "Werebear Form",
     "description": "Transform into a ferocious werebear, increasing your physical capabilities and gaining 4 new abilities. \n\nYour mana is replaced with Rage while in werebear form. When your Rage reaches 0 you automatically transform back into your human form. Your starting Rage is equal to your maximum mana. Rage slowly decays over time at a constant rate.",
     "lore": "",
-    "class": ""
+    "class": "",
+    "base_damage_min": null,
+    "base_damage_max": null,
+    "damage_scaling_stat": null,
+    "attack_type": null
   }
 }

--- a/docs/TheForge MasterPlan v2 - Master Plan.csv
+++ b/docs/TheForge MasterPlan v2 - Master Plan.csv
@@ -28,7 +28,7 @@ THE FORGE — MASTER DEVELOPMENT PLAN,,,,,,,,
 24,Phase 0,0F-2,Review and verify high-impact stat key mappings,Data,CRITICAL,Not Started,FALSE,"Spot-check: damage%, crit, resistances, health, speed keys against in-game tooltips"
 25,Phase 0,0F-3,Build passive_stat_key_map translation layer in engine,Engine,CRITICAL,Not Started,FALSE,Replace the class stat-cycle fallback with real per-node stat resolution
 26,Phase 0,0F-4,Classify 85 behavioral / flag passive stats,Engine,HIGH,Not Started,FALSE,"Create passive_flags set on BuildStats. Examples: CanEquipAxeOffhand, EffectTripledAtLowLife"
-27,Phase 0,0G-1,Add base damage schema fields to skills_metadata.json,Data,CRITICAL,Not Started,FALSE,"Add: base_damage_min, base_damage_max, damage_scaling_stat, attack_type per skill"
+27,Phase 0,0G-1,Add base damage schema fields to skills_metadata.json,Data,CRITICAL,Complete,TRUE,"Schema live on all 161 skills as null placeholders; _schema block self-documents enums; pipeline validates populated values and strips meta keys; new get_skill_base_damage() accessor. Values populated per class in 0G-2..0G-6."
 28,Phase 0,0G-2,Populate skill base damage — Sentinel (all skills),Data,CRITICAL,Not Started,FALSE,Source: LET skill DB + in-game tooltips
 29,Phase 0,0G-3,Populate skill base damage — Mage (all skills),Data,CRITICAL,Not Started,FALSE,Source: LET skill DB + in-game tooltips
 30,Phase 0,0G-4,Populate skill base damage — Acolyte (all skills),Data,CRITICAL,Not Started,FALSE,Source: LET skill DB + in-game tooltips


### PR DESCRIPTION
Extends every skill entry with four Phase-0 fields (CSV row 0G-1):

  base_damage_min     — numeric | null
  base_damage_max     — numeric | null
  damage_scaling_stat — {strength|intelligence|dexterity|vitality|attunement|none} | null
  attack_type         — {melee|ranged|throwing|spell|channeled|dot|minion|aura|utility} | null

All 161 existing skills get the new keys with null placeholders. Values will be populated per class in 0G-2..0G-6.

Added a self-describing `_schema` block at the top of the file so the allowed enums live next to the data, not in a separate doc. The block is stripped by the loader before data reaches consumers.

Pipeline changes (backend/app/game_data/pipeline.py):
  - new `_load_skills_metadata()` replaces the generic `_load_optional` call for skills_meta. Drops `_*` meta keys, iterates every skill, and validates each populated field against its enum or type.
  - `_validate_skill_damage_fields()` raises at startup if a populated value is the wrong type, is outside the allowed enum, or if min > max — bad data cannot silently reach the engine.
  - Log line reports populated / unpopulated counts at load so the progress of 0G-2..0G-6 shows up in ops output.

Loader: `get_skill_base_damage(name)` returns the 4-field payload, or None when the skill is unknown or all four fields are null.

Existing consumers (import_route, maxroll_importer, lastepochtools_importer, base_importer) already filter by `"id" in v` when iterating `skills_metadata.values()`, so the new `_schema` key is a no-op for them.

Tests: 12 new schema/validator/accessor tests pass; full backend suite 10,771 pass / 377 skipped.