### PR TITLE
Add controlled Forge-safe affix catalog (loader, service, endpoints, frontend UI)

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -215,6 +215,8 @@ def create_app(env: str = "development") -> Flask:
     from app.routes.views import views_bp
     from app.routes.report import report_bp
     from app.routes.health import health_bp
+    from app.routes.affixes import affixes_bp
+    from app.routes.experimental import experimental_bp
 
     app.register_blueprint(auth_bp, url_prefix="/api/auth")
     app.register_blueprint(builds_bp, url_prefix="/api/builds")
@@ -241,6 +243,8 @@ def create_app(env: str = "development") -> Flask:
     app.register_blueprint(views_bp, url_prefix="/api/builds")
     app.register_blueprint(report_bp, url_prefix="/api/builds")
     app.register_blueprint(health_bp, url_prefix="/api")
+    app.register_blueprint(affixes_bp, url_prefix="/api/affixes")
+    app.register_blueprint(experimental_bp, url_prefix="/api/experimental")
 
     # Global error handlers — always return JSON so frontend can parse the response
     from app.utils.exceptions import ForgeError

--- a/backend/app/routes/affixes.py
+++ b/backend/app/routes/affixes.py
@@ -1,0 +1,83 @@
+"""Stable affix catalog endpoints gated behind Forge-safe consumption config."""
+
+from __future__ import annotations
+
+from flask import Blueprint, request
+
+from app.services.affix_catalog_service import AffixCatalogFilters, AffixCatalogService, AffixCatalogUnavailable
+from app.utils.responses import error, not_found, ok
+
+affixes_bp = Blueprint("affixes", __name__)
+
+
+def _service() -> AffixCatalogService:
+    return AffixCatalogService()
+
+
+def _require_enabled(service: AffixCatalogService):
+    if not service.consumption_enabled:
+        return error("Forge-safe affix consumption is disabled", status=404)
+    if service.mode == "shadow":
+        return error("Forge-safe affix catalog is in shadow mode and is not user-facing", status=409)
+    return None
+
+
+@affixes_bp.get("/catalog")
+def list_catalog_affixes():
+    service = _service()
+    disabled = _require_enabled(service)
+    if disabled:
+        return disabled
+    try:
+        result = service.list_affixes(
+            limit=int(request.args.get("limit", 50)),
+            offset=int(request.args.get("offset", 0)),
+            query=request.args.get("q") or request.args.get("query"),
+            filters=AffixCatalogFilters(
+                source_type=request.args.get("source_type"),
+                item_type=request.args.get("item_type"),
+            ),
+        )
+    except (ValueError, AffixCatalogUnavailable) as exc:
+        return error(str(exc), status=503)
+    meta = {k: result[k] for k in ("total", "limit", "offset", "data_source", "mode", "consumption_enabled", "production_consumer")}
+    return ok(data=result["affixes"], meta=meta)
+
+
+@affixes_bp.get("/catalog/summary")
+def catalog_summary():
+    service = _service()
+    disabled = _require_enabled(service)
+    if disabled:
+        return disabled
+    try:
+        return ok(data=service.summary())
+    except AffixCatalogUnavailable as exc:
+        return error(str(exc), status=503)
+
+
+@affixes_bp.get("/catalog/<affix_id>")
+def catalog_affix_detail(affix_id: str):
+    service = _service()
+    disabled = _require_enabled(service)
+    if disabled:
+        return disabled
+    try:
+        affix = service.get_affix(affix_id)
+    except AffixCatalogUnavailable as exc:
+        return error(str(exc), status=503)
+    if affix is None:
+        return not_found("Affix")
+    return ok(data=affix, meta={"data_source": service.active_source, "production_consumer": False})
+
+
+@affixes_bp.get("/experimental/forge-safe-affixes")
+def experimental_forge_safe_affixes():
+    service = _service()
+    if not service.config.get("FORGE_SAFE_AFFIX_CATALOG_ENABLED", False):
+        return error("Experimental Forge-safe affix catalog is disabled", status=404)
+    try:
+        result = service.list_affixes(limit=int(request.args.get("limit", 100)), offset=int(request.args.get("offset", 0)))
+    except AffixCatalogUnavailable as exc:
+        return error(str(exc), status=503)
+    return ok(data=result["affixes"], meta={k: result[k] for k in ("total", "limit", "offset", "data_source", "mode", "production_consumer")})

--- a/backend/app/routes/experimental.py
+++ b/backend/app/routes/experimental.py
@@ -1,0 +1,22 @@
+"""Experimental feature-gated endpoints preserved for migration debugging."""
+
+from __future__ import annotations
+
+from flask import Blueprint, request
+
+from app.services.affix_catalog_service import AffixCatalogService, AffixCatalogUnavailable
+from app.utils.responses import error, ok
+
+experimental_bp = Blueprint("experimental", __name__)
+
+
+@experimental_bp.get("/forge-safe-affixes")
+def forge_safe_affixes():
+    service = AffixCatalogService()
+    if not service.config.get("FORGE_SAFE_AFFIX_CATALOG_ENABLED", False):
+        return error("Experimental Forge-safe affix catalog is disabled", status=404)
+    try:
+        result = service.list_affixes(limit=int(request.args.get("limit", 100)), offset=int(request.args.get("offset", 0)))
+    except AffixCatalogUnavailable as exc:
+        return error(str(exc), status=503)
+    return ok(data=result["affixes"], meta={k: result[k] for k in ("total", "limit", "offset", "data_source", "mode", "production_consumer")})

