### PR TITLE
fix(passives): prune stale rows in seed-passives to drop ghost nodes

### DIFF
--- a/backend/app/utils/cli.py
+++ b/backend/app/utils/cli.py
@@ -253,6 +253,18 @@ def register_commands(app: Flask) -> None:
         if warnings:
             click.echo(f"  {warnings} dangling connection ID(s) logged above.")
 
+        # Prune rows that no longer exist in the JSON export — otherwise
+        # older synthetic ids (e.g. collision-disambiguated mg_m0_54 from
+        # earlier sync_game_data.py runs) stick around and get served by
+        # the API, appearing as ghost nodes in the UI.
+        json_ids = all_ids
+        stale = PassiveNode.query.filter(~PassiveNode.id.in_(json_ids)).all()
+        if stale:
+            for row in stale:
+                db.session.delete(row)
+            db.session.commit()
+            click.echo(f"  Pruned {len(stale)} stale row(s) not present in passives.json.")
+
     @app.cli.command("create-admin")
     @click.argument("username")
     def create_admin(username: str):


### PR DESCRIPTION
Root cause of ghost node mg_m0_54 "Amplified Resistance" in the Mage base tree: scripts/sync_game_data.py:445 produces collision-disambiguated ids of the form {prefix}_m{mastery_idx}_{raw_id} when a raw_id appears in multiple masteries within one class. Earlier sync runs seeded those ids into passive_nodes; the 0E merge replaced passives.json with a regenerated set using plain {prefix}_{raw_id} ids. seed-passives upserted the new ids but never deleted the old ones, so the stale rows kept flowing through /api/passives and the Dependency Inspector tooltip.

Fix: after upsert, delete any passive_nodes row whose id is not in the current passives.json. Idempotent; no-op when DB is already clean.

Users seeing ghost nodes should run `flask seed-passives` to prune.