### PR TITLE
feat: add v2 affix infrastructure

### DIFF
--- a/backend/app/repositories/__init__.py
+++ b/backend/app/repositories/__init__.py
@@ -1,0 +1,1 @@
+"""Application repository packages."""

--- a/backend/app/repositories/v2/__init__.py
+++ b/backend/app/repositories/v2/__init__.py
@@ -1,0 +1,5 @@
+"""v2 experimental repositories."""
+
+from .affix_repository import V2AffixBundleError, V2AffixRepository
+
+__all__ = ["V2AffixBundleError", "V2AffixRepository"]

--- a/backend/app/repositories/v2/affix_repository.py
+++ b/backend/app/repositories/v2/affix_repository.py
@@ -1,0 +1,182 @@
+"""Read-only v2 canonical affix repository."""
+
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+from app.data_contracts import SupportStatus, TrustLevel, validate_canonical_id
+from app.data_contracts.validation import is_stable_calculable
+
+
+class V2AffixBundleError(ValueError):
+    """Raised when the v2 affix bundle is missing or invalid."""
+
+
+class V2AffixRepository:
+    """Read-only repository over the generated v2 canonical affix bundle."""
+
+    def __init__(self, bundle_path: str | Path) -> None:
+        self.bundle_path = Path(bundle_path)
+        self._payload: dict[str, Any] | None = None
+        self._records: tuple[dict[str, Any], ...] = ()
+        self._by_id: dict[str, dict[str, Any]] = {}
+
+    def load(self) -> "V2AffixRepository":
+        if not self.bundle_path.exists():
+            raise FileNotFoundError(f"v2 affix bundle not found: {self.bundle_path}")
+        try:
+            payload = json.loads(self.bundle_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise V2AffixBundleError(f"Invalid JSON in v2 affix bundle {self.bundle_path}: {exc}") from exc
+        self.load_payload(payload)
+        return self
+
+    def load_payload(self, payload: dict[str, Any]) -> "V2AffixRepository":
+        if not isinstance(payload, dict):
+            raise V2AffixBundleError("v2 affix bundle must be a JSON object.")
+        records = payload.get("records")
+        if not isinstance(records, dict):
+            raise V2AffixBundleError("v2 affix bundle records must be an object.")
+        affixes = records.get("affixes")
+        if not isinstance(affixes, list):
+            raise V2AffixBundleError("v2 affix bundle records.affixes must be a list.")
+        if not affixes:
+            raise V2AffixBundleError("v2 affix bundle records.affixes must not be empty.")
+        self._validate_records(affixes)
+        self._payload = deepcopy(payload)
+        self._records = tuple(deepcopy(record) for record in affixes)
+        self._by_id = {record["canonical_id"]: record for record in self._records}
+        return self
+
+    def list_affixes(self, *, limit: int | None = None, offset: int = 0) -> list[dict[str, Any]]:
+        start = max(0, offset)
+        end = None if limit is None else start + max(0, limit)
+        return [deepcopy(record) for record in self._records[start:end]]
+
+    def get_affix(self, canonical_id: str) -> dict[str, Any] | None:
+        record = self._by_id.get(canonical_id)
+        return deepcopy(record) if record else None
+
+    def filter_affixes(
+        self,
+        *,
+        query: str = "",
+        slot: str = "",
+        item_type: str = "",
+        class_id: str = "",
+        support_status: str = "",
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        records = list(self._records)
+        if query:
+            needle = query.strip().lower()
+            records = [
+                record for record in records
+                if needle in record["canonical_id"].lower()
+                or needle in str(record.get("display_name", "")).lower()
+                or needle in str(record.get("source_id", "")).lower()
+            ]
+        if slot:
+            expected = slot.strip().lower()
+            records = [
+                record for record in records
+                if expected in {str(value).lower() for value in record.get("slot_restrictions") or []}
+            ]
+        if item_type:
+            expected = item_type.strip().lower()
+            records = [
+                record for record in records
+                if expected in {str(value).lower() for value in record.get("item_type_restrictions") or []}
+            ]
+        if class_id:
+            expected = class_id.strip().lower()
+            records = [
+                record for record in records
+                if expected in {str(value).lower() for value in record.get("class_restrictions") or []}
+            ]
+        if support_status:
+            expected = support_status.strip().lower()
+            records = [
+                record for record in records
+                if str(record.get("support_status", "")).lower() == expected
+            ]
+        start = max(0, offset)
+        end = None if limit is None else start + max(0, limit)
+        return [deepcopy(record) for record in records[start:end]]
+
+    def count(self) -> int:
+        return len(self._records)
+
+    def debug_summary(self) -> dict[str, Any]:
+        payload_summary = self._payload.get("summary", {}) if self._payload else {}
+        status_counts: dict[str, int] = {}
+        domain_counts: dict[str, int] = {}
+        modifier_counts: dict[str, int] = {}
+        for record in self._records:
+            status = str(record.get("support_status", "unknown"))
+            domain = str(record.get("affix_domain", "unknown"))
+            modifier_count = str(len(record.get("modifier_references") or []))
+            status_counts[status] = status_counts.get(status, 0) + 1
+            domain_counts[domain] = domain_counts.get(domain, 0) + 1
+            modifier_counts[modifier_count] = modifier_counts.get(modifier_count, 0) + 1
+        return {
+            "source_path": str(self.bundle_path),
+            "affix_count": self.count(),
+            "summary": deepcopy(payload_summary),
+            "support_status_counts": status_counts,
+            "affix_domain_counts": domain_counts,
+            "modifier_reference_count_distribution": modifier_counts,
+            "production_consumer": False,
+            "production_safe": False,
+        }
+
+    @staticmethod
+    def _validate_records(records: list[Any]) -> None:
+        seen: set[str] = set()
+        for index, record in enumerate(records):
+            if not isinstance(record, dict):
+                raise V2AffixBundleError(f"Affix record {index} must be an object.")
+            canonical_id = record.get("canonical_id")
+            try:
+                validate_canonical_id(canonical_id)
+            except ValueError as exc:
+                raise V2AffixBundleError(f"Affix record {index} has invalid canonical_id: {exc}") from exc
+            if canonical_id in seen:
+                raise V2AffixBundleError(f"Duplicate canonical_id in v2 affix bundle: {canonical_id}")
+            seen.add(canonical_id)
+            if not record.get("display_name"):
+                raise V2AffixBundleError(f"Affix record {canonical_id} is missing display_name.")
+            provenance = record.get("provenance")
+            if not isinstance(provenance, dict) or not provenance.get("source_path"):
+                raise V2AffixBundleError(f"Affix record {canonical_id} is missing provenance.source_path.")
+            try:
+                status = SupportStatus(str(record.get("support_status")))
+            except ValueError as exc:
+                raise V2AffixBundleError(f"Affix record {canonical_id} has invalid support_status.") from exc
+            try:
+                trust_level = TrustLevel(str(record.get("trust_level")))
+            except ValueError as exc:
+                raise V2AffixBundleError(f"Affix record {canonical_id} has invalid trust_level.") from exc
+            if trust_level in {TrustLevel.GAME_EXTRACTED, TrustLevel.GENERATED_FROM_GAME_DATA}:
+                if not provenance.get("source_id") and not record.get("source_id"):
+                    raise V2AffixBundleError(f"Affix record {canonical_id} is missing source reference.")
+            tier_ranges = record.get("tier_ranges")
+            if status in {SupportStatus.TRUSTED, SupportStatus.PARTIAL}:
+                if not isinstance(tier_ranges, list) or not tier_ranges:
+                    raise V2AffixBundleError(f"Affix record {canonical_id} is missing tier_ranges.")
+            if not isinstance(record.get("slot_restrictions"), list):
+                raise V2AffixBundleError(f"Affix record {canonical_id} has invalid slot_restrictions.")
+            if not isinstance(record.get("item_type_restrictions"), list):
+                raise V2AffixBundleError(f"Affix record {canonical_id} has invalid item_type_restrictions.")
+            if record.get("affix_domain") not in {"equipment", "idol", "unknown"}:
+                raise V2AffixBundleError(f"Affix record {canonical_id} has invalid affix_domain.")
+            if record.get("affix_domain") == "equipment" and record.get("source_type") == "idol":
+                raise V2AffixBundleError(f"Affix record {canonical_id} mixes equipment and idol domains.")
+            if is_stable_calculable(status, trust_level) and record.get("stable_calculable") is not True:
+                raise V2AffixBundleError(f"Affix record {canonical_id} has inconsistent stable_calculable flag.")
+            if record.get("stable_calculable") is True and status != SupportStatus.TRUSTED:
+                raise V2AffixBundleError(f"Affix record {canonical_id} is stable_calculable without trusted status.")

--- a/backend/app/routes/experimental.py
+++ b/backend/app/routes/experimental.py
@@ -12,6 +12,7 @@ from typing import Any
 
 from flask import Blueprint, current_app, jsonify, request
 
+from app.repositories.v2.affix_repository import V2AffixBundleError, V2AffixRepository
 from data.loaders.forge_safe_affix_bundle_loader import ForgeSafeAffixBundleLoaderError
 from data.loaders.forge_safe_affixes_loader import ForgeSafeAffixLoaderError
 from data.repositories.forge_safe_affix_bundle_repository import ForgeSafeAffixBundleRepository
@@ -26,6 +27,8 @@ experimental_bp = Blueprint("experimental", __name__)
 
 DEFAULT_LIMIT = 50
 MAX_LIMIT = 100
+ROOT = Path(__file__).resolve().parents[3]
+DEFAULT_V2_AFFIX_BUNDLE_PATH = ROOT / "docs" / "generated" / "v2_affix_bundle.json"
 
 
 @experimental_bp.route("/forge-safe-affixes", methods=["GET"])
@@ -145,6 +148,117 @@ def forge_safe_affix_detail(affix_id: str):
     if _bundle_catalog_enabled():
         return _forge_safe_affix_bundle_catalog(parsed, detail=True)
     return _forge_safe_canonical_affix_catalog(parsed, detail=True)
+
+
+@experimental_bp.route("/v2/affixes", methods=["GET"])
+def v2_affix_catalog():
+    """Query the read-only v2 canonical affix bundle."""
+
+    parsed = _parse_v2_affix_query_args()
+    if parsed["errors"]:
+        return jsonify({
+            "success": False,
+            "error": "invalid_query",
+            "message": "; ".join(parsed["errors"]),
+        }), 400
+
+    try:
+        repository = _load_v2_affix_repository()
+    except FileNotFoundError as exc:
+        return jsonify({
+            "success": False,
+            "error": "v2_affix_bundle_missing",
+            "message": str(exc),
+        }), 404
+    except V2AffixBundleError as exc:
+        return jsonify({
+            "success": False,
+            "error": "v2_affix_bundle_invalid",
+            "message": str(exc),
+        }), 422
+
+    if parsed["affix_id"]:
+        record = repository.get_affix(parsed["affix_id"])
+        records = [record] if record is not None else []
+    else:
+        records = repository.filter_affixes(
+            query=parsed["q"],
+            slot=parsed["slot"],
+            item_type=parsed["item_type"],
+            class_id=parsed["class_id"],
+            support_status=parsed["support_status"],
+            limit=parsed["limit"],
+            offset=parsed["offset"],
+        )
+
+    return jsonify(_v2_affix_response(repository, records, parsed))
+
+
+@experimental_bp.route("/v2/affixes/<path:affix_id>", methods=["GET"])
+def v2_affix_detail(affix_id: str):
+    """Return one v2 canonical affix record by canonical ID."""
+
+    try:
+        repository = _load_v2_affix_repository()
+    except FileNotFoundError as exc:
+        return jsonify({
+            "success": False,
+            "error": "v2_affix_bundle_missing",
+            "message": str(exc),
+        }), 404
+    except V2AffixBundleError as exc:
+        return jsonify({
+            "success": False,
+            "error": "v2_affix_bundle_invalid",
+            "message": str(exc),
+        }), 422
+
+    record = repository.get_affix(affix_id)
+    if record is None:
+        return jsonify({
+            "success": False,
+            "error": "affix_not_found",
+            "message": f"v2 affix not found: {affix_id}",
+        }), 404
+
+    return jsonify({
+        "success": True,
+        "experimental": True,
+        "read_only": True,
+        "production_consumer": False,
+        "data_source": "v2_affix_bundle",
+        "source_path": str(repository.bundle_path),
+        "record": record,
+    })
+
+
+@experimental_bp.route("/v2/affixes/debug", methods=["GET"])
+def v2_affix_debug():
+    """Return a debug summary for the read-only v2 affix bundle."""
+
+    try:
+        repository = _load_v2_affix_repository()
+    except FileNotFoundError as exc:
+        return jsonify({
+            "success": False,
+            "error": "v2_affix_bundle_missing",
+            "message": str(exc),
+        }), 404
+    except V2AffixBundleError as exc:
+        return jsonify({
+            "success": False,
+            "error": "v2_affix_bundle_invalid",
+            "message": str(exc),
+        }), 422
+
+    return jsonify({
+        "success": True,
+        "experimental": True,
+        "read_only": True,
+        "production_consumer": False,
+        "data_source": "v2_affix_bundle",
+        "debug_summary": repository.debug_summary(),
+    })
 
 
 def _forge_safe_canonical_affix_catalog(parsed: dict[str, Any], *, detail: bool = False):
@@ -309,6 +423,17 @@ def _bundle_catalog_enabled() -> bool:
     return current_app.config.get("FORGE_SAFE_AFFIX_BUNDLE_ENABLED", False)
 
 
+def _configured_v2_affix_bundle_path() -> Path:
+    configured = current_app.config.get("V2_AFFIX_BUNDLE_PATH")
+    if configured:
+        return Path(configured)
+    return DEFAULT_V2_AFFIX_BUNDLE_PATH
+
+
+def _load_v2_affix_repository() -> V2AffixRepository:
+    return V2AffixRepository(_configured_v2_affix_bundle_path()).load()
+
+
 def _parse_query_args() -> dict[str, Any]:
     errors: list[str] = []
     limit = _parse_non_negative_int("limit", request.args.get("limit"), DEFAULT_LIMIT, errors)
@@ -321,6 +446,23 @@ def _parse_query_args() -> dict[str, Any]:
         "source_type": request.args.get("source_type") or "",
         "item_type": request.args.get("item_type") or "",
         "include_modifiers": _parse_bool(request.args.get("include_modifiers")),
+        "errors": errors,
+    }
+
+
+def _parse_v2_affix_query_args() -> dict[str, Any]:
+    errors: list[str] = []
+    limit = _parse_non_negative_int("limit", request.args.get("limit"), DEFAULT_LIMIT, errors)
+    offset = _parse_non_negative_int("offset", request.args.get("offset"), 0, errors)
+    return {
+        "limit": min(limit, MAX_LIMIT),
+        "offset": offset,
+        "q": request.args.get("q") or request.args.get("search") or "",
+        "affix_id": request.args.get("affix_id") or "",
+        "slot": request.args.get("slot") or "",
+        "item_type": request.args.get("item_type") or "",
+        "class_id": request.args.get("class_id") or "",
+        "support_status": request.args.get("support_status") or "",
         "errors": errors,
     }
 
@@ -488,3 +630,39 @@ def _source_affix_identity(record: dict[str, Any]) -> str:
     if isinstance(provenance, dict) and provenance.get("source_affix_identity"):
         return str(provenance["source_affix_identity"])
     return ""
+
+
+def _v2_affix_response(
+    repository: V2AffixRepository,
+    records: list[dict[str, Any]],
+    parsed: dict[str, Any],
+) -> dict[str, Any]:
+    summary = repository.debug_summary()
+    return {
+        "success": True,
+        "experimental": True,
+        "read_only": True,
+        "production_consumer": False,
+        "data_source": "v2_affix_bundle",
+        "source_path": str(repository.bundle_path),
+        "result_count": len(records),
+        "total_loaded_count": repository.count(),
+        "total_affixes": repository.count(),
+        "total_modifiers": summary["summary"].get("source_modifier_count"),
+        "query": {
+            "limit": parsed["limit"],
+            "offset": parsed["offset"],
+            "q": parsed["q"],
+            "affix_id": parsed["affix_id"],
+            "slot": parsed["slot"],
+            "item_type": parsed["item_type"],
+            "class_id": parsed["class_id"],
+            "support_status": parsed["support_status"],
+        },
+        "warning_count": summary["summary"].get("records_with_warnings_count", 0),
+        "warnings": [],
+        "export_policy": "v2_affix_bundle",
+        "export_status": "pass" if summary["summary"].get("validation_error_count", 0) == 0 else "blocked",
+        "summary": summary,
+        "records": records,
+    }

--- a/backend/scripts/report_v2_affix_bundle.py
+++ b/backend/scripts/report_v2_affix_bundle.py
@@ -1,0 +1,504 @@
+"""Generate the v2 canonical affix bundle and validation report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter, defaultdict
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "backend"))
+
+from app.data_contracts import SupportStatus, TrustLevel, validate_canonical_id
+from app.repositories.v2.affix_repository import V2AffixBundleError, V2AffixRepository
+from data.loaders.forge_safe_affix_bundle_loader import ForgeSafeAffixBundleLoader
+
+
+DEFAULT_SOURCE_BUNDLE = Path(
+    r"D:\Forge\last-epoch-data\docs\generated\forge_safe_affix_bundle.json"
+)
+DEFAULT_OUTPUT = ROOT / "docs" / "generated" / "v2_affix_bundle.json"
+DEFAULT_VALIDATION_OUTPUT = ROOT / "docs" / "generated" / "v2_affix_validation_report.json"
+DEFAULT_MARKDOWN_OUTPUT = ROOT / "docs" / "migration" / "V2_AFFIX_MIGRATION.md"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Build the v2 canonical affix bundle.")
+    parser.add_argument("--source-bundle", type=Path, default=DEFAULT_SOURCE_BUNDLE)
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument("--validation-output", type=Path, default=DEFAULT_VALIDATION_OUTPUT)
+    parser.add_argument("--markdown-output", type=Path, default=DEFAULT_MARKDOWN_OUTPUT)
+    return parser.parse_args()
+
+
+def build_v2_affix_bundle(source_bundle: Path) -> dict[str, Any]:
+    loaded = ForgeSafeAffixBundleLoader().load(source_bundle)
+    modifier_index = loaded.modifiers_by_affix_identity
+    affixes = [
+        _canonical_affix(record, modifier_index.get(_source_affix_identity(record), ()))
+        for record in loaded.affixes
+    ]
+    validation = validate_v2_affix_records(affixes)
+    summary = _summary(affixes, loaded.summary, validation)
+    return {
+        "schema_version": "v2.affix_bundle.1",
+        "generated_on": date.today().isoformat(),
+        "source_bundle_path": str(source_bundle),
+        "source_schema_version": loaded.schema_version,
+        "source_export_policy": loaded.export_policy,
+        "summary": summary,
+        "validation_summary": validation["summary"],
+        "records": {
+            "affixes": affixes,
+        },
+        "metadata": {
+            "phase": "phase_3_affix_infrastructure",
+            "read_only": True,
+            "experimental": True,
+            "production_consumer": False,
+            "production_safe": False,
+            "uses_canonical_contracts": True,
+            "stable_planner_consumed": False,
+        },
+    }
+
+
+def validate_v2_affix_records(records: list[dict[str, Any]]) -> dict[str, Any]:
+    errors: list[dict[str, Any]] = []
+    warnings: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    equipment_count = 0
+    idol_count = 0
+    stable_calculable_count = 0
+    for index, record in enumerate(records):
+        canonical_id = record.get("canonical_id")
+        context = {"index": index, "canonical_id": canonical_id}
+        try:
+            validate_canonical_id(canonical_id)
+        except ValueError as exc:
+            errors.append({**context, "code": "invalid_canonical_id", "message": str(exc)})
+            continue
+        if canonical_id in seen:
+            errors.append({**context, "code": "duplicate_canonical_id", "message": "Duplicate canonical ID."})
+        seen.add(canonical_id)
+        if not record.get("provenance"):
+            errors.append({**context, "code": "missing_provenance", "message": "Provenance is required."})
+        if not record.get("support_status"):
+            errors.append({**context, "code": "missing_support_status", "message": "Support status is required."})
+        else:
+            try:
+                SupportStatus(str(record["support_status"]))
+            except ValueError:
+                errors.append({**context, "code": "invalid_support_status", "message": "Support status is invalid."})
+        try:
+            TrustLevel(str(record.get("trust_level")))
+        except ValueError:
+            errors.append({**context, "code": "invalid_trust_level", "message": "Trust level is invalid."})
+        if not isinstance(record.get("tier_ranges"), list) or not record.get("tier_ranges"):
+            errors.append({**context, "code": "missing_tier_ranges", "message": "Tier ranges are required."})
+        if not isinstance(record.get("slot_restrictions"), list):
+            errors.append({**context, "code": "invalid_slot_restrictions", "message": "Slot restrictions must be a list."})
+        if not isinstance(record.get("item_type_restrictions"), list):
+            errors.append({**context, "code": "invalid_item_type_restrictions", "message": "Item type restrictions must be a list."})
+        if record.get("stable_calculable") is True:
+            stable_calculable_count += 1
+            if record.get("support_status") != SupportStatus.TRUSTED.value:
+                errors.append({**context, "code": "unsupported_stable_calculation", "message": "Only trusted records may be stable-calculable."})
+        if record.get("affix_domain") == "equipment":
+            equipment_count += 1
+            if str(record.get("source_type")).lower() == "idol":
+                errors.append({**context, "code": "mixed_equipment_idol_domain", "message": "Equipment domain cannot use idol source type."})
+        elif record.get("affix_domain") == "idol":
+            idol_count += 1
+        else:
+            warnings.append({**context, "code": "unknown_affix_domain", "message": "Affix domain could not be classified."})
+        if record.get("support_status") in {SupportStatus.UNKNOWN.value, SupportStatus.UNSUPPORTED.value}:
+            warnings.append({**context, "code": "non_calculable_record", "message": "Record is displayable but not stable-calculable."})
+
+    return {
+        "summary": {
+            "record_count": len(records),
+            "error_count": len(errors),
+            "warning_count": len(warnings),
+            "duplicate_canonical_id_count": _count_code(errors, "duplicate_canonical_id"),
+            "missing_provenance_count": _count_code(errors, "missing_provenance"),
+            "missing_support_status_count": _count_code(errors, "missing_support_status"),
+            "invalid_trust_level_count": _count_code(errors, "invalid_trust_level"),
+            "invalid_tier_data_count": _count_code(errors, "missing_tier_ranges"),
+            "invalid_slot_restriction_shape_count": _count_code(errors, "invalid_slot_restrictions"),
+            "stable_calculable_blocked_count": _count_code(errors, "unsupported_stable_calculation"),
+            "stable_calculable_count": stable_calculable_count,
+            "equipment_affix_count": equipment_count,
+            "idol_affix_count": idol_count,
+            "production_consumed": False,
+        },
+        "errors": errors,
+        "warnings": warnings,
+        "metadata": {
+            "read_only": True,
+            "experimental": True,
+            "production_safe": False,
+            "stable_planner_consumed": False,
+        },
+    }
+
+
+def _canonical_affix(
+    record: dict[str, Any],
+    modifiers: tuple[dict[str, Any], ...],
+) -> dict[str, Any]:
+    source_identity = _source_affix_identity(record)
+    canonical_id = _canonical_id(source_identity, record)
+    categories = [str(value) for value in record.get("categories") or []]
+    source_type = str(record.get("source_type") or "unknown")
+    domain = _affix_domain(record)
+    tier_ranges = [_tier_range(tier) for tier in record.get("tier_data") or []]
+    modifier_references = [_modifier_reference(modifier) for modifier in modifiers]
+    warnings = _warnings(record, tier_ranges, modifier_references)
+    item_values = [str(value) for value in record.get("eligible_item_types") or []]
+    return {
+        "canonical_id": canonical_id,
+        "display_name": record.get("display_name") or record.get("affix_name") or canonical_id,
+        "source_id": source_identity,
+        "source_affix_id": record.get("affix_id"),
+        "source_file": _provenance(record).get("source_path"),
+        "patch_version": None,
+        "support_status": SupportStatus.PARTIAL.value,
+        "trust_level": TrustLevel.GENERATED_FROM_GAME_DATA.value,
+        "provenance": {
+            "source_path": _provenance(record).get("source_path"),
+            "source_type": source_type,
+            "source_id": source_identity,
+            "extraction_method": "forge_safe_affix_bundle",
+            "schema_version": "v2.affix_bundle.1",
+            "notes": [
+                "Source tier values are preserved without planner value-scale normalization.",
+            ],
+            "raw_reference": {
+                "source_affix_identity": source_identity,
+                "affix_id": record.get("affix_id"),
+            },
+        },
+        "source_type": source_type,
+        "affix_domain": domain,
+        "affix_type": _affix_type(categories),
+        "prefix_suffix": _prefix_suffix(categories),
+        "categories": categories,
+        "tags": [str(value) for value in record.get("tags") or []],
+        "item_applicability": item_values,
+        "slot_restrictions": item_values,
+        "item_type_restrictions": item_values,
+        "class_restrictions": [],
+        "mastery_restrictions": [],
+        "tier_ranges": tier_ranges,
+        "tier_count": len(tier_ranges),
+        "modifier_references": modifier_references,
+        "modifier_reference_count": len(modifier_references),
+        "value_scale_policy": "source_units_preserved_pending_v2_value_normalization",
+        "polarity_policy": "source_sign_preserved_no_inference",
+        "stable_calculable": False,
+        "warnings": warnings,
+        "raw_reference": _raw_reference_summary(record, modifiers, source_identity),
+        "normalized_fields": {
+            "tier_ranges": tier_ranges,
+            "modifier_references": modifier_references,
+        },
+        "consumer_safe_fields": {
+            "display_name": record.get("display_name") or record.get("affix_name") or canonical_id,
+            "support_status": SupportStatus.PARTIAL.value,
+            "stable_calculable": False,
+            "slot_restrictions": item_values,
+        },
+    }
+
+
+def _summary(
+    affixes: list[dict[str, Any]],
+    source_summary: dict[str, Any],
+    validation: dict[str, Any],
+) -> dict[str, Any]:
+    status_counts = Counter(record["support_status"] for record in affixes)
+    domain_counts = Counter(record["affix_domain"] for record in affixes)
+    prefix_counts = Counter(record["prefix_suffix"] or "unknown" for record in affixes)
+    modifier_counts = Counter(str(record["modifier_reference_count"]) for record in affixes)
+    return {
+        "affix_count": len(affixes),
+        "support_status_counts": dict(sorted(status_counts.items())),
+        "trust_level_counts": dict(sorted(Counter(record["trust_level"] for record in affixes).items())),
+        "affix_domain_counts": dict(sorted(domain_counts.items())),
+        "prefix_suffix_counts": dict(sorted(prefix_counts.items())),
+        "modifier_reference_count_distribution": dict(sorted(modifier_counts.items())),
+        "stable_calculable_count": sum(1 for record in affixes if record["stable_calculable"]),
+        "records_with_warnings_count": sum(1 for record in affixes if record["warnings"]),
+        "source_affix_count": source_summary.get("affix_count"),
+        "source_modifier_count": source_summary.get("modifier_count"),
+        "validation_error_count": validation["summary"]["error_count"],
+        "validation_warning_count": validation["summary"]["warning_count"],
+        "production_consumed": False,
+    }
+
+
+def render_markdown(
+    bundle: dict[str, Any],
+    validation: dict[str, Any],
+    *,
+    command: str,
+) -> str:
+    summary = bundle["summary"]
+    status_rows = _count_rows(summary["support_status_counts"])
+    domain_rows = _count_rows(summary["affix_domain_counts"])
+    prefix_rows = _count_rows(summary["prefix_suffix_counts"])
+    modifier_rows = _count_rows(summary["modifier_reference_count_distribution"])
+    examples = "\n".join(
+        f"| `{record['canonical_id']}` | {record['display_name']} | {record['affix_domain']} | {record['prefix_suffix'] or 'unknown'} | {record['modifier_reference_count']} |"
+        for record in bundle["records"]["affixes"][:20]
+    )
+    return f"""# v2 Affix Migration
+
+## Purpose
+
+Phase 3 creates a read-only canonical affix bundle on top of the v2 data contracts. The bundle preserves deterministic Forge-safe affix/modifier relationships and exposes validation diagnostics for later repository, API, debug, and planner work.
+
+This phase does not remap planner, crafting, stat aggregation, simulation, item, passive, skill, idol, unique, or set behavior.
+
+## Generation Command
+
+```powershell
+{command}
+```
+
+## Summary
+
+- Affix count: {summary["affix_count"]}
+- Stable-calculable count: {summary["stable_calculable_count"]}
+- Records with warnings: {summary["records_with_warnings_count"]}
+- Validation errors: {validation["summary"]["error_count"]}
+- Validation warnings: {validation["summary"]["warning_count"]}
+- Production consumed: false
+
+## Support Status Counts
+
+| Support status | Count |
+| --- | ---: |
+{status_rows}
+
+## Affix Domain Counts
+
+| Domain | Count |
+| --- | ---: |
+{domain_rows}
+
+## Prefix/Suffix Counts
+
+| Classification | Count |
+| --- | ---: |
+{prefix_rows}
+
+## Modifier Reference Count Distribution
+
+| Modifier references | Affix count |
+| --- | ---: |
+{modifier_rows}
+
+## Example Canonical Affixes
+
+| Canonical ID | Display name | Domain | Prefix/suffix | Modifier references |
+| --- | --- | --- | --- | ---: |
+{examples}
+
+## Value and Polarity Policy
+
+Tier values are preserved in source units. No planner value-scale normalization is applied in this phase. Polarity is preserved from source values without inference.
+
+## Migration Implications
+
+- The generated bundle is appropriate for experimental inspection and validation.
+- Records are `partial`, not `trusted`, because value-scale normalization and planner eligibility remain unresolved.
+- Equipment/idol domain separation is explicit in the bundle.
+- Stable planner consumption remains blocked.
+
+## Deferred
+
+- Full planner remap.
+- Value-scale normalization policy.
+- Item/passive/skill/idol/unique/set infrastructure.
+- Stable API contracts outside experimental routes.
+
+## Checkpoint 3
+
+Checkpoint 3 is ready for review when the generated bundle, validation report, repository, experimental routes, debug page, and focused tests pass.
+"""
+
+
+def _source_affix_identity(record: dict[str, Any]) -> str:
+    return str(_provenance(record).get("source_affix_identity") or f"{record.get('source_type', 'unknown')}:{record.get('affix_id')}")
+
+
+def _canonical_id(source_identity: str, record: dict[str, Any]) -> str:
+    safe = source_identity.lower().replace(" ", "_").replace("/", "_")
+    if ":" not in safe:
+        safe = f"{str(record.get('source_type') or 'unknown').lower()}:{record.get('affix_id')}"
+    return f"affix:{safe}"
+
+
+def _provenance(record: dict[str, Any]) -> dict[str, Any]:
+    provenance = record.get("provenance")
+    return provenance if isinstance(provenance, dict) else {}
+
+
+def _affix_domain(record: dict[str, Any]) -> str:
+    values = [str(record.get("source_type") or ""), str(record.get("item_type") or "")]
+    values.extend(str(value) for value in record.get("eligible_item_types") or [])
+    lowered = " ".join(values).lower()
+    if "idol" in lowered:
+        return "idol"
+    if "equipment" in lowered or record.get("eligible_item_types"):
+        return "equipment"
+    return "unknown"
+
+
+def _affix_type(categories: list[str]) -> str | None:
+    if any(value.upper() == "PREFIX" for value in categories):
+        return "prefix"
+    if any(value.upper() == "SUFFIX" for value in categories):
+        return "suffix"
+    return None
+
+
+def _prefix_suffix(categories: list[str]) -> str | None:
+    return _affix_type(categories)
+
+
+def _tier_range(tier: dict[str, Any]) -> dict[str, Any]:
+    minimum = tier.get("minRoll")
+    maximum = tier.get("maxRoll")
+    return {
+        "tier": tier.get("tier"),
+        "min_value": minimum,
+        "max_value": maximum,
+        "tier_group": tier.get("tier_group"),
+        "value_scale": "source_units",
+        "polarity": _polarity(minimum, maximum),
+    }
+
+
+def _polarity(minimum: Any, maximum: Any) -> str:
+    values = [value for value in (minimum, maximum) if isinstance(value, (int, float))]
+    if not values:
+        return "unknown"
+    if all(value >= 0 for value in values):
+        return "positive"
+    if all(value <= 0 for value in values):
+        return "negative"
+    return "mixed"
+
+
+def _modifier_reference(modifier: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "modifier_id": str(modifier.get("modifier_id")),
+        "property": modifier.get("property"),
+        "property_path": _property_path(modifier),
+        "modifier_type": modifier.get("modifier_type"),
+        "source_record_id": _modifier_source(modifier).get("source_affix_identity"),
+        "tags": [str(value) for value in modifier.get("tags") or []],
+    }
+
+
+def _modifier_source(modifier: dict[str, Any]) -> dict[str, Any]:
+    source = modifier.get("source")
+    return source if isinstance(source, dict) else {}
+
+
+def _property_path(modifier: dict[str, Any]) -> str | None:
+    pieces = [modifier.get("modifier_type"), modifier.get("property")]
+    tags = modifier.get("tags") or []
+    if tags:
+        pieces.append(".".join(str(tag) for tag in tags))
+    text = ".".join(str(piece) for piece in pieces if piece not in (None, ""))
+    return text or None
+
+
+def _raw_reference_summary(
+    record: dict[str, Any],
+    modifiers: tuple[dict[str, Any], ...],
+    source_identity: str,
+) -> dict[str, Any]:
+    return {
+        "source_affix_identity": source_identity,
+        "affix_id": record.get("affix_id"),
+        "source_type": record.get("source_type"),
+        "source_path": _provenance(record).get("source_path"),
+        "categories": [str(value) for value in record.get("categories") or []],
+        "eligible_item_types": [str(value) for value in record.get("eligible_item_types") or []],
+        "deterministic_modifier_data": record.get("deterministic_modifier_data"),
+        "modifier_ids": [str(modifier.get("modifier_id")) for modifier in modifiers],
+    }
+
+
+def _warnings(
+    record: dict[str, Any],
+    tier_ranges: list[dict[str, Any]],
+    modifier_references: list[dict[str, Any]],
+) -> list[str]:
+    warnings = [
+        "Value scale is source-units only; planner normalization is pending.",
+    ]
+    if not tier_ranges:
+        warnings.append("Tier range data is missing.")
+    if not modifier_references:
+        warnings.append("Modifier references are missing.")
+    if not _affix_type([str(value) for value in record.get("categories") or []]):
+        warnings.append("Prefix/suffix classification is unavailable.")
+    if _affix_domain(record) == "unknown":
+        warnings.append("Affix domain could not be classified as equipment or idol.")
+    return warnings
+
+
+def _count_code(items: list[dict[str, Any]], code: str) -> int:
+    return sum(1 for item in items if item.get("code") == code)
+
+
+def _count_rows(counts: dict[str, int]) -> str:
+    return "\n".join(f"| `{key}` | {value} |" for key, value in sorted(counts.items()))
+
+
+def main() -> int:
+    args = parse_args()
+    bundle = build_v2_affix_bundle(args.source_bundle)
+    validation = validate_v2_affix_records(bundle["records"]["affixes"])
+    try:
+        V2AffixRepository(args.output).load_payload(bundle)
+    except V2AffixBundleError as exc:
+        validation["errors"].append({"code": "repository_validation_failed", "message": str(exc)})
+        validation["summary"]["error_count"] = len(validation["errors"])
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(bundle, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    args.validation_output.parent.mkdir(parents=True, exist_ok=True)
+    args.validation_output.write_text(json.dumps(validation, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    command = (
+        ".\\backend\\.venv\\Scripts\\python.exe backend\\scripts\\report_v2_affix_bundle.py "
+        f"--source-bundle {_display_path(args.source_bundle)} "
+        f"--output {_display_path(args.output)} "
+        f"--validation-output {_display_path(args.validation_output)} "
+        f"--markdown-output {_display_path(args.markdown_output)}"
+    )
+    args.markdown_output.parent.mkdir(parents=True, exist_ok=True)
+    args.markdown_output.write_text(render_markdown(bundle, validation, command=command), encoding="utf-8")
+    print(json.dumps({"output": str(args.output), "summary": bundle["summary"], "validation": validation["summary"]}, indent=2))
+    return 0 if validation["summary"]["error_count"] == 0 else 1
+
+
+def _display_path(path: Path) -> str:
+    try:
+        return path.resolve().relative_to(ROOT).as_posix().replace("/", "\\")
+    except ValueError:
+        return str(path)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_v2_affix_infrastructure.py
+++ b/backend/tests/test_v2_affix_infrastructure.py
@@ -1,0 +1,207 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from app.repositories.v2.affix_repository import V2AffixBundleError, V2AffixRepository
+from scripts.report_v2_affix_bundle import (
+    build_v2_affix_bundle,
+    validate_v2_affix_records,
+)
+
+
+def test_v2_affix_bundle_generation_and_reporting(tmp_path):
+    source_path = tmp_path / "forge_safe_affix_bundle.json"
+    source_path.write_text(json.dumps(_source_bundle()), encoding="utf-8")
+
+    bundle = build_v2_affix_bundle(source_path)
+
+    assert bundle["summary"]["affix_count"] == 1
+    assert bundle["summary"]["support_status_counts"] == {"partial": 1}
+    assert bundle["summary"]["stable_calculable_count"] == 0
+    record = bundle["records"]["affixes"][0]
+    assert record["canonical_id"] == "affix:equipment:1"
+    assert record["display_name"] == "Test Health"
+    assert record["provenance"]["source_path"] == "exports_json/affixes.json"
+    assert record["modifier_references"][0]["property"] == "Health"
+
+
+def test_v2_affix_validation_detects_duplicate_ids():
+    payload = _v2_bundle()
+    payload["records"]["affixes"].append(dict(payload["records"]["affixes"][0]))
+
+    with pytest.raises(V2AffixBundleError, match="Duplicate canonical_id"):
+        V2AffixRepository("<memory>").load_payload(payload)
+
+
+def test_v2_affix_validation_requires_provenance():
+    payload = _v2_bundle()
+    payload["records"]["affixes"][0]["provenance"] = {}
+
+    with pytest.raises(V2AffixBundleError, match="provenance.source_path"):
+        V2AffixRepository("<memory>").load_payload(payload)
+
+
+def test_v2_affix_validation_requires_support_status():
+    payload = _v2_bundle()
+    payload["records"]["affixes"][0].pop("support_status")
+
+    report = validate_v2_affix_records(payload["records"]["affixes"])
+
+    assert report["summary"]["missing_support_status_count"] == 1
+    with pytest.raises(V2AffixBundleError, match="invalid support_status"):
+        V2AffixRepository("<memory>").load_payload(payload)
+
+
+def test_v2_affix_repository_lookup_filter_and_debug_summary():
+    repository = V2AffixRepository("<memory>").load_payload(_v2_bundle())
+
+    assert repository.count() == 1
+    assert repository.get_affix("affix:equipment:1")["display_name"] == "Test Health"
+    assert repository.filter_affixes(slot="helmet")[0]["canonical_id"] == "affix:equipment:1"
+    assert repository.filter_affixes(item_type="helmet")[0]["canonical_id"] == "affix:equipment:1"
+    assert repository.debug_summary()["support_status_counts"] == {"partial": 1}
+
+
+def test_v2_affix_routes_list_detail_and_debug(app, tmp_path):
+    bundle_path = tmp_path / "v2_affix_bundle.json"
+    bundle_path.write_text(json.dumps(_v2_bundle()), encoding="utf-8")
+    app.config["V2_AFFIX_BUNDLE_PATH"] = str(bundle_path)
+    client = app.test_client()
+
+    list_response = client.get("/experimental/v2/affixes?slot=HELMET")
+    assert list_response.status_code == 200
+    list_payload = list_response.get_json()
+    assert list_payload["success"] is True
+    assert list_payload["production_consumer"] is False
+    assert list_payload["records"][0]["canonical_id"] == "affix:equipment:1"
+
+    detail_response = client.get("/experimental/v2/affixes/affix:equipment:1")
+    assert detail_response.status_code == 200
+    assert detail_response.get_json()["record"]["display_name"] == "Test Health"
+
+    debug_response = client.get("/experimental/v2/affixes/debug")
+    assert debug_response.status_code == 200
+    assert debug_response.get_json()["debug_summary"]["production_safe"] is False
+
+
+def test_v2_affix_route_reports_missing_bundle(app, tmp_path):
+    app.config["V2_AFFIX_BUNDLE_PATH"] = str(tmp_path / "missing.json")
+
+    response = app.test_client().get("/experimental/v2/affixes")
+
+    assert response.status_code == 404
+    assert response.get_json()["error"] == "v2_affix_bundle_missing"
+
+
+def test_v2_affix_bundle_is_not_referenced_by_production_modules():
+    root = Path(__file__).resolve().parents[2]
+    allowed = {
+        root / "backend" / "app" / "routes" / "experimental.py",
+        root / "backend" / "app" / "repositories" / "v2" / "affix_repository.py",
+        root / "backend" / "app" / "repositories" / "v2" / "__init__.py",
+        root / "backend" / "scripts" / "report_v2_affix_bundle.py",
+        Path(__file__).resolve(),
+    }
+    needles = ("v2_affix_bundle.json", "V2AffixRepository")
+    offenders: list[str] = []
+    for path in (root / "backend" / "app").rglob("*.py"):
+        if path in allowed or "__pycache__" in path.parts:
+            continue
+        text = path.read_text(encoding="utf-8")
+        if any(needle in text for needle in needles):
+            offenders.append(str(path.relative_to(root)))
+
+    assert offenders == []
+
+
+def _source_bundle() -> dict:
+    return {
+        "schema_version": "1.0.0",
+        "export_policy": "deterministic_affix_bundle",
+        "summary": {
+            "production_safe": False,
+            "forge_safe_records_only": True,
+            "affix_count": 1,
+            "modifier_count": 1,
+        },
+        "cross_reference_validation": {
+            "status": "pass",
+            "unmatched_affix_count": 0,
+            "unmatched_modifier_count": 0,
+            "duplicate_affix_id_count": 0,
+            "duplicate_modifier_id_count": 0,
+        },
+        "records": {
+            "affixes": [
+                {
+                    "affix_id": 1,
+                    "affix_name": "Test Health",
+                    "display_name": "Test Health",
+                    "source_type": "equipment",
+                    "item_type": "Equipment",
+                    "eligible_item_types": ["HELMET"],
+                    "categories": ["PREFIX"],
+                    "tags": ["Health"],
+                    "tier_data": [
+                        {"tier": 1, "minRoll": 5, "maxRoll": 10, "tier_group": "T1"}
+                    ],
+                    "provenance": {
+                        "source_affix_identity": "equipment:1",
+                        "source_path": "exports_json/affixes.json",
+                    },
+                    "safety": {"forge_safe": True, "production_safe": False},
+                }
+            ],
+            "modifiers": [
+                {
+                    "modifier_id": "equipment:1",
+                    "modifier_type": "ADDED",
+                    "property": "Health",
+                    "tags": ["Health"],
+                    "source": {"source_affix_identity": "equipment:1"},
+                    "safety": {"forge_safe": True, "production_safe": False},
+                }
+            ],
+        },
+    }
+
+
+def _v2_bundle() -> dict:
+    return {
+        "schema_version": "v2.affix_bundle.1",
+        "summary": {
+            "affix_count": 1,
+            "source_modifier_count": 1,
+            "records_with_warnings_count": 1,
+            "validation_error_count": 0,
+        },
+        "records": {
+            "affixes": [
+                {
+                    "canonical_id": "affix:equipment:1",
+                    "display_name": "Test Health",
+                    "source_id": "equipment:1",
+                    "source_type": "equipment",
+                    "support_status": "partial",
+                    "trust_level": "generated_from_game_data",
+                    "provenance": {
+                        "source_path": "exports_json/affixes.json",
+                        "source_type": "equipment",
+                        "source_id": "equipment:1",
+                        "extraction_method": "test_fixture",
+                        "schema_version": "v2.affix_bundle.1",
+                    },
+                    "affix_domain": "equipment",
+                    "item_applicability": ["HELMET"],
+                    "slot_restrictions": ["HELMET"],
+                    "item_type_restrictions": ["HELMET"],
+                    "class_restrictions": [],
+                    "mastery_restrictions": [],
+                    "tier_ranges": [{"tier": 1, "min_value": 5, "max_value": 10}],
+                    "modifier_references": [{"modifier_id": "equipment:1", "property": "Health"}],
+                    "stable_calculable": False,
+                }
+            ]
+        },
+    }

--- a/docs/generated/v2_affix_validation_report.json
+++ b/docs/generated/v2_affix_validation_report.json
@@ -1,0 +1,26 @@
+{
+  "errors": [],
+  "metadata": {
+    "experimental": true,
+    "production_safe": false,
+    "read_only": true,
+    "stable_planner_consumed": false
+  },
+  "summary": {
+    "duplicate_canonical_id_count": 0,
+    "equipment_affix_count": 615,
+    "error_count": 0,
+    "idol_affix_count": 483,
+    "invalid_slot_restriction_shape_count": 0,
+    "invalid_tier_data_count": 0,
+    "invalid_trust_level_count": 0,
+    "missing_provenance_count": 0,
+    "missing_support_status_count": 0,
+    "production_consumed": false,
+    "record_count": 1098,
+    "stable_calculable_blocked_count": 0,
+    "stable_calculable_count": 0,
+    "warning_count": 0
+  },
+  "warnings": []
+}

--- a/docs/migration/V2_AFFIX_MIGRATION.md
+++ b/docs/migration/V2_AFFIX_MIGRATION.md
@@ -1,0 +1,96 @@
+# v2 Affix Migration
+
+## Purpose
+
+Phase 3 creates a read-only canonical affix bundle on top of the v2 data contracts. The bundle preserves deterministic Forge-safe affix/modifier relationships and exposes validation diagnostics for later repository, API, debug, and planner work.
+
+This phase does not remap planner, crafting, stat aggregation, simulation, item, passive, skill, idol, unique, or set behavior.
+
+## Generation Command
+
+```powershell
+.\backend\.venv\Scripts\python.exe backend\scripts\report_v2_affix_bundle.py --source-bundle D:\Forge\last-epoch-data\docs\generated\forge_safe_affix_bundle.json --output docs\generated\v2_affix_bundle.json --validation-output docs\generated\v2_affix_validation_report.json --markdown-output docs\migration\V2_AFFIX_MIGRATION.md
+```
+
+## Summary
+
+- Affix count: 1098
+- Stable-calculable count: 0
+- Records with warnings: 1098
+- Validation errors: 0
+- Validation warnings: 0
+- Production consumed: false
+
+## Support Status Counts
+
+| Support status | Count |
+| --- | ---: |
+| `partial` | 1098 |
+
+## Affix Domain Counts
+
+| Domain | Count |
+| --- | ---: |
+| `equipment` | 615 |
+| `idol` | 483 |
+
+## Prefix/Suffix Counts
+
+| Classification | Count |
+| --- | ---: |
+| `prefix` | 832 |
+| `suffix` | 266 |
+
+## Modifier Reference Count Distribution
+
+| Modifier references | Affix count |
+| --- | ---: |
+| `1` | 572 |
+| `2` | 526 |
+
+## Example Canonical Affixes
+
+| Canonical ID | Display name | Domain | Prefix/suffix | Modifier references |
+| --- | --- | --- | --- | ---: |
+| `affix:equipment:0` | Void Penetration | equipment | prefix | 1 |
+| `affix:equipment:1` | Armor | equipment | suffix | 1 |
+| `affix:equipment:2` | Increased Melee Attack Speed | equipment | prefix | 1 |
+| `affix:equipment:3` | Added Block Chance | equipment | prefix | 1 |
+| `affix:equipment:4` | Increased Cast Speed | equipment | prefix | 1 |
+| `affix:equipment:5` | Increased Critical Strike Chance | equipment | prefix | 1 |
+| `affix:equipment:6` | Added Critical Strike Multiplier | equipment | prefix | 1 |
+| `affix:equipment:7` | Void Resistance | equipment | suffix | 1 |
+| `affix:equipment:8` | Added Dodge Rating | equipment | suffix | 1 |
+| `affix:equipment:9` | Increased Elemental Damage | equipment | prefix | 1 |
+| `affix:equipment:10` | Necrotic Resistance | equipment | suffix | 1 |
+| `affix:equipment:11` | Freeze Rate Multiplier | equipment | suffix | 1 |
+| `affix:equipment:12` | Increased Fire Damage | equipment | prefix | 1 |
+| `affix:equipment:13` | Fire Resistance | equipment | suffix | 1 |
+| `affix:equipment:15` | Increased Void Damage | equipment | prefix | 1 |
+| `affix:equipment:16` | Increased Cold Damage | equipment | prefix | 1 |
+| `affix:equipment:17` | Cold Resistance | equipment | suffix | 1 |
+| `affix:equipment:18` | Increased Necrotic Damage | equipment | prefix | 1 |
+| `affix:equipment:19` | Poison Resistance | equipment | suffix | 1 |
+| `affix:equipment:20` | Health On Kill | equipment | suffix | 1 |
+
+## Value and Polarity Policy
+
+Tier values are preserved in source units. No planner value-scale normalization is applied in this phase. Polarity is preserved from source values without inference.
+
+## Migration Implications
+
+- The generated bundle is appropriate for experimental inspection and validation.
+- Records are `partial`, not `trusted`, because value-scale normalization and planner eligibility remain unresolved.
+- Equipment/idol domain separation is explicit in the bundle.
+- Stable planner consumption remains blocked.
+
+## Deferred
+
+- Full planner remap.
+- Value-scale normalization policy.
+- Item/passive/skill/idol/unique/set infrastructure.
+- Stable API contracts outside experimental routes.
+
+## Checkpoint 3
+
+Checkpoint 3 is ready for review when the generated bundle, validation report, repository, experimental routes, debug page, and focused tests pass.

--- a/frontend/src/__tests__/pages/forge-safe-affixes-debug-page.test.tsx
+++ b/frontend/src/__tests__/pages/forge-safe-affixes-debug-page.test.tsx
@@ -24,7 +24,7 @@ describe("ForgeSafeAffixesDebugPage", () => {
 
     expect(await screen.findByText("Debug endpoint unavailable")).toBeInTheDocument();
     expect(screen.getByText("Forge-safe affix catalog is disabled.")).toBeInTheDocument();
-    expect(screen.getByText("This page is debug-only and does not power planner behavior.")).toBeInTheDocument();
+    expect(screen.getByText("This page reads the v2 canonical affix bundle for diagnostics and does not power planner behavior.")).toBeInTheDocument();
   });
 
   it("renders successful summary counts and debug labels", async () => {
@@ -33,10 +33,10 @@ describe("ForgeSafeAffixesDebugPage", () => {
     render(<ForgeSafeAffixesDebugPage />);
 
     expect(await screen.findByText("1098")).toBeInTheDocument();
-    expect(screen.getByText("deterministic_affix_bundle")).toBeInTheDocument();
+    expect(screen.getAllByText("v2_affix_bundle").length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText("pass")).toBeInTheDocument();
-    expect(screen.getByText("1227")).toBeInTheDocument();
-    expect(screen.getByText("129")).toBeInTheDocument();
+    expect(screen.getByText("partial: 1098")).toBeInTheDocument();
+    expect(screen.getByText("equipment: 615, idol: 483")).toBeInTheDocument();
     expect(screen.getAllByText("true").length).toBeGreaterThanOrEqual(2);
     expect(screen.getByText("Production consumer")).toBeInTheDocument();
     expect(screen.getByText("false")).toBeInTheDocument();
@@ -64,12 +64,12 @@ describe("ForgeSafeAffixesDebugPage", () => {
     await screen.findByText("Void Penetration");
 
     fireEvent.change(screen.getByLabelText(/Limit/i), { target: { value: "2" } });
-    fireEvent.change(screen.getByLabelText(/Affix ID/i), { target: { value: "7" } });
+    fireEvent.change(screen.getByLabelText(/Affix ID/i), { target: { value: "affix:equipment:7" } });
     fireEvent.click(screen.getByLabelText(/Include modifier detail/i));
     fireEvent.click(screen.getByRole("button", { name: "Load debug data" }));
 
     await waitFor(() => {
-      expect(fetch).toHaveBeenLastCalledWith("/experimental/forge-safe-affixes?limit=2&include_modifiers=true&affix_id=7");
+      expect(fetch).toHaveBeenLastCalledWith("/experimental/v2/affixes?limit=2&include_modifiers=true&affix_id=affix%3Aequipment%3A7");
     });
   });
 });
@@ -87,26 +87,56 @@ function successPayload() {
     debug_only: true,
     read_only: true,
     production_consumer: false,
-    data_source: "forge_safe_affix_bundle",
-    source_path: "D:\\Forge\\last-epoch-data\\docs\\generated\\forge_safe_affix_bundle.json",
+    data_source: "v2_affix_bundle",
+    source_path: "D:\\Forge\\le-the-forge\\docs\\generated\\v2_affix_bundle.json",
     total_loaded_count: 1098,
     total_affixes: 1098,
     total_modifiers: 1624,
     warning_count: 0,
     warnings: [],
-    export_policy: "deterministic_affix_bundle",
+    export_policy: "v2_affix_bundle",
     export_status: "pass",
-    total_affix_records_seen: 1227,
-    excluded_affix_records: 129,
+    summary: {
+      support_status_counts: { partial: 1098 },
+      affix_domain_counts: { equipment: 615, idol: 483 },
+    },
     result_count: 1,
     records: [
       {
-        affix_id: 0,
-        affix_name: "Void Penetration",
+        canonical_id: "affix:equipment:0",
+        display_name: "Void Penetration",
+        support_status: "partial",
+        trust_level: "generated_from_game_data",
+        provenance: {
+          source_path: "exports_json/affixes.json",
+          source_type: "equipment",
+          extraction_method: "forge_safe_affix_bundle",
+          schema_version: "v2.affix_bundle.1",
+          notes: [],
+          raw_reference: {},
+        },
+        source_id: "equipment:0",
+        source_file: "exports_json/affixes.json",
+        patch_version: null,
         source_type: "equipment",
-        item_type: "Equipment",
-        eligible_item_types: ["AMULET"],
-        modifier_count: 1,
+        affix_domain: "equipment",
+        affix_type: "prefix",
+        prefix_suffix: "prefix",
+        item_applicability: ["AMULET"],
+        slot_restrictions: ["AMULET"],
+        item_type_restrictions: ["AMULET"],
+        class_restrictions: [],
+        mastery_restrictions: [],
+        tier_ranges: [{ tier: 1, min_value: 1, max_value: 2 }],
+        modifier_references: [{ modifier_id: "equipment:0", property: "Penetration" }],
+        modifier_reference_count: 1,
+        value_scale_policy: "source_units_preserved_pending_v2_value_normalization",
+        polarity_policy: "source_sign_preserved_no_inference",
+        stable_calculable: false,
+        warnings: [],
+        raw_reference: {},
+        normalized_fields: {},
+        consumer_safe_fields: {},
       },
     ],
   };

--- a/frontend/src/pages/debug/ForgeSafeAffixesDebugPage.tsx
+++ b/frontend/src/pages/debug/ForgeSafeAffixesDebugPage.tsx
@@ -1,18 +1,8 @@
 import { FormEvent, useEffect, useMemo, useState } from "react";
 
-interface ForgeSafeAffixSample {
-  affix_id: number | string;
-  name?: string | null;
-  affix_name?: string | null;
-  display_name?: string | null;
-  source_type?: string | null;
-  item_type?: string | null;
-  eligible_item_types?: string[];
-  modifier_count?: number;
-  modifiers?: Array<Record<string, unknown>>;
-}
+import type { CanonicalAffix } from "@/types";
 
-interface ForgeSafeAffixDebugResponse {
+interface V2AffixDebugResponse {
   success: boolean;
   experimental?: boolean;
   debug_only?: boolean;
@@ -31,9 +21,10 @@ interface ForgeSafeAffixDebugResponse {
   total_affix_records_seen?: number;
   excluded_affix_records?: number;
   sample_count?: number;
-  sample_records?: ForgeSafeAffixSample[];
+  sample_records?: CanonicalAffix[];
   result_count?: number;
-  records?: ForgeSafeAffixSample[];
+  records?: CanonicalAffix[];
+  summary?: Record<string, unknown>;
   error?: string;
   message?: string;
 }
@@ -45,14 +36,14 @@ function buildDebugUrl(limit: number, affixId: string, includeModifiers: boolean
   params.set("limit", String(limit));
   if (includeModifiers) params.set("include_modifiers", "true");
   if (affixId.trim()) params.set("affix_id", affixId.trim());
-  return `/experimental/forge-safe-affixes?${params.toString()}`;
+  return `/experimental/v2/affixes?${params.toString()}`;
 }
 
 async function fetchForgeSafeAffixes(
   limit: number,
   affixId: string,
   includeModifiers: boolean,
-): Promise<ForgeSafeAffixDebugResponse> {
+): Promise<V2AffixDebugResponse> {
   const res = await fetch(buildDebugUrl(limit, affixId, includeModifiers));
   const json = await res.json().catch(() => null);
   if (!json || typeof json !== "object") {
@@ -62,7 +53,7 @@ async function fetchForgeSafeAffixes(
       message: `Backend returned an unreadable response (${res.status}).`,
     };
   }
-  return json as ForgeSafeAffixDebugResponse;
+  return json as V2AffixDebugResponse;
 }
 
 export default function ForgeSafeAffixesDebugPage() {
@@ -70,7 +61,7 @@ export default function ForgeSafeAffixesDebugPage() {
   const [includeModifiers, setIncludeModifiers] = useState(false);
   const [affixIdInput, setAffixIdInput] = useState("");
   const [activeAffixId, setActiveAffixId] = useState("");
-  const [data, setData] = useState<ForgeSafeAffixDebugResponse | null>(null);
+  const [data, setData] = useState<V2AffixDebugResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -116,8 +107,8 @@ export default function ForgeSafeAffixesDebugPage() {
       ["Warnings", data?.warning_count ?? "n/a"],
       ["Export policy", data?.export_policy ?? "n/a"],
       ["Export status", data?.export_status ?? "n/a"],
-      ["Total seen", data?.total_affix_records_seen ?? "n/a"],
-      ["Excluded", data?.excluded_affix_records ?? "n/a"],
+      ["Support", summarizeMap(data?.summary, "support_status_counts")],
+      ["Domains", summarizeMap(data?.summary, "affix_domain_counts")],
       ["Debug only", String((data?.debug_only ?? data?.experimental) ?? false)],
       ["Read only", String(data?.read_only ?? false)],
       ["Production consumer", String(data?.production_consumer ?? false)],
@@ -134,8 +125,8 @@ export default function ForgeSafeAffixesDebugPage() {
         <h1 className="mt-2 font-display text-2xl text-[#f5a623]">
           Forge-safe affix catalog inspection
         </h1>
-        <p className="mt-2 max-w-3xl text-sm text-gray-400">
-          This page is debug-only and does not power planner behavior.
+          <p className="mt-2 max-w-3xl text-sm text-gray-400">
+          This page reads the v2 canonical affix bundle for diagnostics and does not power planner behavior.
         </p>
       </header>
 
@@ -201,7 +192,7 @@ export default function ForgeSafeAffixesDebugPage() {
           <h2 className="text-sm font-semibold text-red-300">Debug endpoint unavailable</h2>
           <p className="mt-2 text-sm text-red-100">{error}</p>
           <p className="mt-2 text-xs text-red-200/80">
-            Enable the backend experimental catalog flag and configure the Forge-safe export or bundle path before using this page.
+            Generate the v2 affix bundle or configure V2_AFFIX_BUNDLE_PATH before using this page.
           </p>
         </section>
       )}
@@ -246,26 +237,30 @@ export default function ForgeSafeAffixesDebugPage() {
               <table className="w-full min-w-[760px] text-left text-sm">
                 <thead className="bg-[#0f172a] text-xs uppercase text-gray-500">
                   <tr>
-                    <th className="px-4 py-3">Affix ID</th>
+                    <th className="px-4 py-3">Canonical ID</th>
                     <th className="px-4 py-3">Name</th>
+                    <th className="px-4 py-3">Support</th>
+                    <th className="px-4 py-3">Trust</th>
                     <th className="px-4 py-3">Source</th>
-                    <th className="px-4 py-3">Item Type</th>
-                    <th className="px-4 py-3">Eligible Types</th>
+                    <th className="px-4 py-3">Domain</th>
+                    <th className="px-4 py-3">Slots</th>
                     <th className="px-4 py-3">Modifiers</th>
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-[#2a3050]">
                   {records.map((record) => (
-                    <tr key={`${record.source_type}-${record.affix_id}`}>
-                      <td className="px-4 py-3 font-mono text-[#f5a623]">{record.affix_id}</td>
-                      <td className="px-4 py-3 text-gray-100">{record.affix_name ?? record.display_name ?? record.name ?? "n/a"}</td>
+                    <tr key={record.canonical_id}>
+                      <td className="px-4 py-3 font-mono text-[#f5a623]">{record.canonical_id}</td>
+                      <td className="px-4 py-3 text-gray-100">{record.display_name}</td>
+                      <td className="px-4 py-3">{statusBadge(record.support_status)}</td>
+                      <td className="px-4 py-3 text-gray-300">{record.trust_level}</td>
                       <td className="px-4 py-3 text-gray-300">{record.source_type ?? "n/a"}</td>
-                      <td className="px-4 py-3 text-gray-300">{record.item_type ?? "n/a"}</td>
+                      <td className="px-4 py-3 text-gray-300">{record.affix_domain}</td>
                       <td className="px-4 py-3 text-gray-400">
-                        {(record.eligible_item_types ?? []).join(", ") || "none"}
+                        {(record.slot_restrictions ?? []).join(", ") || "none"}
                       </td>
                       <td className="px-4 py-3 font-mono text-gray-300">
-                        {record.modifier_count ?? record.modifiers?.length ?? "n/a"}
+                        {record.modifier_reference_count ?? record.modifier_references?.length ?? "n/a"}
                       </td>
                     </tr>
                   ))}
@@ -276,5 +271,27 @@ export default function ForgeSafeAffixesDebugPage() {
         </>
       )}
     </div>
+  );
+}
+
+function summarizeMap(summary: Record<string, unknown> | undefined, key: string): string {
+  const value = summary?.[key];
+  if (!value || typeof value !== "object" || Array.isArray(value)) return "n/a";
+  return Object.entries(value as Record<string, unknown>)
+    .map(([name, count]) => `${name}: ${count}`)
+    .join(", ");
+}
+
+function statusBadge(status: string) {
+  const classes =
+    status === "trusted"
+      ? "border-emerald-700 bg-emerald-950 text-emerald-200"
+      : status === "partial"
+        ? "border-yellow-700 bg-yellow-950 text-yellow-200"
+        : "border-gray-700 bg-gray-900 text-gray-300";
+  return (
+    <span className={`inline-flex rounded border px-2 py-1 font-mono text-xs ${classes}`}>
+      {status}
+    </span>
   );
 }

--- a/frontend/src/types/canonicalAffix.ts
+++ b/frontend/src/types/canonicalAffix.ts
@@ -1,10 +1,30 @@
 import type { CanonicalRecord } from "./canonicalBase";
 import type { CanonicalModifierReference } from "./canonicalModifier";
 
+export interface CanonicalAffixTierRange {
+  tier: number | string | null;
+  min_value: number | null;
+  max_value: number | null;
+  tier_group?: string | null;
+  value_scale?: string | null;
+  polarity?: "positive" | "negative" | "mixed" | "unknown" | string;
+}
+
 export interface CanonicalAffix extends CanonicalRecord {
   affix_type?: string | null;
+  prefix_suffix?: string | null;
+  source_type?: string | null;
+  affix_domain: "equipment" | "idol" | "unknown";
   tier_count?: number | null;
   item_applicability: string[];
+  slot_restrictions: string[];
+  item_type_restrictions: string[];
   class_restrictions: string[];
+  mastery_restrictions: string[];
+  tier_ranges: CanonicalAffixTierRange[];
   modifier_references: CanonicalModifierReference[];
+  modifier_reference_count?: number | null;
+  value_scale_policy: string;
+  polarity_policy: string;
+  stable_calculable: boolean;
 }


### PR DESCRIPTION
## Summary

Adds Phase 3 of the v2 trusted data rebuild: affix infrastructure.

This introduces a read-only v2 affix path built on the canonical v2 contracts without changing production planner/runtime behavior.

## Added

- v2 affix bundle generation
- v2 affix validation report
- v2 affix migration documentation
- read-only `V2AffixRepository`
- experimental v2 affix routes:
  - `GET /experimental/v2/affixes`
  - `GET /experimental/v2/affixes/<affix_id>`
  - `GET /experimental/v2/affixes/debug`
- frontend affix debug page support for the v2 API shape
- support/trust/provenance-oriented affix display fields
- focused backend and frontend tests

## Findings

- Affix count: `1098`
- Equipment affixes: `615`
- Idol affixes: `483`
- Prefix: `832`
- Suffix: `266`
- Validation errors: `0`
- Stable-calculable count: `0`

All affixes are intentionally marked `partial` because value-scale normalization is not solved yet. This prevents the stable planner from treating source-unit affix values as trusted calculated values.

## Validation

- `22 passed` for v2 canonical contract, v2 affix infrastructure, and production non-consumption tests
- `25 passed` for existing experimental forge-safe affix catalog/comparison tests
- Frontend type-check passed
- Frontend affix debug page test passed: `4 passed`
- JSON validation passed for generated affix bundle and validation report
- `git diff --check` passed

## Runtime behavior

Production behavior was not changed.

The new v2 affix access path is experimental and read-only. Planner, crafting, stat aggregation, simulation, and production routes remain blocked from consuming the v2 affix bundle.