### PR TITLE
fix(passives): lock-direction uses requires[] not connections[] (0E follow-up)

### DIFF
--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -305,7 +305,13 @@ class PassiveNode(db.Model):
     max_points = db.Column(db.SmallInteger, default=1, nullable=False)
 
     # Connected node IDs (namespaced strings, e.g. ["ac_1", "ac_5"])
+    # Symmetric neighbour list — includes both parents and children.
     connections = db.Column(db.JSON, nullable=False, default=list)
+
+    # Directed parent requirements: [{parent_id: str, points: int}, ...]
+    # A node unlocks once ANY parent has >= points allocated (LE OR-of-parents).
+    # Empty list = tier root (freely selectable once mastery_requirement is met).
+    requires = db.Column(db.JSON, nullable=False, default=list)
 
     # Stat effects as a JSON array of {key, value} dicts
     stats = db.Column(db.JSON, nullable=True, default=list)

--- a/backend/app/routes/passives.py
+++ b/backend/app/routes/passives.py
@@ -63,6 +63,7 @@ def _serialize(node: PassiveNode) -> dict:
         "y": node.y,
         "max_points": node.max_points,
         "connections": node.connections,
+        "requires": node.requires or [],
         "stats": node.stats,
         "ability_granted": node.ability_granted,
         "icon": node.icon,

--- a/backend/app/utils/cli.py
+++ b/backend/app/utils/cli.py
@@ -221,6 +221,7 @@ def register_commands(app: Flask) -> None:
                 existing.y = node.get("y", 0.0)
                 existing.max_points = node.get("max_points", 1)
                 existing.connections = node.get("connections", [])
+                existing.requires = node.get("requires", [])
                 existing.stats = node.get("stats")
                 existing.ability_granted = node.get("ability_granted")
                 existing.icon = node.get("icon")
@@ -240,6 +241,7 @@ def register_commands(app: Flask) -> None:
                     y=node.get("y", 0.0),
                     max_points=node.get("max_points", 1),
                     connections=node.get("connections", []),
+                    requires=node.get("requires", []),
                     stats=node.get("stats"),
                     ability_granted=node.get("ability_granted"),
                     icon=node.get("icon"),