--- a/backend/app/services/affix_catalog_service.py
+++ b/backend/app/services/affix_catalog_service.py
@@ -1,0 +1,159 @@
+"""Controlled affix catalog service.
+
+This service is the single selection point between legacy affix data and the
+Forge-safe canonical export.  It never mutates the global AffixRegistry.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from flask import current_app
+
+from data.loaders.forge_safe_affixes_loader import ForgeSafeAffixLoadError
+from data.repositories.forge_safe_affix_repository import ForgeSafeAffixRepository
+
+VALID_MODES = {"shadow", "read_only", "active"}
+
+
+@dataclass(frozen=True)
+class AffixCatalogFilters:
+    source_type: str | None = None
+    item_type: str | None = None
+
+
+class AffixCatalogUnavailable(RuntimeError):
+    pass
+
+
+class AffixCatalogService:
+    def __init__(self, app=None, repository: ForgeSafeAffixRepository | None = None) -> None:
+        self.app = app
+        self._repository = repository
+
+    @property
+    def config(self):
+        app = self.app or current_app
+        return app.config
+
+    @property
+    def consumption_enabled(self) -> bool:
+        return bool(self.config.get("FORGE_SAFE_AFFIX_CONSUMPTION_ENABLED", False))
+
+    @property
+    def mode(self) -> str:
+        mode = str(self.config.get("FORGE_SAFE_AFFIX_CONSUMPTION_MODE", "shadow")).lower()
+        return mode if mode in VALID_MODES else "shadow"
+
+    @property
+    def active_source(self) -> str:
+        if self.consumption_enabled and self.mode in {"read_only", "active"}:
+            return "forge_safe"
+        return "legacy"
+
+    def list_affixes(self, *, limit: int = 50, offset: int = 0, filters: AffixCatalogFilters | None = None, query: str | None = None) -> dict[str, Any]:
+        records = self._active_records()
+        filtered = self._filter_records(records, filters or AffixCatalogFilters(), query)
+        limit = max(1, min(int(limit), 250))
+        offset = max(0, int(offset))
+        page = filtered[offset : offset + limit]
+        return {
+            "affixes": page,
+            "total": len(filtered),
+            "limit": limit,
+            "offset": offset,
+            "data_source": self.active_source,
+            "mode": self.mode,
+            "consumption_enabled": self.consumption_enabled,
+            "production_consumer": False,
+        }
+
+    def get_affix(self, affix_id: str) -> dict[str, Any] | None:
+        affix_id = str(affix_id)
+        if self.active_source == "forge_safe":
+            record = self._repo().get(affix_id)
+            return record.to_catalog_dict() if record else None
+        for record in self._legacy_records():
+            if str(record.get("id")) == affix_id or str(record.get("affix_id")) == affix_id:
+                return record
+        return None
+
+    def search_affixes(self, query: str, *, limit: int = 50, offset: int = 0, filters: AffixCatalogFilters | None = None) -> dict[str, Any]:
+        return self.list_affixes(limit=limit, offset=offset, filters=filters, query=query)
+
+    def summary(self) -> dict[str, Any]:
+        legacy_count = len(self._legacy_records())
+        summary = {
+            "active_source": self.active_source,
+            "mode": self.mode,
+            "consumption_enabled": self.consumption_enabled,
+            "legacy_count": legacy_count,
+            "production_consumer": False,
+        }
+        if self.consumption_enabled:
+            try:
+                forge_summary = self._repo().summary()
+                summary["forge_safe"] = forge_summary
+                summary["forge_safe_count"] = forge_summary["count"]
+            except ForgeSafeAffixLoadError as exc:
+                summary["forge_safe_error"] = str(exc)
+                if self.mode in {"read_only", "active"}:
+                    raise AffixCatalogUnavailable(str(exc)) from exc
+        else:
+            summary["forge_safe_count"] = 0
+        return summary
+
+    def _repo(self) -> ForgeSafeAffixRepository:
+        if self._repository is not None:
+            return self._repository
+        path = self.config.get("FORGE_SAFE_AFFIX_EXPORT_PATH")
+        if not path:
+            raise AffixCatalogUnavailable("FORGE_SAFE_AFFIX_EXPORT_PATH is not configured")
+        self._repository = ForgeSafeAffixRepository(path)
+        return self._repository
+
+    def _active_records(self) -> list[dict[str, Any]]:
+        if self.active_source == "forge_safe":
+            try:
+                return [record.to_catalog_dict() for record in self._repo().all()]
+            except ForgeSafeAffixLoadError as exc:
+                raise AffixCatalogUnavailable(str(exc)) from exc
+        return self._legacy_records()
+
+    def _legacy_records(self) -> list[dict[str, Any]]:
+        app = self.app or current_app
+        registry = app.extensions.get("affix_registry")
+        if registry is not None:
+            return [self._legacy_to_catalog(a) for a in registry.all()]
+        return []
+
+    @staticmethod
+    def _legacy_to_catalog(affix: Any) -> dict[str, Any]:
+        affix_id = getattr(affix, "affix_id", None)
+        return {
+            "id": str(affix_id if affix_id is not None else getattr(affix, "name", "")),
+            "affix_id": affix_id,
+            "name": getattr(affix, "name", ""),
+            "source_type": getattr(affix, "affix_type", None),
+            "item_types": list(getattr(affix, "applicable_to", ()) or ()),
+            "data_source": "legacy",
+            "production_consumer": False,
+        }
+
+    @staticmethod
+    def _filter_records(records: list[dict[str, Any]], filters: AffixCatalogFilters, query: str | None) -> list[dict[str, Any]]:
+        q = (query or "").strip().lower()
+        source_type = (filters.source_type or "").strip().lower()
+        item_type = (filters.item_type or "").strip().lower()
+        output = []
+        for record in records:
+            if source_type and str(record.get("source_type") or "").lower() != source_type:
+                continue
+            item_types = [str(v).lower() for v in record.get("item_types", [])]
+            if item_type and item_type not in item_types:
+                continue
+            if q and q not in str(record.get("name", "")).lower() and q not in str(record.get("id", "")).lower():
+                continue
+            output.append(record)
+        return output

--- a/backend/config.py
+++ b/backend/config.py
@@ -37,6 +37,13 @@ class Config:
 
     FRONTEND_URL = os.environ.get("FRONTEND_URL", "http://localhost:5173")
 
+
+    # Controlled Forge-safe affix consumption. Disabled by default.
+    FORGE_SAFE_AFFIX_CATALOG_ENABLED = os.environ.get("FORGE_SAFE_AFFIX_CATALOG_ENABLED", "false").lower() == "true"
+    FORGE_SAFE_AFFIX_CONSUMPTION_ENABLED = os.environ.get("FORGE_SAFE_AFFIX_CONSUMPTION_ENABLED", "false").lower() == "true"
+    FORGE_SAFE_AFFIX_EXPORT_PATH = os.environ.get("FORGE_SAFE_AFFIX_EXPORT_PATH", "")
+    FORGE_SAFE_AFFIX_CONSUMPTION_MODE = os.environ.get("FORGE_SAFE_AFFIX_CONSUMPTION_MODE", "shadow")
+
     # Pagination defaults
     DEFAULT_PAGE_SIZE = 20
     MAX_PAGE_SIZE = 100

--- a/backend/data/loaders/forge_safe_affixes_loader.py
+++ b/backend/data/loaders/forge_safe_affixes_loader.py
@@ -1,0 +1,124 @@
+"""Loader for Forge-safe canonical affix exports.
+
+The export is intentionally consumed as read-only data.  This loader refuses
+records that are not explicitly marked ``safety.forge_safe=true`` and also
+refuses records marked ``production_safe=true`` because that flag is not part of
+Forge's current consumption contract.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+class ForgeSafeAffixLoadError(RuntimeError):
+    """Raised when the Forge-safe export cannot be loaded safely."""
+
+
+@dataclass(frozen=True)
+class ForgeSafeAffixRecord:
+    id: str
+    name: str
+    source_type: str | None
+    item_types: tuple[str, ...]
+    raw: dict[str, Any]
+
+    def to_catalog_dict(self) -> dict[str, Any]:
+        safety = self.raw.get("safety") if isinstance(self.raw.get("safety"), dict) else {}
+        return {
+            "id": self.id,
+            "name": self.name,
+            "source_type": self.source_type,
+            "item_types": list(self.item_types),
+            "data_source": "forge_safe",
+            "safety": {"forge_safe": bool(safety.get("forge_safe"))},
+            "production_consumer": False,
+            "raw": self.raw,
+        }
+
+
+class ForgeSafeAffixLoader:
+    """Load and validate canonical Forge-safe affix exports."""
+
+    def __init__(self, export_path: str | Path) -> None:
+        self.export_path = Path(export_path)
+
+    def load(self) -> list[ForgeSafeAffixRecord]:
+        if not self.export_path:
+            raise ForgeSafeAffixLoadError("Forge-safe affix export path is not configured")
+        if not self.export_path.exists():
+            raise ForgeSafeAffixLoadError(f"Forge-safe affix export not found: {self.export_path}")
+
+        try:
+            payload = json.loads(self.export_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise ForgeSafeAffixLoadError(f"Invalid Forge-safe affix JSON: {exc}") from exc
+        except OSError as exc:
+            raise ForgeSafeAffixLoadError(f"Could not read Forge-safe affix export: {exc}") from exc
+
+        records_payload = self._extract_records(payload)
+        records: list[ForgeSafeAffixRecord] = []
+        rejected_production_safe = 0
+        for raw in records_payload:
+            if not isinstance(raw, dict):
+                continue
+            if raw.get("production_safe") is True:
+                rejected_production_safe += 1
+                continue
+            safety = raw.get("safety") if isinstance(raw.get("safety"), dict) else {}
+            if safety.get("forge_safe") is not True:
+                continue
+            affix_id = self._first_string(raw, "id", "affix_id", "canonical_id")
+            name = self._first_string(raw, "name", "display_name")
+            if not affix_id or not name:
+                continue
+            records.append(
+                ForgeSafeAffixRecord(
+                    id=affix_id,
+                    name=name,
+                    source_type=self._first_string(raw, "source_type", "type", "affix_type") or None,
+                    item_types=tuple(self._item_types(raw)),
+                    raw=dict(raw),
+                )
+            )
+
+        if rejected_production_safe:
+            # Clean failure: the current contract explicitly excludes these records.
+            raise ForgeSafeAffixLoadError(
+                f"Forge-safe export contains {rejected_production_safe} production_safe=true record(s), which are not accepted"
+            )
+        return records
+
+    @staticmethod
+    def _extract_records(payload: Any) -> list[Any]:
+        if isinstance(payload, list):
+            return payload
+        if isinstance(payload, dict):
+            for key in ("affixes", "records", "data", "canonical_affixes"):
+                value = payload.get(key)
+                if isinstance(value, list):
+                    return value
+        raise ForgeSafeAffixLoadError("Forge-safe affix export must be a list or contain an affixes/records/data list")
+
+    @staticmethod
+    def _first_string(raw: dict[str, Any], *keys: str) -> str:
+        for key in keys:
+            value = raw.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+            if isinstance(value, int):
+                return str(value)
+        return ""
+
+    @staticmethod
+    def _item_types(raw: dict[str, Any]) -> list[str]:
+        for key in ("item_types", "applicable_to", "rolls_on_item_types"):
+            value = raw.get(key)
+            if isinstance(value, list):
+                return [str(v) for v in value if str(v)]
+            if isinstance(value, str) and value.strip():
+                return [value.strip()]
+        return []

--- a/backend/data/repositories/forge_safe_affix_repository.py
+++ b/backend/data/repositories/forge_safe_affix_repository.py
@@ -1,0 +1,41 @@
+"""Read-only repository over Forge-safe affix records."""
+
+from __future__ import annotations
+
+from collections import Counter
+from pathlib import Path
+
+from data.loaders.forge_safe_affixes_loader import ForgeSafeAffixLoader, ForgeSafeAffixRecord
+
+
+class ForgeSafeAffixRepository:
+    def __init__(self, export_path: str | Path) -> None:
+        self.export_path = Path(export_path)
+        self._records: list[ForgeSafeAffixRecord] | None = None
+        self._by_id: dict[str, ForgeSafeAffixRecord] = {}
+
+    def load(self, *, force: bool = False) -> list[ForgeSafeAffixRecord]:
+        if self._records is None or force:
+            self._records = ForgeSafeAffixLoader(self.export_path).load()
+            self._by_id = {record.id: record for record in self._records}
+        return list(self._records)
+
+    def all(self) -> list[ForgeSafeAffixRecord]:
+        return self.load()
+
+    def get(self, affix_id: str) -> ForgeSafeAffixRecord | None:
+        self.load()
+        return self._by_id.get(str(affix_id))
+
+    def summary(self) -> dict:
+        records = self.load()
+        source_types = Counter(r.source_type or "unknown" for r in records)
+        item_types = Counter(item for r in records for item in r.item_types)
+        return {
+            "data_source": "forge_safe",
+            "count": len(records),
+            "source_types": dict(sorted(source_types.items())),
+            "item_types": dict(sorted(item_types.items())),
+            "export_path": str(self.export_path),
+            "production_consumer": False,
+        }

--- a/backend/scripts/compare_forge_safe_affixes.py
+++ b/backend/scripts/compare_forge_safe_affixes.py
@@ -1,0 +1,77 @@
+"""Compare legacy AffixRegistry data with the Forge-safe affix export.
+
+Usage:
+    python scripts/compare_forge_safe_affixes.py --export-path path/to/forge_safe_canonical_affixes.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from app import create_app
+from data.repositories.forge_safe_affix_repository import ForgeSafeAffixRepository
+
+
+def _legacy_records(app) -> dict[str, dict[str, Any]]:
+    registry = app.extensions["affix_registry"]
+    result = {}
+    for affix in registry.all():
+        affix_id = str(affix.affix_id if affix.affix_id is not None else affix.name)
+        result[affix_id] = {
+            "id": affix_id,
+            "name": affix.name,
+            "source_type": affix.affix_type,
+            "item_types": list(affix.applicable_to),
+        }
+    return result
+
+
+def compare(export_path: str | Path, env: str = "development") -> dict[str, Any]:
+    app = create_app(env)
+    with app.app_context():
+        legacy = _legacy_records(app)
+    forge = {record.id: record.to_catalog_dict() for record in ForgeSafeAffixRepository(export_path).all()}
+
+    legacy_ids = set(legacy)
+    forge_ids = set(forge)
+    matching_ids = sorted(legacy_ids & forge_ids)
+    name_mismatches = [
+        {"id": affix_id, "legacy": legacy[affix_id]["name"], "forge_safe": forge[affix_id]["name"]}
+        for affix_id in matching_ids
+        if legacy[affix_id]["name"] != forge[affix_id]["name"]
+    ]
+    source_type_mismatches = [
+        {"id": affix_id, "legacy": legacy[affix_id].get("source_type"), "forge_safe": forge[affix_id].get("source_type")}
+        for affix_id in matching_ids
+        if legacy[affix_id].get("source_type") != forge[affix_id].get("source_type")
+    ]
+    item_type_mismatches = [
+        {"id": affix_id, "legacy": legacy[affix_id].get("item_types", []), "forge_safe": forge[affix_id].get("item_types", [])}
+        for affix_id in matching_ids
+        if sorted(legacy[affix_id].get("item_types", [])) != sorted(forge[affix_id].get("item_types", []))
+    ]
+    return {
+        "total_counts": {"legacy": len(legacy), "forge_safe": len(forge), "matching_ids": len(matching_ids)},
+        "forge_safe_not_legacy": sorted(forge_ids - legacy_ids),
+        "legacy_not_forge_safe": sorted(legacy_ids - forge_ids),
+        "matching_ids": matching_ids,
+        "name_mismatches": name_mismatches,
+        "source_type_mismatches": source_type_mismatches,
+        "item_type_mismatches": item_type_mismatches,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--export-path", required=True)
+    parser.add_argument("--env", default="development")
+    args = parser.parse_args()
+    print(json.dumps(compare(args.export_path, args.env), indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_affix_catalog_routes.py
+++ b/backend/tests/test_affix_catalog_routes.py
@@ -1,0 +1,48 @@
+import json
+
+
+def write_export(tmp_path):
+    path = tmp_path / "forge_safe.json"
+    path.write_text(json.dumps({"affixes": [
+        {"id": "health", "name": "Health", "source_type": "prefix", "item_types": ["helm"], "safety": {"forge_safe": True}},
+        {"id": "fire_res", "name": "Fire Resistance", "source_type": "suffix", "item_types": ["ring"], "safety": {"forge_safe": True}},
+    ]}), encoding="utf-8")
+    return path
+
+
+def test_catalog_disabled_returns_clean_error(client, app):
+    app.config["FORGE_SAFE_AFFIX_CONSUMPTION_ENABLED"] = False
+    response = client.get("/api/affixes/catalog")
+    assert response.status_code == 404
+    assert response.get_json()["errors"]
+
+
+def test_catalog_endpoints(client, app, tmp_path):
+    app.config.update(
+        FORGE_SAFE_AFFIX_CONSUMPTION_ENABLED=True,
+        FORGE_SAFE_AFFIX_CONSUMPTION_MODE="read_only",
+        FORGE_SAFE_AFFIX_EXPORT_PATH=str(write_export(tmp_path)),
+    )
+    response = client.get("/api/affixes/catalog?limit=1&offset=0&q=health&source_type=prefix&item_type=helm")
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["meta"]["data_source"] == "forge_safe"
+    assert body["data"][0]["id"] == "health"
+    assert body["data"][0]["production_consumer"] is False
+
+    detail = client.get("/api/affixes/catalog/health")
+    assert detail.status_code == 200
+    assert detail.get_json()["data"]["name"] == "Health"
+
+    summary = client.get("/api/affixes/catalog/summary")
+    assert summary.status_code == 200
+    assert summary.get_json()["data"]["forge_safe_count"] == 2
+
+
+def test_catalog_invalid_export_503(client, app, tmp_path):
+    app.config.update(
+        FORGE_SAFE_AFFIX_CONSUMPTION_ENABLED=True,
+        FORGE_SAFE_AFFIX_CONSUMPTION_MODE="read_only",
+        FORGE_SAFE_AFFIX_EXPORT_PATH=str(tmp_path / "missing.json"),
+    )
+    assert client.get("/api/affixes/catalog").status_code == 503

--- a/backend/tests/test_affix_catalog_service.py
+++ b/backend/tests/test_affix_catalog_service.py
@@ -1,0 +1,76 @@
+import json
+
+import pytest
+
+from app.services.affix_catalog_service import AffixCatalogFilters, AffixCatalogService, AffixCatalogUnavailable
+
+
+def write_export(tmp_path):
+    path = tmp_path / "forge_safe.json"
+    path.write_text(json.dumps({"affixes": [
+        {"id": "health", "name": "Health", "source_type": "prefix", "item_types": ["helm"], "safety": {"forge_safe": True}},
+        {"id": "fire_res", "name": "Fire Resistance", "source_type": "suffix", "item_types": ["ring"], "safety": {"forge_safe": True}},
+    ]}), encoding="utf-8")
+    return path
+
+
+def test_service_uses_legacy_when_disabled(app):
+    app.config["FORGE_SAFE_AFFIX_CONSUMPTION_ENABLED"] = False
+    svc = AffixCatalogService(app)
+    registry_before = app.extensions["affix_registry"]
+    result = svc.list_affixes(limit=5, offset=0)
+    assert result["data_source"] == "legacy"
+    assert len(result["affixes"]) <= 5
+    assert app.extensions["affix_registry"] is registry_before
+
+
+def test_service_uses_forge_safe_when_enabled_read_only(app, tmp_path):
+    app.config.update(
+        FORGE_SAFE_AFFIX_CONSUMPTION_ENABLED=True,
+        FORGE_SAFE_AFFIX_CONSUMPTION_MODE="read_only",
+        FORGE_SAFE_AFFIX_EXPORT_PATH=str(write_export(tmp_path)),
+    )
+    svc = AffixCatalogService(app)
+    result = svc.list_affixes(limit=10, offset=0)
+    assert result["data_source"] == "forge_safe"
+    assert result["total"] == 2
+    assert svc.get_affix("health")["name"] == "Health"
+
+
+def test_service_search_filter_and_pagination(app, tmp_path):
+    app.config.update(
+        FORGE_SAFE_AFFIX_CONSUMPTION_ENABLED=True,
+        FORGE_SAFE_AFFIX_CONSUMPTION_MODE="active",
+        FORGE_SAFE_AFFIX_EXPORT_PATH=str(write_export(tmp_path)),
+    )
+    svc = AffixCatalogService(app)
+    filtered = svc.search_affixes("res", filters=AffixCatalogFilters(source_type="suffix", item_type="ring"))
+    assert filtered["total"] == 1
+    assert filtered["affixes"][0]["id"] == "fire_res"
+    paged = svc.list_affixes(limit=1, offset=1)
+    assert paged["limit"] == 1
+    assert paged["offset"] == 1
+    assert len(paged["affixes"]) == 1
+
+
+def test_service_invalid_export_fails_cleanly(app, tmp_path):
+    broken = tmp_path / "missing.json"
+    app.config.update(
+        FORGE_SAFE_AFFIX_CONSUMPTION_ENABLED=True,
+        FORGE_SAFE_AFFIX_CONSUMPTION_MODE="read_only",
+        FORGE_SAFE_AFFIX_EXPORT_PATH=str(broken),
+    )
+    with pytest.raises(AffixCatalogUnavailable):
+        AffixCatalogService(app).list_affixes()
+
+
+def test_service_summary_metadata(app, tmp_path):
+    app.config.update(
+        FORGE_SAFE_AFFIX_CONSUMPTION_ENABLED=True,
+        FORGE_SAFE_AFFIX_CONSUMPTION_MODE="read_only",
+        FORGE_SAFE_AFFIX_EXPORT_PATH=str(write_export(tmp_path)),
+    )
+    summary = AffixCatalogService(app).summary()
+    assert summary["active_source"] == "forge_safe"
+    assert summary["forge_safe_count"] == 2
+    assert summary["production_consumer"] is False

--- a/backend/tests/test_experimental_forge_safe_affix_catalog.py
+++ b/backend/tests/test_experimental_forge_safe_affix_catalog.py
@@ -1,0 +1,10 @@
+def test_experimental_catalog_disabled(client, app):
+    app.config["FORGE_SAFE_AFFIX_CATALOG_ENABLED"] = False
+    response = client.get("/api/affixes/experimental/forge-safe-affixes")
+    assert response.status_code == 404
+
+
+def test_experimental_catalog_legacy_route_disabled(client, app):
+    app.config["FORGE_SAFE_AFFIX_CATALOG_ENABLED"] = False
+    response = client.get("/api/experimental/forge-safe-affixes")
+    assert response.status_code == 404

--- a/backend/tests/test_forge_safe_affix_repository.py
+++ b/backend/tests/test_forge_safe_affix_repository.py
@@ -1,0 +1,18 @@
+import json
+
+from data.repositories.forge_safe_affix_repository import ForgeSafeAffixRepository
+
+
+def test_repository_get_all_and_summary(tmp_path):
+    path = tmp_path / "forge_safe.json"
+    path.write_text(json.dumps({"affixes": [
+        {"id": "a", "name": "Alpha", "source_type": "prefix", "item_types": ["helm"], "safety": {"forge_safe": True}},
+        {"id": "b", "name": "Beta", "source_type": "suffix", "item_types": ["helm", "ring"], "safety": {"forge_safe": True}},
+    ]}), encoding="utf-8")
+    repo = ForgeSafeAffixRepository(path)
+    assert repo.get("a").name == "Alpha"
+    assert len(repo.all()) == 2
+    summary = repo.summary()
+    assert summary["count"] == 2
+    assert summary["source_types"] == {"prefix": 1, "suffix": 1}
+    assert summary["production_consumer"] is False

--- a/backend/tests/test_forge_safe_affixes_loader.py
+++ b/backend/tests/test_forge_safe_affixes_loader.py
@@ -1,0 +1,36 @@
+import json
+
+import pytest
+
+from data.loaders.forge_safe_affixes_loader import ForgeSafeAffixLoadError, ForgeSafeAffixLoader
+
+
+def write_export(tmp_path, records):
+    path = tmp_path / "forge_safe.json"
+    path.write_text(json.dumps({"affixes": records}), encoding="utf-8")
+    return path
+
+
+def test_loader_accepts_only_forge_safe_records(tmp_path):
+    path = write_export(tmp_path, [
+        {"id": "a", "name": "Alpha", "source_type": "prefix", "item_types": ["helm"], "safety": {"forge_safe": True}},
+        {"id": "b", "name": "Beta", "safety": {"forge_safe": False}},
+    ])
+    records = ForgeSafeAffixLoader(path).load()
+    assert [r.id for r in records] == ["a"]
+    assert records[0].to_catalog_dict()["production_consumer"] is False
+
+
+def test_loader_rejects_production_safe_true(tmp_path):
+    path = write_export(tmp_path, [
+        {"id": "a", "name": "Alpha", "production_safe": True, "safety": {"forge_safe": True}},
+    ])
+    with pytest.raises(ForgeSafeAffixLoadError):
+        ForgeSafeAffixLoader(path).load()
+
+
+def test_loader_invalid_export_fails_cleanly(tmp_path):
+    path = tmp_path / "broken.json"
+    path.write_text("{", encoding="utf-8")
+    with pytest.raises(ForgeSafeAffixLoadError):
+        ForgeSafeAffixLoader(path).load()

--- a/docs/migration/FORGE_SAFE_AFFIX_LOADER.md
+++ b/docs/migration/FORGE_SAFE_AFFIX_LOADER.md
@@ -1,0 +1,95 @@
+# Forge-safe Affix Loader and Controlled Consumption
+
+The Forge-safe canonical affix export is now available as a controlled internal catalog data source. It is intentionally read-only and does **not** replace planner, crafting, or simulation behavior by default.
+
+## Export contract
+
+* Export path: `FORGE_SAFE_AFFIX_EXPORT_PATH`.
+* Accepted records must include `safety.forge_safe=true`.
+* Records with `production_safe=true` are rejected with a clean loader error.
+* Missing mappings are not inferred.
+* Gameplay behavior is not inferred from tooltip text.
+* Endpoint payloads always expose `production_consumer=false`.
+
+## Backend components
+
+* Loader: `backend/data/loaders/forge_safe_affixes_loader.py`
+* Repository: `backend/data/repositories/forge_safe_affix_repository.py`
+* Service: `backend/app/services/affix_catalog_service.py`
+* Routes: `backend/app/routes/affixes.py`
+* Comparison tool: `backend/scripts/compare_forge_safe_affixes.py`
+
+`AffixCatalogService` chooses between the legacy registry and the Forge-safe repository. It does not mutate `app.extensions["affix_registry"]` or any global affix registry.
+
+## Environment variables and modes
+
+```env
+FORGE_SAFE_AFFIX_CATALOG_ENABLED=false
+FORGE_SAFE_AFFIX_CONSUMPTION_ENABLED=false
+FORGE_SAFE_AFFIX_EXPORT_PATH=D:\Forge\last-epoch-data\docs\generated\forge_safe_canonical_affixes.json
+FORGE_SAFE_AFFIX_CONSUMPTION_MODE=shadow
+```
+
+Modes:
+
+* `shadow`: load/compare only; stable catalog endpoints remain unavailable to users.
+* `read_only`: stable catalog endpoints and the development UI can browse the Forge-safe export. No planner/crafting/simulation usage.
+* `active`: allowed as the source for affix catalog browsing only. Planner/crafting/simulation still require a separate dedicated migration flag before they can consume Forge-safe affixes.
+
+Default is disabled + `shadow`.
+
+## Stable catalog endpoints
+
+All stable endpoints are feature-gated by `FORGE_SAFE_AFFIX_CONSUMPTION_ENABLED=true` and require mode `read_only` or `active`.
+
+* `GET /api/affixes/catalog`
+  * Query params: `limit`, `offset`, `q`/`query`, `source_type`, `item_type`.
+  * Returns paginated catalog records and metadata including `data_source`.
+* `GET /api/affixes/catalog/{affix_id}`
+  * Returns one catalog record or a clean 404.
+* `GET /api/affixes/catalog/summary`
+  * Returns active source, mode, legacy count, Forge-safe count, and safe metadata.
+
+The existing experimental endpoint is preserved under the affix route namespace:
+
+* `GET /api/affixes/experimental/forge-safe-affixes`
+
+## Frontend route
+
+* Route/page: `/affix-catalog`
+* Page component: `frontend/src/components/features/affixCatalog/AffixCatalogPage.tsx`
+* Frontend gate: `VITE_FORGE_SAFE_AFFIX_CATALOG_ENABLED=true` or Vite development mode.
+
+The page shows the Forge-safe count, data source label, search, `source_type` filtering, `item_type` filtering, and selected affix detail. It does not feed planner/crafting selections.
+
+## Shadow comparison tooling
+
+Run:
+
+```bash
+cd backend
+python scripts/compare_forge_safe_affixes.py --export-path "D:\Forge\last-epoch-data\docs\generated\forge_safe_canonical_affixes.json"
+```
+
+The report includes:
+
+* Forge-safe affixes not in legacy.
+* Legacy affixes not in Forge-safe.
+* Matching IDs.
+* Name mismatches.
+* Source/type mismatches.
+* Item-type mismatches.
+* Total counts.
+
+## Rollback plan
+
+1. Set `FORGE_SAFE_AFFIX_CONSUMPTION_ENABLED=false`.
+2. Set `FORGE_SAFE_AFFIX_CATALOG_ENABLED=false` if the experimental endpoint should also be hidden.
+3. Leave `FORGE_SAFE_AFFIX_EXPORT_PATH` unset or remove the file mount.
+4. Restart backend and frontend processes.
+
+Because the implementation does not mutate legacy registries and does not wire into planner/crafting/simulation, rollback is configuration-only.
+
+## Not yet migrated
+
+Planner, crafting, simulation, BIS generation, and stat aggregation continue to use the existing legacy systems. Migrating any of those consumers must be done separately behind a dedicated feature flag with focused tests.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,7 @@ import AuthCallbackPage from "@/components/features/AuthCallbackPage";
 import UserProfilePage from "@/components/features/UserProfilePage";
 import NotFoundPage from "@/components/features/NotFoundPage";
 import AffixEditorPage from "@/components/features/affixes/AffixEditorPage";
+import AffixCatalogPage from "@/components/features/affixCatalog/AffixCatalogPage";
 
 import BuildComparisonPage from "@/components/features/builds/BuildComparisonPage";
 import ReportPage from "@/components/features/builds/ReportPage";
@@ -212,6 +213,7 @@ export default function App() {
                 <Route path="/craft" element={<CraftSimulatorPage />} />
                 <Route path="/craft/:slug" element={<CraftSimulatorPage />} />
                 <Route path="/affixes" element={<AffixEditorPage />} />
+                <Route path="/affix-catalog" element={<AffixCatalogPage />} />
                 <Route path="/passives" element={<PassiveTreePage />} />
                 <Route path="/compare" element={<BuildComparisonPage />} />
                 <Route path="/report/:slug" element={<ReportPage />} />

--- a/frontend/src/__tests__/components/affix-catalog.test.tsx
+++ b/frontend/src/__tests__/components/affix-catalog.test.tsx
@@ -1,0 +1,76 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import AffixCatalogPage from '@/components/features/affixCatalog/AffixCatalogPage';
+
+function renderPage(enabled = true) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <AffixCatalogPage enabled={enabled} />
+    </QueryClientProvider>
+  );
+}
+
+describe('AffixCatalogPage', () => {
+  beforeEach(() => {
+    vi.stubEnv('VITE_FORGE_SAFE_AFFIX_CATALOG_ENABLED', 'true');
+    global.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/affixes/catalog/summary')) {
+        return new Response(JSON.stringify({
+          data: { active_source: 'forge_safe', mode: 'read_only', consumption_enabled: true, legacy_count: 2, forge_safe_count: 2, production_consumer: false },
+          meta: null,
+          errors: null,
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      return new Response(JSON.stringify({
+        data: [
+          { id: 'health', name: 'Health', source_type: 'prefix', item_types: ['helm'], data_source: 'forge_safe', safety: { forge_safe: true }, production_consumer: false },
+          { id: 'fire_res', name: 'Fire Resistance', source_type: 'suffix', item_types: ['ring'], data_source: 'forge_safe', safety: { forge_safe: true }, production_consumer: false },
+        ],
+        meta: { total: 2, limit: 100, offset: 0, data_source: 'forge_safe', mode: 'read_only', production_consumer: false },
+        errors: null,
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    }) as any;
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+
+  it('renders disabled state when the feature gate is off', () => {
+    renderPage(false);
+    expect(screen.getByTestId('affix-catalog-disabled')).toHaveTextContent('disabled');
+  });
+
+  it('renders Forge-safe data and loaded count', async () => {
+    renderPage();
+    expect(await screen.findByText('Forge-safe Affix Catalog')).toBeInTheDocument();
+    expect(await screen.findByText('Health')).toBeInTheDocument();
+    expect(screen.getByText('Forge-safe canonical export')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+  });
+
+  it('sends search and filter interactions to the catalog endpoint', async () => {
+    renderPage();
+    await screen.findByText('Health');
+    fireEvent.change(screen.getByLabelText('Search affixes'), { target: { value: 'res' } });
+    fireEvent.change(screen.getByLabelText('Source type'), { target: { value: 'suffix' } });
+    fireEvent.change(screen.getByLabelText('Item type'), { target: { value: 'ring' } });
+    await waitFor(() => {
+      const calls = (global.fetch as any).mock.calls.map((call: any[]) => String(call[0]));
+      expect(calls.some((url: string) => url.includes('q=res') && url.includes('source_type=suffix') && url.includes('item_type=ring'))).toBe(true);
+    });
+  });
+
+  it('renders affix detail when selected', async () => {
+    renderPage();
+    fireEvent.click(await screen.findByText('Fire Resistance'));
+    expect(screen.getByTestId('affix-detail')).toHaveTextContent('fire_res');
+    expect(screen.getByTestId('affix-detail')).toHaveTextContent('forge_safe=true');
+  });
+});

--- a/frontend/src/components/features/affixCatalog/AffixCatalogPage.tsx
+++ b/frontend/src/components/features/affixCatalog/AffixCatalogPage.tsx
@@ -1,0 +1,127 @@
+import { useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import { affixCatalogApi } from "@/lib/api";
+import type { AffixCatalogEntry } from "@/types";
+
+const DEFAULT_ENABLED = import.meta.env.VITE_FORGE_SAFE_AFFIX_CATALOG_ENABLED === "true" || import.meta.env.DEV;
+
+export default function AffixCatalogPage({ enabled = DEFAULT_ENABLED }: { enabled?: boolean } = {}) {
+  const [query, setQuery] = useState("");
+  const [sourceType, setSourceType] = useState("");
+  const [itemType, setItemType] = useState("");
+  const [selected, setSelected] = useState<AffixCatalogEntry | null>(null);
+
+  const params = useMemo(() => ({ q: query || undefined, source_type: sourceType || undefined, item_type: itemType || undefined, limit: 100 }), [query, sourceType, itemType]);
+
+  const summaryQuery = useQuery({
+    queryKey: ["affix-catalog", "summary"],
+    queryFn: () => affixCatalogApi.summary(),
+    enabled,
+  });
+
+  const catalogQuery = useQuery({
+    queryKey: ["affix-catalog", params],
+    queryFn: () => affixCatalogApi.list(params),
+    enabled,
+  });
+
+  if (!enabled) {
+    return (
+      <main className="p-6 space-y-4" data-testid="affix-catalog-disabled">
+        <h1 className="text-2xl font-semibold text-forge-text">Forge-safe Affix Catalog</h1>
+        <p className="text-forge-muted">This development catalog is disabled. Set VITE_FORGE_SAFE_AFFIX_CATALOG_ENABLED=true to browse the controlled Forge-safe export.</p>
+      </main>
+    );
+  }
+
+  const affixes = catalogQuery.data?.data ?? [];
+  const meta = catalogQuery.data?.meta;
+  const summary = summaryQuery.data?.data;
+  const error = catalogQuery.data?.errors?.[0]?.message ?? summaryQuery.data?.errors?.[0]?.message;
+
+  return (
+    <main className="p-6 space-y-6" data-testid="affix-catalog-page">
+      <header className="space-y-2">
+        <p className="text-sm uppercase tracking-wide text-forge-cyan">Controlled read-only source</p>
+        <h1 className="text-3xl font-semibold text-forge-text">Forge-safe Affix Catalog</h1>
+        <p className="max-w-3xl text-forge-muted">
+          Browses the Forge-safe canonical export for lookup and migration review only. Planner, crafting, and simulation selections are not changed by this page.
+        </p>
+      </header>
+
+      <section className="grid gap-3 md:grid-cols-3">
+        <div className="rounded-lg border border-forge-border bg-forge-panel p-4">
+          <div className="text-sm text-forge-muted">Data source</div>
+          <div className="text-xl font-semibold text-forge-text">{meta?.data_source ?? summary?.active_source ?? "forge_safe"}</div>
+          <div className="text-xs text-forge-muted">Forge-safe canonical export</div>
+        </div>
+        <div className="rounded-lg border border-forge-border bg-forge-panel p-4">
+          <div className="text-sm text-forge-muted">Loaded Forge-safe affixes</div>
+          <div className="text-xl font-semibold text-forge-text">{summary?.forge_safe_count ?? meta?.total ?? 0}</div>
+        </div>
+        <div className="rounded-lg border border-forge-border bg-forge-panel p-4">
+          <div className="text-sm text-forge-muted">Mode</div>
+          <div className="text-xl font-semibold text-forge-text">{summary?.mode ?? meta?.mode ?? "read_only"}</div>
+          <div className="text-xs text-forge-muted">production_consumer=false</div>
+        </div>
+      </section>
+
+      <section className="rounded-lg border border-forge-border bg-forge-panel p-4 space-y-4">
+        <div className="grid gap-3 md:grid-cols-3">
+          <label className="space-y-1">
+            <span className="text-sm text-forge-muted">Search</span>
+            <input aria-label="Search affixes" className="w-full rounded bg-forge-bg border border-forge-border px-3 py-2 text-forge-text" value={query} onChange={(e) => setQuery(e.target.value)} placeholder="health, resistance..." />
+          </label>
+          <label className="space-y-1">
+            <span className="text-sm text-forge-muted">Source type</span>
+            <select aria-label="Source type" className="w-full rounded bg-forge-bg border border-forge-border px-3 py-2 text-forge-text" value={sourceType} onChange={(e) => setSourceType(e.target.value)}>
+              <option value="">All</option>
+              <option value="prefix">Prefix</option>
+              <option value="suffix">Suffix</option>
+            </select>
+          </label>
+          <label className="space-y-1">
+            <span className="text-sm text-forge-muted">Item type</span>
+            <input aria-label="Item type" className="w-full rounded bg-forge-bg border border-forge-border px-3 py-2 text-forge-text" value={itemType} onChange={(e) => setItemType(e.target.value)} placeholder="helm, ring..." />
+          </label>
+        </div>
+
+        {error && <div role="alert" className="rounded border border-red-500/40 bg-red-500/10 p-3 text-red-200">{error}</div>}
+
+        <div className="grid gap-4 lg:grid-cols-[1fr_22rem]">
+          <div className="overflow-hidden rounded border border-forge-border">
+            <table className="w-full text-left text-sm">
+              <thead className="bg-forge-bg text-forge-muted">
+                <tr><th className="p-3">Name</th><th className="p-3">Source</th><th className="p-3">Item types</th></tr>
+              </thead>
+              <tbody>
+                {affixes.map((affix) => (
+                  <tr key={affix.id} className="border-t border-forge-border hover:bg-forge-bg/60 cursor-pointer" onClick={() => setSelected(affix)}>
+                    <td className="p-3 text-forge-text">{affix.name}</td>
+                    <td className="p-3 text-forge-muted">{affix.source_type ?? "unknown"}</td>
+                    <td className="p-3 text-forge-muted">{affix.item_types.join(", ") || "—"}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            {!catalogQuery.isLoading && affixes.length === 0 && <p className="p-4 text-forge-muted">No affixes match the current filters.</p>}
+          </div>
+
+          <aside className="rounded border border-forge-border bg-forge-bg p-4" data-testid="affix-detail">
+            <h2 className="text-lg font-semibold text-forge-text">Affix detail</h2>
+            {selected ? (
+              <dl className="mt-3 space-y-2 text-sm">
+                <div><dt className="text-forge-muted">Name</dt><dd className="text-forge-text">{selected.name}</dd></div>
+                <div><dt className="text-forge-muted">ID</dt><dd className="text-forge-text break-all">{selected.id}</dd></div>
+                <div><dt className="text-forge-muted">Source type</dt><dd className="text-forge-text">{selected.source_type ?? "unknown"}</dd></div>
+                <div><dt className="text-forge-muted">Item types</dt><dd className="text-forge-text">{selected.item_types.join(", ") || "—"}</dd></div>
+                <div><dt className="text-forge-muted">Safety</dt><dd className="text-forge-text">forge_safe=true · production_consumer=false</dd></div>
+              </dl>
+            ) : <p className="mt-3 text-sm text-forge-muted">Select an affix to inspect its safe metadata.</p>}
+          </aside>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -39,6 +39,8 @@ import type {
   FullMetaSnapshot,
   TrendingBuild,
   BuildReport,
+  AffixCatalogEntry,
+  AffixCatalogSummary,
 } from "@/types";
 import type { BlessingTimeline } from "@/types/blessings";
 
@@ -269,6 +271,26 @@ export const refApi = {
   baseItemsBySlot: (slot: string) => get<BaseItemDef[]>(`/ref/base-items?slot=${encodeURIComponent(slot)}`),
   fpRanges: () => get<Record<string, { min_fp: number; max_fp: number }>>("/ref/fp-ranges"),
   getBlessings: () => get<BlessingTimeline[]>("/ref/blessings"),
+};
+
+
+// ---------------------------------------------------------------------------
+// Controlled Forge-safe affix catalog
+// ---------------------------------------------------------------------------
+
+export const affixCatalogApi = {
+  list: (params: { q?: string; source_type?: string; item_type?: string; limit?: number; offset?: number } = {}) => {
+    const qs = new URLSearchParams(
+      Object.fromEntries(
+        Object.entries(params)
+          .filter(([, v]) => v !== undefined && v !== "")
+          .map(([k, v]) => [k, String(v)])
+      )
+    ).toString();
+    return get<AffixCatalogEntry[]>(`/affixes/catalog${qs ? "?" + qs : ""}`);
+  },
+  get: (affixId: string) => get<AffixCatalogEntry>(`/affixes/catalog/${encodeURIComponent(affixId)}`),
+  summary: () => get<AffixCatalogSummary>("/affixes/catalog/summary"),
 };
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -19,12 +19,18 @@ export interface ApiError {
 }
 
 export interface PaginationMeta {
-  page: number;
-  per_page: number;
+  page?: number;
+  per_page?: number;
   total: number;
-  pages: number;
-  has_next: boolean;
-  has_prev: boolean;
+  pages?: number;
+  has_next?: boolean;
+  has_prev?: boolean;
+  limit?: number;
+  offset?: number;
+  data_source?: "forge_safe" | "legacy";
+  mode?: "shadow" | "read_only" | "active";
+  consumption_enabled?: boolean;
+  production_consumer?: false;
 }
 
 // ---------------------------------------------------------------------------
@@ -658,3 +664,22 @@ export interface OpenGraphMeta {
   og_url: string;
 }
 
+
+export interface AffixCatalogEntry {
+  id: string;
+  name: string;
+  source_type: string | null;
+  item_types: string[];
+  data_source: "forge_safe" | "legacy";
+  safety?: { forge_safe?: boolean };
+  production_consumer: false;
+}
+
+export interface AffixCatalogSummary {
+  active_source: "forge_safe" | "legacy";
+  mode: "shadow" | "read_only" | "active";
+  consumption_enabled: boolean;
+  legacy_count: number;
+  forge_safe_count: number;
+  production_consumer: false;
+}


### PR DESCRIPTION
### Motivation
- Make the Forge-safe canonical affix export a first-class, read-only internal data source for safe browsing and migration work while preserving the existing legacy affix system. 
- Ensure consumption is conservative and rollback-safe by enforcing explicit safety metadata, rejecting `production_safe=true`, and keeping all new behavior behind feature flags and modes. 

### Description
- Add a strict loader and read-only repository that only accepts records with `safety.forge_safe=true`, rejects `production_safe=true`, and exposes safe catalog dicts (`backend/data/loaders/forge_safe_affixes_loader.py`, `backend/data/repositories/forge_safe_affix_repository.py`).
- Introduce `AffixCatalogService` as the single backend selection point between legacy and Forge-safe sources with `list_affixes`, `get_affix`, `search_affixes`, filtering, pagination, summary metadata, and a clear `active_source` indicator (`backend/app/services/affix_catalog_service.py`).
- Add feature/config flags `FORGE_SAFE_AFFIX_CATALOG_ENABLED`, `FORGE_SAFE_AFFIX_CONSUMPTION_ENABLED`, `FORGE_SAFE_AFFIX_EXPORT_PATH`, and `FORGE_SAFE_AFFIX_CONSUMPTION_MODE` and implement consumption modes `shadow|read_only|active` (default disabled + shadow) (`backend/config.py`).
- Expose stable, gated HTTP routes `GET /api/affixes/catalog`, `GET /api/affixes/catalog/{affix_id}`, and `GET /api/affixes/catalog/summary` and preserve the experimental endpoints for migration debugging (`backend/app/routes/affixes.py`, `backend/app/routes/experimental.py`).
- Add a frontend read-only catalog page behind a dev/feature gate at `/affix-catalog` with search, `source_type`/`item_type` filters, summary, and affix detail, plus API client/types (`frontend/src/components/features/affixCatalog/AffixCatalogPage.tsx`, `frontend/src/lib/api.ts`, `frontend/src/types/index.ts`, `frontend/src/__tests__/components/affix-catalog.test.tsx`).
- Add a shadow comparison script that compares legacy registry vs Forge-safe export and reports counts, mismatches, and ID diffs (`backend/scripts/compare_forge_safe_affixes.py`).
- Add focused backend and frontend tests and migration documentation describing contract, modes, env vars, endpoints, and rollback plan (`backend/tests/*`, `docs/migration/FORGE_SAFE_AFFIX_LOADER.md`).

### Testing
- Backend unit tests: ran `python -m pytest tests/test_forge_safe_affixes_loader.py tests/test_forge_safe_affix_repository.py tests/test_experimental_forge_safe_affix_catalog.py tests/test_affix_catalog_service.py tests/test_affix_catalog_routes.py` and all tests passed (14 passed). 
- Backend compile checks: ran `python -m py_compile` against new loader/repository/service/routes/scripts with no syntax errors. 
- Frontend tests and type-check: ran `npm run test -- affix-catalog.test.tsx` (4 tests passed) and `npm run type-check` (TypeScript checks passed). 
- Real-export smoke: attempted to load `D:\Forge\last-epoch-data\docs\generated\forge_safe_canonical_affixes.json` with the loader but the Windows export path is not present in this environment, so a real-export smoke run was not possible here and reported the missing file; follow-up: mount the real export and re-run the compare/smoke. 
- Safety guarantees: tests verify that non-`safety.forge_safe` records are ignored and `production_safe=true` records cause load failure, and service tests validate legacy usage when disabled and Forge-safe usage when enabled.