--- a/backend/migrations/versions/dd1840cac963_add_requires_to_passive_nodes.py
+++ b/backend/migrations/versions/dd1840cac963_add_requires_to_passive_nodes.py
@@ -1,0 +1,33 @@
+"""Add requires column to passive_nodes
+
+Revision ID: dd1840cac963
+Revises: 654f2ebcd332
+Create Date: 2026-04-18 00:00:00.000000
+
+Stores directed parent requirements as JSON:
+    [{"parent_id": str, "points": int}, ...]
+
+A node unlocks once ANY listed parent has >= points allocated
+(LE "OR-of-parents" rule). Empty list == tier root.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "dd1840cac963"
+down_revision = "654f2ebcd332"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("passive_nodes", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column("requires", sa.JSON(), nullable=False, server_default="[]")
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("passive_nodes", schema=None) as batch_op:
+        batch_op.drop_column("requires")

--- a/frontend/src/components/features/build/BuildPassiveTree.tsx
+++ b/frontend/src/components/features/build/BuildPassiveTree.tsx
@@ -223,14 +223,14 @@ export default function BuildPassiveTree({
 
       if (key === "__base__") {
         // Base tree: always accessible, tier gating within the tree
-        result[key] = computeAvailableNodes(sd.nodes, allocatedIds, basePointsSpent);
+        result[key] = computeAvailableNodes(sd.nodes, allocatedIds, basePointsSpent, allocatedPoints);
       } else if (!masteryTreesUnlocked) {
         // Mastery trees locked until 20 base points
         result[key] = new Set();
       } else {
         // Mastery tree: compute available nodes using that tree's own points for tier gating
         const sectionPoints = pointsBySection[key] ?? 0;
-        const available = computeAvailableNodes(sd.nodes, allocatedIds, sectionPoints);
+        const available = computeAvailableNodes(sd.nodes, allocatedIds, sectionPoints, allocatedPoints);
         // Remove mastery-locked nodes from available set
         for (const id of masteryLockedIds) {
           available.delete(id);
@@ -239,7 +239,7 @@ export default function BuildPassiveTree({
       }
     }
     return result;
-  }, [sectionKeys, sectionData, allocatedIds, basePointsSpent, masteryTreesUnlocked, pointsBySection, masteryLockedIds]);
+  }, [sectionKeys, sectionData, allocatedIds, allocatedPoints, basePointsSpent, masteryTreesUnlocked, pointsBySection, masteryLockedIds]);
 
   // Section cap: how many more points can go into a section
   const sectionCapRemaining = useCallback(

--- a/frontend/src/pages/PassiveTreePage.tsx
+++ b/frontend/src/pages/PassiveTreePage.tsx
@@ -125,8 +125,8 @@ export default function PassiveTreePage() {
 
   // Part 6: Available nodes cached via useMemo
   const availableIds = useMemo(
-    () => computeAvailableNodes(filteredNodes, allocatedIds, totalBasePointsSpent),
-    [filteredNodes, allocatedIds, totalBasePointsSpent],
+    () => computeAvailableNodes(filteredNodes, allocatedIds, totalBasePointsSpent, allocatedPoints),
+    [filteredNodes, allocatedIds, totalBasePointsSpent, allocatedPoints],
   );
 
   // Passive stat aggregation — recomputes when allocations change

--- a/frontend/src/services/passiveTreeService.ts
+++ b/frontend/src/services/passiveTreeService.ts
@@ -16,6 +16,11 @@ export interface PassiveNodeStat {
   value: string | number;
 }
 
+export interface PassiveRequirement {
+  parent_id: string;
+  points: number;
+}
+
 export interface PassiveNode {
   id: string;             // namespaced, e.g. "ac_0"
   raw_node_id: number;
@@ -29,7 +34,8 @@ export interface PassiveNode {
   x: number;
   y: number;
   max_points: number;
-  connections: string[];  // IDs of parent/adjacent nodes
+  connections: string[];  // symmetric neighbor ids (for rendering)
+  requires: PassiveRequirement[]; // directed parents with point thresholds
   stats: PassiveNodeStat[];
   ability_granted: string | null;
   icon: string | null;

--- a/frontend/src/utils/passiveGraph.ts
+++ b/frontend/src/utils/passiveGraph.ts
@@ -32,8 +32,9 @@ export const enum NodeState {
  * Build a bidirectional adjacency map from the node list.
  * Computed once per tree load via useMemo in the page.
  *
- * The API `connections` field lists a node's PARENTS. We add edges in
- * both directions so BFS can traverse parent→child and child→parent.
+ * ``connections`` is already symmetric (each edge lists both endpoints),
+ * but we iterate defensively — any one-sided entry still produces a
+ * valid bidirectional edge in the returned map.
  */
 export function buildBidirectionalAdjacency(nodes: PassiveNode[]): Map<string, Set<string>> {
   const adj = new Map<string, Set<string>>();
@@ -43,10 +44,10 @@ export function buildBidirectionalAdjacency(nodes: PassiveNode[]): Map<string, S
   }
 
   for (const node of nodes) {
-    for (const parentId of node.connections) {
-      if (!adj.has(parentId)) adj.set(parentId, new Set());
-      adj.get(node.id)!.add(parentId);
-      adj.get(parentId)!.add(node.id);
+    for (const neighborId of node.connections) {
+      if (!adj.has(neighborId)) adj.set(neighborId, new Set());
+      adj.get(node.id)!.add(neighborId);
+      adj.get(neighborId)!.add(node.id);
     }
   }
 
@@ -63,13 +64,15 @@ export const buildAdjacency = buildBidirectionalAdjacency;
 /**
  * Find starting nodes — the true graph roots.
  *
- * Start nodes: mastery_requirement === 0 AND no parent connections.
- * These are the BFS seeds for reachability checks.
+ * Start nodes: mastery_requirement === 0 AND zero parent requirements.
+ * Parents live in ``requires[]`` after the 0E-* merge; ``connections[]``
+ * is now a symmetric neighbour list that includes children too, so it
+ * can't be used to detect roots.
  */
 export function findStartNodes(nodes: PassiveNode[]): Set<string> {
   const starts = new Set<string>();
   for (const node of nodes) {
-    if (node.mastery_requirement === 0 && node.connections.length === 0) {
+    if (node.mastery_requirement === 0 && (node.requires?.length ?? 0) === 0) {
       starts.add(node.id);
     }
   }
@@ -127,27 +130,41 @@ export function getReachableNodes(
  * A node is available if:
  *   1. mastery_requirement <= totalBasePointsSpent (tier gate met)
  *   2. AND one of:
- *      a. No parent connections (tier root — freely selectable at this tier)
- *      b. At least one parent connection is already allocated
+ *      a. No parent requirements (tier root — freely selectable at this tier)
+ *      b. At least one parent in ``requires[]`` is allocated with
+ *         ``allocated[parent] >= points_required`` (LE is OR-of-parents)
+ *
+ * ``allocatedPoints`` maps node_id -> currently-allocated points. The
+ * threshold check uses it; if it's omitted we fall back to treating any
+ * allocation as satisfying the threshold, which preserves the old
+ * behaviour for callers that only track a set of allocated ids.
  */
 export function computeAvailableNodes(
   nodes: PassiveNode[],
   allocatedIds: Set<string>,
   totalBasePointsSpent: number,
+  allocatedPoints?: Map<string, number> | Record<string, number>,
 ): Set<string> {
   const available = new Set<string>();
+
+  const pointsFor = (id: string): number => {
+    if (!allocatedPoints) return allocatedIds.has(id) ? Number.POSITIVE_INFINITY : 0;
+    if (allocatedPoints instanceof Map) return allocatedPoints.get(id) ?? 0;
+    return allocatedPoints[id] ?? 0;
+  };
 
   for (const node of nodes) {
     if (allocatedIds.has(node.id)) continue;
     if (totalBasePointsSpent < node.mastery_requirement) continue;
 
-    if (node.connections.length === 0) {
+    const reqs = node.requires ?? [];
+    if (reqs.length === 0) {
       available.add(node.id);
       continue;
     }
 
-    for (const parentId of node.connections) {
-      if (allocatedIds.has(parentId)) {
+    for (const req of reqs) {
+      if (pointsFor(req.parent_id) >= req.points) {
         available.add(node.id);
         break;
       }
@@ -195,13 +212,13 @@ export function canRemoveNode(
   if (remaining.size === 0) return true;
 
   // Find ALL valid roots in the remaining set.
-  // A root is any node with no parent connections (connections.length === 0).
+  // A root is any node with no parent requirements (requires.length === 0).
   // These are independently valid at their tier and don't need a path from startIds.
   const roots = new Set<string>();
 
   if (nodes) {
     for (const node of nodes) {
-      if (remaining.has(node.id) && node.connections.length === 0) {
+      if (remaining.has(node.id) && (node.requires?.length ?? 0) === 0) {
         roots.add(node.id);
       }
     }


### PR DESCRIPTION
Problem: after the 0E-1 merge, connections[] became a symmetric neighbour list (includes both parents and children) while directed parent thresholds moved to the new requires[] field. The frontend lock logic still treated connections[] as the parent list, so nodes with downstream children were flagged as unlocked roots (e.g. mg_2 showed "needs mg_6 or mg_7" even though those are its children).

Frontend:
  - passiveGraph.ts: findStartNodes, computeAvailableNodes, canRemoveNode all switch from connections[] to requires[] for parent-direction checks
  - computeAvailableNodes gains optional allocatedPoints map so the points_required threshold is actually enforced (was previously ignored — any allocation satisfied the gate)
  - PassiveNode service type gains requires: PassiveRequirement[]
  - BuildPassiveTree + PassiveTreePage pass allocatedPoints through

Backend:
  - PassiveNode ORM model gains requires JSON column
  - /api/passives _serialize() emits requires
  - seed-passives CLI upserts the field
  - Alembic migration dd1840cac963 adds the column (default [])

Tests: backend passive suites green (76 passed).
Typecheck: frontend tsc --noEmit clean.