### PR TITLE
feat: add v2 unique and set infrastructure

### DIFF
--- a/backend/app/repositories/v2/__init__.py
+++ b/backend/app/repositories/v2/__init__.py
@@ -2,10 +2,13 @@
 
 from .affix_repository import V2AffixBundleError, V2AffixRepository
 from .item_repository import V2ItemBundleError, V2ItemRepository
+from .unique_set_repository import V2UniqueSetBundleError, V2UniqueSetRepository
 
 __all__ = [
     "V2AffixBundleError",
     "V2AffixRepository",
     "V2ItemBundleError",
     "V2ItemRepository",
+    "V2UniqueSetBundleError",
+    "V2UniqueSetRepository",
 ]

--- a/backend/app/repositories/v2/unique_set_repository.py
+++ b/backend/app/repositories/v2/unique_set_repository.py
@@ -1,0 +1,294 @@
+"""Read-only v2 unique and set item repository."""
+
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+from app.data_contracts import SupportStatus, TrustLevel, validate_canonical_id
+
+
+class V2UniqueSetBundleError(ValueError):
+    """Raised when v2 unique/set bundles are missing or invalid."""
+
+
+class V2UniqueSetRepository:
+    """Read-only repository over generated v2 unique and set bundles."""
+
+    def __init__(self, unique_bundle_path: str | Path, set_bundle_path: str | Path) -> None:
+        self.unique_bundle_path = Path(unique_bundle_path)
+        self.set_bundle_path = Path(set_bundle_path)
+        self._unique_payload: dict[str, Any] | None = None
+        self._set_payload: dict[str, Any] | None = None
+        self._uniques: tuple[dict[str, Any], ...] = ()
+        self._sets: tuple[dict[str, Any], ...] = ()
+        self._set_items: tuple[dict[str, Any], ...] = ()
+        self._set_bonuses: tuple[dict[str, Any], ...] = ()
+        self._uniques_by_id: dict[str, dict[str, Any]] = {}
+        self._sets_by_id: dict[str, dict[str, Any]] = {}
+        self._set_items_by_group: dict[str, tuple[dict[str, Any], ...]] = {}
+        self._set_bonuses_by_group: dict[str, tuple[dict[str, Any], ...]] = {}
+
+    def load(self) -> "V2UniqueSetRepository":
+        return self.load_payloads(
+            _read_json(self.unique_bundle_path, "v2 unique bundle"),
+            _read_json(self.set_bundle_path, "v2 set bundle"),
+        )
+
+    def load_payloads(self, unique_payload: dict[str, Any], set_payload: dict[str, Any]) -> "V2UniqueSetRepository":
+        uniques = _records(unique_payload, "uniques", "v2 unique bundle")
+        sets = _records(set_payload, "sets", "v2 set bundle")
+        set_items = _records(set_payload, "set_items", "v2 set bundle")
+        set_bonuses = _records(set_payload, "set_bonuses", "v2 set bundle")
+        self._validate_uniques(uniques)
+        self._validate_sets(sets, set_items, set_bonuses)
+        self._unique_payload = deepcopy(unique_payload)
+        self._set_payload = deepcopy(set_payload)
+        self._uniques = tuple(deepcopy(record) for record in uniques)
+        self._sets = tuple(deepcopy(record) for record in sets)
+        self._set_items = tuple(deepcopy(record) for record in set_items)
+        self._set_bonuses = tuple(deepcopy(record) for record in set_bonuses)
+        self._uniques_by_id = {record["canonical_id"]: record for record in self._uniques}
+        self._sets_by_id = {record["canonical_id"]: record for record in self._sets}
+        self._set_items_by_group = _group_by(self._set_items, "set_group_id")
+        self._set_bonuses_by_group = _group_by(self._set_bonuses, "set_group_id")
+        return self
+
+    def list_uniques(self, *, limit: int | None = None, offset: int = 0) -> list[dict[str, Any]]:
+        return _page(self._uniques, limit=limit, offset=offset)
+
+    def get_unique(self, canonical_id: str) -> dict[str, Any] | None:
+        record = self._uniques_by_id.get(canonical_id)
+        return deepcopy(record) if record else None
+
+    def filter_uniques(
+        self,
+        *,
+        query: str = "",
+        slot: str = "",
+        item_type: str = "",
+        class_id: str = "",
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        return _filter_item_like(self._uniques, query=query, slot=slot, item_type=item_type, class_id=class_id, limit=limit, offset=offset)
+
+    def list_sets(self, *, limit: int | None = None, offset: int = 0) -> list[dict[str, Any]]:
+        return _page(self._sets, limit=limit, offset=offset)
+
+    def get_set(self, canonical_id: str) -> dict[str, Any] | None:
+        record = self._sets_by_id.get(canonical_id)
+        return deepcopy(record) if record else None
+
+    def get_set_items(self, set_group_id: str) -> list[dict[str, Any]]:
+        return [deepcopy(record) for record in self._set_items_by_group.get(set_group_id, ())]
+
+    def get_set_bonuses(self, set_group_id: str) -> list[dict[str, Any]]:
+        return [deepcopy(record) for record in self._set_bonuses_by_group.get(set_group_id, ())]
+
+    def filter_set_items(
+        self,
+        *,
+        query: str = "",
+        slot: str = "",
+        item_type: str = "",
+        class_id: str = "",
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        return _filter_item_like(self._set_items, query=query, slot=slot, item_type=item_type, class_id=class_id, limit=limit, offset=offset)
+
+    def count_uniques(self) -> int:
+        return len(self._uniques)
+
+    def count_sets(self) -> int:
+        return len(self._sets)
+
+    def count_set_items(self) -> int:
+        return len(self._set_items)
+
+    def count_set_bonuses(self) -> int:
+        return len(self._set_bonuses)
+
+    def debug_summary(self) -> dict[str, Any]:
+        unique_summary = self._unique_payload.get("summary", {}) if self._unique_payload else {}
+        set_summary = self._set_payload.get("summary", {}) if self._set_payload else {}
+        return {
+            "unique_bundle_path": str(self.unique_bundle_path),
+            "set_bundle_path": str(self.set_bundle_path),
+            "unique_count": self.count_uniques(),
+            "set_group_count": self.count_sets(),
+            "set_item_count": self.count_set_items(),
+            "set_bonus_count": self.count_set_bonuses(),
+            "unique_summary": deepcopy(unique_summary),
+            "set_summary": deepcopy(set_summary),
+            "production_consumer": False,
+            "production_safe": False,
+        }
+
+    @staticmethod
+    def _validate_uniques(records: list[Any]) -> None:
+        seen: set[str] = set()
+        for index, record in enumerate(records):
+            _validate_common(record, index, "Unique")
+            canonical_id = record["canonical_id"]
+            if canonical_id in seen:
+                raise V2UniqueSetBundleError(f"Duplicate canonical_id in v2 unique bundle: {canonical_id}")
+            seen.add(canonical_id)
+            _validate_modifier_rows(record, "Unique")
+            _validate_classification(record, "Unique")
+
+    @staticmethod
+    def _validate_sets(sets: list[Any], set_items: list[Any], set_bonuses: list[Any]) -> None:
+        set_ids: set[str] = set()
+        seen_items: set[str] = set()
+        seen_bonuses: set[str] = set()
+        for index, record in enumerate(sets):
+            _validate_common(record, index, "Set")
+            canonical_id = record["canonical_id"]
+            if canonical_id in set_ids:
+                raise V2UniqueSetBundleError(f"Duplicate canonical_id in v2 set bundle: {canonical_id}")
+            if record.get("set_group_id") != canonical_id:
+                raise V2UniqueSetBundleError(f"Set {canonical_id} has conflicting set_group_id.")
+            set_ids.add(canonical_id)
+        for index, record in enumerate(set_items):
+            _validate_common(record, index, "Set item")
+            canonical_id = record["canonical_id"]
+            if canonical_id in seen_items:
+                raise V2UniqueSetBundleError(f"Duplicate canonical_id in v2 set item bundle: {canonical_id}")
+            seen_items.add(canonical_id)
+            if record.get("set_group_id") not in set_ids:
+                raise V2UniqueSetBundleError(f"Set item {canonical_id} references missing set group: {record.get('set_group_id')}")
+            _validate_modifier_rows(record, "Set item")
+            _validate_classification(record, "Set item")
+        for index, record in enumerate(set_bonuses):
+            _validate_common(record, index, "Set bonus")
+            canonical_id = record["canonical_id"]
+            if canonical_id in seen_bonuses:
+                raise V2UniqueSetBundleError(f"Duplicate canonical_id in v2 set bonus bundle: {canonical_id}")
+            seen_bonuses.add(canonical_id)
+            if record.get("set_group_id") not in set_ids:
+                raise V2UniqueSetBundleError(f"Set bonus {canonical_id} references missing set group: {record.get('set_group_id')}")
+            _validate_modifier_rows(record, "Set bonus")
+            _validate_classification(record, "Set bonus")
+
+
+def _read_json(path: Path, label: str) -> dict[str, Any]:
+    if not path.exists():
+        raise FileNotFoundError(f"{label} not found: {path}")
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise V2UniqueSetBundleError(f"Invalid JSON in {label} {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise V2UniqueSetBundleError(f"{label} must be a JSON object.")
+    return payload
+
+
+def _records(payload: dict[str, Any], key: str, label: str) -> list[Any]:
+    records = payload.get("records")
+    if not isinstance(records, dict):
+        raise V2UniqueSetBundleError(f"{label} records must be an object.")
+    values = records.get(key)
+    if not isinstance(values, list):
+        raise V2UniqueSetBundleError(f"{label} records.{key} must be a list.")
+    return values
+
+
+def _validate_common(record: Any, index: int, label: str) -> None:
+    if not isinstance(record, dict):
+        raise V2UniqueSetBundleError(f"{label} record {index} must be an object.")
+    canonical_id = record.get("canonical_id")
+    try:
+        validate_canonical_id(canonical_id)
+    except ValueError as exc:
+        raise V2UniqueSetBundleError(f"{label} record {index} has invalid canonical_id: {exc}") from exc
+    if not record.get("display_name"):
+        raise V2UniqueSetBundleError(f"{label} {canonical_id} is missing display_name.")
+    provenance = record.get("provenance")
+    if not isinstance(provenance, dict) or not provenance.get("source_path"):
+        raise V2UniqueSetBundleError(f"{label} {canonical_id} is missing provenance.source_path.")
+    try:
+        status = SupportStatus(str(record.get("support_status")))
+    except ValueError as exc:
+        raise V2UniqueSetBundleError(f"{label} {canonical_id} has invalid support_status.") from exc
+    try:
+        trust_level = TrustLevel(str(record.get("trust_level")))
+    except ValueError as exc:
+        raise V2UniqueSetBundleError(f"{label} {canonical_id} has invalid trust_level.") from exc
+    if trust_level in {TrustLevel.GAME_EXTRACTED, TrustLevel.GENERATED_FROM_GAME_DATA}:
+        if not provenance.get("source_id") and not record.get("source_id"):
+            raise V2UniqueSetBundleError(f"{label} {canonical_id} is missing source reference.")
+    if record.get("stable_calculable") is True or status == SupportStatus.TRUSTED:
+        raise V2UniqueSetBundleError(f"{label} {canonical_id} is not approved for stable calculation in Phase 5.")
+
+
+def _validate_modifier_rows(record: dict[str, Any], label: str) -> None:
+    for modifier in record.get("modifier_rows") or []:
+        if not isinstance(modifier, dict) or not modifier.get("provenance"):
+            raise V2UniqueSetBundleError(f"{label} {record['canonical_id']} has modifier row without provenance.")
+        if not modifier.get("support_status"):
+            raise V2UniqueSetBundleError(f"{label} {record['canonical_id']} has modifier row without support_status.")
+        if modifier.get("stable_calculable") is True:
+            raise V2UniqueSetBundleError(f"{label} {record['canonical_id']} has stable-calculable modifier row.")
+
+
+def _validate_classification(record: dict[str, Any], label: str) -> None:
+    if record.get("special_mechanic_classification") not in {
+        "trusted_modifier",
+        "partial_modifier",
+        "text_only_effect",
+        "scripted_runtime_behavior",
+        "unsupported_special_behavior",
+        "unknown",
+    }:
+        raise V2UniqueSetBundleError(f"{label} {record['canonical_id']} has invalid special mechanic classification.")
+
+
+def _filter_item_like(
+    records: tuple[dict[str, Any], ...],
+    *,
+    query: str,
+    slot: str,
+    item_type: str,
+    class_id: str,
+    limit: int | None,
+    offset: int,
+) -> list[dict[str, Any]]:
+    filtered = list(records)
+    if query:
+        needle = query.strip().lower()
+        filtered = [
+            record for record in filtered
+            if needle in record["canonical_id"].lower()
+            or needle in str(record.get("display_name", "")).lower()
+            or needle in str(record.get("source_id", "")).lower()
+        ]
+    if slot:
+        expected = slot.strip().lower()
+        filtered = [record for record in filtered if str(record.get("slot", "")).lower() == expected]
+    if item_type:
+        expected = item_type.strip().lower()
+        filtered = [record for record in filtered if str(record.get("item_type", "")).lower() == expected]
+    if class_id:
+        expected = class_id.strip().lower()
+        filtered = [
+            record for record in filtered
+            if expected in {str(value).lower() for value in record.get("class_restrictions") or []}
+        ]
+    return _page(tuple(filtered), limit=limit, offset=offset)
+
+
+def _group_by(records: tuple[dict[str, Any], ...], key: str) -> dict[str, tuple[dict[str, Any], ...]]:
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for record in records:
+        grouped.setdefault(str(record.get(key)), []).append(record)
+    return {group: tuple(values) for group, values in grouped.items()}
+
+
+def _page(records: tuple[dict[str, Any], ...], *, limit: int | None, offset: int) -> list[dict[str, Any]]:
+    start = max(0, offset)
+    end = None if limit is None else start + max(0, limit)
+    return [deepcopy(record) for record in records[start:end]]

--- a/backend/app/routes/experimental.py
+++ b/backend/app/routes/experimental.py
@@ -14,6 +14,7 @@ from flask import Blueprint, current_app, jsonify, request
 
 from app.repositories.v2.affix_repository import V2AffixBundleError, V2AffixRepository
 from app.repositories.v2.item_repository import V2ItemBundleError, V2ItemRepository
+from app.repositories.v2.unique_set_repository import V2UniqueSetBundleError, V2UniqueSetRepository
 from data.loaders.forge_safe_affix_bundle_loader import ForgeSafeAffixBundleLoaderError
 from data.loaders.forge_safe_affixes_loader import ForgeSafeAffixLoaderError
 from data.repositories.forge_safe_affix_bundle_repository import ForgeSafeAffixBundleRepository
@@ -32,6 +33,8 @@ ROOT = Path(__file__).resolve().parents[3]
 DEFAULT_V2_AFFIX_BUNDLE_PATH = ROOT / "docs" / "generated" / "v2_affix_bundle.json"
 DEFAULT_V2_ITEM_BASE_BUNDLE_PATH = ROOT / "docs" / "generated" / "v2_item_base_bundle.json"
 DEFAULT_V2_ITEM_IMPLICIT_BUNDLE_PATH = ROOT / "docs" / "generated" / "v2_item_implicit_bundle.json"
+DEFAULT_V2_UNIQUE_BUNDLE_PATH = ROOT / "docs" / "generated" / "v2_unique_bundle.json"
+DEFAULT_V2_SET_BUNDLE_PATH = ROOT / "docs" / "generated" / "v2_set_bundle.json"
 
 
 @experimental_bp.route("/forge-safe-affixes", methods=["GET"])
@@ -401,6 +404,160 @@ def v2_item_debug():
     })
 
 
+@experimental_bp.route("/v2/uniques", methods=["GET"])
+def v2_uniques():
+    """Query the read-only v2 unique bundle."""
+
+    parsed = _parse_v2_item_query_args()
+    if parsed["errors"]:
+        return jsonify({
+            "success": False,
+            "error": "invalid_query",
+            "message": "; ".join(parsed["errors"]),
+        }), 400
+    try:
+        repository = _load_v2_unique_set_repository()
+    except FileNotFoundError as exc:
+        return jsonify({
+            "success": False,
+            "error": "v2_unique_set_bundle_missing",
+            "message": str(exc),
+        }), 404
+    except V2UniqueSetBundleError as exc:
+        return jsonify({
+            "success": False,
+            "error": "v2_unique_set_bundle_invalid",
+            "message": str(exc),
+        }), 422
+
+    records = repository.filter_uniques(
+        query=parsed["q"],
+        slot=parsed["slot"],
+        item_type=parsed["item_type"],
+        class_id=parsed["class_id"],
+        limit=parsed["limit"],
+        offset=parsed["offset"],
+    )
+    return jsonify(_v2_unique_response(repository, records, parsed))
+
+
+@experimental_bp.route("/v2/uniques/<path:unique_id>", methods=["GET"])
+def v2_unique_detail(unique_id: str):
+    """Return one v2 unique record by canonical ID."""
+
+    try:
+        repository = _load_v2_unique_set_repository()
+    except FileNotFoundError as exc:
+        return jsonify({
+            "success": False,
+            "error": "v2_unique_set_bundle_missing",
+            "message": str(exc),
+        }), 404
+    except V2UniqueSetBundleError as exc:
+        return jsonify({
+            "success": False,
+            "error": "v2_unique_set_bundle_invalid",
+            "message": str(exc),
+        }), 422
+    record = repository.get_unique(unique_id)
+    if record is None:
+        return jsonify({
+            "success": False,
+            "error": "unique_not_found",
+            "message": f"v2 unique not found: {unique_id}",
+        }), 404
+    return jsonify({
+        "success": True,
+        "experimental": True,
+        "read_only": True,
+        "production_consumer": False,
+        "data_source": "v2_unique_bundle",
+        "source_path": str(repository.unique_bundle_path),
+        "record": record,
+    })
+
+
+@experimental_bp.route("/v2/sets", methods=["GET"])
+def v2_sets():
+    """Query the read-only v2 set bundle."""
+
+    parsed = _parse_v2_item_query_args()
+    if parsed["errors"]:
+        return jsonify({
+            "success": False,
+            "error": "invalid_query",
+            "message": "; ".join(parsed["errors"]),
+        }), 400
+    try:
+        repository = _load_v2_unique_set_repository()
+    except FileNotFoundError as exc:
+        return jsonify({
+            "success": False,
+            "error": "v2_unique_set_bundle_missing",
+            "message": str(exc),
+        }), 404
+    except V2UniqueSetBundleError as exc:
+        return jsonify({
+            "success": False,
+            "error": "v2_unique_set_bundle_invalid",
+            "message": str(exc),
+        }), 422
+    records = repository.list_sets(limit=parsed["limit"], offset=parsed["offset"])
+    return jsonify(_v2_set_response(repository, records, parsed))
+
+
+@experimental_bp.route("/v2/sets/<path:set_id>", methods=["GET"])
+def v2_set_detail(set_id: str):
+    """Return one v2 set group with items and bonuses."""
+
+    try:
+        repository = _load_v2_unique_set_repository()
+    except FileNotFoundError as exc:
+        return jsonify({
+            "success": False,
+            "error": "v2_unique_set_bundle_missing",
+            "message": str(exc),
+        }), 404
+    except V2UniqueSetBundleError as exc:
+        return jsonify({
+            "success": False,
+            "error": "v2_unique_set_bundle_invalid",
+            "message": str(exc),
+        }), 422
+    record = repository.get_set(set_id)
+    if record is None:
+        return jsonify({
+            "success": False,
+            "error": "set_not_found",
+            "message": f"v2 set not found: {set_id}",
+        }), 404
+    return jsonify({
+        "success": True,
+        "experimental": True,
+        "read_only": True,
+        "production_consumer": False,
+        "data_source": "v2_set_bundle",
+        "source_path": str(repository.set_bundle_path),
+        "record": record,
+        "items": repository.get_set_items(set_id),
+        "bonuses": repository.get_set_bonuses(set_id),
+    })
+
+
+@experimental_bp.route("/v2/uniques/debug", methods=["GET"])
+def v2_unique_debug():
+    """Return a debug summary for read-only v2 unique bundle."""
+
+    return _v2_unique_set_debug("v2_unique_bundle")
+
+
+@experimental_bp.route("/v2/sets/debug", methods=["GET"])
+def v2_set_debug():
+    """Return a debug summary for read-only v2 set bundle."""
+
+    return _v2_unique_set_debug("v2_set_bundle")
+
+
 def _forge_safe_canonical_affix_catalog(parsed: dict[str, Any], *, detail: bool = False):
     source_path = _configured_export_path()
     if not source_path:
@@ -584,6 +741,20 @@ def _configured_v2_item_implicit_bundle_path() -> Path:
     return DEFAULT_V2_ITEM_IMPLICIT_BUNDLE_PATH
 
 
+def _configured_v2_unique_bundle_path() -> Path:
+    configured = current_app.config.get("V2_UNIQUE_BUNDLE_PATH")
+    if configured:
+        return Path(configured)
+    return DEFAULT_V2_UNIQUE_BUNDLE_PATH
+
+
+def _configured_v2_set_bundle_path() -> Path:
+    configured = current_app.config.get("V2_SET_BUNDLE_PATH")
+    if configured:
+        return Path(configured)
+    return DEFAULT_V2_SET_BUNDLE_PATH
+
+
 def _load_v2_affix_repository() -> V2AffixRepository:
     return V2AffixRepository(_configured_v2_affix_bundle_path()).load()
 
@@ -592,6 +763,13 @@ def _load_v2_item_repository() -> V2ItemRepository:
     return V2ItemRepository(
         _configured_v2_item_base_bundle_path(),
         _configured_v2_item_implicit_bundle_path(),
+    ).load()
+
+
+def _load_v2_unique_set_repository() -> V2UniqueSetRepository:
+    return V2UniqueSetRepository(
+        _configured_v2_unique_bundle_path(),
+        _configured_v2_set_bundle_path(),
     ).load()
 
 
@@ -897,3 +1075,86 @@ def _v2_item_implicit_response(
         "summary": summary["implicit_summary"],
         "records": records,
     }
+
+
+def _v2_unique_response(
+    repository: V2UniqueSetRepository,
+    records: list[dict[str, Any]],
+    parsed: dict[str, Any],
+) -> dict[str, Any]:
+    summary = repository.debug_summary()
+    return {
+        "success": True,
+        "experimental": True,
+        "read_only": True,
+        "production_consumer": False,
+        "data_source": "v2_unique_bundle",
+        "source_path": str(repository.unique_bundle_path),
+        "result_count": len(records),
+        "total_loaded_count": repository.count_uniques(),
+        "total_uniques": repository.count_uniques(),
+        "total_sets": repository.count_sets(),
+        "total_set_items": repository.count_set_items(),
+        "total_set_bonuses": repository.count_set_bonuses(),
+        "query": parsed,
+        "warning_count": 0,
+        "warnings": [],
+        "export_policy": "v2_unique_bundle",
+        "export_status": "pass" if summary["unique_summary"].get("validation_error_count", 0) == 0 else "blocked",
+        "summary": summary["unique_summary"],
+        "records": records,
+    }
+
+
+def _v2_set_response(
+    repository: V2UniqueSetRepository,
+    records: list[dict[str, Any]],
+    parsed: dict[str, Any],
+) -> dict[str, Any]:
+    summary = repository.debug_summary()
+    return {
+        "success": True,
+        "experimental": True,
+        "read_only": True,
+        "production_consumer": False,
+        "data_source": "v2_set_bundle",
+        "source_path": str(repository.set_bundle_path),
+        "result_count": len(records),
+        "total_loaded_count": repository.count_sets(),
+        "total_uniques": repository.count_uniques(),
+        "total_sets": repository.count_sets(),
+        "total_set_items": repository.count_set_items(),
+        "total_set_bonuses": repository.count_set_bonuses(),
+        "query": parsed,
+        "warning_count": 0,
+        "warnings": [],
+        "export_policy": "v2_set_bundle",
+        "export_status": "pass" if summary["set_summary"].get("validation_error_count", 0) == 0 else "blocked",
+        "summary": summary["set_summary"],
+        "records": records,
+    }
+
+
+def _v2_unique_set_debug(data_source: str):
+    try:
+        repository = _load_v2_unique_set_repository()
+    except FileNotFoundError as exc:
+        return jsonify({
+            "success": False,
+            "error": "v2_unique_set_bundle_missing",
+            "message": str(exc),
+        }), 404
+    except V2UniqueSetBundleError as exc:
+        return jsonify({
+            "success": False,
+            "error": "v2_unique_set_bundle_invalid",
+            "message": str(exc),
+        }), 422
+    return jsonify({
+        "success": True,
+        "experimental": True,
+        "read_only": True,
+        "production_consumer": False,
+        "data_source": data_source,
+        "debug_summary": repository.debug_summary(),
+    })

--- a/backend/scripts/report_v2_unique_set_bundles.py
+++ b/backend/scripts/report_v2_unique_set_bundles.py
@@ -1,0 +1,948 @@
+"""Generate v2 canonical unique and set item bundles."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections import Counter, defaultdict
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "backend"))
+
+from app.data_contracts import SupportStatus, TrustLevel, validate_canonical_id
+
+
+DEFAULT_SOURCE_UNIQUES = Path(r"D:\Forge\last-epoch-data\exports_json\uniques.json")
+DEFAULT_SOURCE_SET_BONUSES = Path(r"D:\Forge\last-epoch-data\exports_json\set_bonuses.json")
+DEFAULT_ITEM_BASE_BUNDLE = ROOT / "docs" / "generated" / "v2_item_base_bundle.json"
+DEFAULT_UNIQUE_OUTPUT = ROOT / "docs" / "generated" / "v2_unique_bundle.json"
+DEFAULT_SET_OUTPUT = ROOT / "docs" / "generated" / "v2_set_bundle.json"
+DEFAULT_VALIDATION_OUTPUT = ROOT / "docs" / "generated" / "v2_unique_set_validation_report.json"
+DEFAULT_UNSUPPORTED_OUTPUT = ROOT / "docs" / "generated" / "v2_unique_set_unsupported_report.json"
+DEFAULT_MARKDOWN_OUTPUT = ROOT / "docs" / "migration" / "V2_UNIQUE_SET_MIGRATION.md"
+SPECIAL_MECHANIC_CLASSIFICATIONS = {
+    "trusted_modifier",
+    "partial_modifier",
+    "text_only_effect",
+    "scripted_runtime_behavior",
+    "unsupported_special_behavior",
+    "unknown",
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Build v2 unique and set item bundles.")
+    parser.add_argument("--source-uniques", type=Path, default=DEFAULT_SOURCE_UNIQUES)
+    parser.add_argument("--source-set-bonuses", type=Path, default=DEFAULT_SOURCE_SET_BONUSES)
+    parser.add_argument("--item-base-bundle", type=Path, default=DEFAULT_ITEM_BASE_BUNDLE)
+    parser.add_argument("--unique-output", type=Path, default=DEFAULT_UNIQUE_OUTPUT)
+    parser.add_argument("--set-output", type=Path, default=DEFAULT_SET_OUTPUT)
+    parser.add_argument("--validation-output", type=Path, default=DEFAULT_VALIDATION_OUTPUT)
+    parser.add_argument("--unsupported-output", type=Path, default=DEFAULT_UNSUPPORTED_OUTPUT)
+    parser.add_argument("--markdown-output", type=Path, default=DEFAULT_MARKDOWN_OUTPUT)
+    return parser.parse_args()
+
+
+def build_v2_unique_set_bundles(
+    source_uniques: Path,
+    source_set_bonuses: Path,
+    item_base_bundle_path: Path,
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any]]:
+    source = _read_unique_source(source_uniques)
+    set_bonus_source = _read_set_bonus_source(source_set_bonuses)
+    base_index = _item_base_index(item_base_bundle_path)
+
+    uniques = [
+        _unique_record(source_uniques, source, record, base_index)
+        for record in source.get("uniques") or []
+        if isinstance(record, dict)
+    ]
+    set_items = [
+        _set_item_record(source_uniques, source, record, base_index)
+        for record in source.get("setItems") or []
+        if isinstance(record, dict)
+    ]
+    set_groups = _set_group_records(source_uniques, source_set_bonuses, source, set_bonus_source, set_items)
+    set_bonuses = _set_bonus_records(source_set_bonuses, set_bonus_source)
+
+    validation = validate_v2_unique_set_records(uniques, set_groups, set_items, set_bonuses, set(base_index.values()))
+    unsupported = unsupported_special_behavior_report(uniques, set_groups, set_items, set_bonuses)
+    unique_bundle = {
+        "schema_version": "v2.unique_bundle.1",
+        "generated_on": date.today().isoformat(),
+        "source_uniques_path": str(source_uniques),
+        "source_metadata": source.get("_meta", {}),
+        "summary": _unique_summary(uniques, validation),
+        "records": {"uniques": uniques},
+        "metadata": _metadata(),
+    }
+    set_bundle = {
+        "schema_version": "v2.set_bundle.1",
+        "generated_on": date.today().isoformat(),
+        "source_uniques_path": str(source_uniques),
+        "source_set_bonuses_path": str(source_set_bonuses),
+        "source_metadata": {
+            "uniques": source.get("_meta", {}),
+            "set_bonuses": set_bonus_source.get("_meta", {}),
+        },
+        "summary": _set_summary(set_groups, set_items, set_bonuses, validation),
+        "records": {
+            "sets": set_groups,
+            "set_items": set_items,
+            "set_bonuses": set_bonuses,
+        },
+        "metadata": _metadata(),
+    }
+    return unique_bundle, set_bundle, validation, unsupported
+
+
+def validate_v2_unique_set_records(
+    uniques: list[dict[str, Any]],
+    set_groups: list[dict[str, Any]],
+    set_items: list[dict[str, Any]],
+    set_bonuses: list[dict[str, Any]],
+    item_base_ids: set[str] | None = None,
+) -> dict[str, Any]:
+    errors: list[dict[str, Any]] = []
+    warnings: list[dict[str, Any]] = []
+    item_base_ids = item_base_ids or set()
+    unique_ids = _validate_canonical_records(uniques, "unique", errors)
+    set_group_ids = _validate_canonical_records(set_groups, "set_group", errors)
+    set_item_ids = _validate_canonical_records(set_items, "set_item", errors)
+    bonus_ids = _validate_canonical_records(set_bonuses, "set_bonus", errors)
+    del unique_ids, set_item_ids, bonus_ids
+
+    for record in uniques:
+        _validate_claimed_base_link(record, item_base_ids, errors)
+        _validate_modifier_rows(record, errors)
+        _validate_special_classification(record, errors)
+    for record in set_items:
+        set_id = record.get("set_group_id")
+        if not set_id:
+            errors.append(_error(record.get("canonical_id"), "missing_set_group_id", "Set item must include set_group_id."))
+        elif set_id not in set_group_ids:
+            errors.append(_error(record.get("canonical_id"), "set_group_link_missing", f"Set group is missing: {set_id}"))
+        _validate_claimed_base_link(record, item_base_ids, errors)
+        _validate_modifier_rows(record, errors)
+        _validate_special_classification(record, errors)
+    for record in set_bonuses:
+        set_id = record.get("set_group_id")
+        if not set_id:
+            errors.append(_error(record.get("canonical_id"), "missing_set_group_id", "Set bonus must include set_group_id."))
+        elif set_id not in set_group_ids:
+            errors.append(_error(record.get("canonical_id"), "set_bonus_group_missing", f"Set bonus references missing set group: {set_id}"))
+        _validate_modifier_rows(record, errors)
+        _validate_special_classification(record, errors)
+    for record in set_groups:
+        if record.get("canonical_id") != record.get("set_group_id"):
+            errors.append(_error(record.get("canonical_id"), "set_group_id_conflict", "Set group canonical_id and set_group_id must match."))
+
+    return {
+        "summary": {
+            "unique_count": len(uniques),
+            "set_group_count": len(set_groups),
+            "set_item_count": len(set_items),
+            "set_bonus_count": len(set_bonuses),
+            "error_count": len(errors),
+            "warning_count": len(warnings),
+            "duplicate_unique_id_count": _count_code(errors, "duplicate_unique_id"),
+            "duplicate_set_item_id_count": _count_code(errors, "duplicate_set_item_id"),
+            "duplicate_set_group_id_count": _count_code(errors, "duplicate_set_group_id"),
+            "missing_provenance_count": _count_code(errors, "missing_provenance"),
+            "missing_support_status_count": _count_code(errors, "missing_support_status"),
+            "invalid_trust_level_count": _count_code(errors, "invalid_trust_level"),
+            "missing_base_link_count": _count_code(errors, "base_item_link_missing"),
+            "set_group_link_missing_count": _count_code(errors, "set_group_link_missing"),
+            "set_bonus_group_missing_count": _count_code(errors, "set_bonus_group_missing"),
+            "unsupported_stable_calculation_count": _count_code(errors, "unsupported_stable_calculation"),
+            "stable_calculable_count": 0,
+            "production_consumed": False,
+        },
+        "errors": errors,
+        "warnings": warnings,
+        "metadata": _metadata(),
+    }
+
+
+def unsupported_special_behavior_report(
+    uniques: list[dict[str, Any]],
+    set_groups: list[dict[str, Any]],
+    set_items: list[dict[str, Any]],
+    set_bonuses: list[dict[str, Any]],
+) -> dict[str, Any]:
+    records: list[dict[str, Any]] = []
+    for kind, collection in (
+        ("unique", uniques),
+        ("set_group", set_groups),
+        ("set_item", set_items),
+        ("set_bonus", set_bonuses),
+    ):
+        for record in collection:
+            classification = record.get("special_mechanic_classification")
+            text_evidence = (
+                record.get("tooltip_text")
+                or record.get("unique_effect_text")
+                or record.get("bonus_text")
+                or record.get("description_text")
+                or []
+            )
+            if classification == "partial_modifier" and not text_evidence:
+                continue
+            records.append({
+                "record_type": kind,
+                "canonical_id": record.get("canonical_id"),
+                "display_name": record.get("display_name"),
+                "special_mechanic_classification": classification,
+                "support_status": record.get("support_status"),
+                "text_evidence_count": len(text_evidence),
+                "notes": record.get("notes") or record.get("warnings") or [],
+            })
+    counts = Counter(record["special_mechanic_classification"] for record in records)
+    return {
+        "summary": {
+            "unsupported_or_text_only_count": len(records),
+            "classification_counts": dict(sorted(counts.items())),
+            "production_consumed": False,
+        },
+        "records": records,
+        "metadata": _metadata(),
+    }
+
+
+def render_markdown(
+    unique_bundle: dict[str, Any],
+    set_bundle: dict[str, Any],
+    validation: dict[str, Any],
+    unsupported: dict[str, Any],
+    *,
+    command: str,
+) -> str:
+    unique_summary = unique_bundle["summary"]
+    set_summary = set_bundle["summary"]
+    unique_examples = "\n".join(
+        f"| `{record['canonical_id']}` | {record['display_name']} | {record['item_type']} | {record['special_mechanic_classification']} | {len(record['modifier_rows'])} |"
+        for record in unique_bundle["records"]["uniques"][:15]
+    )
+    set_examples = "\n".join(
+        f"| `{record['canonical_id']}` | {record['display_name']} | `{record['set_group_id']}` | {record['special_mechanic_classification']} | {len(record['modifier_rows'])} |"
+        for record in set_bundle["records"]["set_items"][:15]
+    )
+    return f"""# v2 Unique and Set Migration
+
+## Purpose
+
+Phase 5 creates read-only canonical unique and set item bundles on top of the v2 contracts and the Phase 4 item base infrastructure. It preserves extracted modifier rows, set membership, base links where available, and text-only/special effect evidence without simulating unique or set mechanics.
+
+This phase does not remap planner behavior, implement special runtime behavior, or mark unique/set records as stable planner inputs.
+
+## Generation Command
+
+```powershell
+{command}
+```
+
+## Summary
+
+- Unique count: {unique_summary["unique_count"]}
+- Set group count: {set_summary["set_group_count"]}
+- Set item count: {set_summary["set_item_count"]}
+- Set bonus count: {set_summary["set_bonus_count"]}
+- Stable-calculable count: 0
+- Validation errors: {validation["summary"]["error_count"]}
+- Validation warnings: {validation["summary"]["warning_count"]}
+- Unsupported/text-only/special behavior records: {unsupported["summary"]["unsupported_or_text_only_count"]}
+- Production consumed: false
+
+## Unique Classification Counts
+
+| Classification | Count |
+| --- | ---: |
+{_count_rows(unique_summary["special_mechanic_classification_counts"])}
+
+## Set Classification Counts
+
+| Classification | Count |
+| --- | ---: |
+{_count_rows(set_summary["special_mechanic_classification_counts"])}
+
+## Unsupported and Text-Only Findings
+
+| Classification | Count |
+| --- | ---: |
+{_count_rows(unsupported["summary"]["classification_counts"])}
+
+Tooltip and description text is retained as display/debug evidence only. It is not converted into calculated mechanics.
+
+## Example Uniques
+
+| Canonical ID | Display name | Item type | Classification | Modifier rows |
+| --- | --- | --- | --- | ---: |
+{unique_examples}
+
+## Example Set Items
+
+| Canonical ID | Display name | Set group | Classification | Modifier rows |
+| --- | --- | --- | --- | ---: |
+{set_examples}
+
+## Migration Implications
+
+- Unique and set records are available for experimental lookup and debug inspection.
+- Structured modifier rows remain `partial`; value-scale and modifier normalization are unresolved.
+- Text-only and special behavior remains displayable but is not calculated.
+- Existing planner and `/api/ref/uniques` behavior remain unchanged.
+
+## Deferred
+
+- Runtime simulation for unique and set special mechanics.
+- Stable modifier normalization and value-scale policy.
+- Planner, crafting, stat aggregation, and simulation consumption.
+- Idol, passive, and skill infrastructure.
+
+## Checkpoint 5
+
+Checkpoint 5 is ready for review when generated bundles, validation reports, unsupported report, repository, routes, debug page, and focused tests pass.
+"""
+
+
+def _unique_record(source_path: Path, payload: dict[str, Any], record: dict[str, Any], base_index: dict[str, str]) -> dict[str, Any]:
+    source_id = f"unique:{record.get('id')}"
+    canonical_id = f"unique:{_id_part(record.get('id'))}"
+    base_item_id = _base_link(record, base_index)
+    modifiers = _modifier_rows(source_path, payload, record.get("mods") or [], source_id, "unique_modifier")
+    tooltip_text = _tooltip_text(record)
+    classification = _special_classification(modifiers, tooltip_text)
+    return _item_like_record(
+        source_path,
+        payload,
+        record,
+        canonical_id=canonical_id,
+        source_id=source_id,
+        provenance_type="unique",
+        base_item_id=base_item_id,
+        modifier_rows=modifiers,
+        tooltip_text=tooltip_text,
+        special_mechanic_classification=classification,
+        extra={
+            "unique_effect_text": tooltip_text,
+            "implicit_links": _implicit_links(record, base_item_id),
+            "legendary_type": record.get("legendaryType"),
+            "can_drop_randomly": record.get("canDropRandomly"),
+            "special_mechanic_notes": _special_notes(classification),
+        },
+    )
+
+
+def _set_item_record(source_path: Path, payload: dict[str, Any], record: dict[str, Any], base_index: dict[str, str]) -> dict[str, Any]:
+    set_group_id = _set_group_id(record.get("setId"))
+    source_id = f"set_item:{record.get('id')}"
+    canonical_id = f"set_item:{_id_part(record.get('id'))}"
+    base_item_id = _base_link(record, base_index)
+    modifiers = _modifier_rows(source_path, payload, record.get("mods") or [], source_id, "set_item_modifier")
+    tooltip_text = _tooltip_text(record)
+    classification = _special_classification(modifiers, tooltip_text)
+    return _item_like_record(
+        source_path,
+        payload,
+        record,
+        canonical_id=canonical_id,
+        source_id=source_id,
+        provenance_type="set_item",
+        base_item_id=base_item_id,
+        modifier_rows=modifiers,
+        tooltip_text=tooltip_text,
+        special_mechanic_classification=classification,
+        extra={
+            "set_group_id": set_group_id,
+            "set_group_display_name": None,
+            "set_id": set_group_id,
+            "bonus_text": tooltip_text,
+            "implicit_links": _implicit_links(record, base_item_id),
+            "special_mechanic_notes": _special_notes(classification),
+        },
+    )
+
+
+def _item_like_record(
+    source_path: Path,
+    payload: dict[str, Any],
+    record: dict[str, Any],
+    *,
+    canonical_id: str,
+    source_id: str,
+    provenance_type: str,
+    base_item_id: str | None,
+    modifier_rows: list[dict[str, Any]],
+    tooltip_text: list[str],
+    special_mechanic_classification: str,
+    extra: dict[str, Any],
+) -> dict[str, Any]:
+    base = record.get("resolvedBaseItem") if isinstance(record.get("resolvedBaseItem"), dict) else {}
+    subtype = base.get("subType") if isinstance(base.get("subType"), dict) else {}
+    item_type = str(record.get("baseType") or base.get("type") or "unknown").lower()
+    modifier_refs = [_modifier_ref(row) for row in modifier_rows]
+    warnings = ["Unique/set record is not stable planner-consumed in Phase 5."]
+    if base_item_id is None:
+        warnings.append("No v2 item base link was established from extracted base identifiers.")
+    if special_mechanic_classification != "partial_modifier":
+        warnings.append("Special behavior is retained for display/debug only.")
+    return {
+        "canonical_id": canonical_id,
+        "display_name": record.get("displayName") or record.get("name") or canonical_id,
+        "source_id": source_id,
+        "source_file": str(source_path),
+        "patch_version": _game_version(payload),
+        "support_status": SupportStatus.PARTIAL.value,
+        "trust_level": TrustLevel.GENERATED_FROM_GAME_DATA.value,
+        "provenance": _provenance(source_path, source_id, provenance_type, payload, record),
+        "base_item_id": base_item_id,
+        "item_category": "equipment",
+        "item_type": item_type,
+        "subtype": subtype.get("name") or (record.get("subTypes") or [None])[0],
+        "equipment_slot": item_type,
+        "slot": item_type,
+        "classification": _item_classification(item_type),
+        "class_restrictions": _restriction_values(record.get("classRequirement") or subtype.get("classRequirement")),
+        "mastery_restrictions": _restriction_values(record.get("subClassRequirement") or subtype.get("subClassRequirement")),
+        "requirements": {
+            "level": record.get("levelRequirement") or subtype.get("levelRequirement"),
+            "attributes": {},
+            "class": record.get("classRequirement") or subtype.get("classRequirement"),
+            "mastery": record.get("subClassRequirement") or subtype.get("subClassRequirement"),
+        },
+        "level_requirement": record.get("levelRequirement") or subtype.get("levelRequirement"),
+        "attribute_requirements": {},
+        "modifier_references": modifier_refs,
+        "modifier_rows": modifier_rows,
+        "implicit_ids": [],
+        "tooltip_text": tooltip_text,
+        "lore_text": record.get("loreText"),
+        "special_mechanic_classification": special_mechanic_classification,
+        "stable_calculable": False,
+        "warnings": warnings,
+        "raw_reference": {
+            "id": record.get("id"),
+            "name": record.get("name"),
+            "baseType": record.get("baseType"),
+            "subTypes": record.get("subTypes"),
+            "resolutionStatus": record.get("resolutionStatus"),
+            "resolvedBaseItem": record.get("resolvedBaseItem"),
+        },
+        "normalized_fields": {"modifier_references": modifier_refs},
+        "consumer_safe_fields": {
+            "display_name": record.get("displayName") or record.get("name") or canonical_id,
+            "support_status": SupportStatus.PARTIAL.value,
+            "stable_calculable": False,
+            "special_mechanic_classification": special_mechanic_classification,
+        },
+        **extra,
+    }
+
+
+def _set_group_records(
+    unique_source_path: Path,
+    set_bonus_source_path: Path,
+    unique_source: dict[str, Any],
+    set_bonus_source: dict[str, Any],
+    set_items: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    item_ids_by_set: dict[str, list[str]] = defaultdict(list)
+    names_by_set: dict[str, str] = {}
+    for item in set_items:
+        set_group_id = str(item["set_group_id"])
+        item_ids_by_set[set_group_id].append(item["canonical_id"])
+    for group in set_bonus_source.get("setBonuses") or []:
+        if not isinstance(group, dict):
+            continue
+        set_group_id = _set_group_id(group.get("setId"))
+        if group.get("setName"):
+            names_by_set[set_group_id] = str(group["setName"])
+    groups: list[dict[str, Any]] = []
+    for set_group_id in sorted(item_ids_by_set, key=lambda value: int(value.split(":")[-1]) if value.split(":")[-1].isdigit() else value):
+        source_id = f"set_group:{set_group_id.split(':')[-1]}"
+        display_name = names_by_set.get(set_group_id) or f"Set {set_group_id.split(':')[-1]}"
+        groups.append({
+            "canonical_id": set_group_id,
+            "display_name": display_name,
+            "source_id": source_id,
+            "source_file": str(set_bonus_source_path),
+            "patch_version": _game_version(unique_source),
+            "support_status": SupportStatus.PARTIAL.value,
+            "trust_level": TrustLevel.GENERATED_FROM_GAME_DATA.value,
+            "provenance": {
+                "source_path": str(set_bonus_source_path),
+                "source_type": "set_group",
+                "source_id": source_id,
+                "extraction_method": "last_epoch_set_bonus_export",
+                "patch_version": _game_version(unique_source),
+                "schema_version": "v2.unique_set.1",
+                "notes": ["Generated from extracted set item and set bonus data."],
+                "raw_reference": {"setId": set_group_id.split(":")[-1]},
+            },
+            "set_group_id": set_group_id,
+            "set_group_display_name": display_name,
+            "item_ids": sorted(item_ids_by_set[set_group_id]),
+            "bonus_ids": [],
+            "bonus_modifier_references": [],
+            "bonus_text": [],
+            "special_mechanic_classification": "unknown",
+            "stable_calculable": False,
+            "warnings": ["Set group is not stable planner-consumed in Phase 5."],
+            "raw_reference": {"setId": set_group_id.split(":")[-1]},
+            "normalized_fields": {},
+            "consumer_safe_fields": {
+                "display_name": display_name,
+                "support_status": SupportStatus.PARTIAL.value,
+                "stable_calculable": False,
+            },
+        })
+    bonus_ids_by_set: dict[str, list[str]] = defaultdict(list)
+    bonus_text_by_set: dict[str, list[str]] = defaultdict(list)
+    bonus_refs_by_set: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for bonus in _set_bonus_records(set_bonus_source_path, set_bonus_source):
+        bonus_ids_by_set[bonus["set_group_id"]].append(bonus["canonical_id"])
+        bonus_text_by_set[bonus["set_group_id"]].extend(bonus.get("description_text") or [])
+        bonus_refs_by_set[bonus["set_group_id"]].extend(bonus.get("modifier_references") or [])
+    for group in groups:
+        group["bonus_ids"] = bonus_ids_by_set[group["set_group_id"]]
+        group["bonus_text"] = bonus_text_by_set[group["set_group_id"]]
+        group["bonus_modifier_references"] = bonus_refs_by_set[group["set_group_id"]]
+        group["special_mechanic_classification"] = _group_classification(group)
+    return groups
+
+
+def _set_bonus_records(source_path: Path, payload: dict[str, Any]) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for group in payload.get("setBonuses") or []:
+        if not isinstance(group, dict):
+            continue
+        set_group_id = _set_group_id(group.get("setId"))
+        for index, bonus in enumerate(group.get("bonuses") or []):
+            if not isinstance(bonus, dict):
+                continue
+            source_id = f"set_bonus:{group.get('setId')}:{index}"
+            canonical_id = f"set_bonus:{_id_part(group.get('setId'))}:{index}"
+            modifier_rows = []
+            if isinstance(bonus.get("mod"), dict):
+                modifier_rows = _modifier_rows(source_path, payload, [bonus["mod"]], source_id, "set_bonus_modifier")
+            description_text = _bonus_text(bonus)
+            classification = _special_classification(modifier_rows, description_text)
+            records.append({
+                "canonical_id": canonical_id,
+                "display_name": f"{group.get('setName') or set_group_id} {bonus.get('piecesRequired')} piece bonus",
+                "source_id": source_id,
+                "source_file": str(source_path),
+                "patch_version": _game_version(payload),
+                "support_status": SupportStatus.PARTIAL.value,
+                "trust_level": TrustLevel.GENERATED_FROM_GAME_DATA.value,
+                "provenance": {
+                    "source_path": str(source_path),
+                    "source_type": "set_bonus",
+                    "source_id": source_id,
+                    "extraction_method": "last_epoch_set_bonus_export",
+                    "patch_version": _game_version(payload),
+                    "schema_version": "v2.unique_set.1",
+                    "notes": ["Generated from extracted set bonus data; text descriptions are not inferred as mechanics."],
+                    "raw_reference": {"setId": group.get("setId"), "bonus_index": index},
+                },
+                "set_group_id": set_group_id,
+                "set_group_display_name": group.get("setName"),
+                "required_pieces": bonus.get("piecesRequired"),
+                "description_text": description_text,
+                "modifier_references": [_modifier_ref(row) for row in modifier_rows],
+                "modifier_rows": modifier_rows,
+                "special_mechanic_classification": classification,
+                "stable_calculable": False,
+                "warnings": ["Set bonus is not stable planner-consumed in Phase 5."],
+                "raw_reference": {"setId": group.get("setId"), "bonus_index": index, "kind": bonus.get("kind")},
+                "normalized_fields": {"modifier_references": [_modifier_ref(row) for row in modifier_rows]},
+                "consumer_safe_fields": {
+                    "display_name": f"{group.get('setName') or set_group_id} {bonus.get('piecesRequired')} piece bonus",
+                    "support_status": SupportStatus.PARTIAL.value,
+                    "stable_calculable": False,
+                    "special_mechanic_classification": classification,
+                },
+            })
+    return records
+
+
+def _modifier_rows(source_path: Path, payload: dict[str, Any], mods: list[Any], source_id: str, source_type: str) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for index, mod in enumerate(mods):
+        if not isinstance(mod, dict):
+            continue
+        modifier_id = f"{source_type}:{source_id}:{index}".replace(":", "_", 1)
+        source_modifier_id = f"{source_id}:modifier:{index}"
+        row = {
+            "modifier_id": modifier_id,
+            "property": mod.get("property"),
+            "property_path": _property_path(mod),
+            "modifier_type": mod.get("modifierType"),
+            "value_min": mod.get("value"),
+            "value_max": mod.get("maxValue", mod.get("value")),
+            "tags": [str(tag) for tag in mod.get("tags") or []],
+            "special_tag": mod.get("specialTag", mod.get("extraTag")),
+            "extra_tag": mod.get("extraTag"),
+            "can_roll": mod.get("canRoll"),
+            "roll_id": mod.get("rollId"),
+            "hide_in_tooltip": mod.get("hideInTooltip"),
+            "support_status": SupportStatus.PARTIAL.value,
+            "trust_level": TrustLevel.GENERATED_FROM_GAME_DATA.value,
+            "stable_calculable": False,
+            "provenance": {
+                "source_path": str(source_path),
+                "source_type": source_type,
+                "source_id": source_modifier_id,
+                "extraction_method": "last_epoch_unique_set_export",
+                "patch_version": _game_version(payload),
+                "schema_version": "v2.unique_set.1",
+                "notes": ["Value scale remains source-preserved; stable normalization is deferred."],
+                "raw_reference": {"modifier_index": index, "property": mod.get("property")},
+            },
+        }
+        rows.append(row)
+    return rows
+
+
+def _validate_canonical_records(records: list[dict[str, Any]], kind: str, errors: list[dict[str, Any]]) -> set[str]:
+    seen: set[str] = set()
+    for record in records:
+        canonical_id = record.get("canonical_id")
+        try:
+            validate_canonical_id(canonical_id)
+        except ValueError as exc:
+            errors.append(_error(canonical_id, "invalid_canonical_id", str(exc)))
+            continue
+        if canonical_id in seen:
+            errors.append(_error(canonical_id, f"duplicate_{kind}_id", "Duplicate canonical ID."))
+        seen.add(canonical_id)
+        if not record.get("provenance"):
+            errors.append(_error(canonical_id, "missing_provenance", "Provenance is required."))
+        try:
+            SupportStatus(str(record.get("support_status")))
+        except ValueError:
+            errors.append(_error(canonical_id, "missing_support_status", "Support status is required or invalid."))
+        try:
+            TrustLevel(str(record.get("trust_level")))
+        except ValueError:
+            errors.append(_error(canonical_id, "invalid_trust_level", "Trust level is invalid."))
+        provenance = record.get("provenance")
+        if record.get("trust_level") in {TrustLevel.GAME_EXTRACTED.value, TrustLevel.GENERATED_FROM_GAME_DATA.value}:
+            if not isinstance(provenance, dict) or not provenance.get("source_id"):
+                errors.append(_error(canonical_id, "missing_source_reference", "Generated or extracted records require source_id."))
+        if record.get("stable_calculable") is True or record.get("support_status") == SupportStatus.TRUSTED.value:
+            errors.append(_error(canonical_id, "unsupported_stable_calculation", "Phase 5 records must not be stable-calculable."))
+    return seen
+
+
+def _validate_claimed_base_link(record: dict[str, Any], item_base_ids: set[str], errors: list[dict[str, Any]]) -> None:
+    base_id = record.get("base_item_id")
+    if base_id and item_base_ids and base_id not in item_base_ids:
+        errors.append(_error(record.get("canonical_id"), "base_item_link_missing", f"Claimed base item is missing: {base_id}"))
+
+
+def _validate_modifier_rows(record: dict[str, Any], errors: list[dict[str, Any]]) -> None:
+    for modifier in record.get("modifier_rows") or []:
+        if not isinstance(modifier, dict):
+            errors.append(_error(record.get("canonical_id"), "invalid_modifier_row", "Modifier row must be an object."))
+            continue
+        if not modifier.get("provenance"):
+            errors.append(_error(record.get("canonical_id"), "modifier_missing_provenance", "Modifier row is missing provenance."))
+        if not modifier.get("support_status"):
+            errors.append(_error(record.get("canonical_id"), "modifier_missing_support_status", "Modifier row is missing support status."))
+        if modifier.get("stable_calculable") is True:
+            errors.append(_error(record.get("canonical_id"), "unsupported_stable_calculation", "Modifier row is not stable-calculable in Phase 5."))
+
+
+def _validate_special_classification(record: dict[str, Any], errors: list[dict[str, Any]]) -> None:
+    if record.get("special_mechanic_classification") not in SPECIAL_MECHANIC_CLASSIFICATIONS:
+        errors.append(_error(record.get("canonical_id"), "invalid_special_mechanic_classification", "Special mechanic classification is invalid."))
+
+
+def _read_unique_source(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise FileNotFoundError(f"unique export not found: {path}")
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict) or not isinstance(data.get("uniques"), list) or not isinstance(data.get("setItems"), list):
+        raise ValueError("unique export must contain uniques and setItems lists")
+    return data
+
+
+def _read_set_bonus_source(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise FileNotFoundError(f"set bonus export not found: {path}")
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict) or not isinstance(data.get("setBonuses"), list):
+        raise ValueError("set bonus export must contain setBonuses list")
+    return data
+
+
+def _item_base_index(path: Path) -> dict[str, str]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    index: dict[str, str] = {}
+    for record in payload.get("records", {}).get("item_bases", []):
+        raw = record.get("raw_reference") if isinstance(record, dict) else {}
+        key = _base_key(raw.get("baseTypeID"), raw.get("subTypeID"))
+        if key:
+            index[key] = record["canonical_id"]
+    return index
+
+
+def _base_link(record: dict[str, Any], base_index: dict[str, str]) -> str | None:
+    resolved = record.get("resolvedBaseItem") if isinstance(record.get("resolvedBaseItem"), dict) else {}
+    subtype = resolved.get("subType") if isinstance(resolved.get("subType"), dict) else {}
+    key = _base_key(resolved.get("baseTypeID"), subtype.get("subTypeID"))
+    if key and key in base_index:
+        return base_index[key]
+    base_type_id = resolved.get("baseTypeID")
+    for subtype_id in record.get("subTypes") or []:
+        key = _base_key(base_type_id, subtype_id)
+        if key and key in base_index:
+            return base_index[key]
+    return None
+
+
+def _base_key(base_type_id: Any, subtype_id: Any) -> str | None:
+    if base_type_id is None or subtype_id is None:
+        return None
+    return f"{base_type_id}:{subtype_id}"
+
+
+def _metadata() -> dict[str, Any]:
+    return {
+        "phase": "phase_5_unique_set_infrastructure",
+        "read_only": True,
+        "experimental": True,
+        "production_consumer": False,
+        "production_safe": False,
+        "stable_planner_consumed": False,
+        "uses_canonical_contracts": True,
+    }
+
+
+def _provenance(source_path: Path, source_id: str, source_type: str, payload: dict[str, Any], record: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "source_path": str(source_path),
+        "source_type": source_type,
+        "source_id": source_id,
+        "extraction_method": "last_epoch_unique_set_export",
+        "patch_version": _game_version(payload),
+        "schema_version": "v2.unique_set.1",
+        "notes": ["Generated from extracted unique/set data; tooltip text is not inferred as mechanics."],
+        "raw_reference": {"id": record.get("id"), "name": record.get("name")},
+    }
+
+
+def _unique_summary(records: list[dict[str, Any]], validation: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "unique_count": len(records),
+        "support_status_counts": dict(sorted(Counter(record["support_status"] for record in records).items())),
+        "trust_level_counts": dict(sorted(Counter(record["trust_level"] for record in records).items())),
+        "item_type_counts": dict(sorted(Counter(record["item_type"] for record in records).items())),
+        "special_mechanic_classification_counts": dict(sorted(Counter(record["special_mechanic_classification"] for record in records).items())),
+        "records_with_base_links_count": sum(1 for record in records if record.get("base_item_id")),
+        "records_with_tooltip_text_count": sum(1 for record in records if record.get("tooltip_text")),
+        "modifier_row_count": sum(len(record.get("modifier_rows") or []) for record in records),
+        "stable_calculable_count": 0,
+        "validation_error_count": validation["summary"]["error_count"],
+        "production_consumed": False,
+    }
+
+
+def _set_summary(groups: list[dict[str, Any]], items: list[dict[str, Any]], bonuses: list[dict[str, Any]], validation: dict[str, Any]) -> dict[str, Any]:
+    all_records = groups + items + bonuses
+    return {
+        "set_group_count": len(groups),
+        "set_item_count": len(items),
+        "set_bonus_count": len(bonuses),
+        "support_status_counts": dict(sorted(Counter(record["support_status"] for record in all_records).items())),
+        "trust_level_counts": dict(sorted(Counter(record["trust_level"] for record in all_records).items())),
+        "item_type_counts": dict(sorted(Counter(record.get("item_type", "set_group_or_bonus") for record in items).items())),
+        "special_mechanic_classification_counts": dict(sorted(Counter(record["special_mechanic_classification"] for record in all_records).items())),
+        "set_items_with_base_links_count": sum(1 for record in items if record.get("base_item_id")),
+        "set_bonuses_with_modifier_rows_count": sum(1 for record in bonuses if record.get("modifier_rows")),
+        "modifier_row_count": sum(len(record.get("modifier_rows") or []) for record in items + bonuses),
+        "stable_calculable_count": 0,
+        "validation_error_count": validation["summary"]["error_count"],
+        "production_consumed": False,
+    }
+
+
+def _tooltip_text(record: dict[str, Any]) -> list[str]:
+    values: list[str] = []
+    for entry in record.get("tooltipDescriptions") or []:
+        if not isinstance(entry, dict):
+            continue
+        for key in ("text", "altText"):
+            value = entry.get(key)
+            if value:
+                values.append(str(value))
+    return values
+
+
+def _bonus_text(bonus: dict[str, Any]) -> list[str]:
+    values = []
+    for key in ("text", "altText"):
+        if bonus.get(key):
+            values.append(str(bonus[key]))
+    return values
+
+
+def _special_classification(modifier_rows: list[dict[str, Any]], text: list[str]) -> str:
+    if modifier_rows:
+        return "partial_modifier"
+    if text:
+        return "text_only_effect"
+    return "unknown"
+
+
+def _group_classification(group: dict[str, Any]) -> str:
+    if group.get("bonus_modifier_references"):
+        return "partial_modifier"
+    if group.get("bonus_text"):
+        return "text_only_effect"
+    return "unknown"
+
+
+def _special_notes(classification: str) -> list[str]:
+    if classification == "partial_modifier":
+        return ["Structured modifier rows exist but remain partial until value normalization is solved."]
+    if classification == "text_only_effect":
+        return ["Text effect is display/debug evidence only and is not calculated."]
+    return ["No deterministic modifier or text effect was available in extracted data."]
+
+
+def _modifier_ref(row: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "modifier_id": row.get("modifier_id"),
+        "property": row.get("property"),
+        "property_path": row.get("property_path"),
+        "source_record_id": row.get("provenance", {}).get("source_id"),
+    }
+
+
+def _implicit_links(record: dict[str, Any], base_item_id: str | None) -> list[dict[str, Any]]:
+    return [
+        {
+            "base_item_id": base_item_id,
+            "implicit_index": index,
+            "property": mod.get("property"),
+            "modifier_type": mod.get("modifierType"),
+        }
+        for index, mod in enumerate(record.get("resolvedImplicitMods") or [])
+        if isinstance(mod, dict)
+    ]
+
+
+def _property_path(mod: dict[str, Any]) -> str:
+    parts = [mod.get("modifierType"), mod.get("property")]
+    parts.extend(str(tag) for tag in mod.get("tags") or [] if str(tag) != "None")
+    if mod.get("specialTag") not in (None, 0):
+        parts.append(f"special:{mod.get('specialTag')}")
+    return ".".join(str(part) for part in parts if part not in (None, ""))
+
+
+def _item_classification(item_type: str) -> str:
+    if any(token in item_type for token in ("axe", "dagger", "mace", "sceptre", "sword", "wand", "staff", "bow", "crossbow", "spear", "fist")):
+        return "weapon"
+    if any(token in item_type for token in ("helmet", "body", "boots", "gloves", "shield")):
+        return "armor"
+    if any(token in item_type for token in ("belt", "amulet", "ring", "relic", "quiver", "catalyst")):
+        return "accessory"
+    return "unknown"
+
+
+def _restriction_values(value: Any) -> list[str]:
+    if value in (None, "", "Any"):
+        return []
+    return [str(value)]
+
+
+def _set_group_id(set_id: Any) -> str:
+    return f"set:{_id_part(set_id)}"
+
+
+def _id_part(value: Any) -> str:
+    if value is None:
+        return "unknown"
+    return _slug(str(value))
+
+
+def _slug(value: str) -> str:
+    slug = re.sub(r"[^a-z0-9._:-]+", "_", value.strip().lower())
+    slug = slug.strip("._:-")
+    return slug or "unknown"
+
+
+def _game_version(payload: dict[str, Any]) -> str | None:
+    meta = payload.get("_meta") or {}
+    game_build = meta.get("game_build") if isinstance(meta, dict) else {}
+    if isinstance(game_build, dict) and game_build.get("installPath"):
+        return str(game_build["installPath"]).split("\\")[-1]
+    return None
+
+
+def _error(canonical_id: Any, code: str, message: str) -> dict[str, Any]:
+    return {"canonical_id": canonical_id, "code": code, "message": message}
+
+
+def _count_code(errors: list[dict[str, Any]], code: str) -> int:
+    return sum(1 for error in errors if error.get("code") == code)
+
+
+def _count_rows(counts: dict[str, int]) -> str:
+    if not counts:
+        return "| none | 0 |"
+    return "\n".join(f"| {key} | {value} |" for key, value in sorted(counts.items()))
+
+
+def main() -> int:
+    args = parse_args()
+    command = (
+        ".\\backend\\.venv\\Scripts\\python.exe backend\\scripts\\report_v2_unique_set_bundles.py "
+        f"--source-uniques {args.source_uniques} "
+        f"--source-set-bonuses {args.source_set_bonuses} "
+        f"--item-base-bundle {args.item_base_bundle} "
+        f"--unique-output {args.unique_output} "
+        f"--set-output {args.set_output} "
+        f"--validation-output {args.validation_output} "
+        f"--unsupported-output {args.unsupported_output} "
+        f"--markdown-output {args.markdown_output}"
+    )
+    unique_bundle, set_bundle, validation, unsupported = build_v2_unique_set_bundles(
+        args.source_uniques,
+        args.source_set_bonuses,
+        args.item_base_bundle,
+    )
+    for path, payload in (
+        (args.unique_output, unique_bundle),
+        (args.set_output, set_bundle),
+        (args.validation_output, validation),
+        (args.unsupported_output, unsupported),
+    ):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    args.markdown_output.parent.mkdir(parents=True, exist_ok=True)
+    args.markdown_output.write_text(
+        render_markdown(unique_bundle, set_bundle, validation, unsupported, command=command),
+        encoding="utf-8",
+    )
+    print(json.dumps({
+        "unique_count": unique_bundle["summary"]["unique_count"],
+        "set_group_count": set_bundle["summary"]["set_group_count"],
+        "set_item_count": set_bundle["summary"]["set_item_count"],
+        "set_bonus_count": set_bundle["summary"]["set_bonus_count"],
+        "validation_error_count": validation["summary"]["error_count"],
+        "unsupported_or_text_only_count": unsupported["summary"]["unsupported_or_text_only_count"],
+    }, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_v2_unique_set_infrastructure.py
+++ b/backend/tests/test_v2_unique_set_infrastructure.py
@@ -1,0 +1,270 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from app.repositories.v2.unique_set_repository import V2UniqueSetBundleError, V2UniqueSetRepository
+from scripts.report_v2_unique_set_bundles import (
+    build_v2_unique_set_bundles,
+    unsupported_special_behavior_report,
+    validate_v2_unique_set_records,
+)
+
+
+def test_v2_unique_and_set_bundle_generation(tmp_path):
+    source_uniques, source_set_bonuses, item_bases = _write_sources(tmp_path)
+
+    unique_bundle, set_bundle, validation, unsupported = build_v2_unique_set_bundles(
+        source_uniques,
+        source_set_bonuses,
+        item_bases,
+    )
+
+    assert unique_bundle["summary"]["unique_count"] == 2
+    assert set_bundle["summary"]["set_group_count"] == 1
+    assert set_bundle["summary"]["set_item_count"] == 1
+    assert set_bundle["summary"]["set_bonus_count"] == 2
+    assert validation["summary"]["error_count"] == 0
+    assert unsupported["summary"]["classification_counts"] == {"partial_modifier": 1, "text_only_effect": 2}
+    unique = unique_bundle["records"]["uniques"][0]
+    assert unique["canonical_id"] == "unique:1"
+    assert unique["base_item_id"] == "item_base:equippable:0:1"
+    assert unique["modifier_rows"][0]["support_status"] == "partial"
+    assert unique["stable_calculable"] is False
+
+
+def test_v2_unique_validation_detects_duplicate_unique_id(tmp_path):
+    unique_bundle, set_bundle, _validation, _unsupported = _bundles(tmp_path)
+    unique_bundle["records"]["uniques"].append(dict(unique_bundle["records"]["uniques"][0]))
+
+    with pytest.raises(V2UniqueSetBundleError, match="Duplicate canonical_id"):
+        V2UniqueSetRepository("<unique>", "<set>").load_payloads(unique_bundle, set_bundle)
+
+
+def test_v2_set_validation_detects_duplicate_set_item_id(tmp_path):
+    unique_bundle, set_bundle, _validation, _unsupported = _bundles(tmp_path)
+    set_bundle["records"]["set_items"].append(dict(set_bundle["records"]["set_items"][0]))
+
+    report = validate_v2_unique_set_records(
+        unique_bundle["records"]["uniques"],
+        set_bundle["records"]["sets"],
+        set_bundle["records"]["set_items"],
+        set_bundle["records"]["set_bonuses"],
+        {"item_base:equippable:0:1"},
+    )
+
+    assert report["summary"]["duplicate_set_item_id_count"] == 1
+    with pytest.raises(V2UniqueSetBundleError, match="Duplicate canonical_id"):
+        V2UniqueSetRepository("<unique>", "<set>").load_payloads(unique_bundle, set_bundle)
+
+
+def test_v2_unique_set_validation_requires_provenance_and_support_status(tmp_path):
+    unique_bundle, set_bundle, _validation, _unsupported = _bundles(tmp_path)
+    unique_bundle["records"]["uniques"][0]["provenance"] = {}
+    set_bundle["records"]["set_items"][0].pop("support_status")
+
+    report = validate_v2_unique_set_records(
+        unique_bundle["records"]["uniques"],
+        set_bundle["records"]["sets"],
+        set_bundle["records"]["set_items"],
+        set_bundle["records"]["set_bonuses"],
+        {"item_base:equippable:0:1"},
+    )
+
+    assert report["summary"]["missing_provenance_count"] == 1
+    assert report["summary"]["missing_support_status_count"] == 1
+    with pytest.raises(V2UniqueSetBundleError, match="provenance.source_path"):
+        V2UniqueSetRepository("<unique>", "<set>").load_payloads(unique_bundle, set_bundle)
+
+
+def test_v2_unique_set_validation_detects_base_and_set_links(tmp_path):
+    unique_bundle, set_bundle, _validation, _unsupported = _bundles(tmp_path)
+    unique_bundle["records"]["uniques"][0]["base_item_id"] = "item_base:missing"
+    set_bundle["records"]["set_items"][0]["set_group_id"] = "set:missing"
+    set_bundle["records"]["set_bonuses"][0]["set_group_id"] = "set:missing"
+
+    report = validate_v2_unique_set_records(
+        unique_bundle["records"]["uniques"],
+        set_bundle["records"]["sets"],
+        set_bundle["records"]["set_items"],
+        set_bundle["records"]["set_bonuses"],
+        {"item_base:equippable:0:1"},
+    )
+
+    assert report["summary"]["missing_base_link_count"] == 1
+    assert report["summary"]["set_group_link_missing_count"] == 1
+    assert report["summary"]["set_bonus_group_missing_count"] == 1
+
+
+def test_v2_unique_set_unsupported_report_and_repository(tmp_path):
+    unique_bundle, set_bundle, _validation, _unsupported = _bundles(tmp_path)
+    repository = V2UniqueSetRepository("<unique>", "<set>").load_payloads(unique_bundle, set_bundle)
+
+    assert repository.count_uniques() == 2
+    assert repository.count_sets() == 1
+    assert repository.get_unique("unique:1")["display_name"] == "Test Unique"
+    assert repository.filter_uniques(slot="helmet")[0]["canonical_id"] == "unique:1"
+    assert repository.get_set("set:7")["display_name"] == "Test Set"
+    assert repository.get_set_items("set:7")[0]["canonical_id"] == "set_item:10"
+    assert repository.get_set_bonuses("set:7")[0]["canonical_id"] == "set_bonus:7:0"
+    assert repository.debug_summary()["production_safe"] is False
+
+    unsupported = unsupported_special_behavior_report(
+        unique_bundle["records"]["uniques"],
+        set_bundle["records"]["sets"],
+        set_bundle["records"]["set_items"],
+        set_bundle["records"]["set_bonuses"],
+    )
+    assert unsupported["summary"]["unsupported_or_text_only_count"] == 3
+
+
+def test_v2_unique_set_routes(app, tmp_path):
+    unique_bundle, set_bundle, _validation, _unsupported = _bundles(tmp_path)
+    unique_path = tmp_path / "v2_unique_bundle.json"
+    set_path = tmp_path / "v2_set_bundle.json"
+    unique_path.write_text(json.dumps(unique_bundle), encoding="utf-8")
+    set_path.write_text(json.dumps(set_bundle), encoding="utf-8")
+    app.config["V2_UNIQUE_BUNDLE_PATH"] = str(unique_path)
+    app.config["V2_SET_BUNDLE_PATH"] = str(set_path)
+    client = app.test_client()
+
+    uniques = client.get("/experimental/v2/uniques?slot=helmet")
+    assert uniques.status_code == 200
+    assert uniques.get_json()["records"][0]["canonical_id"] == "unique:1"
+
+    unique_detail = client.get("/experimental/v2/uniques/unique:1")
+    assert unique_detail.status_code == 200
+    assert unique_detail.get_json()["record"]["display_name"] == "Test Unique"
+
+    sets = client.get("/experimental/v2/sets")
+    assert sets.status_code == 200
+    assert sets.get_json()["records"][0]["canonical_id"] == "set:7"
+
+    set_detail = client.get("/experimental/v2/sets/set:7")
+    assert set_detail.status_code == 200
+    assert set_detail.get_json()["items"][0]["canonical_id"] == "set_item:10"
+    assert set_detail.get_json()["bonuses"][0]["canonical_id"] == "set_bonus:7:0"
+
+    debug = client.get("/experimental/v2/uniques/debug")
+    assert debug.status_code == 200
+    assert debug.get_json()["debug_summary"]["production_consumer"] is False
+
+
+def test_v2_unique_set_bundle_is_not_referenced_by_production_modules():
+    root = Path(__file__).resolve().parents[2]
+    allowed = {
+        root / "backend" / "app" / "routes" / "experimental.py",
+        root / "backend" / "app" / "repositories" / "v2" / "unique_set_repository.py",
+        root / "backend" / "app" / "repositories" / "v2" / "__init__.py",
+        root / "backend" / "scripts" / "report_v2_unique_set_bundles.py",
+        Path(__file__).resolve(),
+    }
+    needles = ("v2_unique_bundle.json", "v2_set_bundle.json", "V2UniqueSetRepository")
+    offenders: list[str] = []
+    for path in (root / "backend" / "app").rglob("*.py"):
+        if path in allowed or "__pycache__" in path.parts:
+            continue
+        text = path.read_text(encoding="utf-8")
+        if any(needle in text for needle in needles):
+            offenders.append(str(path.relative_to(root)))
+
+    assert offenders == []
+
+
+def _write_sources(tmp_path: Path) -> tuple[Path, Path, Path]:
+    source_uniques = tmp_path / "uniques.json"
+    source_set_bonuses = tmp_path / "set_bonuses.json"
+    item_bases = tmp_path / "v2_item_base_bundle.json"
+    source_uniques.write_text(json.dumps(_source_uniques()), encoding="utf-8")
+    source_set_bonuses.write_text(json.dumps(_source_set_bonuses()), encoding="utf-8")
+    item_bases.write_text(json.dumps(_item_base_bundle()), encoding="utf-8")
+    return source_uniques, source_set_bonuses, item_bases
+
+
+def _bundles(tmp_path: Path) -> tuple[dict, dict, dict, dict]:
+    return build_v2_unique_set_bundles(*_write_sources(tmp_path))
+
+
+def _source_uniques() -> dict:
+    return {
+        "_meta": {"game_build": {"installPath": "D:\\LastEpochTools\\game_files\\current\\1.4.6_22986002"}},
+        "uniques": [
+            _item_record(1, "TestUnique", "Test Unique", mods=[_mod("Armour", 5.0, 10.0)]),
+            _item_record(2, "TextOnlyUnique", "Text Only Unique", mods=[], tooltip="Summons a source-defined effect."),
+        ],
+        "setItems": [
+            _item_record(10, "TestSetItem", "Test Set Item", set_id=7, mods=[_mod("Health", 3.0, 6.0)]),
+        ],
+        "setBonusData": {},
+    }
+
+
+def _source_set_bonuses() -> dict:
+    return {
+        "_meta": {"game_build": {"installPath": "D:\\LastEpochTools\\game_files\\current\\1.4.6_22986002"}},
+        "setBonuses": [
+            {
+                "setId": 7,
+                "setName": "Test Set",
+                "mappingConfidence": "confirmed",
+                "bonuses": [
+                    {"kind": "mod", "piecesRequired": 2, "mod": _mod("Damage", 0.1, None)},
+                    {"kind": "description", "piecesRequired": 3, "text": "Text-only behavior"},
+                ],
+            }
+        ],
+    }
+
+
+def _item_record(item_id: int, name: str, display_name: str, *, mods: list[dict], set_id: int | None = None, tooltip: str | None = None) -> dict:
+    record = {
+        "id": item_id,
+        "name": name,
+        "displayName": display_name,
+        "baseType": "HELMET",
+        "subTypes": [1],
+        "mods": mods,
+        "legendaryType": "None",
+        "canDropRandomly": True,
+        "rerollChance": 0.0,
+        "resolvedBaseItem": {
+            "baseTypeID": 0,
+            "type": "HELMET",
+            "displayName": "Helmet",
+            "subType": {"subTypeID": 1, "name": "Iron Helmet", "displayName": "Iron Casque", "levelRequirement": 10},
+        },
+        "resolvedImplicitMods": [],
+        "resolutionStatus": "resolved",
+    }
+    if set_id is not None:
+        record["isSetItem"] = True
+        record["setId"] = set_id
+    if tooltip:
+        record["tooltipDescriptions"] = [{"text": tooltip}]
+    return record
+
+
+def _mod(property_name: str, value: float, max_value: float | None) -> dict:
+    mod = {
+        "value": value,
+        "property": property_name,
+        "tags": ["None"],
+        "extraTag": 0,
+        "modifierType": "ADDED",
+    }
+    if max_value is not None:
+        mod["maxValue"] = max_value
+    return mod
+
+
+def _item_base_bundle() -> dict:
+    return {
+        "records": {
+            "item_bases": [
+                {
+                    "canonical_id": "item_base:equippable:0:1",
+                    "raw_reference": {"baseTypeID": 0, "subTypeID": 1},
+                }
+            ]
+        }
+    }

--- a/docs/generated/v2_set_bundle.json
+++ b/docs/generated/v2_set_bundle.json
@@ -1,0 +1,24857 @@
+{
+  "generated_on": "2026-05-12",
+  "metadata": {
+    "experimental": true,
+    "phase": "phase_5_unique_set_infrastructure",
+    "production_consumer": false,
+    "production_safe": false,
+    "read_only": true,
+    "stable_planner_consumed": false,
+    "uses_canonical_contracts": true
+  },
+  "records": {
+    "set_bonuses": [
+      {
+        "canonical_id": "set_bonus:1:0",
+        "consumer_safe_fields": {
+          "display_name": "Isadora's 2 piece bonus",
+          "special_mechanic_classification": "text_only_effect",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "description_text": [
+          "+100% Chance to apply Damned on hit with Necrotic Spells",
+          "Damned deals necrotic damage over time and reduces health regen by 20%. An enemy can have multiple stacks of Damned at once."
+        ],
+        "display_name": "Isadora's 2 piece bonus",
+        "modifier_references": [],
+        "modifier_rows": [],
+        "normalized_fields": {
+          "modifier_references": []
+        },
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set bonus data; text descriptions are not inferred as mechanics."
+          ],
+          "patch_version": "1.4.6_22986002",
+          "raw_reference": {
+            "bonus_index": 0,
+            "setId": 1
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_bonus:1:0",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_bonus"
+        },
+        "raw_reference": {
+          "bonus_index": 0,
+          "kind": "description",
+          "setId": 1
+        },
+        "required_pieces": 2,
+        "set_group_display_name": "Isadora's",
+        "set_group_id": "set:1",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_bonus:1:0",
+        "special_mechanic_classification": "text_only_effect",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set bonus is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "canonical_id": "set_bonus:1:1",
+        "consumer_safe_fields": {
+          "display_name": "Isadora's 3 piece bonus",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "description_text": [],
+        "display_name": "Isadora's 3 piece bonus",
+        "modifier_references": [
+          {
+            "modifier_id": "set_bonus_modifier_set_bonus:1:1:0",
+            "property": "IncreasedAilmentEffect",
+            "property_path": "ADDED.IncreasedAilmentEffect.special:39",
+            "source_record_id": "set_bonus:1:1:modifier:0"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": 0,
+            "modifier_id": "set_bonus_modifier_set_bonus:1:1:0",
+            "modifier_type": "ADDED",
+            "property": "IncreasedAilmentEffect",
+            "property_path": "ADDED.IncreasedAilmentEffect.special:39",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": "1.4.6_22986002",
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "IncreasedAilmentEffect"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_bonus:1:1:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+              "source_type": "set_bonus_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 39,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.30000001192092896,
+            "value_min": 0.30000001192092896
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_bonus_modifier_set_bonus:1:1:0",
+              "property": "IncreasedAilmentEffect",
+              "property_path": "ADDED.IncreasedAilmentEffect.special:39",
+              "source_record_id": "set_bonus:1:1:modifier:0"
+            }
+          ]
+        },
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set bonus data; text descriptions are not inferred as mechanics."
+          ],
+          "patch_version": "1.4.6_22986002",
+          "raw_reference": {
+            "bonus_index": 1,
+            "setId": 1
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_bonus:1:1",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_bonus"
+        },
+        "raw_reference": {
+          "bonus_index": 1,
+          "kind": "mod",
+          "setId": 1
+        },
+        "required_pieces": 3,
+        "set_group_display_name": "Isadora's",
+        "set_group_id": "set:1",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_bonus:1:1",
+        "special_mechanic_classification": "partial_modifier",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set bonus is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "canonical_id": "set_bonus:1:2",
+        "consumer_safe_fields": {
+          "display_name": "Isadora's 3 piece bonus",
+          "special_mechanic_classification": "text_only_effect",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "description_text": [
+          "+30% Mana Efficiency with Necrotic Spells"
+        ],
+        "display_name": "Isadora's 3 piece bonus",
+        "modifier_references": [],
+        "modifier_rows": [],
+        "normalized_fields": {
+          "modifier_references": []
+        },
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set bonus data; text descriptions are not inferred as mechanics."
+          ],
+          "patch_version": "1.4.6_22986002",
+          "raw_reference": {
+            "bonus_index": 2,
+            "setId": 1
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_bonus:1:2",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_bonus"
+        },
+        "raw_reference": {
+          "bonus_index": 2,
+          "kind": "description",
+          "setId": 1
+        },
+        "required_pieces": 3,
+        "set_group_display_name": "Isadora's",
+        "set_group_id": "set:1",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_bonus:1:2",
+        "special_mechanic_classification": "text_only_effect",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set bonus is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "canonical_id": "set_bonus:2:0",
+        "consumer_safe_fields": {
+          "display_name": "The Invoker's 2 piece bonus",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "description_text": [],
+        "display_name": "The Invoker's 2 piece bonus",
+        "modifier_references": [
+          {
+            "modifier_id": "set_bonus_modifier_set_bonus:2:0:0",
+            "property": "CastSpeed",
+            "property_path": "INCREASED.CastSpeed.Elemental",
+            "source_record_id": "set_bonus:2:0:modifier:0"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": 0,
+            "modifier_id": "set_bonus_modifier_set_bonus:2:0:0",
+            "modifier_type": "INCREASED",
+            "property": "CastSpeed",
+            "property_path": "INCREASED.CastSpeed.Elemental",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": "1.4.6_22986002",
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "CastSpeed"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_bonus:2:0:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+              "source_type": "set_bonus_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Elemental"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.15000000596046448,
+            "value_min": 0.15000000596046448
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_bonus_modifier_set_bonus:2:0:0",
+              "property": "CastSpeed",
+              "property_path": "INCREASED.CastSpeed.Elemental",
+              "source_record_id": "set_bonus:2:0:modifier:0"
+            }
+          ]
+        },
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set bonus data; text descriptions are not inferred as mechanics."
+          ],
+          "patch_version": "1.4.6_22986002",
+          "raw_reference": {
+            "bonus_index": 0,
+            "setId": 2
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_bonus:2:0",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_bonus"
+        },
+        "raw_reference": {
+          "bonus_index": 0,
+          "kind": "mod",
+          "setId": 2
+        },
+        "required_pieces": 2,
+        "set_group_display_name": "The Invoker's",
+        "set_group_id": "set:2",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_bonus:2:0",
+        "special_mechanic_classification": "partial_modifier",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set bonus is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "canonical_id": "set_bonus:2:1",
+        "consumer_safe_fields": {
+          "display_name": "The Invoker's 3 piece bonus",
+          "special_mechanic_classification": "text_only_effect",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "description_text": [
+          "+2 to Fire Spells\n+2 to Lightning Spells\n+2 to Cold Spells"
+        ],
+        "display_name": "The Invoker's 3 piece bonus",
+        "modifier_references": [],
+        "modifier_rows": [],
+        "normalized_fields": {
+          "modifier_references": []
+        },
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set bonus data; text descriptions are not inferred as mechanics."
+          ],
+          "patch_version": "1.4.6_22986002",
+          "raw_reference": {
+            "bonus_index": 1,
+            "setId": 2
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_bonus:2:1",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_bonus"
+        },
+        "raw_reference": {
+          "bonus_index": 1,
+          "kind": "description",
+          "setId": 2
+        },
+        "required_pieces": 3,
+        "set_group_display_name": "The Invoker's",
+        "set_group_id": "set:2",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_bonus:2:1",
+        "special_mechanic_classification": "text_only_effect",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set bonus is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "canonical_id": "set_bonus:3:0",
+        "consumer_safe_fields": {
+          "display_name": "Apiarist's 2 piece bonus",
+          "special_mechanic_classification": "text_only_effect",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "description_text": [
+          "Your bees cannot be damaged for 4 seconds after being summoned"
+        ],
+        "display_name": "Apiarist's 2 piece bonus",
+        "modifier_references": [],
+        "modifier_rows": [],
+        "normalized_fields": {
+          "modifier_references": []
+        },
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set bonus data; text descriptions are not inferred as mechanics."
+          ],
+          "patch_version": "1.4.6_22986002",
+          "raw_reference": {
+            "bonus_index": 0,
+            "setId": 3
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_bonus:3:0",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_bonus"
+        },
+        "raw_reference": {
+          "bonus_index": 0,
+          "kind": "description",
+          "setId": 3
+        },
+        "required_pieces": 2,
+        "set_group_display_name": "Apiarist's",
+        "set_group_id": "set:3",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_bonus:3:0",
+        "special_mechanic_classification": "text_only_effect",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set bonus is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "canonical_id": "set_bonus:3:1",
+        "consumer_safe_fields": {
+          "display_name": "Apiarist's 3 piece bonus",
+          "special_mechanic_classification": "text_only_effect",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "description_text": [
+          "Summon the Queen Bee",
+          "The Queen Bee is a powerful minion and grants Frenzy and Haste to other bees"
+        ],
+        "display_name": "Apiarist's 3 piece bonus",
+        "modifier_references": [],
+        "modifier_rows": [],
+        "normalized_fields": {
+          "modifier_references": []
+        },
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set bonus data; text descriptions are not inferred as mechanics."
+          ],
+          "patch_version": "1.4.6_22986002",
+          "raw_reference": {
+            "bonus_index": 1,
+            "setId": 3
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_bonus:3:1",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_bonus"
+        },
+        "raw_reference": {
+          "bonus_index": 1,
+          "kind": "description",
+          "setId": 3
+        },
+        "required_pieces": 3,
+        "set_group_display_name": "Apiarist's",
+        "set_group_id": "set:3",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_bonus:3:1",
+        "special_mechanic_classification": "text_only_effect",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set bonus is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "canonical_id": "set_bonus:4:0",
+        "consumer_safe_fields": {
+          "display_name": "Sunforged 2 piece bonus",
+          "special_mechanic_classification": "text_only_effect",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "description_text": [
+          "+3 to Forge Strike\n+3 to Smelter's Wrath"
+        ],
+        "display_name": "Sunforged 2 piece bonus",
+        "modifier_references": [],
+        "modifier_rows": [],
+        "normalized_fields": {
+          "modifier_references": []
+        },
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set bonus data; text descriptions are not inferred as mechanics."
+          ],
+          "patch_version": "1.4.6_22986002",
+          "raw_reference": {
+            "bonus_index": 0,
+            "setId": 4
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_bonus:4:0",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_bonus"
+        },
+        "raw_reference": {
+          "bonus_index": 0,
+          "kind": "description",
+          "setId": 4
+        },
+        "required_pieces": 2,
+        "set_group_display_name": "Sunforged",
+        "set_group_id": "set:4",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_bonus:4:0",
+        "special_mechanic_classification": "text_only_effect",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set bonus is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "canonical_id": "set_bonus:4:1",
+        "consumer_safe_fields": {
+          "display_name": "Sunforged 3 piece bonus",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "description_text": [],
+        "display_name": "Sunforged 3 piece bonus",
+        "modifier_references": [
+          {
+            "modifier_id": "set_bonus_modifier_set_bonus:4:1:0",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Cold.Fire.Void.Poison.Elemental",
+            "source_record_id": "set_bonus:4:1:modifier:0"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": 0,
+            "modifier_id": "set_bonus_modifier_set_bonus:4:1:0",
+            "modifier_type": "ADDED",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Cold.Fire.Void.Poison.Elemental",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": "1.4.6_22986002",
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "AbilityProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_bonus:4:1:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+              "source_type": "set_bonus_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Cold",
+              "Fire",
+              "Void",
+              "Poison",
+              "Elemental"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 3.0,
+            "value_min": 3.0
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_bonus_modifier_set_bonus:4:1:0",
+              "property": "AbilityProperty",
+              "property_path": "ADDED.AbilityProperty.Cold.Fire.Void.Poison.Elemental",
+              "source_record_id": "set_bonus:4:1:modifier:0"
+            }
+          ]
+        },
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set bonus data; text descriptions are not inferred as mechanics."
+          ],
+          "patch_version": "1.4.6_22986002",
+          "raw_reference": {
+            "bonus_index": 1,
+            "setId": 4
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_bonus:4:1",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_bonus"
+        },
+        "raw_reference": {
+          "bonus_index": 1,
+          "kind": "mod",
+          "setId": 4
+        },
+        "required_pieces": 3,
+        "set_group_display_name": "Sunforged",
+        "set_group_id": "set:4",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_bonus:4:1",
+        "special_mechanic_classification": "partial_modifier",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set bonus is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "canonical_id": "set_bonus:5:0",
+        "consumer_safe_fields": {
+          "display_name": "Forgotten Knight 2 piece bonus",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "description_text": [],
+        "display_name": "Forgotten Knight 2 piece bonus",
+        "modifier_references": [
+          {
+            "modifier_id": "set_bonus_modifier_set_bonus:5:0:0",
+            "property": "IncreasedAilmentEffect",
+            "property_path": "ADDED.IncreasedAilmentEffect.special:9",
+            "source_record_id": "set_bonus:5:0:modifier:0"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": 0,
+            "modifier_id": "set_bonus_modifier_set_bonus:5:0:0",
+            "modifier_type": "ADDED",
+            "property": "IncreasedAilmentEffect",
+            "property_path": "ADDED.IncreasedAilmentEffect.special:9",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": "1.4.6_22986002",
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "IncreasedAilmentEffect"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_bonus:5:0:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+              "source_type": "set_bonus_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 9,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.5,
+            "value_min": 0.5
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_bonus_modifier_set_bonus:5:0:0",
+              "property": "IncreasedAilmentEffect",
+              "property_path": "ADDED.IncreasedAilmentEffect.special:9",
+              "source_record_id": "set_bonus:5:0:modifier:0"
+            }
+          ]
+        },
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set bonus data; text descriptions are not inferred as mechanics."
+          ],
+          "patch_version": "1.4.6_22986002",
+          "raw_reference": {
+            "bonus_index": 0,
+            "setId": 5
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_bonus:5:0",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_bonus"
+        },
+        "raw_reference": {
+          "bonus_index": 0,
+          "kind": "mod",
+          "setId": 5
+        },
+        "required_pieces": 2,
+        "set_group_display_name": "Forgotten Knight",
+        "set_group_id": "set:5",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_bonus:5:0",
+        "special_mechanic_classification": "partial_modifier",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set bonus is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "canonical_id": "set_bonus:5:1",
+        "consumer_safe_fields": {
+          "display_name": "Forgotten Knight 3 piece bonus",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "description_text": [],
+        "display_name": "Forgotten Knight 3 piece bonus",
+        "modifier_references": [
+          {
+            "modifier_id": "set_bonus_modifier_set_bonus:5:1:0",
+            "property": "DamagePerStackOfAilment",
+            "property_path": "MORE.DamagePerStackOfAilment.Void.special:9",
+            "source_record_id": "set_bonus:5:1:modifier:0"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": 0,
+            "modifier_id": "set_bonus_modifier_set_bonus:5:1:0",
+            "modifier_type": "MORE",
+            "property": "DamagePerStackOfAilment",
+            "property_path": "MORE.DamagePerStackOfAilment.Void.special:9",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": "1.4.6_22986002",
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "DamagePerStackOfAilment"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_bonus:5:1:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+              "source_type": "set_bonus_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 9,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Void"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.029999999329447746,
+            "value_min": 0.029999999329447746
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_bonus_modifier_set_bonus:5:1:0",
+              "property": "DamagePerStackOfAilment",
+              "property_path": "MORE.DamagePerStackOfAilment.Void.special:9",
+              "source_record_id": "set_bonus:5:1:modifier:0"
+            }
+          ]
+        },
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set bonus data; text descriptions are not inferred as mechanics."
+          ],
+          "patch_version": "1.4.6_22986002",
+          "raw_reference": {
+            "bonus_index": 1,
+            "setId": 5
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_bonus:5:1",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_bonus"
+        },
+        "raw_reference": {
+          "bonus_index": 1,
+          "kind": "mod",
+          "setId": 5
+        },
+        "required_pieces": 3,
+        "set_group_display_name": "Forgotten Knight",
+        "set_group_id": "set:5",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_bonus:5:1",
+        "special_mechanic_classification": "partial_modifier",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set bonus is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "canonical_id": "set_bonus:6:0",
+        "consumer_safe_fields": {
+          "display_name": "The Last Bear's 2 piece bonus",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "description_text": [],
+        "display_name": "The Last Bear's 2 piece bonus",
+        "modifier_references": [
+          {
+            "modifier_id": "set_bonus_modifier_set_bonus:6:0:0",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Physical.Lightning.Melee",
+            "source_record_id": "set_bonus:6:0:modifier:0"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": 0,
+            "modifier_id": "set_bonus_modifier_set_bonus:6:0:0",
+            "modifier_type": "ADDED",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Physical.Lightning.Melee",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": "1.4.6_22986002",
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "PlayerProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_bonus:6:0:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+              "source_type": "set_bonus_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Physical",
+              "Lightning",
+              "Melee"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 2.0,
+            "value_min": 2.0
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_bonus_modifier_set_bonus:6:0:0",
+              "property": "PlayerProperty",
+              "property_path": "ADDED.PlayerProperty.Physical.Lightning.Melee",
+              "source_record_id": "set_bonus:6:0:modifier:0"
+            }
+          ]
+        },
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set bonus data; text descriptions are not inferred as mechanics."
+          ],
+          "patch_version": "1.4.6_22986002",
+          "raw_reference": {
+            "bonus_index": 0,
+            "setId": 6
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_bonus:6:0",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_bonus"
+        },
+        "raw_reference": {
+          "bonus_index": 0,
+          "kind": "mod",
+          "setId": 6
+        },
+        "required_pieces": 2,
+        "set_group_display_name": "The Last Bear's",
+        "set_group_id": "set:6",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_bonus:6:0",
+        "special_mechanic_classification": "partial_modifier",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set bonus is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "canonical_id": "set_bonus:6:1",
+        "consumer_safe_fields": {
+          "display_name": "The Last Bear's 3 piece bonus",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "description_text": [],
+        "display_name": "The Last Bear's 3 piece bonus",
+        "modifier_references": [
+          {
+            "modifier_id": "set_bonus_modifier_set_bonus:6:1:0",
+            "property": "Strength",
+            "property_path": "ADDED.Strength",
+            "source_record_id": "set_bonus:6:1:modifier:0"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": 0,
+            "modifier_id": "set_bonus_modifier_set_bonus:6:1:0",
+            "modifier_type": "ADDED",
+            "property": "Strength",
+            "property_path": "ADDED.Strength",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": "1.4.6_22986002",
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "Strength"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_bonus:6:1:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+              "source_type": "set_bonus_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 30.0,
+            "value_min": 30.0
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_bonus_modifier_set_bonus:6:1:0",
+              "property": "Strength",
+              "property_path": "ADDED.Strength",
+              "source_record_id": "set_bonus:6:1:modifier:0"
+            }
+          ]
+        },
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set bonus data; text descriptions are not inferred as mechanics."
+          ],
+          "patch_version": "1.4.6_22986002",
+          "raw_reference": {
+            "bonus_index": 1,
+            "setId": 6
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_bonus:6:1",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_bonus"
+        },
+        "raw_reference": {
+          "bonus_index": 1,
+          "kind": "mod",
+          "setId": 6
+        },
+        "required_pieces": 3,
+        "set_group_display_name": "The Last Bear's",
+        "set_group_id": "set:6",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_bonus:6:1",
+        "special_mechanic_classification": "partial_modifier",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set bonus is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "canonical_id": "set_bonus:7:0",
+        "consumer_safe_fields": {
+          "display_name": "Halvar's 2 piece bonus",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "description_text": [],
+        "display_name": "Halvar's 2 piece bonus",
+        "modifier_references": [
+          {
+            "modifier_id": "set_bonus_modifier_set_bonus:7:0:0",
+            "property": "Damage",
+            "property_path": "ADDED.Damage.Cold.Spell",
+            "source_record_id": "set_bonus:7:0:modifier:0"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": 0,
+            "modifier_id": "set_bonus_modifier_set_bonus:7:0:0",
+            "modifier_type": "ADDED",
+            "property": "Damage",
+            "property_path": "ADDED.Damage.Cold.Spell",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": "1.4.6_22986002",
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "Damage"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_bonus:7:0:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+              "source_type": "set_bonus_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Cold",
+              "Spell"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 20.0,
+            "value_min": 20.0
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_bonus_modifier_set_bonus:7:0:0",
+              "property": "Damage",
+              "property_path": "ADDED.Damage.Cold.Spell",
+              "source_record_id": "set_bonus:7:0:modifier:0"
+            }
+          ]
+        },
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set bonus data; text descriptions are not inferred as mechanics."
+          ],
+          "patch_version": "1.4.6_22986002",
+          "raw_reference": {
+            "bonus_index": 0,
+            "setId": 7
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_bonus:7:0",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_bonus"
+        },
+        "raw_reference": {
+          "bonus_index": 0,
+          "kind": "mod",
+          "setId": 7
+        },
+        "required_pieces": 2,
+        "set_group_display_name": "Halvar's",
+        "set_group_id": "set:7",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_bonus:7:0",
+        "special_mechanic_classification": "partial_modifier",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set bonus is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "canonical_id": "set_bonus:7:1",
+        "consumer_safe_fields": {
+          "display_name": "Halvar's 2 piece bonus",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "description_text": [],
+        "display_name": "Halvar's 2 piece bonus",
+        "modifier_references": [
+          {
+            "modifier_id": "set_bonus_modifier_set_bonus:7:1:0",
+            "property": "Damage",
+            "property_path": "ADDED.Damage.Physical.Spell",
+            "source_record_id": "set_bonus:7:1:modifier:0"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": 0,
+            "modifier_id": "set_bonus_modifier_set_bonus:7:1:0",
+            "modifier_type": "ADDED",
+            "property": "Damage",
+            "property_path": "ADDED.Damage.Physical.Spell",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": "1.4.6_22986002",
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "Damage"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_bonus:7:1:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+              "source_type": "set_bonus_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Physical",
+              "Spell"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 20.0,
+            "value_min": 20.0
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_bonus_modifier_set_bonus:7:1:0",
+              "property": "Damage",
+              "property_path": "ADDED.Damage.Physical.Spell",
+              "source_record_id": "set_bonus:7:1:modifier:0"
+            }
+          ]
+        },
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set bonus data; text descriptions are not inferred as mechanics."
+          ],
+          "patch_version": "1.4.6_22986002",
+          "raw_reference": {
+            "bonus_index": 1,
+            "setId": 7
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_bonus:7:1",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_bonus"
+        },
+        "raw_reference": {
+          "bonus_index": 1,
+          "kind": "mod",
+          "setId": 7
+        },
+        "required_pieces": 2,
+        "set_group_display_name": "Halvar's",
+        "set_group_id": "set:7",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_bonus:7:1",
+        "special_mechanic_classification": "partial_modifier",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set bonus is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "canonical_id": "set_bonus:7:2",
+        "consumer_safe_fields": {
+          "display_name": "Halvar's 3 piece bonus",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "description_text": [],
+        "display_name": "Halvar's 3 piece bonus",
+        "modifier_references": [
+          {
+            "modifier_id": "set_bonus_modifier_set_bonus:7:2:0",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Cold.Poison",
+            "source_record_id": "set_bonus:7:2:modifier:0"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": 0,
+            "modifier_id": "set_bonus_modifier_set_bonus:7:2:0",
+            "modifier_type": "ADDED",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Cold.Poison",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": "1.4.6_22986002",
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "PlayerProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_bonus:7:2:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+              "source_type": "set_bonus_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Cold",
+              "Poison"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 1.0,
+            "value_min": 1.0
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_bonus_modifier_set_bonus:7:2:0",
+              "property": "PlayerProperty",
+              "property_path": "ADDED.PlayerProperty.Cold.Poison",
+              "source_record_id": "set_bonus:7:2:modifier:0"
+            }
+          ]
+        },
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set bonus data; text descriptions are not inferred as mechanics."
+          ],
+          "patch_version": "1.4.6_22986002",
+          "raw_reference": {
+            "bonus_index": 2,
+            "setId": 7
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_bonus:7:2",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_bonus"
+        },
+        "raw_reference": {
+          "bonus_index": 2,
+          "kind": "mod",
+          "setId": 7
+        },
+        "required_pieces": 3,
+        "set_group_display_name": "Halvar's",
+        "set_group_id": "set:7",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_bonus:7:2",
+        "special_mechanic_classification": "partial_modifier",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set bonus is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "canonical_id": "set_bonus:7:3",
+        "consumer_safe_fields": {
+          "display_name": "Halvar's 3 piece bonus",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "description_text": [],
+        "display_name": "Halvar's 3 piece bonus",
+        "modifier_references": [
+          {
+            "modifier_id": "set_bonus_modifier_set_bonus:7:3:0",
+            "property": "LevelOfSkills",
+            "property_path": "ADDED.LevelOfSkills.Physical.Void.Poison.Elemental.special:1",
+            "source_record_id": "set_bonus:7:3:modifier:0"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": 0,
+            "modifier_id": "set_bonus_modifier_set_bonus:7:3:0",
+            "modifier_type": "ADDED",
+            "property": "LevelOfSkills",
+            "property_path": "ADDED.LevelOfSkills.Physical.Void.Poison.Elemental.special:1",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": "1.4.6_22986002",
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "LevelOfSkills"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_bonus:7:3:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+              "source_type": "set_bonus_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 1,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Physical",
+              "Void",
+              "Poison",
+              "Elemental"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 2.0,
+            "value_min": 2.0
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_bonus_modifier_set_bonus:7:3:0",
+              "property": "LevelOfSkills",
+              "property_path": "ADDED.LevelOfSkills.Physical.Void.Poison.Elemental.special:1",
+              "source_record_id": "set_bonus:7:3:modifier:0"
+            }
+          ]
+        },
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set bonus data; text descriptions are not inferred as mechanics."
+          ],
+          "patch_version": "1.4.6_22986002",
+          "raw_reference": {
+            "bonus_index": 3,
+            "setId": 7
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_bonus:7:3",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_bonus"
+        },
+        "raw_reference": {
+          "bonus_index": 3,
+          "kind": "mod",
+          "setId": 7
+        },
+        "required_pieces": 3,
+        "set_group_display_name": "Halvar's",
+        "set_group_id": "set:7",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_bonus:7:3",
+        "special_mechanic_classification": "partial_modifier",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set bonus is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "canonical_id": "set_bonus:8:0",
+        "consumer_safe_fields": {
+          "display_name": "Pebbles' 2 piece bonus",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "description_text": [],
+        "display_name": "Pebbles' 2 piece bonus",
+        "modifier_references": [
+          {
+            "modifier_id": "set_bonus_modifier_set_bonus:8:0:0",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Cold.Fire.Void.Elemental.special:3",
+            "source_record_id": "set_bonus:8:0:modifier:0"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": 0,
+            "modifier_id": "set_bonus_modifier_set_bonus:8:0:0",
+            "modifier_type": "ADDED",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Cold.Fire.Void.Elemental.special:3",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": "1.4.6_22986002",
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "AbilityProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_bonus:8:0:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+              "source_type": "set_bonus_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 3,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Physical",
+              "Cold",
+              "Fire",
+              "Void",
+              "Elemental"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.05000000074505806,
+            "value_min": 0.05000000074505806
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_bonus_modifier_set_bonus:8:0:0",
+              "property": "AbilityProperty",
+              "property_path": "ADDED.AbilityProperty.Physical.Cold.Fire.Void.Elemental.special:3",
+              "source_record_id": "set_bonus:8:0:modifier:0"
+            }
+          ]
+        },
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set bonus data; text descriptions are not inferred as mechanics."
+          ],
+          "patch_version": "1.4.6_22986002",
+          "raw_reference": {
+            "bonus_index": 0,
+            "setId": 8
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_bonus:8:0",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_bonus"
+        },
+        "raw_reference": {
+          "bonus_index": 0,
+          "kind": "mod",
+          "setId": 8
+        },
+        "required_pieces": 2,
+        "set_group_display_name": "Pebbles'",
+        "set_group_id": "set:8",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_bonus:8:0",
+        "special_mechanic_classification": "partial_modifier",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set bonus is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "canonical_id": "set_bonus:8:1",
+        "consumer_safe_fields": {
+          "display_name": "Pebbles' 3 piece bonus",
+          "special_mechanic_classification": "text_only_effect",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "description_text": [
+          "Your Summon Skeletons' spells and attacks deal +42 fire, cold or lightning damage. The element selected is your lowest elemental resistance."
+        ],
+        "display_name": "Pebbles' 3 piece bonus",
+        "modifier_references": [],
+        "modifier_rows": [],
+        "normalized_fields": {
+          "modifier_references": []
+        },
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set bonus data; text descriptions are not inferred as mechanics."
+          ],
+          "patch_version": "1.4.6_22986002",
+          "raw_reference": {
+            "bonus_index": 1,
+            "setId": 8
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_bonus:8:1",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_bonus"
+        },
+        "raw_reference": {
+          "bonus_index": 1,
+          "kind": "description",
+          "setId": 8
+        },
+        "required_pieces": 3,
+        "set_group_display_name": "Pebbles'",
+        "set_group_id": "set:8",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_bonus:8:1",
+        "special_mechanic_classification": "text_only_effect",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set bonus is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "canonical_id": "set_bonus:9:0",
+        "consumer_safe_fields": {
+          "display_name": "Shattered Lance 2 piece bonus",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "description_text": [],
+        "display_name": "Shattered Lance 2 piece bonus",
+        "modifier_references": [
+          {
+            "modifier_id": "set_bonus_modifier_set_bonus:9:0:0",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Cold.Poison.Elemental",
+            "source_record_id": "set_bonus:9:0:modifier:0"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": 0,
+            "modifier_id": "set_bonus_modifier_set_bonus:9:0:0",
+            "modifier_type": "ADDED",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Cold.Poison.Elemental",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": "1.4.6_22986002",
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "PlayerProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_bonus:9:0:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+              "source_type": "set_bonus_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Cold",
+              "Poison",
+              "Elemental"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.03999999910593033,
+            "value_min": 0.03999999910593033
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_bonus_modifier_set_bonus:9:0:0",
+              "property": "PlayerProperty",
+              "property_path": "ADDED.PlayerProperty.Cold.Poison.Elemental",
+              "source_record_id": "set_bonus:9:0:modifier:0"
+            }
+          ]
+        },
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set bonus data; text descriptions are not inferred as mechanics."
+          ],
+          "patch_version": "1.4.6_22986002",
+          "raw_reference": {
+            "bonus_index": 0,
+            "setId": 9
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_bonus:9:0",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_bonus"
+        },
+        "raw_reference": {
+          "bonus_index": 0,
+          "kind": "mod",
+          "setId": 9
+        },
+        "required_pieces": 2,
+        "set_group_display_name": "Shattered Lance",
+        "set_group_id": "set:9",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_bonus:9:0",
+        "special_mechanic_classification": "partial_modifier",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set bonus is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "canonical_id": "set_bonus:10:0",
+        "consumer_safe_fields": {
+          "display_name": "Boardman's 1 piece bonus",
+          "special_mechanic_classification": "text_only_effect",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "description_text": [
+          "Limited to One Active Companion"
+        ],
+        "display_name": "Boardman's 1 piece bonus",
+        "modifier_references": [],
+        "modifier_rows": [],
+        "normalized_fields": {
+          "modifier_references": []
+        },
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set bonus data; text descriptions are not inferred as mechanics."
+          ],
+          "patch_version": "1.4.6_22986002",
+          "raw_reference": {
+            "bonus_index": 0,
+            "setId": 10
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_bonus:10:0",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_bonus"
+        },
+        "raw_reference": {
+          "bonus_index": 0,
+          "kind": "description",
+          "setId": 10
+        },
+        "required_pieces": 1,
+        "set_group_display_name": "Boardman's",
+        "set_group_id": "set:10",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_bonus:10:0",
+        "special_mechanic_classification": "text_only_effect",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set bonus is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "canonical_id": "set_bonus:10:1",
+        "consumer_safe_fields": {
+          "display_name": "Boardman's 2 piece bonus",
+          "special_mechanic_classification": "text_only_effect",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "description_text": [
+          "Storm Totem can hit allies to grant 21 health",
+          "Health granted is not affected by minion healing effectiveness"
+        ],
+        "display_name": "Boardman's 2 piece bonus",
+        "modifier_references": [],
+        "modifier_rows": [],
+        "normalized_fields": {
+          "modifier_references": []
+        },
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set bonus data; text descriptions are not inferred as mechanics."
+          ],
+          "patch_version": "1.4.6_22986002",
+          "raw_reference": {
+            "bonus_index": 1,
+            "setId": 10
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_bonus:10:1",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_bonus"
+        },
+        "raw_reference": {
+          "bonus_index": 1,
+          "kind": "description",
+          "setId": 10
+        },
+        "required_pieces": 2,
+        "set_group_display_name": "Boardman's",
+        "set_group_id": "set:10",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_bonus:10:1",
+        "special_mechanic_classification": "text_only_effect",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set bonus is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "canonical_id": "set_bonus:10:2",
+        "consumer_safe_fields": {
+          "display_name": "Boardman's 3 piece bonus",
+          "special_mechanic_classification": "text_only_effect",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "description_text": [
+          "Storm Totem can hit allies to grant 21 ward"
+        ],
+        "display_name": "Boardman's 3 piece bonus",
+        "modifier_references": [],
+        "modifier_rows": [],
+        "normalized_fields": {
+          "modifier_references": []
+        },
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set bonus data; text descriptions are not inferred as mechanics."
+          ],
+          "patch_version": "1.4.6_22986002",
+          "raw_reference": {
+            "bonus_index": 2,
+            "setId": 10
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_bonus:10:2",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_bonus"
+        },
+        "raw_reference": {
+          "bonus_index": 2,
+          "kind": "description",
+          "setId": 10
+        },
+        "required_pieces": 3,
+        "set_group_display_name": "Boardman's",
+        "set_group_id": "set:10",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_bonus:10:2",
+        "special_mechanic_classification": "text_only_effect",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set bonus is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "canonical_id": "set_bonus:11:0",
+        "consumer_safe_fields": {
+          "display_name": "Zerrick's 2 piece bonus",
+          "special_mechanic_classification": "text_only_effect",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "description_text": [
+          "Potions no longer heal you, but instead grant +54 necrotic damage to melee and throwing attacks and mark you for death for 4 seconds.",
+          "Mark for Death is a curse that reduces all resistances by 25%."
+        ],
+        "display_name": "Zerrick's 2 piece bonus",
+        "modifier_references": [],
+        "modifier_rows": [],
+        "normalized_fields": {
+          "modifier_references": []
+        },
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set bonus data; text descriptions are not inferred as mechanics."
+          ],
+          "patch_version": "1.4.6_22986002",
+          "raw_reference": {
+            "bonus_index": 0,
+            "setId": 11
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_bonus:11:0",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_bonus"
+        },
+        "raw_reference": {
+          "bonus_index": 0,
+          "kind": "description",
+          "setId": 11
+        },
+        "required_pieces": 2,
+        "set_group_display_name": "Zerrick's",
+        "set_group_id": "set:11",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_bonus:11:0",
+        "special_mechanic_classification": "text_only_effect",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set bonus is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "canonical_id": "set_bonus:11:1",
+        "consumer_safe_fields": {
+          "display_name": "Zerrick's 3 piece bonus",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "description_text": [],
+        "display_name": "Zerrick's 3 piece bonus",
+        "modifier_references": [
+          {
+            "modifier_id": "set_bonus_modifier_set_bonus:11:1:0",
+            "property": "IncreasedPotionDropRate",
+            "property_path": "ADDED.IncreasedPotionDropRate",
+            "source_record_id": "set_bonus:11:1:modifier:0"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": 0,
+            "modifier_id": "set_bonus_modifier_set_bonus:11:1:0",
+            "modifier_type": "ADDED",
+            "property": "IncreasedPotionDropRate",
+            "property_path": "ADDED.IncreasedPotionDropRate",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": "1.4.6_22986002",
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "IncreasedPotionDropRate"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_bonus:11:1:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+              "source_type": "set_bonus_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.7200000286102295,
+            "value_min": 0.7200000286102295
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_bonus_modifier_set_bonus:11:1:0",
+              "property": "IncreasedPotionDropRate",
+              "property_path": "ADDED.IncreasedPotionDropRate",
+              "source_record_id": "set_bonus:11:1:modifier:0"
+            }
+          ]
+        },
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set bonus data; text descriptions are not inferred as mechanics."
+          ],
+          "patch_version": "1.4.6_22986002",
+          "raw_reference": {
+            "bonus_index": 1,
+            "setId": 11
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_bonus:11:1",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_bonus"
+        },
+        "raw_reference": {
+          "bonus_index": 1,
+          "kind": "mod",
+          "setId": 11
+        },
+        "required_pieces": 3,
+        "set_group_display_name": "Zerrick's",
+        "set_group_id": "set:11",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_bonus:11:1",
+        "special_mechanic_classification": "partial_modifier",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set bonus is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "canonical_id": "set_bonus:11:2",
+        "consumer_safe_fields": {
+          "display_name": "Zerrick's 3 piece bonus",
+          "special_mechanic_classification": "text_only_effect",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "description_text": [
+          "18% less Poison and Necrotic Damage Taken",
+          "Multiplicative with other modifiers"
+        ],
+        "display_name": "Zerrick's 3 piece bonus",
+        "modifier_references": [],
+        "modifier_rows": [],
+        "normalized_fields": {
+          "modifier_references": []
+        },
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set bonus data; text descriptions are not inferred as mechanics."
+          ],
+          "patch_version": "1.4.6_22986002",
+          "raw_reference": {
+            "bonus_index": 2,
+            "setId": 11
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_bonus:11:2",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_bonus"
+        },
+        "raw_reference": {
+          "bonus_index": 2,
+          "kind": "description",
+          "setId": 11
+        },
+        "required_pieces": 3,
+        "set_group_display_name": "Zerrick's",
+        "set_group_id": "set:11",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_bonus:11:2",
+        "special_mechanic_classification": "text_only_effect",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set bonus is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "canonical_id": "set_bonus:12:0",
+        "consumer_safe_fields": {
+          "display_name": "Gaspar's 2 piece bonus",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "description_text": [],
+        "display_name": "Gaspar's 2 piece bonus",
+        "modifier_references": [
+          {
+            "modifier_id": "set_bonus_modifier_set_bonus:12:0:0",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Cold.Melee.special:4",
+            "source_record_id": "set_bonus:12:0:modifier:0"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": 0,
+            "modifier_id": "set_bonus_modifier_set_bonus:12:0:0",
+            "modifier_type": "ADDED",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Cold.Melee.special:4",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": "1.4.6_22986002",
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "AbilityProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_bonus:12:0:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+              "source_type": "set_bonus_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 4,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Physical",
+              "Cold",
+              "Melee"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.5,
+            "value_min": 0.5
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_bonus_modifier_set_bonus:12:0:0",
+              "property": "AbilityProperty",
+              "property_path": "ADDED.AbilityProperty.Physical.Cold.Melee.special:4",
+              "source_record_id": "set_bonus:12:0:modifier:0"
+            }
+          ]
+        },
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set bonus data; text descriptions are not inferred as mechanics."
+          ],
+          "patch_version": "1.4.6_22986002",
+          "raw_reference": {
+            "bonus_index": 0,
+            "setId": 12
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_bonus:12:0",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_bonus"
+        },
+        "raw_reference": {
+          "bonus_index": 0,
+          "kind": "mod",
+          "setId": 12
+        },
+        "required_pieces": 2,
+        "set_group_display_name": "Gaspar's",
+        "set_group_id": "set:12",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_bonus:12:0",
+        "special_mechanic_classification": "partial_modifier",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set bonus is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "canonical_id": "set_bonus:12:1",
+        "consumer_safe_fields": {
+          "display_name": "Gaspar's 3 piece bonus",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "description_text": [],
+        "display_name": "Gaspar's 3 piece bonus",
+        "modifier_references": [
+          {
+            "modifier_id": "set_bonus_modifier_set_bonus:12:1:0",
+            "property": "GlobalConditionalDamage",
+            "property_path": "MORE.GlobalConditionalDamage.Void.special:4",
+            "source_record_id": "set_bonus:12:1:modifier:0"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": 0,
+            "modifier_id": "set_bonus_modifier_set_bonus:12:1:0",
+            "modifier_type": "MORE",
+            "property": "GlobalConditionalDamage",
+            "property_path": "MORE.GlobalConditionalDamage.Void.special:4",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": "1.4.6_22986002",
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "GlobalConditionalDamage"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_bonus:12:1:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+              "source_type": "set_bonus_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 4,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Void"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.15000000596046448,
+            "value_min": 0.15000000596046448
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_bonus_modifier_set_bonus:12:1:0",
+              "property": "GlobalConditionalDamage",
+              "property_path": "MORE.GlobalConditionalDamage.Void.special:4",
+              "source_record_id": "set_bonus:12:1:modifier:0"
+            }
+          ]
+        },
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set bonus data; text descriptions are not inferred as mechanics."
+          ],
+          "patch_version": "1.4.6_22986002",
+          "raw_reference": {
+            "bonus_index": 1,
+            "setId": 12
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_bonus:12:1",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_bonus"
+        },
+        "raw_reference": {
+          "bonus_index": 1,
+          "kind": "mod",
+          "setId": 12
+        },
+        "required_pieces": 3,
+        "set_group_display_name": "Gaspar's",
+        "set_group_id": "set:12",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_bonus:12:1",
+        "special_mechanic_classification": "partial_modifier",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set bonus is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "canonical_id": "set_bonus:12:2",
+        "consumer_safe_fields": {
+          "display_name": "Gaspar's 3 piece bonus",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "description_text": [],
+        "display_name": "Gaspar's 3 piece bonus",
+        "modifier_references": [
+          {
+            "modifier_id": "set_bonus_modifier_set_bonus:12:2:0",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Cold.Melee",
+            "source_record_id": "set_bonus:12:2:modifier:0"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": 0,
+            "modifier_id": "set_bonus_modifier_set_bonus:12:2:0",
+            "modifier_type": "ADDED",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Cold.Melee",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": "1.4.6_22986002",
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "AbilityProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_bonus:12:2:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+              "source_type": "set_bonus_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Physical",
+              "Cold",
+              "Melee"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 1.0,
+            "value_min": 1.0
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_bonus_modifier_set_bonus:12:2:0",
+              "property": "AbilityProperty",
+              "property_path": "ADDED.AbilityProperty.Physical.Cold.Melee",
+              "source_record_id": "set_bonus:12:2:modifier:0"
+            }
+          ]
+        },
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set bonus data; text descriptions are not inferred as mechanics."
+          ],
+          "patch_version": "1.4.6_22986002",
+          "raw_reference": {
+            "bonus_index": 2,
+            "setId": 12
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_bonus:12:2",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_bonus"
+        },
+        "raw_reference": {
+          "bonus_index": 2,
+          "kind": "mod",
+          "setId": 12
+        },
+        "required_pieces": 3,
+        "set_group_display_name": "Gaspar's",
+        "set_group_id": "set:12",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_bonus:12:2",
+        "special_mechanic_classification": "partial_modifier",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set bonus is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "canonical_id": "set_bonus:13:0",
+        "consumer_safe_fields": {
+          "display_name": "Sinathia's 2 piece bonus",
+          "special_mechanic_classification": "text_only_effect",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "description_text": [
+          "+3 to Curse Skills\n+3 to Minion Skills"
+        ],
+        "display_name": "Sinathia's 2 piece bonus",
+        "modifier_references": [],
+        "modifier_rows": [],
+        "normalized_fields": {
+          "modifier_references": []
+        },
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set bonus data; text descriptions are not inferred as mechanics."
+          ],
+          "patch_version": "1.4.6_22986002",
+          "raw_reference": {
+            "bonus_index": 0,
+            "setId": 13
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_bonus:13:0",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_bonus"
+        },
+        "raw_reference": {
+          "bonus_index": 0,
+          "kind": "description",
+          "setId": 13
+        },
+        "required_pieces": 2,
+        "set_group_display_name": "Sinathia's",
+        "set_group_id": "set:13",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_bonus:13:0",
+        "special_mechanic_classification": "text_only_effect",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set bonus is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "canonical_id": "set_bonus:14:0",
+        "consumer_safe_fields": {
+          "display_name": "Ruby Fang 2 piece bonus",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "description_text": [],
+        "display_name": "Ruby Fang 2 piece bonus",
+        "modifier_references": [
+          {
+            "modifier_id": "set_bonus_modifier_set_bonus:14:0:0",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Physical.Lightning.Poison.Elemental",
+            "source_record_id": "set_bonus:14:0:modifier:0"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": 0,
+            "modifier_id": "set_bonus_modifier_set_bonus:14:0:0",
+            "modifier_type": "ADDED",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Physical.Lightning.Poison.Elemental",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": "1.4.6_22986002",
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "PlayerProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_bonus:14:0:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+              "source_type": "set_bonus_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Physical",
+              "Lightning",
+              "Poison",
+              "Elemental"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.009999999776482582,
+            "value_min": 0.009999999776482582
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_bonus_modifier_set_bonus:14:0:0",
+              "property": "PlayerProperty",
+              "property_path": "ADDED.PlayerProperty.Physical.Lightning.Poison.Elemental",
+              "source_record_id": "set_bonus:14:0:modifier:0"
+            }
+          ]
+        },
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set bonus data; text descriptions are not inferred as mechanics."
+          ],
+          "patch_version": "1.4.6_22986002",
+          "raw_reference": {
+            "bonus_index": 0,
+            "setId": 14
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_bonus:14:0",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_bonus"
+        },
+        "raw_reference": {
+          "bonus_index": 0,
+          "kind": "mod",
+          "setId": 14
+        },
+        "required_pieces": 2,
+        "set_group_display_name": "Ruby Fang",
+        "set_group_id": "set:14",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_bonus:14:0",
+        "special_mechanic_classification": "partial_modifier",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set bonus is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "canonical_id": "set_bonus:14:1",
+        "consumer_safe_fields": {
+          "display_name": "Ruby Fang 2 piece bonus",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "description_text": [],
+        "display_name": "Ruby Fang 2 piece bonus",
+        "modifier_references": [
+          {
+            "modifier_id": "set_bonus_modifier_set_bonus:14:1:0",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Lightning.Cold.Void.Elemental.Melee",
+            "source_record_id": "set_bonus:14:1:modifier:0"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": 0,
+            "modifier_id": "set_bonus_modifier_set_bonus:14:1:0",
+            "modifier_type": "ADDED",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Lightning.Cold.Void.Elemental.Melee",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": "1.4.6_22986002",
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "PlayerProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_bonus:14:1:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+              "source_type": "set_bonus_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Lightning",
+              "Cold",
+              "Void",
+              "Elemental",
+              "Melee"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 1.0,
+            "value_min": 1.0
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_bonus_modifier_set_bonus:14:1:0",
+              "property": "PlayerProperty",
+              "property_path": "ADDED.PlayerProperty.Lightning.Cold.Void.Elemental.Melee",
+              "source_record_id": "set_bonus:14:1:modifier:0"
+            }
+          ]
+        },
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set bonus data; text descriptions are not inferred as mechanics."
+          ],
+          "patch_version": "1.4.6_22986002",
+          "raw_reference": {
+            "bonus_index": 1,
+            "setId": 14
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_bonus:14:1",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_bonus"
+        },
+        "raw_reference": {
+          "bonus_index": 1,
+          "kind": "mod",
+          "setId": 14
+        },
+        "required_pieces": 2,
+        "set_group_display_name": "Ruby Fang",
+        "set_group_id": "set:14",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_bonus:14:1",
+        "special_mechanic_classification": "partial_modifier",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set bonus is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "canonical_id": "set_bonus:15:0",
+        "consumer_safe_fields": {
+          "display_name": "Vilatria's 2 piece bonus",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "description_text": [],
+        "display_name": "Vilatria's 2 piece bonus",
+        "modifier_references": [
+          {
+            "modifier_id": "set_bonus_modifier_set_bonus:15:0:0",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Lightning.Void.Elemental",
+            "source_record_id": "set_bonus:15:0:modifier:0"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": 0,
+            "modifier_id": "set_bonus_modifier_set_bonus:15:0:0",
+            "modifier_type": "ADDED",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Lightning.Void.Elemental",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": "1.4.6_22986002",
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "PlayerProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_bonus:15:0:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+              "source_type": "set_bonus_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Lightning",
+              "Void",
+              "Elemental"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 1.0,
+            "value_min": 1.0
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_bonus_modifier_set_bonus:15:0:0",
+              "property": "PlayerProperty",
+              "property_path": "ADDED.PlayerProperty.Lightning.Void.Elemental",
+              "source_record_id": "set_bonus:15:0:modifier:0"
+            }
+          ]
+        },
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set bonus data; text descriptions are not inferred as mechanics."
+          ],
+          "patch_version": "1.4.6_22986002",
+          "raw_reference": {
+            "bonus_index": 0,
+            "setId": 15
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_bonus:15:0",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_bonus"
+        },
+        "raw_reference": {
+          "bonus_index": 0,
+          "kind": "mod",
+          "setId": 15
+        },
+        "required_pieces": 2,
+        "set_group_display_name": "Vilatria's",
+        "set_group_id": "set:15",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_bonus:15:0",
+        "special_mechanic_classification": "partial_modifier",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set bonus is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "canonical_id": "set_bonus:16:0",
+        "consumer_safe_fields": {
+          "display_name": "Corsair's 2 piece bonus",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "description_text": [],
+        "display_name": "Corsair's 2 piece bonus",
+        "modifier_references": [
+          {
+            "modifier_id": "set_bonus_modifier_set_bonus:16:0:0",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Physical.Cold.Void.Elemental",
+            "source_record_id": "set_bonus:16:0:modifier:0"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": 0,
+            "modifier_id": "set_bonus_modifier_set_bonus:16:0:0",
+            "modifier_type": "ADDED",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Physical.Cold.Void.Elemental",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": "1.4.6_22986002",
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "PlayerProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_bonus:16:0:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+              "source_type": "set_bonus_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Physical",
+              "Cold",
+              "Void",
+              "Elemental"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 1.0,
+            "value_min": 1.0
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_bonus_modifier_set_bonus:16:0:0",
+              "property": "PlayerProperty",
+              "property_path": "ADDED.PlayerProperty.Physical.Cold.Void.Elemental",
+              "source_record_id": "set_bonus:16:0:modifier:0"
+            }
+          ]
+        },
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set bonus data; text descriptions are not inferred as mechanics."
+          ],
+          "patch_version": "1.4.6_22986002",
+          "raw_reference": {
+            "bonus_index": 0,
+            "setId": 16
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_bonus:16:0",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_bonus"
+        },
+        "raw_reference": {
+          "bonus_index": 0,
+          "kind": "mod",
+          "setId": 16
+        },
+        "required_pieces": 2,
+        "set_group_display_name": "Corsair's",
+        "set_group_id": "set:16",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_bonus:16:0",
+        "special_mechanic_classification": "partial_modifier",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set bonus is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "canonical_id": "set_bonus:16:1",
+        "consumer_safe_fields": {
+          "display_name": "Corsair's 2 piece bonus",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "description_text": [],
+        "display_name": "Corsair's 2 piece bonus",
+        "modifier_references": [
+          {
+            "modifier_id": "set_bonus_modifier_set_bonus:16:1:0",
+            "property": "DamageTaken",
+            "property_path": "MORE.DamageTaken.Necrotic.special:6",
+            "source_record_id": "set_bonus:16:1:modifier:0"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": 0,
+            "modifier_id": "set_bonus_modifier_set_bonus:16:1:0",
+            "modifier_type": "MORE",
+            "property": "DamageTaken",
+            "property_path": "MORE.DamageTaken.Necrotic.special:6",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": "1.4.6_22986002",
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "DamageTaken"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_bonus:16:1:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+              "source_type": "set_bonus_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 6,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Necrotic"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": -0.3499999940395355,
+            "value_min": -0.3499999940395355
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_bonus_modifier_set_bonus:16:1:0",
+              "property": "DamageTaken",
+              "property_path": "MORE.DamageTaken.Necrotic.special:6",
+              "source_record_id": "set_bonus:16:1:modifier:0"
+            }
+          ]
+        },
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set bonus data; text descriptions are not inferred as mechanics."
+          ],
+          "patch_version": "1.4.6_22986002",
+          "raw_reference": {
+            "bonus_index": 1,
+            "setId": 16
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_bonus:16:1",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_bonus"
+        },
+        "raw_reference": {
+          "bonus_index": 1,
+          "kind": "mod",
+          "setId": 16
+        },
+        "required_pieces": 2,
+        "set_group_display_name": "Corsair's",
+        "set_group_id": "set:16",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_bonus:16:1",
+        "special_mechanic_classification": "partial_modifier",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set bonus is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "canonical_id": "set_bonus:17:0",
+        "consumer_safe_fields": {
+          "display_name": "Ferebor's 2 piece bonus",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "description_text": [],
+        "display_name": "Ferebor's 2 piece bonus",
+        "modifier_references": [
+          {
+            "modifier_id": "set_bonus_modifier_set_bonus:17:0:0",
+            "property": "LevelOfSkills",
+            "property_path": "ADDED.LevelOfSkills.Totem",
+            "source_record_id": "set_bonus:17:0:modifier:0"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": 0,
+            "modifier_id": "set_bonus_modifier_set_bonus:17:0:0",
+            "modifier_type": "ADDED",
+            "property": "LevelOfSkills",
+            "property_path": "ADDED.LevelOfSkills.Totem",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": "1.4.6_22986002",
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "LevelOfSkills"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_bonus:17:0:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+              "source_type": "set_bonus_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Totem"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 2.0,
+            "value_min": 2.0
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_bonus_modifier_set_bonus:17:0:0",
+              "property": "LevelOfSkills",
+              "property_path": "ADDED.LevelOfSkills.Totem",
+              "source_record_id": "set_bonus:17:0:modifier:0"
+            }
+          ]
+        },
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set bonus data; text descriptions are not inferred as mechanics."
+          ],
+          "patch_version": "1.4.6_22986002",
+          "raw_reference": {
+            "bonus_index": 0,
+            "setId": 17
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_bonus:17:0",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_bonus"
+        },
+        "raw_reference": {
+          "bonus_index": 0,
+          "kind": "mod",
+          "setId": 17
+        },
+        "required_pieces": 2,
+        "set_group_display_name": "Ferebor's",
+        "set_group_id": "set:17",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_bonus:17:0",
+        "special_mechanic_classification": "partial_modifier",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set bonus is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "canonical_id": "set_bonus:18:0",
+        "consumer_safe_fields": {
+          "display_name": "Lich's 2 piece bonus",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "description_text": [],
+        "display_name": "Lich's 2 piece bonus",
+        "modifier_references": [
+          {
+            "modifier_id": "set_bonus_modifier_set_bonus:18:0:0",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Lightning.Void.Necrotic.Poison.Spell",
+            "source_record_id": "set_bonus:18:0:modifier:0"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": 0,
+            "modifier_id": "set_bonus_modifier_set_bonus:18:0:0",
+            "modifier_type": "ADDED",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Lightning.Void.Necrotic.Poison.Spell",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": "1.4.6_22986002",
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "AbilityProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_bonus:18:0:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+              "source_type": "set_bonus_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Lightning",
+              "Void",
+              "Necrotic",
+              "Poison",
+              "Spell"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 4.0,
+            "value_min": 4.0
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_bonus_modifier_set_bonus:18:0:0",
+              "property": "AbilityProperty",
+              "property_path": "ADDED.AbilityProperty.Lightning.Void.Necrotic.Poison.Spell",
+              "source_record_id": "set_bonus:18:0:modifier:0"
+            }
+          ]
+        },
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set bonus data; text descriptions are not inferred as mechanics."
+          ],
+          "patch_version": "1.4.6_22986002",
+          "raw_reference": {
+            "bonus_index": 0,
+            "setId": 18
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_bonus:18:0",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_bonus"
+        },
+        "raw_reference": {
+          "bonus_index": 0,
+          "kind": "mod",
+          "setId": 18
+        },
+        "required_pieces": 2,
+        "set_group_display_name": "Lich's",
+        "set_group_id": "set:18",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_bonus:18:0",
+        "special_mechanic_classification": "partial_modifier",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set bonus is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "canonical_id": "set_bonus:19:0",
+        "consumer_safe_fields": {
+          "display_name": "Doppelganger's 2 piece bonus",
+          "special_mechanic_classification": "text_only_effect",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "description_text": [
+          "Evade creates a Shadow at your original position"
+        ],
+        "display_name": "Doppelganger's 2 piece bonus",
+        "modifier_references": [],
+        "modifier_rows": [],
+        "normalized_fields": {
+          "modifier_references": []
+        },
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set bonus data; text descriptions are not inferred as mechanics."
+          ],
+          "patch_version": "1.4.6_22986002",
+          "raw_reference": {
+            "bonus_index": 0,
+            "setId": 19
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_bonus:19:0",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_bonus"
+        },
+        "raw_reference": {
+          "bonus_index": 0,
+          "kind": "description",
+          "setId": 19
+        },
+        "required_pieces": 2,
+        "set_group_display_name": "Doppelganger's",
+        "set_group_id": "set:19",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_bonus:19:0",
+        "special_mechanic_classification": "text_only_effect",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set bonus is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "canonical_id": "set_bonus:19:1",
+        "consumer_safe_fields": {
+          "display_name": "Doppelganger's 3 piece bonus",
+          "special_mechanic_classification": "text_only_effect",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "description_text": [
+          "Traversal skills create 2 Shadows along their path"
+        ],
+        "display_name": "Doppelganger's 3 piece bonus",
+        "modifier_references": [],
+        "modifier_rows": [],
+        "normalized_fields": {
+          "modifier_references": []
+        },
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set bonus data; text descriptions are not inferred as mechanics."
+          ],
+          "patch_version": "1.4.6_22986002",
+          "raw_reference": {
+            "bonus_index": 1,
+            "setId": 19
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_bonus:19:1",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_bonus"
+        },
+        "raw_reference": {
+          "bonus_index": 1,
+          "kind": "description",
+          "setId": 19
+        },
+        "required_pieces": 3,
+        "set_group_display_name": "Doppelganger's",
+        "set_group_id": "set:19",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_bonus:19:1",
+        "special_mechanic_classification": "text_only_effect",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set bonus is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "canonical_id": "set_bonus:20:0",
+        "consumer_safe_fields": {
+          "display_name": "set:20 2 piece bonus",
+          "special_mechanic_classification": "text_only_effect",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "description_text": [
+          "Legendary affixes on equipped Weaver's Will weapons have 50% increased effect"
+        ],
+        "display_name": "set:20 2 piece bonus",
+        "modifier_references": [],
+        "modifier_rows": [],
+        "normalized_fields": {
+          "modifier_references": []
+        },
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set bonus data; text descriptions are not inferred as mechanics."
+          ],
+          "patch_version": "1.4.6_22986002",
+          "raw_reference": {
+            "bonus_index": 0,
+            "setId": 20
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_bonus:20:0",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_bonus"
+        },
+        "raw_reference": {
+          "bonus_index": 0,
+          "kind": "description",
+          "setId": 20
+        },
+        "required_pieces": 2,
+        "set_group_display_name": null,
+        "set_group_id": "set:20",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_bonus:20:0",
+        "special_mechanic_classification": "text_only_effect",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set bonus is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "canonical_id": "set_bonus:21:0",
+        "consumer_safe_fields": {
+          "display_name": "Kuzon's 2 piece bonus",
+          "special_mechanic_classification": "text_only_effect",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "description_text": [
+          "Throwing a Burning Dagger grants a stack of Dancing Dragon for 4 seconds, which grants 2% increased dodge rating, 4% increased fire damage, and 4% increased area for fire area skills for 4 seconds. This effect can trigger up to 40 times per 4 seconds."
+        ],
+        "display_name": "Kuzon's 2 piece bonus",
+        "modifier_references": [],
+        "modifier_rows": [],
+        "normalized_fields": {
+          "modifier_references": []
+        },
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set bonus data; text descriptions are not inferred as mechanics."
+          ],
+          "patch_version": "1.4.6_22986002",
+          "raw_reference": {
+            "bonus_index": 0,
+            "setId": 21
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_bonus:21:0",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_bonus"
+        },
+        "raw_reference": {
+          "bonus_index": 0,
+          "kind": "description",
+          "setId": 21
+        },
+        "required_pieces": 2,
+        "set_group_display_name": "Kuzon's",
+        "set_group_id": "set:21",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_bonus:21:0",
+        "special_mechanic_classification": "text_only_effect",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set bonus is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "canonical_id": "set_bonus:22:0",
+        "consumer_safe_fields": {
+          "display_name": "Jormun's 2 piece bonus",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "description_text": [],
+        "display_name": "Jormun's 2 piece bonus",
+        "modifier_references": [
+          {
+            "modifier_id": "set_bonus_modifier_set_bonus:22:0:0",
+            "property": "PlayerProperty",
+            "property_path": "MORE.PlayerProperty.Fire.Void.Necrotic.Poison.Melee",
+            "source_record_id": "set_bonus:22:0:modifier:0"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": 0,
+            "modifier_id": "set_bonus_modifier_set_bonus:22:0:0",
+            "modifier_type": "MORE",
+            "property": "PlayerProperty",
+            "property_path": "MORE.PlayerProperty.Fire.Void.Necrotic.Poison.Melee",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": "1.4.6_22986002",
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "PlayerProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_bonus:22:0:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+              "source_type": "set_bonus_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Fire",
+              "Void",
+              "Necrotic",
+              "Poison",
+              "Melee"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.20000000298023224,
+            "value_min": 0.20000000298023224
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_bonus_modifier_set_bonus:22:0:0",
+              "property": "PlayerProperty",
+              "property_path": "MORE.PlayerProperty.Fire.Void.Necrotic.Poison.Melee",
+              "source_record_id": "set_bonus:22:0:modifier:0"
+            }
+          ]
+        },
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set bonus data; text descriptions are not inferred as mechanics."
+          ],
+          "patch_version": "1.4.6_22986002",
+          "raw_reference": {
+            "bonus_index": 0,
+            "setId": 22
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_bonus:22:0",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_bonus"
+        },
+        "raw_reference": {
+          "bonus_index": 0,
+          "kind": "mod",
+          "setId": 22
+        },
+        "required_pieces": 2,
+        "set_group_display_name": "Jormun's",
+        "set_group_id": "set:22",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_bonus:22:0",
+        "special_mechanic_classification": "partial_modifier",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set bonus is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "canonical_id": "set_bonus:22:1",
+        "consumer_safe_fields": {
+          "display_name": "Jormun's 3 piece bonus",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "description_text": [],
+        "display_name": "Jormun's 3 piece bonus",
+        "modifier_references": [
+          {
+            "modifier_id": "set_bonus_modifier_set_bonus:22:1:0",
+            "property": "CriticalMultiplier",
+            "property_path": "ADDED.CriticalMultiplier",
+            "source_record_id": "set_bonus:22:1:modifier:0"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": 0,
+            "modifier_id": "set_bonus_modifier_set_bonus:22:1:0",
+            "modifier_type": "ADDED",
+            "property": "CriticalMultiplier",
+            "property_path": "ADDED.CriticalMultiplier",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": "1.4.6_22986002",
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "CriticalMultiplier"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_bonus:22:1:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+              "source_type": "set_bonus_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.10000000149011612,
+            "value_min": 0.10000000149011612
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_bonus_modifier_set_bonus:22:1:0",
+              "property": "CriticalMultiplier",
+              "property_path": "ADDED.CriticalMultiplier",
+              "source_record_id": "set_bonus:22:1:modifier:0"
+            }
+          ]
+        },
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set bonus data; text descriptions are not inferred as mechanics."
+          ],
+          "patch_version": "1.4.6_22986002",
+          "raw_reference": {
+            "bonus_index": 1,
+            "setId": 22
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_bonus:22:1",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_bonus"
+        },
+        "raw_reference": {
+          "bonus_index": 1,
+          "kind": "mod",
+          "setId": 22
+        },
+        "required_pieces": 3,
+        "set_group_display_name": "Jormun's",
+        "set_group_id": "set:22",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_bonus:22:1",
+        "special_mechanic_classification": "partial_modifier",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set bonus is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "canonical_id": "set_bonus:23:0",
+        "consumer_safe_fields": {
+          "display_name": "Keplahan's 2 piece bonus",
+          "special_mechanic_classification": "text_only_effect",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "description_text": [
+          "Volcanic Orbs now orbit you",
+          "Orbiting Volcanic Orbs cannot have their speed reduced by more than 50%"
+        ],
+        "display_name": "Keplahan's 2 piece bonus",
+        "modifier_references": [],
+        "modifier_rows": [],
+        "normalized_fields": {
+          "modifier_references": []
+        },
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set bonus data; text descriptions are not inferred as mechanics."
+          ],
+          "patch_version": "1.4.6_22986002",
+          "raw_reference": {
+            "bonus_index": 0,
+            "setId": 23
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_bonus:23:0",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_bonus"
+        },
+        "raw_reference": {
+          "bonus_index": 0,
+          "kind": "description",
+          "setId": 23
+        },
+        "required_pieces": 2,
+        "set_group_display_name": "Keplahan's",
+        "set_group_id": "set:23",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_bonus:23:0",
+        "special_mechanic_classification": "text_only_effect",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set bonus is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "canonical_id": "set_bonus:23:1",
+        "consumer_safe_fields": {
+          "display_name": "Keplahan's 2 piece bonus",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "description_text": [],
+        "display_name": "Keplahan's 2 piece bonus",
+        "modifier_references": [
+          {
+            "modifier_id": "set_bonus_modifier_set_bonus:23:1:0",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Lightning.Cold.Fire.Poison.special:11",
+            "source_record_id": "set_bonus:23:1:modifier:0"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": 0,
+            "modifier_id": "set_bonus_modifier_set_bonus:23:1:0",
+            "modifier_type": "ADDED",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Lightning.Cold.Fire.Poison.special:11",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": "1.4.6_22986002",
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "AbilityProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_bonus:23:1:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+              "source_type": "set_bonus_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 11,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Lightning",
+              "Cold",
+              "Fire",
+              "Poison"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.30000001192092896,
+            "value_min": 0.30000001192092896
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_bonus_modifier_set_bonus:23:1:0",
+              "property": "AbilityProperty",
+              "property_path": "ADDED.AbilityProperty.Lightning.Cold.Fire.Poison.special:11",
+              "source_record_id": "set_bonus:23:1:modifier:0"
+            }
+          ]
+        },
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set bonus data; text descriptions are not inferred as mechanics."
+          ],
+          "patch_version": "1.4.6_22986002",
+          "raw_reference": {
+            "bonus_index": 1,
+            "setId": 23
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_bonus:23:1",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_bonus"
+        },
+        "raw_reference": {
+          "bonus_index": 1,
+          "kind": "mod",
+          "setId": 23
+        },
+        "required_pieces": 2,
+        "set_group_display_name": "Keplahan's",
+        "set_group_id": "set:23",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_bonus:23:1",
+        "special_mechanic_classification": "partial_modifier",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set bonus is not stable planner-consumed in Phase 5."
+        ]
+      }
+    ],
+    "set_items": [
+      {
+        "attribute_requirements": {},
+        "base_item_id": "item_base:equippable:0:5",
+        "bonus_text": [
+          "[36,48,2]% Increased Duration of Chill Applied by Necrotic Spells"
+        ],
+        "canonical_id": "set_item:5",
+        "class_restrictions": [],
+        "classification": "armor",
+        "consumer_safe_fields": {
+          "display_name": "Isadora's Revenge",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Isadora's Revenge",
+        "equipment_slot": "helmet",
+        "implicit_ids": [],
+        "implicit_links": [
+          {
+            "base_item_id": "item_base:equippable:0:5",
+            "implicit_index": 0,
+            "modifier_type": "ADDED",
+            "property": "Armour"
+          }
+        ],
+        "item_category": "equipment",
+        "item_type": "helmet",
+        "level_requirement": 39,
+        "lore_text": "\"...and enraged she arose with murder in her eyes...\"",
+        "mastery_restrictions": [],
+        "modifier_references": [
+          {
+            "modifier_id": "set_item_modifier_set_item:5:0",
+            "property": "Penetration",
+            "property_path": "ADDED.Penetration.Necrotic",
+            "source_record_id": "set_item:5:modifier:0"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:5:1",
+            "property": "StunAvoidance",
+            "property_path": "ADDED.StunAvoidance",
+            "source_record_id": "set_item:5:modifier:1"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:5:2",
+            "property": "Health",
+            "property_path": "ADDED.Health",
+            "source_record_id": "set_item:5:modifier:2"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:5:3",
+            "property": "IncreasedAilmentDuration",
+            "property_path": "ADDED.IncreasedAilmentDuration.Necrotic.Spell",
+            "source_record_id": "set_item:5:modifier:3"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:5:0",
+            "modifier_type": "ADDED",
+            "property": "Penetration",
+            "property_path": "ADDED.Penetration.Necrotic",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "Penetration"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:5:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Necrotic"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.12,
+            "value_min": 0.06
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:5:1",
+            "modifier_type": "ADDED",
+            "property": "StunAvoidance",
+            "property_path": "ADDED.StunAvoidance",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 1,
+                "property": "StunAvoidance"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:5:modifier:1",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 1,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 300.0,
+            "value_min": 180.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:5:2",
+            "modifier_type": "ADDED",
+            "property": "Health",
+            "property_path": "ADDED.Health",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 2,
+                "property": "Health"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:5:modifier:2",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 3,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 82.0,
+            "value_min": 40.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": true,
+            "modifier_id": "set_item_modifier_set_item:5:3",
+            "modifier_type": "ADDED",
+            "property": "IncreasedAilmentDuration",
+            "property_path": "ADDED.IncreasedAilmentDuration.Necrotic.Spell",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 3,
+                "property": "IncreasedAilmentDuration"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:5:modifier:3",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 2,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Necrotic",
+              "Spell"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.48,
+            "value_min": 0.36
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_item_modifier_set_item:5:0",
+              "property": "Penetration",
+              "property_path": "ADDED.Penetration.Necrotic",
+              "source_record_id": "set_item:5:modifier:0"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:5:1",
+              "property": "StunAvoidance",
+              "property_path": "ADDED.StunAvoidance",
+              "source_record_id": "set_item:5:modifier:1"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:5:2",
+              "property": "Health",
+              "property_path": "ADDED.Health",
+              "source_record_id": "set_item:5:modifier:2"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:5:3",
+              "property": "IncreasedAilmentDuration",
+              "property_path": "ADDED.IncreasedAilmentDuration.Necrotic.Spell",
+              "source_record_id": "set_item:5:modifier:3"
+            }
+          ]
+        },
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_unique_set_export",
+          "notes": [
+            "Generated from extracted unique/set data; tooltip text is not inferred as mechanics."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "id": 5,
+            "name": "IsadoraRevenge"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_item:5",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+          "source_type": "set_item"
+        },
+        "raw_reference": {
+          "baseType": "HELMET",
+          "id": 5,
+          "name": "IsadoraRevenge",
+          "resolutionStatus": "resolved",
+          "resolvedBaseItem": {
+            "baseTypeID": 0,
+            "displayName": "Helmet",
+            "name": "Helmets",
+            "subType": {
+              "displayName": "Bronze Casque",
+              "levelRequirement": 39,
+              "name": "Bronze Helmet",
+              "subTypeID": 5
+            },
+            "type": "HELMET"
+          },
+          "subTypes": [
+            5
+          ]
+        },
+        "requirements": {
+          "attributes": {},
+          "class": null,
+          "level": 39,
+          "mastery": null
+        },
+        "set_group_display_name": null,
+        "set_group_id": "set:1",
+        "set_id": "set:1",
+        "slot": "helmet",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+        "source_id": "set_item:5",
+        "special_mechanic_classification": "partial_modifier",
+        "special_mechanic_notes": [
+          "Structured modifier rows exist but remain partial until value normalization is solved."
+        ],
+        "stable_calculable": false,
+        "subtype": "Bronze Helmet",
+        "support_status": "partial",
+        "tooltip_text": [
+          "[36,48,2]% Increased Duration of Chill Applied by Necrotic Spells"
+        ],
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Unique/set record is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "attribute_requirements": {},
+        "base_item_id": "item_base:equippable:2:2",
+        "bonus_text": [],
+        "canonical_id": "set_item:16",
+        "class_restrictions": [],
+        "classification": "accessory",
+        "consumer_safe_fields": {
+          "display_name": "Isadora's Tomb Binding",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Isadora's Tomb Binding",
+        "equipment_slot": "belt",
+        "implicit_ids": [],
+        "implicit_links": [
+          {
+            "base_item_id": "item_base:equippable:2:2",
+            "implicit_index": 0,
+            "modifier_type": "ADDED",
+            "property": "Armour"
+          },
+          {
+            "base_item_id": "item_base:equippable:2:2",
+            "implicit_index": 1,
+            "modifier_type": "ADDED",
+            "property": "PotionSlots"
+          }
+        ],
+        "item_category": "equipment",
+        "item_type": "belt",
+        "level_requirement": 19,
+        "lore_text": "\"...with a stake they slew her, and with silver they bound her...\"",
+        "mastery_restrictions": [],
+        "modifier_references": [
+          {
+            "modifier_id": "set_item_modifier_set_item:16:0",
+            "property": "Armour",
+            "property_path": "ADDED.Armour",
+            "source_record_id": "set_item:16:modifier:0"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:16:1",
+            "property": "CastSpeed",
+            "property_path": "INCREASED.CastSpeed",
+            "source_record_id": "set_item:16:modifier:1"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:16:2",
+            "property": "Armour",
+            "property_path": "INCREASED.Armour",
+            "source_record_id": "set_item:16:modifier:2"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:16:3",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Physical.Lightning.Fire.Necrotic",
+            "source_record_id": "set_item:16:modifier:3"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:16:0",
+            "modifier_type": "ADDED",
+            "property": "Armour",
+            "property_path": "ADDED.Armour",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "Armour"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:16:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 200.0,
+            "value_min": 200.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:16:1",
+            "modifier_type": "INCREASED",
+            "property": "CastSpeed",
+            "property_path": "INCREASED.CastSpeed",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 1,
+                "property": "CastSpeed"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:16:modifier:1",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.15,
+            "value_min": 0.1
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:16:2",
+            "modifier_type": "INCREASED",
+            "property": "Armour",
+            "property_path": "INCREASED.Armour",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 2,
+                "property": "Armour"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:16:modifier:2",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 1,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.35,
+            "value_min": 0.2
+          },
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:16:3",
+            "modifier_type": "ADDED",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Physical.Lightning.Fire.Necrotic",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 3,
+                "property": "PlayerProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:16:modifier:3",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Physical",
+              "Lightning",
+              "Fire",
+              "Necrotic"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.8,
+            "value_min": 0.8
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_item_modifier_set_item:16:0",
+              "property": "Armour",
+              "property_path": "ADDED.Armour",
+              "source_record_id": "set_item:16:modifier:0"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:16:1",
+              "property": "CastSpeed",
+              "property_path": "INCREASED.CastSpeed",
+              "source_record_id": "set_item:16:modifier:1"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:16:2",
+              "property": "Armour",
+              "property_path": "INCREASED.Armour",
+              "source_record_id": "set_item:16:modifier:2"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:16:3",
+              "property": "PlayerProperty",
+              "property_path": "ADDED.PlayerProperty.Physical.Lightning.Fire.Necrotic",
+              "source_record_id": "set_item:16:modifier:3"
+            }
+          ]
+        },
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_unique_set_export",
+          "notes": [
+            "Generated from extracted unique/set data; tooltip text is not inferred as mechanics."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "id": 16,
+            "name": "IsadoraTombbinding"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_item:16",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+          "source_type": "set_item"
+        },
+        "raw_reference": {
+          "baseType": "BELT",
+          "id": 16,
+          "name": "IsadoraTombbinding",
+          "resolutionStatus": "resolved",
+          "resolvedBaseItem": {
+            "baseTypeID": 2,
+            "displayName": "Belt",
+            "name": "Belts",
+            "subType": {
+              "displayName": "",
+              "levelRequirement": 19,
+              "name": "Plated Belt",
+              "subTypeID": 2
+            },
+            "type": "BELT"
+          },
+          "subTypes": [
+            2
+          ]
+        },
+        "requirements": {
+          "attributes": {},
+          "class": null,
+          "level": 19,
+          "mastery": null
+        },
+        "set_group_display_name": null,
+        "set_group_id": "set:1",
+        "set_id": "set:1",
+        "slot": "belt",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+        "source_id": "set_item:16",
+        "special_mechanic_classification": "partial_modifier",
+        "special_mechanic_notes": [
+          "Structured modifier rows exist but remain partial until value normalization is solved."
+        ],
+        "stable_calculable": false,
+        "subtype": "Plated Belt",
+        "support_status": "partial",
+        "tooltip_text": [],
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Unique/set record is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "attribute_requirements": {},
+        "base_item_id": "item_base:equippable:4:4",
+        "bonus_text": [
+          "+100% chance to chill with necrotic abilities if you have killed an enemy in the last 5 seconds"
+        ],
+        "canonical_id": "set_item:26",
+        "class_restrictions": [],
+        "classification": "armor",
+        "consumer_safe_fields": {
+          "display_name": "Isadora's Gravechill",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Isadora's Gravechill",
+        "equipment_slot": "gloves",
+        "implicit_ids": [],
+        "implicit_links": [
+          {
+            "base_item_id": "item_base:equippable:4:4",
+            "implicit_index": 0,
+            "modifier_type": "ADDED",
+            "property": "Armour"
+          },
+          {
+            "base_item_id": "item_base:equippable:4:4",
+            "implicit_index": 1,
+            "modifier_type": "INCREASED",
+            "property": "ManaRegen"
+          }
+        ],
+        "item_category": "equipment",
+        "item_type": "gloves",
+        "level_requirement": 31,
+        "lore_text": "\"...yet her strength was not blood, but of bone...\"",
+        "mastery_restrictions": [],
+        "modifier_references": [
+          {
+            "modifier_id": "set_item_modifier_set_item:26:0",
+            "property": "Damage",
+            "property_path": "ADDED.Damage.Cold.Spell",
+            "source_record_id": "set_item:26:modifier:0"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:26:1",
+            "property": "Health",
+            "property_path": "ADDED.Health",
+            "source_record_id": "set_item:26:modifier:1"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:26:0",
+            "modifier_type": "ADDED",
+            "property": "Damage",
+            "property_path": "ADDED.Damage.Cold.Spell",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "Damage"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:26:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 1,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Cold",
+              "Spell"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 20.0,
+            "value_min": 12.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:26:1",
+            "modifier_type": "ADDED",
+            "property": "Health",
+            "property_path": "ADDED.Health",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 1,
+                "property": "Health"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:26:modifier:1",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 80.0,
+            "value_min": 48.0
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_item_modifier_set_item:26:0",
+              "property": "Damage",
+              "property_path": "ADDED.Damage.Cold.Spell",
+              "source_record_id": "set_item:26:modifier:0"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:26:1",
+              "property": "Health",
+              "property_path": "ADDED.Health",
+              "source_record_id": "set_item:26:modifier:1"
+            }
+          ]
+        },
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_unique_set_export",
+          "notes": [
+            "Generated from extracted unique/set data; tooltip text is not inferred as mechanics."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "id": 26,
+            "name": "IsadoraGravechill"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_item:26",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+          "source_type": "set_item"
+        },
+        "raw_reference": {
+          "baseType": "GLOVES",
+          "id": 26,
+          "name": "IsadoraGravechill",
+          "resolutionStatus": "resolved",
+          "resolvedBaseItem": {
+            "baseTypeID": 4,
+            "displayName": "Gloves",
+            "name": "Gloves",
+            "subType": {
+              "displayName": "",
+              "levelRequirement": 31,
+              "name": "Noble Gloves",
+              "subTypeID": 4
+            },
+            "type": "GLOVES"
+          },
+          "subTypes": [
+            4
+          ]
+        },
+        "requirements": {
+          "attributes": {},
+          "class": null,
+          "level": 31,
+          "mastery": null
+        },
+        "set_group_display_name": null,
+        "set_group_id": "set:1",
+        "set_id": "set:1",
+        "slot": "gloves",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+        "source_id": "set_item:26",
+        "special_mechanic_classification": "partial_modifier",
+        "special_mechanic_notes": [
+          "Structured modifier rows exist but remain partial until value normalization is solved."
+        ],
+        "stable_calculable": false,
+        "subtype": "Noble Gloves",
+        "support_status": "partial",
+        "tooltip_text": [
+          "+100% chance to chill with necrotic abilities if you have killed an enemy in the last 5 seconds"
+        ],
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Unique/set record is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "attribute_requirements": {},
+        "base_item_id": "item_base:equippable:20:2",
+        "bonus_text": [],
+        "canonical_id": "set_item:57",
+        "class_restrictions": [],
+        "classification": "accessory",
+        "consumer_safe_fields": {
+          "display_name": "The Invoker's Frozen Heart",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "The Invoker's Frozen Heart",
+        "equipment_slot": "amulet",
+        "implicit_ids": [],
+        "implicit_links": [
+          {
+            "base_item_id": "item_base:equippable:20:2",
+            "implicit_index": 0,
+            "modifier_type": "INCREASED",
+            "property": "CriticalChance"
+          }
+        ],
+        "item_category": "equipment",
+        "item_type": "amulet",
+        "level_requirement": 24,
+        "lore_text": "...alone with ice in his heart, he gained mastery of his art...",
+        "mastery_restrictions": [],
+        "modifier_references": [
+          {
+            "modifier_id": "set_item_modifier_set_item:57:0",
+            "property": "CastSpeed",
+            "property_path": "INCREASED.CastSpeed.Cold",
+            "source_record_id": "set_item:57:modifier:0"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:57:1",
+            "property": "FreezeRateMultiplier",
+            "property_path": "ADDED.FreezeRateMultiplier",
+            "source_record_id": "set_item:57:modifier:1"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:57:2",
+            "property": "LevelOfSkills",
+            "property_path": "ADDED.LevelOfSkills.Lightning.Cold.Necrotic.Elemental",
+            "source_record_id": "set_item:57:modifier:2"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:57:3",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Physical.Melee",
+            "source_record_id": "set_item:57:modifier:3"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:57:0",
+            "modifier_type": "INCREASED",
+            "property": "CastSpeed",
+            "property_path": "INCREASED.CastSpeed.Cold",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "CastSpeed"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:57:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Cold"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.21,
+            "value_min": 0.21
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:57:1",
+            "modifier_type": "ADDED",
+            "property": "FreezeRateMultiplier",
+            "property_path": "ADDED.FreezeRateMultiplier",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 1,
+                "property": "FreezeRateMultiplier"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:57:modifier:1",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.75,
+            "value_min": 0.3
+          },
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:57:2",
+            "modifier_type": "ADDED",
+            "property": "LevelOfSkills",
+            "property_path": "ADDED.LevelOfSkills.Lightning.Cold.Necrotic.Elemental",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 2,
+                "property": "LevelOfSkills"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:57:modifier:2",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Lightning",
+              "Cold",
+              "Necrotic",
+              "Elemental"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 1.0,
+            "value_min": 1.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:57:3",
+            "modifier_type": "ADDED",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Physical.Melee",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 3,
+                "property": "PlayerProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:57:modifier:3",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 1,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Physical",
+              "Melee"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.6,
+            "value_min": 0.3
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_item_modifier_set_item:57:0",
+              "property": "CastSpeed",
+              "property_path": "INCREASED.CastSpeed.Cold",
+              "source_record_id": "set_item:57:modifier:0"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:57:1",
+              "property": "FreezeRateMultiplier",
+              "property_path": "ADDED.FreezeRateMultiplier",
+              "source_record_id": "set_item:57:modifier:1"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:57:2",
+              "property": "LevelOfSkills",
+              "property_path": "ADDED.LevelOfSkills.Lightning.Cold.Necrotic.Elemental",
+              "source_record_id": "set_item:57:modifier:2"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:57:3",
+              "property": "PlayerProperty",
+              "property_path": "ADDED.PlayerProperty.Physical.Melee",
+              "source_record_id": "set_item:57:modifier:3"
+            }
+          ]
+        },
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_unique_set_export",
+          "notes": [
+            "Generated from extracted unique/set data; tooltip text is not inferred as mechanics."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "id": 57,
+            "name": "ElementalistFrozenHeart"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_item:57",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+          "source_type": "set_item"
+        },
+        "raw_reference": {
+          "baseType": "AMULET",
+          "id": 57,
+          "name": "ElementalistFrozenHeart",
+          "resolutionStatus": "resolved",
+          "resolvedBaseItem": {
+            "baseTypeID": 20,
+            "displayName": "Amulet",
+            "name": "Amulet",
+            "subType": {
+              "displayName": "",
+              "levelRequirement": 24,
+              "name": "Silver Amulet",
+              "subTypeID": 2
+            },
+            "type": "AMULET"
+          },
+          "subTypes": [
+            2
+          ]
+        },
+        "requirements": {
+          "attributes": {},
+          "class": null,
+          "level": 24,
+          "mastery": null
+        },
+        "set_group_display_name": null,
+        "set_group_id": "set:2",
+        "set_id": "set:2",
+        "slot": "amulet",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+        "source_id": "set_item:57",
+        "special_mechanic_classification": "partial_modifier",
+        "special_mechanic_notes": [
+          "Structured modifier rows exist but remain partial until value normalization is solved."
+        ],
+        "stable_calculable": false,
+        "subtype": "Silver Amulet",
+        "support_status": "partial",
+        "tooltip_text": [],
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Unique/set record is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "attribute_requirements": {},
+        "base_item_id": "item_base:equippable:21:1",
+        "bonus_text": [],
+        "canonical_id": "set_item:63",
+        "class_restrictions": [],
+        "classification": "accessory",
+        "consumer_safe_fields": {
+          "display_name": "The Invoker's Scorching Grasp",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "The Invoker's Scorching Grasp",
+        "equipment_slot": "ring",
+        "implicit_ids": [],
+        "implicit_links": [
+          {
+            "base_item_id": "item_base:equippable:21:1",
+            "implicit_index": 0,
+            "modifier_type": "ADDED",
+            "property": "FireResistance"
+          },
+          {
+            "base_item_id": "item_base:equippable:21:1",
+            "implicit_index": 1,
+            "modifier_type": "INCREASED",
+            "property": "Damage"
+          }
+        ],
+        "item_category": "equipment",
+        "item_type": "ring",
+        "level_requirement": 35,
+        "lore_text": "...his master fell, a firey death knell...",
+        "mastery_restrictions": [],
+        "modifier_references": [
+          {
+            "modifier_id": "set_item_modifier_set_item:63:0",
+            "property": "AilmentChance",
+            "property_path": "ADDED.AilmentChance",
+            "source_record_id": "set_item:63:modifier:0"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:63:1",
+            "property": "Damage",
+            "property_path": "INCREASED.Damage.Fire.DoT",
+            "source_record_id": "set_item:63:modifier:1"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:63:2",
+            "property": "CastSpeed",
+            "property_path": "INCREASED.CastSpeed.Fire",
+            "source_record_id": "set_item:63:modifier:2"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:63:3",
+            "property": "LevelOfSkills",
+            "property_path": "ADDED.LevelOfSkills.Void.Poison.Spell",
+            "source_record_id": "set_item:63:modifier:3"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:63:0",
+            "modifier_type": "ADDED",
+            "property": "AilmentChance",
+            "property_path": "ADDED.AilmentChance",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "AilmentChance"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:63:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.75,
+            "value_min": 0.3
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:63:1",
+            "modifier_type": "INCREASED",
+            "property": "Damage",
+            "property_path": "INCREASED.Damage.Fire.DoT",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 1,
+                "property": "Damage"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:63:modifier:1",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 1,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Fire",
+              "DoT"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.75,
+            "value_min": 0.3
+          },
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:63:2",
+            "modifier_type": "INCREASED",
+            "property": "CastSpeed",
+            "property_path": "INCREASED.CastSpeed.Fire",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 2,
+                "property": "CastSpeed"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:63:modifier:2",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Fire"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.21,
+            "value_min": 0.21
+          },
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:63:3",
+            "modifier_type": "ADDED",
+            "property": "LevelOfSkills",
+            "property_path": "ADDED.LevelOfSkills.Void.Poison.Spell",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 3,
+                "property": "LevelOfSkills"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:63:modifier:3",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Void",
+              "Poison",
+              "Spell"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 1.0,
+            "value_min": 1.0
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_item_modifier_set_item:63:0",
+              "property": "AilmentChance",
+              "property_path": "ADDED.AilmentChance",
+              "source_record_id": "set_item:63:modifier:0"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:63:1",
+              "property": "Damage",
+              "property_path": "INCREASED.Damage.Fire.DoT",
+              "source_record_id": "set_item:63:modifier:1"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:63:2",
+              "property": "CastSpeed",
+              "property_path": "INCREASED.CastSpeed.Fire",
+              "source_record_id": "set_item:63:modifier:2"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:63:3",
+              "property": "LevelOfSkills",
+              "property_path": "ADDED.LevelOfSkills.Void.Poison.Spell",
+              "source_record_id": "set_item:63:modifier:3"
+            }
+          ]
+        },
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_unique_set_export",
+          "notes": [
+            "Generated from extracted unique/set data; tooltip text is not inferred as mechanics."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "id": 63,
+            "name": "ElementalistScorchingGrasp"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_item:63",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+          "source_type": "set_item"
+        },
+        "raw_reference": {
+          "baseType": "RING",
+          "id": 63,
+          "name": "ElementalistScorchingGrasp",
+          "resolutionStatus": "resolved",
+          "resolvedBaseItem": {
+            "baseTypeID": 21,
+            "displayName": "Ring",
+            "name": "Ring",
+            "subType": {
+              "displayName": "",
+              "levelRequirement": 62,
+              "name": "Ruby Ring",
+              "subTypeID": 1
+            },
+            "type": "RING"
+          },
+          "subTypes": [
+            1
+          ]
+        },
+        "requirements": {
+          "attributes": {},
+          "class": null,
+          "level": 35,
+          "mastery": null
+        },
+        "set_group_display_name": null,
+        "set_group_id": "set:2",
+        "set_id": "set:2",
+        "slot": "ring",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+        "source_id": "set_item:63",
+        "special_mechanic_classification": "partial_modifier",
+        "special_mechanic_notes": [
+          "Structured modifier rows exist but remain partial until value normalization is solved."
+        ],
+        "stable_calculable": false,
+        "subtype": "Ruby Ring",
+        "support_status": "partial",
+        "tooltip_text": [],
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Unique/set record is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "attribute_requirements": {},
+        "base_item_id": "item_base:equippable:21:2",
+        "bonus_text": [],
+        "canonical_id": "set_item:64",
+        "class_restrictions": [],
+        "classification": "accessory",
+        "consumer_safe_fields": {
+          "display_name": "The Invoker's Static Touch",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "The Invoker's Static Touch",
+        "equipment_slot": "ring",
+        "implicit_ids": [],
+        "implicit_links": [
+          {
+            "base_item_id": "item_base:equippable:21:2",
+            "implicit_index": 0,
+            "modifier_type": "ADDED",
+            "property": "Mana"
+          },
+          {
+            "base_item_id": "item_base:equippable:21:2",
+            "implicit_index": 1,
+            "modifier_type": "INCREASED",
+            "property": "ManaRegen"
+          }
+        ],
+        "item_category": "equipment",
+        "item_type": "ring",
+        "level_requirement": 29,
+        "lore_text": "...electrified with ambition, he cast spells beyond his cognition...",
+        "mastery_restrictions": [],
+        "modifier_references": [
+          {
+            "modifier_id": "set_item_modifier_set_item:64:0",
+            "property": "AilmentChance",
+            "property_path": "ADDED.AilmentChance.Spell",
+            "source_record_id": "set_item:64:modifier:0"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:64:1",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Fire.Necrotic.Poison.Elemental",
+            "source_record_id": "set_item:64:modifier:1"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:64:2",
+            "property": "Damage",
+            "property_path": "ADDED.Damage.Lightning.Spell",
+            "source_record_id": "set_item:64:modifier:2"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:64:3",
+            "property": "LevelOfSkills",
+            "property_path": "ADDED.LevelOfSkills.Lightning.Cold.Necrotic.Spell",
+            "source_record_id": "set_item:64:modifier:3"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:64:0",
+            "modifier_type": "ADDED",
+            "property": "AilmentChance",
+            "property_path": "ADDED.AilmentChance.Spell",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "AilmentChance"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:64:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 1,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Spell"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.75,
+            "value_min": 0.3
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:64:1",
+            "modifier_type": "ADDED",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Fire.Necrotic.Poison.Elemental",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 1,
+                "property": "PlayerProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:64:modifier:1",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Fire",
+              "Necrotic",
+              "Poison",
+              "Elemental"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.1,
+            "value_min": 0.05
+          },
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:64:2",
+            "modifier_type": "ADDED",
+            "property": "Damage",
+            "property_path": "ADDED.Damage.Lightning.Spell",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 2,
+                "property": "Damage"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:64:modifier:2",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Lightning",
+              "Spell"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 15.0,
+            "value_min": 15.0
+          },
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:64:3",
+            "modifier_type": "ADDED",
+            "property": "LevelOfSkills",
+            "property_path": "ADDED.LevelOfSkills.Lightning.Cold.Necrotic.Spell",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 3,
+                "property": "LevelOfSkills"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:64:modifier:3",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Lightning",
+              "Cold",
+              "Necrotic",
+              "Spell"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 1.0,
+            "value_min": 1.0
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_item_modifier_set_item:64:0",
+              "property": "AilmentChance",
+              "property_path": "ADDED.AilmentChance.Spell",
+              "source_record_id": "set_item:64:modifier:0"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:64:1",
+              "property": "PlayerProperty",
+              "property_path": "ADDED.PlayerProperty.Fire.Necrotic.Poison.Elemental",
+              "source_record_id": "set_item:64:modifier:1"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:64:2",
+              "property": "Damage",
+              "property_path": "ADDED.Damage.Lightning.Spell",
+              "source_record_id": "set_item:64:modifier:2"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:64:3",
+              "property": "LevelOfSkills",
+              "property_path": "ADDED.LevelOfSkills.Lightning.Cold.Necrotic.Spell",
+              "source_record_id": "set_item:64:modifier:3"
+            }
+          ]
+        },
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_unique_set_export",
+          "notes": [
+            "Generated from extracted unique/set data; tooltip text is not inferred as mechanics."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "id": 64,
+            "name": "ElementalistStaticTouch"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_item:64",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+          "source_type": "set_item"
+        },
+        "raw_reference": {
+          "baseType": "RING",
+          "id": 64,
+          "name": "ElementalistStaticTouch",
+          "resolutionStatus": "resolved",
+          "resolvedBaseItem": {
+            "baseTypeID": 21,
+            "displayName": "Ring",
+            "name": "Ring",
+            "subType": {
+              "displayName": "",
+              "levelRequirement": 40,
+              "name": "Sapphire Ring",
+              "subTypeID": 2
+            },
+            "type": "RING"
+          },
+          "subTypes": [
+            2
+          ]
+        },
+        "requirements": {
+          "attributes": {},
+          "class": null,
+          "level": 29,
+          "mastery": null
+        },
+        "set_group_display_name": null,
+        "set_group_id": "set:2",
+        "set_id": "set:2",
+        "slot": "ring",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+        "source_id": "set_item:64",
+        "special_mechanic_classification": "partial_modifier",
+        "special_mechanic_notes": [
+          "Structured modifier rows exist but remain partial until value normalization is solved."
+        ],
+        "stable_calculable": false,
+        "subtype": "Sapphire Ring",
+        "support_status": "partial",
+        "tooltip_text": [],
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Unique/set record is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "attribute_requirements": {},
+        "base_item_id": "item_base:equippable:19:20",
+        "bonus_text": [
+          "Your bees are immune to damage over time"
+        ],
+        "canonical_id": "set_item:77",
+        "class_restrictions": [],
+        "classification": "accessory",
+        "consumer_safe_fields": {
+          "display_name": "Apiarist's Smoker",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Apiarist's Smoker",
+        "equipment_slot": "catalyst",
+        "implicit_ids": [],
+        "implicit_links": [
+          {
+            "base_item_id": "item_base:equippable:19:20",
+            "implicit_index": 0,
+            "modifier_type": "ADDED",
+            "property": "HealthRegen"
+          }
+        ],
+        "item_category": "equipment",
+        "item_type": "catalyst",
+        "level_requirement": 40,
+        "lore_text": null,
+        "mastery_restrictions": [],
+        "modifier_references": [
+          {
+            "modifier_id": "set_item_modifier_set_item:77:0",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Cold",
+            "source_record_id": "set_item:77:modifier:0"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:77:1",
+            "property": "AilmentChance",
+            "property_path": "ADDED.AilmentChance.Minion",
+            "source_record_id": "set_item:77:modifier:1"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:77:2",
+            "property": "DamageTaken",
+            "property_path": "MORE.DamageTaken.DoT",
+            "source_record_id": "set_item:77:modifier:2"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:77:3",
+            "property": "Movespeed",
+            "property_path": "INCREASED.Movespeed.Minion",
+            "source_record_id": "set_item:77:modifier:3"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:77:4",
+            "property": "DodgeRating",
+            "property_path": "ADDED.DodgeRating.Minion",
+            "source_record_id": "set_item:77:modifier:4"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:77:5",
+            "property": "Endurance",
+            "property_path": "ADDED.Endurance",
+            "source_record_id": "set_item:77:modifier:5"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:77:0",
+            "modifier_type": "ADDED",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Cold",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "PlayerProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:77:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Cold"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 3.0,
+            "value_min": 2.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:77:1",
+            "modifier_type": "ADDED",
+            "property": "AilmentChance",
+            "property_path": "ADDED.AilmentChance.Minion",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 1,
+                "property": "AilmentChance"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:77:modifier:1",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Minion"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.6,
+            "value_min": 0.3
+          },
+          {
+            "can_roll": null,
+            "extra_tag": 353,
+            "hide_in_tooltip": true,
+            "modifier_id": "set_item_modifier_set_item:77:2",
+            "modifier_type": "MORE",
+            "property": "DamageTaken",
+            "property_path": "MORE.DamageTaken.DoT",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 2,
+                "property": "DamageTaken"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:77:modifier:2",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 353,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "DoT"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": -1.0,
+            "value_min": -1.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:77:3",
+            "modifier_type": "INCREASED",
+            "property": "Movespeed",
+            "property_path": "INCREASED.Movespeed.Minion",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 3,
+                "property": "Movespeed"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:77:modifier:3",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Minion"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.35,
+            "value_min": 0.2
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:77:4",
+            "modifier_type": "ADDED",
+            "property": "DodgeRating",
+            "property_path": "ADDED.DodgeRating.Minion",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 4,
+                "property": "DodgeRating"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:77:modifier:4",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Minion"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 400.0,
+            "value_min": 200.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:77:5",
+            "modifier_type": "ADDED",
+            "property": "Endurance",
+            "property_path": "ADDED.Endurance",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 5,
+                "property": "Endurance"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:77:modifier:5",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.18,
+            "value_min": 0.12
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_item_modifier_set_item:77:0",
+              "property": "PlayerProperty",
+              "property_path": "ADDED.PlayerProperty.Cold",
+              "source_record_id": "set_item:77:modifier:0"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:77:1",
+              "property": "AilmentChance",
+              "property_path": "ADDED.AilmentChance.Minion",
+              "source_record_id": "set_item:77:modifier:1"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:77:2",
+              "property": "DamageTaken",
+              "property_path": "MORE.DamageTaken.DoT",
+              "source_record_id": "set_item:77:modifier:2"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:77:3",
+              "property": "Movespeed",
+              "property_path": "INCREASED.Movespeed.Minion",
+              "source_record_id": "set_item:77:modifier:3"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:77:4",
+              "property": "DodgeRating",
+              "property_path": "ADDED.DodgeRating.Minion",
+              "source_record_id": "set_item:77:modifier:4"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:77:5",
+              "property": "Endurance",
+              "property_path": "ADDED.Endurance",
+              "source_record_id": "set_item:77:modifier:5"
+            }
+          ]
+        },
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_unique_set_export",
+          "notes": [
+            "Generated from extracted unique/set data; tooltip text is not inferred as mechanics."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "id": 77,
+            "name": "Apiarists Smoker"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_item:77",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+          "source_type": "set_item"
+        },
+        "raw_reference": {
+          "baseType": "CATALYST",
+          "id": 77,
+          "name": "Apiarists Smoker",
+          "resolutionStatus": "resolved",
+          "resolvedBaseItem": {
+            "baseTypeID": 19,
+            "displayName": "Off-Hand Catalyst",
+            "name": "Catalyst",
+            "subType": {
+              "displayName": "Iron Smoker",
+              "levelRequirement": 40,
+              "name": "Iron Smoker",
+              "subTypeID": 20
+            },
+            "type": "CATALYST"
+          },
+          "subTypes": [
+            20
+          ]
+        },
+        "requirements": {
+          "attributes": {},
+          "class": null,
+          "level": 40,
+          "mastery": null
+        },
+        "set_group_display_name": null,
+        "set_group_id": "set:3",
+        "set_id": "set:3",
+        "slot": "catalyst",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+        "source_id": "set_item:77",
+        "special_mechanic_classification": "partial_modifier",
+        "special_mechanic_notes": [
+          "Structured modifier rows exist but remain partial until value normalization is solved."
+        ],
+        "stable_calculable": false,
+        "subtype": "Iron Smoker",
+        "support_status": "partial",
+        "tooltip_text": [
+          "Your bees are immune to damage over time"
+        ],
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Unique/set record is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "attribute_requirements": {},
+        "base_item_id": "item_base:equippable:1:1",
+        "bonus_text": [
+          "+[80, 150, 3] health for you and your minions",
+          "+[200, 400, 5] armor for you and your minions"
+        ],
+        "canonical_id": "set_item:78",
+        "class_restrictions": [],
+        "classification": "armor",
+        "consumer_safe_fields": {
+          "display_name": "Apiarist's Suit",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Apiarist's Suit",
+        "equipment_slot": "body_armor",
+        "implicit_ids": [],
+        "implicit_links": [
+          {
+            "base_item_id": "item_base:equippable:1:1",
+            "implicit_index": 0,
+            "modifier_type": "ADDED",
+            "property": "Armour"
+          }
+        ],
+        "item_category": "equipment",
+        "item_type": "body_armor",
+        "level_requirement": 38,
+        "lore_text": null,
+        "mastery_restrictions": [],
+        "modifier_references": [
+          {
+            "modifier_id": "set_item_modifier_set_item:78:0",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Cold",
+            "source_record_id": "set_item:78:modifier:0"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:78:1",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Physical.Fire.Void.Necrotic.Poison.Melee",
+            "source_record_id": "set_item:78:modifier:1"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:78:2",
+            "property": "Attunement",
+            "property_path": "ADDED.Attunement",
+            "source_record_id": "set_item:78:modifier:2"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:78:3",
+            "property": "Health",
+            "property_path": "ADDED.Health",
+            "source_record_id": "set_item:78:modifier:3"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:78:4",
+            "property": "Health",
+            "property_path": "ADDED.Health.Minion",
+            "source_record_id": "set_item:78:modifier:4"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:78:5",
+            "property": "Armour",
+            "property_path": "ADDED.Armour",
+            "source_record_id": "set_item:78:modifier:5"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:78:6",
+            "property": "Armour",
+            "property_path": "ADDED.Armour.Minion",
+            "source_record_id": "set_item:78:modifier:6"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:78:7",
+            "property": "PhysicalResistance",
+            "property_path": "ADDED.PhysicalResistance",
+            "source_record_id": "set_item:78:modifier:7"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:78:8",
+            "property": "PoisonResistance",
+            "property_path": "ADDED.PoisonResistance",
+            "source_record_id": "set_item:78:modifier:8"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:78:0",
+            "modifier_type": "ADDED",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Cold",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "PlayerProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:78:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Cold"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 3.0,
+            "value_min": 2.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:78:1",
+            "modifier_type": "ADDED",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Physical.Fire.Void.Necrotic.Poison.Melee",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 1,
+                "property": "PlayerProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:78:modifier:1",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Physical",
+              "Fire",
+              "Void",
+              "Necrotic",
+              "Poison",
+              "Melee"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 6.0,
+            "value_min": 4.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:78:2",
+            "modifier_type": "ADDED",
+            "property": "Attunement",
+            "property_path": "ADDED.Attunement",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 2,
+                "property": "Attunement"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:78:modifier:2",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 18.0,
+            "value_min": 8.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": true,
+            "modifier_id": "set_item_modifier_set_item:78:3",
+            "modifier_type": "ADDED",
+            "property": "Health",
+            "property_path": "ADDED.Health",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 3,
+                "property": "Health"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:78:modifier:3",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 150.0,
+            "value_min": 80.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": true,
+            "modifier_id": "set_item_modifier_set_item:78:4",
+            "modifier_type": "ADDED",
+            "property": "Health",
+            "property_path": "ADDED.Health.Minion",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 4,
+                "property": "Health"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:78:modifier:4",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Minion"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 150.0,
+            "value_min": 80.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": true,
+            "modifier_id": "set_item_modifier_set_item:78:5",
+            "modifier_type": "ADDED",
+            "property": "Armour",
+            "property_path": "ADDED.Armour",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 5,
+                "property": "Armour"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:78:modifier:5",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 400.0,
+            "value_min": 200.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": true,
+            "modifier_id": "set_item_modifier_set_item:78:6",
+            "modifier_type": "ADDED",
+            "property": "Armour",
+            "property_path": "ADDED.Armour.Minion",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 6,
+                "property": "Armour"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:78:modifier:6",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Minion"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 400.0,
+            "value_min": 200.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:78:7",
+            "modifier_type": "ADDED",
+            "property": "PhysicalResistance",
+            "property_path": "ADDED.PhysicalResistance",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 7,
+                "property": "PhysicalResistance"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:78:modifier:7",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.3,
+            "value_min": 0.2
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:78:8",
+            "modifier_type": "ADDED",
+            "property": "PoisonResistance",
+            "property_path": "ADDED.PoisonResistance",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 8,
+                "property": "PoisonResistance"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:78:modifier:8",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.75,
+            "value_min": 0.5
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_item_modifier_set_item:78:0",
+              "property": "PlayerProperty",
+              "property_path": "ADDED.PlayerProperty.Cold",
+              "source_record_id": "set_item:78:modifier:0"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:78:1",
+              "property": "PlayerProperty",
+              "property_path": "ADDED.PlayerProperty.Physical.Fire.Void.Necrotic.Poison.Melee",
+              "source_record_id": "set_item:78:modifier:1"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:78:2",
+              "property": "Attunement",
+              "property_path": "ADDED.Attunement",
+              "source_record_id": "set_item:78:modifier:2"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:78:3",
+              "property": "Health",
+              "property_path": "ADDED.Health",
+              "source_record_id": "set_item:78:modifier:3"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:78:4",
+              "property": "Health",
+              "property_path": "ADDED.Health.Minion",
+              "source_record_id": "set_item:78:modifier:4"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:78:5",
+              "property": "Armour",
+              "property_path": "ADDED.Armour",
+              "source_record_id": "set_item:78:modifier:5"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:78:6",
+              "property": "Armour",
+              "property_path": "ADDED.Armour.Minion",
+              "source_record_id": "set_item:78:modifier:6"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:78:7",
+              "property": "PhysicalResistance",
+              "property_path": "ADDED.PhysicalResistance",
+              "source_record_id": "set_item:78:modifier:7"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:78:8",
+              "property": "PoisonResistance",
+              "property_path": "ADDED.PoisonResistance",
+              "source_record_id": "set_item:78:modifier:8"
+            }
+          ]
+        },
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_unique_set_export",
+          "notes": [
+            "Generated from extracted unique/set data; tooltip text is not inferred as mechanics."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "id": 78,
+            "name": "Apiarists Suit"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_item:78",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+          "source_type": "set_item"
+        },
+        "raw_reference": {
+          "baseType": "BODY_ARMOR",
+          "id": 78,
+          "name": "Apiarists Suit",
+          "resolutionStatus": "resolved",
+          "resolvedBaseItem": {
+            "baseTypeID": 1,
+            "displayName": "Body Armor",
+            "name": "Body Armor",
+            "subType": {
+              "displayName": "Leather Coat",
+              "levelRequirement": 5,
+              "name": "Leather Coat",
+              "subTypeID": 1
+            },
+            "type": "BODY_ARMOR"
+          },
+          "subTypes": [
+            1
+          ]
+        },
+        "requirements": {
+          "attributes": {},
+          "class": null,
+          "level": 38,
+          "mastery": null
+        },
+        "set_group_display_name": null,
+        "set_group_id": "set:3",
+        "set_id": "set:3",
+        "slot": "body_armor",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+        "source_id": "set_item:78",
+        "special_mechanic_classification": "partial_modifier",
+        "special_mechanic_notes": [
+          "Structured modifier rows exist but remain partial until value normalization is solved."
+        ],
+        "stable_calculable": false,
+        "subtype": "Leather Coat",
+        "support_status": "partial",
+        "tooltip_text": [
+          "+[80, 150, 3] health for you and your minions",
+          "+[200, 400, 5] armor for you and your minions"
+        ],
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Unique/set record is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "attribute_requirements": {},
+        "base_item_id": "item_base:equippable:7:3",
+        "bonus_text": [
+          "+[12,24,1] Melee Damage for your Summoned Bees"
+        ],
+        "canonical_id": "set_item:79",
+        "class_restrictions": [],
+        "classification": "weapon",
+        "consumer_safe_fields": {
+          "display_name": "Apiarist's Comb",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Apiarist's Comb",
+        "equipment_slot": "one_handed_maces",
+        "implicit_ids": [],
+        "implicit_links": [
+          {
+            "base_item_id": "item_base:equippable:7:3",
+            "implicit_index": 0,
+            "modifier_type": "ADDED",
+            "property": "Damage"
+          },
+          {
+            "base_item_id": "item_base:equippable:7:3",
+            "implicit_index": 1,
+            "modifier_type": "INCREASED",
+            "property": "Damage"
+          }
+        ],
+        "item_category": "equipment",
+        "item_type": "one_handed_maces",
+        "level_requirement": 42,
+        "lore_text": null,
+        "mastery_restrictions": [],
+        "modifier_references": [
+          {
+            "modifier_id": "set_item_modifier_set_item:79:0",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Cold",
+            "source_record_id": "set_item:79:modifier:0"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:79:1",
+            "property": "Damage",
+            "property_path": "ADDED.Damage.Melee",
+            "source_record_id": "set_item:79:modifier:1"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:79:2",
+            "property": "Damage",
+            "property_path": "INCREASED.Damage.Minion",
+            "source_record_id": "set_item:79:modifier:2"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:79:3",
+            "property": "AttackSpeed",
+            "property_path": "INCREASED.AttackSpeed.Minion",
+            "source_record_id": "set_item:79:modifier:3"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:79:4",
+            "property": "AilmentChance",
+            "property_path": "ADDED.AilmentChance.Minion",
+            "source_record_id": "set_item:79:modifier:4"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:79:0",
+            "modifier_type": "ADDED",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Cold",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "PlayerProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:79:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Cold"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 8.0,
+            "value_min": 4.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 353,
+            "hide_in_tooltip": true,
+            "modifier_id": "set_item_modifier_set_item:79:1",
+            "modifier_type": "ADDED",
+            "property": "Damage",
+            "property_path": "ADDED.Damage.Melee",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 1,
+                "property": "Damage"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:79:modifier:1",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 353,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Melee"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 24.0,
+            "value_min": 12.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:79:2",
+            "modifier_type": "INCREASED",
+            "property": "Damage",
+            "property_path": "INCREASED.Damage.Minion",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 2,
+                "property": "Damage"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:79:modifier:2",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Minion"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.8,
+            "value_min": 0.4
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:79:3",
+            "modifier_type": "INCREASED",
+            "property": "AttackSpeed",
+            "property_path": "INCREASED.AttackSpeed.Minion",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 3,
+                "property": "AttackSpeed"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:79:modifier:3",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Minion"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.18,
+            "value_min": 0.08
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:79:4",
+            "modifier_type": "ADDED",
+            "property": "AilmentChance",
+            "property_path": "ADDED.AilmentChance.Minion",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 4,
+                "property": "AilmentChance"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:79:modifier:4",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Minion"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.6,
+            "value_min": 0.3
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_item_modifier_set_item:79:0",
+              "property": "PlayerProperty",
+              "property_path": "ADDED.PlayerProperty.Cold",
+              "source_record_id": "set_item:79:modifier:0"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:79:1",
+              "property": "Damage",
+              "property_path": "ADDED.Damage.Melee",
+              "source_record_id": "set_item:79:modifier:1"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:79:2",
+              "property": "Damage",
+              "property_path": "INCREASED.Damage.Minion",
+              "source_record_id": "set_item:79:modifier:2"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:79:3",
+              "property": "AttackSpeed",
+              "property_path": "INCREASED.AttackSpeed.Minion",
+              "source_record_id": "set_item:79:modifier:3"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:79:4",
+              "property": "AilmentChance",
+              "property_path": "ADDED.AilmentChance.Minion",
+              "source_record_id": "set_item:79:modifier:4"
+            }
+          ]
+        },
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_unique_set_export",
+          "notes": [
+            "Generated from extracted unique/set data; tooltip text is not inferred as mechanics."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "id": 79,
+            "name": "Apiarists Comb"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_item:79",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+          "source_type": "set_item"
+        },
+        "raw_reference": {
+          "baseType": "ONE_HANDED_MACES",
+          "id": 79,
+          "name": "Apiarists Comb",
+          "resolutionStatus": "resolved",
+          "resolvedBaseItem": {
+            "baseTypeID": 7,
+            "displayName": "One-Handed Mace",
+            "name": "1H Maces",
+            "subType": {
+              "displayName": "",
+              "levelRequirement": 29,
+              "name": "Morning Star",
+              "subTypeID": 3
+            },
+            "type": "ONE_HANDED_MACES"
+          },
+          "subTypes": [
+            3
+          ]
+        },
+        "requirements": {
+          "attributes": {},
+          "class": null,
+          "level": 42,
+          "mastery": null
+        },
+        "set_group_display_name": null,
+        "set_group_id": "set:3",
+        "set_id": "set:3",
+        "slot": "one_handed_maces",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+        "source_id": "set_item:79",
+        "special_mechanic_classification": "partial_modifier",
+        "special_mechanic_notes": [
+          "Structured modifier rows exist but remain partial until value normalization is solved."
+        ],
+        "stable_calculable": false,
+        "subtype": "Morning Star",
+        "support_status": "partial",
+        "tooltip_text": [
+          "+[12,24,1] Melee Damage for your Summoned Bees"
+        ],
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Unique/set record is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "attribute_requirements": {},
+        "base_item_id": "item_base:equippable:13:5",
+        "bonus_text": [],
+        "canonical_id": "set_item:85",
+        "class_restrictions": [],
+        "classification": "weapon",
+        "consumer_safe_fields": {
+          "display_name": "Sunforged Hammer",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Sunforged Hammer",
+        "equipment_slot": "two_handed_mace",
+        "implicit_ids": [],
+        "implicit_links": [
+          {
+            "base_item_id": "item_base:equippable:13:5",
+            "implicit_index": 0,
+            "modifier_type": "ADDED",
+            "property": "Damage"
+          },
+          {
+            "base_item_id": "item_base:equippable:13:5",
+            "implicit_index": 1,
+            "modifier_type": "ADDED",
+            "property": "IncreasedStunChance"
+          }
+        ],
+        "item_category": "equipment",
+        "item_type": "two_handed_mace",
+        "level_requirement": 68,
+        "lore_text": null,
+        "mastery_restrictions": [],
+        "modifier_references": [
+          {
+            "modifier_id": "set_item_modifier_set_item:85:0",
+            "property": "IncreasedStunDuration",
+            "property_path": "ADDED.IncreasedStunDuration",
+            "source_record_id": "set_item:85:modifier:0"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:85:1",
+            "property": "Damage",
+            "property_path": "ADDED.Damage.Physical.Melee",
+            "source_record_id": "set_item:85:modifier:1"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:85:2",
+            "property": "IncreasedStunChance",
+            "property_path": "ADDED.IncreasedStunChance",
+            "source_record_id": "set_item:85:modifier:2"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:85:3",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Cold.Fire.Void.Poison.Elemental",
+            "source_record_id": "set_item:85:modifier:3"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:85:4",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Lightning.Melee",
+            "source_record_id": "set_item:85:modifier:4"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:85:5",
+            "property": "Damage",
+            "property_path": "INCREASED.Damage.Fire",
+            "source_record_id": "set_item:85:modifier:5"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:85:0",
+            "modifier_type": "ADDED",
+            "property": "IncreasedStunDuration",
+            "property_path": "ADDED.IncreasedStunDuration",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "IncreasedStunDuration"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:85:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 4,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.42,
+            "value_min": 0.25
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:85:1",
+            "modifier_type": "ADDED",
+            "property": "Damage",
+            "property_path": "ADDED.Damage.Physical.Melee",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 1,
+                "property": "Damage"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:85:modifier:1",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Physical",
+              "Melee"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 84.0,
+            "value_min": 42.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:85:2",
+            "modifier_type": "ADDED",
+            "property": "IncreasedStunChance",
+            "property_path": "ADDED.IncreasedStunChance",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 2,
+                "property": "IncreasedStunChance"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:85:modifier:2",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 1,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 4.2,
+            "value_min": 2.5
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:85:3",
+            "modifier_type": "ADDED",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Cold.Fire.Void.Poison.Elemental",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 3,
+                "property": "AbilityProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:85:modifier:3",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 2,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Cold",
+              "Fire",
+              "Void",
+              "Poison",
+              "Elemental"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.6,
+            "value_min": 0.3
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:85:4",
+            "modifier_type": "ADDED",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Lightning.Melee",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 4,
+                "property": "PlayerProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:85:modifier:4",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 3,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Lightning",
+              "Melee"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 30.0,
+            "value_min": 15.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:85:5",
+            "modifier_type": "INCREASED",
+            "property": "Damage",
+            "property_path": "INCREASED.Damage.Fire",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 5,
+                "property": "Damage"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:85:modifier:5",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 4,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Fire"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.75,
+            "value_min": 0.5
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_item_modifier_set_item:85:0",
+              "property": "IncreasedStunDuration",
+              "property_path": "ADDED.IncreasedStunDuration",
+              "source_record_id": "set_item:85:modifier:0"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:85:1",
+              "property": "Damage",
+              "property_path": "ADDED.Damage.Physical.Melee",
+              "source_record_id": "set_item:85:modifier:1"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:85:2",
+              "property": "IncreasedStunChance",
+              "property_path": "ADDED.IncreasedStunChance",
+              "source_record_id": "set_item:85:modifier:2"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:85:3",
+              "property": "AbilityProperty",
+              "property_path": "ADDED.AbilityProperty.Cold.Fire.Void.Poison.Elemental",
+              "source_record_id": "set_item:85:modifier:3"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:85:4",
+              "property": "PlayerProperty",
+              "property_path": "ADDED.PlayerProperty.Lightning.Melee",
+              "source_record_id": "set_item:85:modifier:4"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:85:5",
+              "property": "Damage",
+              "property_path": "INCREASED.Damage.Fire",
+              "source_record_id": "set_item:85:modifier:5"
+            }
+          ]
+        },
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_unique_set_export",
+          "notes": [
+            "Generated from extracted unique/set data; tooltip text is not inferred as mechanics."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "id": 85,
+            "name": "Sunforged Hammer"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_item:85",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+          "source_type": "set_item"
+        },
+        "raw_reference": {
+          "baseType": "TWO_HANDED_MACE",
+          "id": 85,
+          "name": "Sunforged Hammer",
+          "resolutionStatus": "resolved",
+          "resolvedBaseItem": {
+            "baseTypeID": 13,
+            "displayName": "Two-Handed Mace",
+            "name": "2H Maces",
+            "subType": {
+              "displayName": "",
+              "levelRequirement": 52,
+              "name": "Great Hammer",
+              "subTypeID": 5
+            },
+            "type": "TWO_HANDED_MACE"
+          },
+          "subTypes": [
+            5
+          ]
+        },
+        "requirements": {
+          "attributes": {},
+          "class": null,
+          "level": 68,
+          "mastery": null
+        },
+        "set_group_display_name": null,
+        "set_group_id": "set:4",
+        "set_id": "set:4",
+        "slot": "two_handed_mace",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+        "source_id": "set_item:85",
+        "special_mechanic_classification": "partial_modifier",
+        "special_mechanic_notes": [
+          "Structured modifier rows exist but remain partial until value normalization is solved."
+        ],
+        "stable_calculable": false,
+        "subtype": "Great Hammer",
+        "support_status": "partial",
+        "tooltip_text": [],
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Unique/set record is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "attribute_requirements": {},
+        "base_item_id": "item_base:equippable:1:39",
+        "bonus_text": [],
+        "canonical_id": "set_item:86",
+        "class_restrictions": [],
+        "classification": "armor",
+        "consumer_safe_fields": {
+          "display_name": "Sunforged Cuirass",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Sunforged Cuirass",
+        "equipment_slot": "body_armor",
+        "implicit_ids": [],
+        "implicit_links": [
+          {
+            "base_item_id": "item_base:equippable:1:39",
+            "implicit_index": 0,
+            "modifier_type": "ADDED",
+            "property": "Armour"
+          },
+          {
+            "base_item_id": "item_base:equippable:1:39",
+            "implicit_index": 1,
+            "modifier_type": "ADDED",
+            "property": "Endurance"
+          },
+          {
+            "base_item_id": "item_base:equippable:1:39",
+            "implicit_index": 2,
+            "modifier_type": "INCREASED",
+            "property": "Damage"
+          }
+        ],
+        "item_category": "equipment",
+        "item_type": "body_armor",
+        "level_requirement": 60,
+        "lore_text": null,
+        "mastery_restrictions": [],
+        "modifier_references": [
+          {
+            "modifier_id": "set_item_modifier_set_item:86:0",
+            "property": "Armour",
+            "property_path": "ADDED.Armour",
+            "source_record_id": "set_item:86:modifier:0"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:86:1",
+            "property": "FireResistance",
+            "property_path": "ADDED.FireResistance",
+            "source_record_id": "set_item:86:modifier:1"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:86:2",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Physical.Cold.Necrotic",
+            "source_record_id": "set_item:86:modifier:2"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:86:3",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Cold.Fire.Void.Poison.Elemental",
+            "source_record_id": "set_item:86:modifier:3"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:86:0",
+            "modifier_type": "ADDED",
+            "property": "Armour",
+            "property_path": "ADDED.Armour",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "Armour"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:86:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 850.0,
+            "value_min": 600.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:86:1",
+            "modifier_type": "ADDED",
+            "property": "FireResistance",
+            "property_path": "ADDED.FireResistance",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 1,
+                "property": "FireResistance"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:86:modifier:1",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 1,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.85,
+            "value_min": 0.6
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:86:2",
+            "modifier_type": "ADDED",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Physical.Cold.Necrotic",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 2,
+                "property": "PlayerProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:86:modifier:2",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 2,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Physical",
+              "Cold",
+              "Necrotic"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.2,
+            "value_min": 0.1
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:86:3",
+            "modifier_type": "ADDED",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Cold.Fire.Void.Poison.Elemental",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 3,
+                "property": "AbilityProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:86:modifier:3",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 3,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Cold",
+              "Fire",
+              "Void",
+              "Poison",
+              "Elemental"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.4,
+            "value_min": 0.2
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_item_modifier_set_item:86:0",
+              "property": "Armour",
+              "property_path": "ADDED.Armour",
+              "source_record_id": "set_item:86:modifier:0"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:86:1",
+              "property": "FireResistance",
+              "property_path": "ADDED.FireResistance",
+              "source_record_id": "set_item:86:modifier:1"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:86:2",
+              "property": "PlayerProperty",
+              "property_path": "ADDED.PlayerProperty.Physical.Cold.Necrotic",
+              "source_record_id": "set_item:86:modifier:2"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:86:3",
+              "property": "AbilityProperty",
+              "property_path": "ADDED.AbilityProperty.Cold.Fire.Void.Poison.Elemental",
+              "source_record_id": "set_item:86:modifier:3"
+            }
+          ]
+        },
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_unique_set_export",
+          "notes": [
+            "Generated from extracted unique/set data; tooltip text is not inferred as mechanics."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "id": 86,
+            "name": "Sunforged Cuirass"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_item:86",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+          "source_type": "set_item"
+        },
+        "raw_reference": {
+          "baseType": "BODY_ARMOR",
+          "id": 86,
+          "name": "Sunforged Cuirass",
+          "resolutionStatus": "resolved",
+          "resolvedBaseItem": {
+            "baseTypeID": 1,
+            "displayName": "Body Armor",
+            "name": "Body Armor",
+            "subType": {
+              "displayName": "",
+              "levelRequirement": 68,
+              "name": "Solarum Plate",
+              "subTypeID": 39
+            },
+            "type": "BODY_ARMOR"
+          },
+          "subTypes": [
+            39
+          ]
+        },
+        "requirements": {
+          "attributes": {},
+          "class": null,
+          "level": 60,
+          "mastery": null
+        },
+        "set_group_display_name": null,
+        "set_group_id": "set:4",
+        "set_id": "set:4",
+        "slot": "body_armor",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+        "source_id": "set_item:86",
+        "special_mechanic_classification": "partial_modifier",
+        "special_mechanic_notes": [
+          "Structured modifier rows exist but remain partial until value normalization is solved."
+        ],
+        "stable_calculable": false,
+        "subtype": "Solarum Plate",
+        "support_status": "partial",
+        "tooltip_text": [],
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Unique/set record is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "attribute_requirements": {},
+        "base_item_id": "item_base:equippable:0:39",
+        "bonus_text": [],
+        "canonical_id": "set_item:87",
+        "class_restrictions": [],
+        "classification": "armor",
+        "consumer_safe_fields": {
+          "display_name": "Sunforged Greathelm",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Sunforged Greathelm",
+        "equipment_slot": "helmet",
+        "implicit_ids": [],
+        "implicit_links": [
+          {
+            "base_item_id": "item_base:equippable:0:39",
+            "implicit_index": 0,
+            "modifier_type": "ADDED",
+            "property": "Armour"
+          },
+          {
+            "base_item_id": "item_base:equippable:0:39",
+            "implicit_index": 1,
+            "modifier_type": "ADDED",
+            "property": "EnduranceThreshold"
+          },
+          {
+            "base_item_id": "item_base:equippable:0:39",
+            "implicit_index": 2,
+            "modifier_type": "INCREASED",
+            "property": "Damage"
+          }
+        ],
+        "item_category": "equipment",
+        "item_type": "helmet",
+        "level_requirement": 72,
+        "lore_text": null,
+        "mastery_restrictions": [],
+        "modifier_references": [
+          {
+            "modifier_id": "set_item_modifier_set_item:87:0",
+            "property": "Armour",
+            "property_path": "INCREASED.Armour",
+            "source_record_id": "set_item:87:modifier:0"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:87:1",
+            "property": "Armour",
+            "property_path": "ADDED.Armour",
+            "source_record_id": "set_item:87:modifier:1"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:87:2",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Cold.Fire.Void.Poison.Elemental",
+            "source_record_id": "set_item:87:modifier:2"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:87:3",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Cold.Fire.Void.Poison.Elemental",
+            "source_record_id": "set_item:87:modifier:3"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:87:0",
+            "modifier_type": "INCREASED",
+            "property": "Armour",
+            "property_path": "INCREASED.Armour",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "Armour"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:87:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.35,
+            "value_min": 0.25
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:87:1",
+            "modifier_type": "ADDED",
+            "property": "Armour",
+            "property_path": "ADDED.Armour",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 1,
+                "property": "Armour"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:87:modifier:1",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 1,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 350.0,
+            "value_min": 250.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:87:2",
+            "modifier_type": "ADDED",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Cold.Fire.Void.Poison.Elemental",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 2,
+                "property": "AbilityProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:87:modifier:2",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 3,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Cold",
+              "Fire",
+              "Void",
+              "Poison",
+              "Elemental"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.12,
+            "value_min": 0.1
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:87:3",
+            "modifier_type": "ADDED",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Cold.Fire.Void.Poison.Elemental",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 3,
+                "property": "AbilityProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:87:modifier:3",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 2,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Cold",
+              "Fire",
+              "Void",
+              "Poison",
+              "Elemental"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 6.0,
+            "value_min": 3.0
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_item_modifier_set_item:87:0",
+              "property": "Armour",
+              "property_path": "INCREASED.Armour",
+              "source_record_id": "set_item:87:modifier:0"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:87:1",
+              "property": "Armour",
+              "property_path": "ADDED.Armour",
+              "source_record_id": "set_item:87:modifier:1"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:87:2",
+              "property": "AbilityProperty",
+              "property_path": "ADDED.AbilityProperty.Cold.Fire.Void.Poison.Elemental",
+              "source_record_id": "set_item:87:modifier:2"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:87:3",
+              "property": "AbilityProperty",
+              "property_path": "ADDED.AbilityProperty.Cold.Fire.Void.Poison.Elemental",
+              "source_record_id": "set_item:87:modifier:3"
+            }
+          ]
+        },
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_unique_set_export",
+          "notes": [
+            "Generated from extracted unique/set data; tooltip text is not inferred as mechanics."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "id": 87,
+            "name": "Sunforged Greathelm"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_item:87",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+          "source_type": "set_item"
+        },
+        "raw_reference": {
+          "baseType": "HELMET",
+          "id": 87,
+          "name": "Sunforged Greathelm",
+          "resolutionStatus": "resolved",
+          "resolvedBaseItem": {
+            "baseTypeID": 0,
+            "displayName": "Helmet",
+            "name": "Helmets",
+            "subType": {
+              "displayName": "",
+              "levelRequirement": 72,
+              "name": "Solarum Greathelm",
+              "subTypeID": 39
+            },
+            "type": "HELMET"
+          },
+          "subTypes": [
+            39
+          ]
+        },
+        "requirements": {
+          "attributes": {},
+          "class": null,
+          "level": 72,
+          "mastery": null
+        },
+        "set_group_display_name": null,
+        "set_group_id": "set:4",
+        "set_id": "set:4",
+        "slot": "helmet",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+        "source_id": "set_item:87",
+        "special_mechanic_classification": "partial_modifier",
+        "special_mechanic_notes": [
+          "Structured modifier rows exist but remain partial until value normalization is solved."
+        ],
+        "stable_calculable": false,
+        "subtype": "Solarum Greathelm",
+        "support_status": "partial",
+        "tooltip_text": [],
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Unique/set record is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "attribute_requirements": {},
+        "base_item_id": "item_base:equippable:9:6",
+        "bonus_text": [
+          "20% increased Attack and Cast Speed"
+        ],
+        "canonical_id": "set_item:88",
+        "class_restrictions": [],
+        "classification": "weapon",
+        "consumer_safe_fields": {
+          "display_name": "Blade of the Forgotten Knight",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Blade of the Forgotten Knight",
+        "equipment_slot": "one_handed_sword",
+        "implicit_ids": [],
+        "implicit_links": [
+          {
+            "base_item_id": "item_base:equippable:9:6",
+            "implicit_index": 0,
+            "modifier_type": "ADDED",
+            "property": "Damage"
+          }
+        ],
+        "item_category": "equipment",
+        "item_type": "one_handed_sword",
+        "level_requirement": 60,
+        "lore_text": "Incongruous shards of iron from distant eras woven together through time.",
+        "mastery_restrictions": [],
+        "modifier_references": [
+          {
+            "modifier_id": "set_item_modifier_set_item:88:0",
+            "property": "Damage",
+            "property_path": "ADDED.Damage.Void.Melee",
+            "source_record_id": "set_item:88:modifier:0"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:88:1",
+            "property": "Damage",
+            "property_path": "ADDED.Damage.Void.Spell",
+            "source_record_id": "set_item:88:modifier:1"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:88:2",
+            "property": "Damage",
+            "property_path": "INCREASED.Damage.Void",
+            "source_record_id": "set_item:88:modifier:2"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:88:3",
+            "property": "HasteOnHitChance",
+            "property_path": "ADDED.HasteOnHitChance",
+            "source_record_id": "set_item:88:modifier:3"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:88:4",
+            "property": "CastSpeed",
+            "property_path": "INCREASED.CastSpeed",
+            "source_record_id": "set_item:88:modifier:4"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:88:5",
+            "property": "AttackSpeed",
+            "property_path": "INCREASED.AttackSpeed",
+            "source_record_id": "set_item:88:modifier:5"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:88:0",
+            "modifier_type": "ADDED",
+            "property": "Damage",
+            "property_path": "ADDED.Damage.Void.Melee",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "Damage"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:88:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Void",
+              "Melee"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 35.0,
+            "value_min": 25.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:88:1",
+            "modifier_type": "ADDED",
+            "property": "Damage",
+            "property_path": "ADDED.Damage.Void.Spell",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 1,
+                "property": "Damage"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:88:modifier:1",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 1,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Void",
+              "Spell"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 50.0,
+            "value_min": 35.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:88:2",
+            "modifier_type": "INCREASED",
+            "property": "Damage",
+            "property_path": "INCREASED.Damage.Void",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 2,
+                "property": "Damage"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:88:modifier:2",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 2,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Void"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.7,
+            "value_min": 0.3
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:88:3",
+            "modifier_type": "ADDED",
+            "property": "HasteOnHitChance",
+            "property_path": "ADDED.HasteOnHitChance",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 3,
+                "property": "HasteOnHitChance"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:88:modifier:3",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 3,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.25,
+            "value_min": 0.15
+          },
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": true,
+            "modifier_id": "set_item_modifier_set_item:88:4",
+            "modifier_type": "INCREASED",
+            "property": "CastSpeed",
+            "property_path": "INCREASED.CastSpeed",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 4,
+                "property": "CastSpeed"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:88:modifier:4",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.2,
+            "value_min": 0.2
+          },
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": true,
+            "modifier_id": "set_item_modifier_set_item:88:5",
+            "modifier_type": "INCREASED",
+            "property": "AttackSpeed",
+            "property_path": "INCREASED.AttackSpeed",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 5,
+                "property": "AttackSpeed"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:88:modifier:5",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.2,
+            "value_min": 0.2
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_item_modifier_set_item:88:0",
+              "property": "Damage",
+              "property_path": "ADDED.Damage.Void.Melee",
+              "source_record_id": "set_item:88:modifier:0"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:88:1",
+              "property": "Damage",
+              "property_path": "ADDED.Damage.Void.Spell",
+              "source_record_id": "set_item:88:modifier:1"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:88:2",
+              "property": "Damage",
+              "property_path": "INCREASED.Damage.Void",
+              "source_record_id": "set_item:88:modifier:2"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:88:3",
+              "property": "HasteOnHitChance",
+              "property_path": "ADDED.HasteOnHitChance",
+              "source_record_id": "set_item:88:modifier:3"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:88:4",
+              "property": "CastSpeed",
+              "property_path": "INCREASED.CastSpeed",
+              "source_record_id": "set_item:88:modifier:4"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:88:5",
+              "property": "AttackSpeed",
+              "property_path": "INCREASED.AttackSpeed",
+              "source_record_id": "set_item:88:modifier:5"
+            }
+          ]
+        },
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_unique_set_export",
+          "notes": [
+            "Generated from extracted unique/set data; tooltip text is not inferred as mechanics."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "id": 88,
+            "name": "Blade of the Forgotten Knight"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_item:88",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+          "source_type": "set_item"
+        },
+        "raw_reference": {
+          "baseType": "ONE_HANDED_SWORD",
+          "id": 88,
+          "name": "Blade of the Forgotten Knight",
+          "resolutionStatus": "resolved",
+          "resolvedBaseItem": {
+            "baseTypeID": 9,
+            "displayName": "One-Handed Sword",
+            "name": "1H Swords",
+            "subType": {
+              "displayName": "",
+              "levelRequirement": 50,
+              "name": "Longsword",
+              "subTypeID": 6
+            },
+            "type": "ONE_HANDED_SWORD"
+          },
+          "subTypes": [
+            6
+          ]
+        },
+        "requirements": {
+          "attributes": {},
+          "class": null,
+          "level": 60,
+          "mastery": null
+        },
+        "set_group_display_name": null,
+        "set_group_id": "set:5",
+        "set_id": "set:5",
+        "slot": "one_handed_sword",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+        "source_id": "set_item:88",
+        "special_mechanic_classification": "partial_modifier",
+        "special_mechanic_notes": [
+          "Structured modifier rows exist but remain partial until value normalization is solved."
+        ],
+        "stable_calculable": false,
+        "subtype": "Longsword",
+        "support_status": "partial",
+        "tooltip_text": [
+          "20% increased Attack and Cast Speed"
+        ],
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Unique/set record is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "attribute_requirements": {},
+        "base_item_id": "item_base:equippable:18:5",
+        "bonus_text": [],
+        "canonical_id": "set_item:89",
+        "class_restrictions": [],
+        "classification": "armor",
+        "consumer_safe_fields": {
+          "display_name": "Defiance of the Forgotten Knight",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Defiance of the Forgotten Knight",
+        "equipment_slot": "shield",
+        "implicit_ids": [],
+        "implicit_links": [
+          {
+            "base_item_id": "item_base:equippable:18:5",
+            "implicit_index": 0,
+            "modifier_type": "ADDED",
+            "property": "BlockChance"
+          },
+          {
+            "base_item_id": "item_base:equippable:18:5",
+            "implicit_index": 1,
+            "modifier_type": "ADDED",
+            "property": "BlockEffectiveness"
+          }
+        ],
+        "item_category": "equipment",
+        "item_type": "shield",
+        "level_requirement": 40,
+        "lore_text": "Dread not the passage of time nor the eternal void beyond.",
+        "mastery_restrictions": [],
+        "modifier_references": [
+          {
+            "modifier_id": "set_item_modifier_set_item:89:0",
+            "property": "Damage",
+            "property_path": "INCREASED.Damage.Void",
+            "source_record_id": "set_item:89:modifier:0"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:89:1",
+            "property": "BlockChance",
+            "property_path": "ADDED.BlockChance",
+            "source_record_id": "set_item:89:modifier:1"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:89:2",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Physical.Lightning.Cold.Necrotic",
+            "source_record_id": "set_item:89:modifier:2"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:89:3",
+            "property": "Damage",
+            "property_path": "ADDED.Damage.Void.Melee",
+            "source_record_id": "set_item:89:modifier:3"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:89:4",
+            "property": "DamageTaken",
+            "property_path": "MORE.DamageTaken.Void",
+            "source_record_id": "set_item:89:modifier:4"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:89:5",
+            "property": "AilmentChance",
+            "property_path": "ADDED.AilmentChance",
+            "source_record_id": "set_item:89:modifier:5"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:89:0",
+            "modifier_type": "INCREASED",
+            "property": "Damage",
+            "property_path": "INCREASED.Damage.Void",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "Damage"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:89:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Void"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 1.05,
+            "value_min": 0.7
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:89:1",
+            "modifier_type": "ADDED",
+            "property": "BlockChance",
+            "property_path": "ADDED.BlockChance",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 1,
+                "property": "BlockChance"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:89:modifier:1",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 1,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.25,
+            "value_min": 0.15
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:89:2",
+            "modifier_type": "ADDED",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Physical.Lightning.Cold.Necrotic",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 2,
+                "property": "PlayerProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:89:modifier:2",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 2,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Physical",
+              "Lightning",
+              "Cold",
+              "Necrotic"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.28,
+            "value_min": 0.21
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:89:3",
+            "modifier_type": "ADDED",
+            "property": "Damage",
+            "property_path": "ADDED.Damage.Void.Melee",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 3,
+                "property": "Damage"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:89:modifier:3",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 3,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Void",
+              "Melee"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 12.0,
+            "value_min": 6.0
+          },
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:89:4",
+            "modifier_type": "MORE",
+            "property": "DamageTaken",
+            "property_path": "MORE.DamageTaken.Void",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 4,
+                "property": "DamageTaken"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:89:modifier:4",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Void"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": -0.5,
+            "value_min": -0.5
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:89:5",
+            "modifier_type": "ADDED",
+            "property": "AilmentChance",
+            "property_path": "ADDED.AilmentChance",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 5,
+                "property": "AilmentChance"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:89:modifier:5",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 4,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.28,
+            "value_min": 0.21
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_item_modifier_set_item:89:0",
+              "property": "Damage",
+              "property_path": "INCREASED.Damage.Void",
+              "source_record_id": "set_item:89:modifier:0"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:89:1",
+              "property": "BlockChance",
+              "property_path": "ADDED.BlockChance",
+              "source_record_id": "set_item:89:modifier:1"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:89:2",
+              "property": "PlayerProperty",
+              "property_path": "ADDED.PlayerProperty.Physical.Lightning.Cold.Necrotic",
+              "source_record_id": "set_item:89:modifier:2"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:89:3",
+              "property": "Damage",
+              "property_path": "ADDED.Damage.Void.Melee",
+              "source_record_id": "set_item:89:modifier:3"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:89:4",
+              "property": "DamageTaken",
+              "property_path": "MORE.DamageTaken.Void",
+              "source_record_id": "set_item:89:modifier:4"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:89:5",
+              "property": "AilmentChance",
+              "property_path": "ADDED.AilmentChance",
+              "source_record_id": "set_item:89:modifier:5"
+            }
+          ]
+        },
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_unique_set_export",
+          "notes": [
+            "Generated from extracted unique/set data; tooltip text is not inferred as mechanics."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "id": 89,
+            "name": "Defiance of the Forgotten Knight"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_item:89",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+          "source_type": "set_item"
+        },
+        "raw_reference": {
+          "baseType": "SHIELD",
+          "id": 89,
+          "name": "Defiance of the Forgotten Knight",
+          "resolutionStatus": "resolved",
+          "resolvedBaseItem": {
+            "baseTypeID": 18,
+            "displayName": "Shield",
+            "name": "Shield",
+            "subType": {
+              "displayName": "",
+              "levelRequirement": 30,
+              "name": "Tower Shield",
+              "subTypeID": 5
+            },
+            "type": "SHIELD"
+          },
+          "subTypes": [
+            5
+          ]
+        },
+        "requirements": {
+          "attributes": {},
+          "class": null,
+          "level": 40,
+          "mastery": null
+        },
+        "set_group_display_name": null,
+        "set_group_id": "set:5",
+        "set_id": "set:5",
+        "slot": "shield",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+        "source_id": "set_item:89",
+        "special_mechanic_classification": "partial_modifier",
+        "special_mechanic_notes": [
+          "Structured modifier rows exist but remain partial until value normalization is solved."
+        ],
+        "stable_calculable": false,
+        "subtype": "Tower Shield",
+        "support_status": "partial",
+        "tooltip_text": [],
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Unique/set record is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "attribute_requirements": {},
+        "base_item_id": "item_base:equippable:20:2",
+        "bonus_text": [
+          "+[2,3,1]% Critical Strike Chance with Void Skills"
+        ],
+        "canonical_id": "set_item:90",
+        "class_restrictions": [],
+        "classification": "accessory",
+        "consumer_safe_fields": {
+          "display_name": "Locket of the Forgotten Knight",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Locket of the Forgotten Knight",
+        "equipment_slot": "amulet",
+        "implicit_ids": [],
+        "implicit_links": [
+          {
+            "base_item_id": "item_base:equippable:20:2",
+            "implicit_index": 0,
+            "modifier_type": "INCREASED",
+            "property": "CriticalChance"
+          }
+        ],
+        "item_category": "equipment",
+        "item_type": "amulet",
+        "level_requirement": 24,
+        "lore_text": "A sanctuary for memories lost.",
+        "mastery_restrictions": [],
+        "modifier_references": [
+          {
+            "modifier_id": "set_item_modifier_set_item:90:0",
+            "property": "Damage",
+            "property_path": "INCREASED.Damage.Void",
+            "source_record_id": "set_item:90:modifier:0"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:90:1",
+            "property": "CriticalChance",
+            "property_path": "ADDED.CriticalChance.Void",
+            "source_record_id": "set_item:90:modifier:1"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:90:2",
+            "property": "AilmentChance",
+            "property_path": "ADDED.AilmentChance",
+            "source_record_id": "set_item:90:modifier:2"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:90:3",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Fire.Necrotic",
+            "source_record_id": "set_item:90:modifier:3"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:90:0",
+            "modifier_type": "INCREASED",
+            "property": "Damage",
+            "property_path": "INCREASED.Damage.Void",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "Damage"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:90:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Void"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.7,
+            "value_min": 0.29
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": true,
+            "modifier_id": "set_item_modifier_set_item:90:1",
+            "modifier_type": "ADDED",
+            "property": "CriticalChance",
+            "property_path": "ADDED.CriticalChance.Void",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 1,
+                "property": "CriticalChance"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:90:modifier:1",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 1,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Void"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.03,
+            "value_min": 0.02
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:90:2",
+            "modifier_type": "ADDED",
+            "property": "AilmentChance",
+            "property_path": "ADDED.AilmentChance",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 2,
+                "property": "AilmentChance"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:90:modifier:2",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 3,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.28,
+            "value_min": 0.21
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:90:3",
+            "modifier_type": "ADDED",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Fire.Necrotic",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 3,
+                "property": "PlayerProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:90:modifier:3",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Fire",
+              "Necrotic"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.2,
+            "value_min": 0.15
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_item_modifier_set_item:90:0",
+              "property": "Damage",
+              "property_path": "INCREASED.Damage.Void",
+              "source_record_id": "set_item:90:modifier:0"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:90:1",
+              "property": "CriticalChance",
+              "property_path": "ADDED.CriticalChance.Void",
+              "source_record_id": "set_item:90:modifier:1"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:90:2",
+              "property": "AilmentChance",
+              "property_path": "ADDED.AilmentChance",
+              "source_record_id": "set_item:90:modifier:2"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:90:3",
+              "property": "PlayerProperty",
+              "property_path": "ADDED.PlayerProperty.Fire.Necrotic",
+              "source_record_id": "set_item:90:modifier:3"
+            }
+          ]
+        },
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_unique_set_export",
+          "notes": [
+            "Generated from extracted unique/set data; tooltip text is not inferred as mechanics."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "id": 90,
+            "name": "Locket of the Forgotten Knight"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_item:90",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+          "source_type": "set_item"
+        },
+        "raw_reference": {
+          "baseType": "AMULET",
+          "id": 90,
+          "name": "Locket of the Forgotten Knight",
+          "resolutionStatus": "resolved",
+          "resolvedBaseItem": {
+            "baseTypeID": 20,
+            "displayName": "Amulet",
+            "name": "Amulet",
+            "subType": {
+              "displayName": "",
+              "levelRequirement": 24,
+              "name": "Silver Amulet",
+              "subTypeID": 2
+            },
+            "type": "AMULET"
+          },
+          "subTypes": [
+            2
+          ]
+        },
+        "requirements": {
+          "attributes": {},
+          "class": null,
+          "level": 24,
+          "mastery": null
+        },
+        "set_group_display_name": null,
+        "set_group_id": "set:5",
+        "set_id": "set:5",
+        "slot": "amulet",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+        "source_id": "set_item:90",
+        "special_mechanic_classification": "partial_modifier",
+        "special_mechanic_notes": [
+          "Structured modifier rows exist but remain partial until value normalization is solved."
+        ],
+        "stable_calculable": false,
+        "subtype": "Silver Amulet",
+        "support_status": "partial",
+        "tooltip_text": [
+          "+[2,3,1]% Critical Strike Chance with Void Skills"
+        ],
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Unique/set record is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "attribute_requirements": {},
+        "base_item_id": "item_base:equippable:4:5",
+        "bonus_text": [],
+        "canonical_id": "set_item:94",
+        "class_restrictions": [],
+        "classification": "armor",
+        "consumer_safe_fields": {
+          "display_name": "The Last Bear's Fury",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "The Last Bear's Fury",
+        "equipment_slot": "gloves",
+        "implicit_ids": [],
+        "implicit_links": [
+          {
+            "base_item_id": "item_base:equippable:4:5",
+            "implicit_index": 0,
+            "modifier_type": "ADDED",
+            "property": "Armour"
+          },
+          {
+            "base_item_id": "item_base:equippable:4:5",
+            "implicit_index": 1,
+            "modifier_type": "ADDED",
+            "property": "Endurance"
+          }
+        ],
+        "item_category": "equipment",
+        "item_type": "gloves",
+        "level_requirement": 31,
+        "lore_text": "The last bear stood alone against the void, guarding the cave in which she thought her cubs still rested.",
+        "mastery_restrictions": [],
+        "modifier_references": [
+          {
+            "modifier_id": "set_item_modifier_set_item:94:0",
+            "property": "Damage",
+            "property_path": "INCREASED.Damage.Physical.Melee",
+            "source_record_id": "set_item:94:modifier:0"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:94:1",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Physical.Cold.Fire.Necrotic",
+            "source_record_id": "set_item:94:modifier:1"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:94:2",
+            "property": "IncreasedStunChance",
+            "property_path": "ADDED.IncreasedStunChance.Melee",
+            "source_record_id": "set_item:94:modifier:2"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:94:3",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Lightning.Void",
+            "source_record_id": "set_item:94:modifier:3"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:94:4",
+            "property": "LevelOfSkills",
+            "property_path": "ADDED.LevelOfSkills.Physical.Lightning.Void",
+            "source_record_id": "set_item:94:modifier:4"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:94:0",
+            "modifier_type": "INCREASED",
+            "property": "Damage",
+            "property_path": "INCREASED.Damage.Physical.Melee",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "Damage"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:94:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Physical",
+              "Melee"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.75,
+            "value_min": 0.3
+          },
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:94:1",
+            "modifier_type": "ADDED",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Physical.Cold.Fire.Necrotic",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 1,
+                "property": "PlayerProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:94:modifier:1",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Physical",
+              "Cold",
+              "Fire",
+              "Necrotic"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.03,
+            "value_min": 0.03
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:94:2",
+            "modifier_type": "ADDED",
+            "property": "IncreasedStunChance",
+            "property_path": "ADDED.IncreasedStunChance.Melee",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 2,
+                "property": "IncreasedStunChance"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:94:modifier:2",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 1,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Melee"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 1.0,
+            "value_min": 0.3
+          },
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:94:3",
+            "modifier_type": "ADDED",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Lightning.Void",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 3,
+                "property": "AbilityProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:94:modifier:3",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Physical",
+              "Lightning",
+              "Void"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.03,
+            "value_min": 0.03
+          },
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:94:4",
+            "modifier_type": "ADDED",
+            "property": "LevelOfSkills",
+            "property_path": "ADDED.LevelOfSkills.Physical.Lightning.Void",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 4,
+                "property": "LevelOfSkills"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:94:modifier:4",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Physical",
+              "Lightning",
+              "Void"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 1.0,
+            "value_min": 1.0
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_item_modifier_set_item:94:0",
+              "property": "Damage",
+              "property_path": "INCREASED.Damage.Physical.Melee",
+              "source_record_id": "set_item:94:modifier:0"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:94:1",
+              "property": "PlayerProperty",
+              "property_path": "ADDED.PlayerProperty.Physical.Cold.Fire.Necrotic",
+              "source_record_id": "set_item:94:modifier:1"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:94:2",
+              "property": "IncreasedStunChance",
+              "property_path": "ADDED.IncreasedStunChance.Melee",
+              "source_record_id": "set_item:94:modifier:2"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:94:3",
+              "property": "AbilityProperty",
+              "property_path": "ADDED.AbilityProperty.Physical.Lightning.Void",
+              "source_record_id": "set_item:94:modifier:3"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:94:4",
+              "property": "LevelOfSkills",
+              "property_path": "ADDED.LevelOfSkills.Physical.Lightning.Void",
+              "source_record_id": "set_item:94:modifier:4"
+            }
+          ]
+        },
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_unique_set_export",
+          "notes": [
+            "Generated from extracted unique/set data; tooltip text is not inferred as mechanics."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "id": 94,
+            "name": "The Last Bears Fury"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_item:94",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+          "source_type": "set_item"
+        },
+        "raw_reference": {
+          "baseType": "GLOVES",
+          "id": 94,
+          "name": "The Last Bears Fury",
+          "resolutionStatus": "resolved",
+          "resolvedBaseItem": {
+            "baseTypeID": 4,
+            "displayName": "Gloves",
+            "name": "Gloves",
+            "subType": {
+              "displayName": "",
+              "levelRequirement": 45,
+              "name": "Plated Gauntlets",
+              "subTypeID": 5
+            },
+            "type": "GLOVES"
+          },
+          "subTypes": [
+            5
+          ]
+        },
+        "requirements": {
+          "attributes": {},
+          "class": null,
+          "level": 31,
+          "mastery": null
+        },
+        "set_group_display_name": null,
+        "set_group_id": "set:6",
+        "set_id": "set:6",
+        "slot": "gloves",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+        "source_id": "set_item:94",
+        "special_mechanic_classification": "partial_modifier",
+        "special_mechanic_notes": [
+          "Structured modifier rows exist but remain partial until value normalization is solved."
+        ],
+        "stable_calculable": false,
+        "subtype": "Plated Gauntlets",
+        "support_status": "partial",
+        "tooltip_text": [],
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Unique/set record is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "attribute_requirements": {},
+        "base_item_id": "item_base:equippable:1:4",
+        "bonus_text": [],
+        "canonical_id": "set_item:95",
+        "class_restrictions": [],
+        "classification": "armor",
+        "consumer_safe_fields": {
+          "display_name": "The Last Bear's Scorn",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "The Last Bear's Scorn",
+        "equipment_slot": "body_armor",
+        "implicit_ids": [],
+        "implicit_links": [
+          {
+            "base_item_id": "item_base:equippable:1:4",
+            "implicit_index": 0,
+            "modifier_type": "ADDED",
+            "property": "Armour"
+          }
+        ],
+        "item_category": "equipment",
+        "item_type": "body_armor",
+        "level_requirement": 27,
+        "lore_text": "The last bear's bloodline survived wars between gods, and empires.",
+        "mastery_restrictions": [],
+        "modifier_references": [
+          {
+            "modifier_id": "set_item_modifier_set_item:95:0",
+            "property": "Strength",
+            "property_path": "ADDED.Strength",
+            "source_record_id": "set_item:95:modifier:0"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:95:1",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Lightning.Cold.Fire.Necrotic",
+            "source_record_id": "set_item:95:modifier:1"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:95:2",
+            "property": "HealthLeech",
+            "property_path": "ADDED.HealthLeech.Physical",
+            "source_record_id": "set_item:95:modifier:2"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:95:3",
+            "property": "Endurance",
+            "property_path": "ADDED.Endurance",
+            "source_record_id": "set_item:95:modifier:3"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:95:4",
+            "property": "LevelOfSkills",
+            "property_path": "ADDED.LevelOfSkills.Physical.Lightning.Cold.Void.Poison.Elemental",
+            "source_record_id": "set_item:95:modifier:4"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:95:0",
+            "modifier_type": "ADDED",
+            "property": "Strength",
+            "property_path": "ADDED.Strength",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "Strength"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:95:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 10.0,
+            "value_min": 10.0
+          },
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:95:1",
+            "modifier_type": "ADDED",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Lightning.Cold.Fire.Necrotic",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 1,
+                "property": "PlayerProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:95:modifier:1",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Lightning",
+              "Cold",
+              "Fire",
+              "Necrotic"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 1.0,
+            "value_min": 1.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:95:2",
+            "modifier_type": "ADDED",
+            "property": "HealthLeech",
+            "property_path": "ADDED.HealthLeech.Physical",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 2,
+                "property": "HealthLeech"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:95:modifier:2",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 1,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Physical"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.3,
+            "value_min": 0.15
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:95:3",
+            "modifier_type": "ADDED",
+            "property": "Endurance",
+            "property_path": "ADDED.Endurance",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 3,
+                "property": "Endurance"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:95:modifier:3",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 2,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.3,
+            "value_min": 0.2
+          },
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:95:4",
+            "modifier_type": "ADDED",
+            "property": "LevelOfSkills",
+            "property_path": "ADDED.LevelOfSkills.Physical.Lightning.Cold.Void.Poison.Elemental",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 4,
+                "property": "LevelOfSkills"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:95:modifier:4",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Physical",
+              "Lightning",
+              "Cold",
+              "Void",
+              "Poison",
+              "Elemental"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 3.0,
+            "value_min": 3.0
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_item_modifier_set_item:95:0",
+              "property": "Strength",
+              "property_path": "ADDED.Strength",
+              "source_record_id": "set_item:95:modifier:0"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:95:1",
+              "property": "PlayerProperty",
+              "property_path": "ADDED.PlayerProperty.Lightning.Cold.Fire.Necrotic",
+              "source_record_id": "set_item:95:modifier:1"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:95:2",
+              "property": "HealthLeech",
+              "property_path": "ADDED.HealthLeech.Physical",
+              "source_record_id": "set_item:95:modifier:2"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:95:3",
+              "property": "Endurance",
+              "property_path": "ADDED.Endurance",
+              "source_record_id": "set_item:95:modifier:3"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:95:4",
+              "property": "LevelOfSkills",
+              "property_path": "ADDED.LevelOfSkills.Physical.Lightning.Cold.Void.Poison.Elemental",
+              "source_record_id": "set_item:95:modifier:4"
+            }
+          ]
+        },
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_unique_set_export",
+          "notes": [
+            "Generated from extracted unique/set data; tooltip text is not inferred as mechanics."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "id": 95,
+            "name": "The Last Bears Scorn"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_item:95",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+          "source_type": "set_item"
+        },
+        "raw_reference": {
+          "baseType": "BODY_ARMOR",
+          "id": 95,
+          "name": "The Last Bears Scorn",
+          "resolutionStatus": "resolved",
+          "resolvedBaseItem": {
+            "baseTypeID": 1,
+            "displayName": "Body Armor",
+            "name": "Body Armor",
+            "subType": {
+              "displayName": "Banded Armor",
+              "levelRequirement": 27,
+              "name": "Banded Armor",
+              "subTypeID": 4
+            },
+            "type": "BODY_ARMOR"
+          },
+          "subTypes": [
+            4
+          ]
+        },
+        "requirements": {
+          "attributes": {},
+          "class": null,
+          "level": 27,
+          "mastery": null
+        },
+        "set_group_display_name": null,
+        "set_group_id": "set:6",
+        "set_id": "set:6",
+        "slot": "body_armor",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+        "source_id": "set_item:95",
+        "special_mechanic_classification": "partial_modifier",
+        "special_mechanic_notes": [
+          "Structured modifier rows exist but remain partial until value normalization is solved."
+        ],
+        "stable_calculable": false,
+        "subtype": "Banded Armor",
+        "support_status": "partial",
+        "tooltip_text": [],
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Unique/set record is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "attribute_requirements": {},
+        "base_item_id": "item_base:equippable:0:4",
+        "bonus_text": [],
+        "canonical_id": "set_item:96",
+        "class_restrictions": [],
+        "classification": "armor",
+        "consumer_safe_fields": {
+          "display_name": "The Last Bear's Lament",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "The Last Bear's Lament",
+        "equipment_slot": "helmet",
+        "implicit_ids": [],
+        "implicit_links": [
+          {
+            "base_item_id": "item_base:equippable:0:4",
+            "implicit_index": 0,
+            "modifier_type": "ADDED",
+            "property": "Armour"
+          }
+        ],
+        "item_category": "equipment",
+        "item_type": "helmet",
+        "level_requirement": 20,
+        "lore_text": "The last bear's ancestors watched as the Temple of Eterra fell from the sky.",
+        "mastery_restrictions": [],
+        "modifier_references": [
+          {
+            "modifier_id": "set_item_modifier_set_item:96:0",
+            "property": "VoidResistance",
+            "property_path": "ADDED.VoidResistance",
+            "source_record_id": "set_item:96:modifier:0"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:96:1",
+            "property": "EnduranceThreshold",
+            "property_path": "ADDED.EnduranceThreshold",
+            "source_record_id": "set_item:96:modifier:1"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:96:2",
+            "property": "HealthRegen",
+            "property_path": "ADDED.HealthRegen",
+            "source_record_id": "set_item:96:modifier:2"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:96:3",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Void.Necrotic",
+            "source_record_id": "set_item:96:modifier:3"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:96:4",
+            "property": "LevelOfSkills",
+            "property_path": "ADDED.LevelOfSkills.Physical.Fire.Void.Necrotic.Poison.Elemental.Spell",
+            "source_record_id": "set_item:96:modifier:4"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:96:0",
+            "modifier_type": "ADDED",
+            "property": "VoidResistance",
+            "property_path": "ADDED.VoidResistance",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "VoidResistance"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:96:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 2,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.45,
+            "value_min": 0.25
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:96:1",
+            "modifier_type": "ADDED",
+            "property": "EnduranceThreshold",
+            "property_path": "ADDED.EnduranceThreshold",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 1,
+                "property": "EnduranceThreshold"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:96:modifier:1",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 150.0,
+            "value_min": 50.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:96:2",
+            "modifier_type": "ADDED",
+            "property": "HealthRegen",
+            "property_path": "ADDED.HealthRegen",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 2,
+                "property": "HealthRegen"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:96:modifier:2",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 1,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 20.0,
+            "value_min": 10.0
+          },
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:96:3",
+            "modifier_type": "ADDED",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Void.Necrotic",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 3,
+                "property": "PlayerProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:96:modifier:3",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Void",
+              "Necrotic"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 1.0,
+            "value_min": 1.0
+          },
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:96:4",
+            "modifier_type": "ADDED",
+            "property": "LevelOfSkills",
+            "property_path": "ADDED.LevelOfSkills.Physical.Fire.Void.Necrotic.Poison.Elemental.Spell",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 4,
+                "property": "LevelOfSkills"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:96:modifier:4",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Physical",
+              "Fire",
+              "Void",
+              "Necrotic",
+              "Poison",
+              "Elemental",
+              "Spell"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 2.0,
+            "value_min": 2.0
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_item_modifier_set_item:96:0",
+              "property": "VoidResistance",
+              "property_path": "ADDED.VoidResistance",
+              "source_record_id": "set_item:96:modifier:0"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:96:1",
+              "property": "EnduranceThreshold",
+              "property_path": "ADDED.EnduranceThreshold",
+              "source_record_id": "set_item:96:modifier:1"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:96:2",
+              "property": "HealthRegen",
+              "property_path": "ADDED.HealthRegen",
+              "source_record_id": "set_item:96:modifier:2"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:96:3",
+              "property": "PlayerProperty",
+              "property_path": "ADDED.PlayerProperty.Void.Necrotic",
+              "source_record_id": "set_item:96:modifier:3"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:96:4",
+              "property": "LevelOfSkills",
+              "property_path": "ADDED.LevelOfSkills.Physical.Fire.Void.Necrotic.Poison.Elemental.Spell",
+              "source_record_id": "set_item:96:modifier:4"
+            }
+          ]
+        },
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_unique_set_export",
+          "notes": [
+            "Generated from extracted unique/set data; tooltip text is not inferred as mechanics."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "id": 96,
+            "name": "The Last Bears Lament"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_item:96",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+          "source_type": "set_item"
+        },
+        "raw_reference": {
+          "baseType": "HELMET",
+          "id": 96,
+          "name": "The Last Bears Lament",
+          "resolutionStatus": "resolved",
+          "resolvedBaseItem": {
+            "baseTypeID": 0,
+            "displayName": "Helmet",
+            "name": "Helmets",
+            "subType": {
+              "displayName": "Dome Cap",
+              "levelRequirement": 24,
+              "name": "Dome Helmet",
+              "subTypeID": 4
+            },
+            "type": "HELMET"
+          },
+          "subTypes": [
+            4
+          ]
+        },
+        "requirements": {
+          "attributes": {},
+          "class": null,
+          "level": 20,
+          "mastery": null
+        },
+        "set_group_display_name": null,
+        "set_group_id": "set:6",
+        "set_id": "set:6",
+        "slot": "helmet",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+        "source_id": "set_item:96",
+        "special_mechanic_classification": "partial_modifier",
+        "special_mechanic_notes": [
+          "Structured modifier rows exist but remain partial until value normalization is solved."
+        ],
+        "stable_calculable": false,
+        "subtype": "Dome Helmet",
+        "support_status": "partial",
+        "tooltip_text": [],
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Unique/set record is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "attribute_requirements": {},
+        "base_item_id": "item_base:equippable:15:6",
+        "bonus_text": [],
+        "canonical_id": "set_item:97",
+        "class_restrictions": [],
+        "classification": "weapon",
+        "consumer_safe_fields": {
+          "display_name": "Halvar's Pledge",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Halvar's Pledge",
+        "equipment_slot": "two_handed_staff",
+        "implicit_ids": [],
+        "implicit_links": [
+          {
+            "base_item_id": "item_base:equippable:15:6",
+            "implicit_index": 0,
+            "modifier_type": "ADDED",
+            "property": "Damage"
+          },
+          {
+            "base_item_id": "item_base:equippable:15:6",
+            "implicit_index": 1,
+            "modifier_type": "ADDED",
+            "property": "Damage"
+          },
+          {
+            "base_item_id": "item_base:equippable:15:6",
+            "implicit_index": 2,
+            "modifier_type": "INCREASED",
+            "property": "Damage"
+          }
+        ],
+        "item_category": "equipment",
+        "item_type": "two_handed_staff",
+        "level_requirement": 46,
+        "lore_text": "The shaman Halvar bound himself with the spirit of the mountain.",
+        "mastery_restrictions": [],
+        "modifier_references": [
+          {
+            "modifier_id": "set_item_modifier_set_item:97:0",
+            "property": "Damage",
+            "property_path": "ADDED.Damage.Physical.Spell",
+            "source_record_id": "set_item:97:modifier:0"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:97:1",
+            "property": "CriticalChance",
+            "property_path": "ADDED.CriticalChance",
+            "source_record_id": "set_item:97:modifier:1"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:97:2",
+            "property": "Attunement",
+            "property_path": "ADDED.Attunement",
+            "source_record_id": "set_item:97:modifier:2"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:97:3",
+            "property": "Mana",
+            "property_path": "ADDED.Mana",
+            "source_record_id": "set_item:97:modifier:3"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:97:4",
+            "property": "ManaEfficiency",
+            "property_path": "ADDED.ManaEfficiency",
+            "source_record_id": "set_item:97:modifier:4"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:97:0",
+            "modifier_type": "ADDED",
+            "property": "Damage",
+            "property_path": "ADDED.Damage.Physical.Spell",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "Damage"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:97:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Physical",
+              "Spell"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 45.0,
+            "value_min": 30.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:97:1",
+            "modifier_type": "ADDED",
+            "property": "CriticalChance",
+            "property_path": "ADDED.CriticalChance",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 1,
+                "property": "CriticalChance"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:97:modifier:1",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 1,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.04,
+            "value_min": 0.02
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:97:2",
+            "modifier_type": "ADDED",
+            "property": "Attunement",
+            "property_path": "ADDED.Attunement",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 2,
+                "property": "Attunement"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:97:modifier:2",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 3,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 14.0,
+            "value_min": 8.0
+          },
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:97:3",
+            "modifier_type": "ADDED",
+            "property": "Mana",
+            "property_path": "ADDED.Mana",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 3,
+                "property": "Mana"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:97:modifier:3",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 30.0,
+            "value_min": 30.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:97:4",
+            "modifier_type": "ADDED",
+            "property": "ManaEfficiency",
+            "property_path": "ADDED.ManaEfficiency",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 4,
+                "property": "ManaEfficiency"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:97:modifier:4",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 4,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.1,
+            "value_min": 0.05
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_item_modifier_set_item:97:0",
+              "property": "Damage",
+              "property_path": "ADDED.Damage.Physical.Spell",
+              "source_record_id": "set_item:97:modifier:0"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:97:1",
+              "property": "CriticalChance",
+              "property_path": "ADDED.CriticalChance",
+              "source_record_id": "set_item:97:modifier:1"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:97:2",
+              "property": "Attunement",
+              "property_path": "ADDED.Attunement",
+              "source_record_id": "set_item:97:modifier:2"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:97:3",
+              "property": "Mana",
+              "property_path": "ADDED.Mana",
+              "source_record_id": "set_item:97:modifier:3"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:97:4",
+              "property": "ManaEfficiency",
+              "property_path": "ADDED.ManaEfficiency",
+              "source_record_id": "set_item:97:modifier:4"
+            }
+          ]
+        },
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_unique_set_export",
+          "notes": [
+            "Generated from extracted unique/set data; tooltip text is not inferred as mechanics."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "id": 97,
+            "name": "Halvars Pledge"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_item:97",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+          "source_type": "set_item"
+        },
+        "raw_reference": {
+          "baseType": "TWO_HANDED_STAFF",
+          "id": 97,
+          "name": "Halvars Pledge",
+          "resolutionStatus": "resolved",
+          "resolvedBaseItem": {
+            "baseTypeID": 15,
+            "displayName": "Two-Handed Staff",
+            "name": "2H Staff",
+            "subType": {
+              "displayName": "",
+              "levelRequirement": 46,
+              "name": "Shamanic Staff",
+              "subTypeID": 6
+            },
+            "type": "TWO_HANDED_STAFF"
+          },
+          "subTypes": [
+            6
+          ]
+        },
+        "requirements": {
+          "attributes": {},
+          "class": null,
+          "level": 46,
+          "mastery": null
+        },
+        "set_group_display_name": null,
+        "set_group_id": "set:7",
+        "set_id": "set:7",
+        "slot": "two_handed_staff",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+        "source_id": "set_item:97",
+        "special_mechanic_classification": "partial_modifier",
+        "special_mechanic_notes": [
+          "Structured modifier rows exist but remain partial until value normalization is solved."
+        ],
+        "stable_calculable": false,
+        "subtype": "Shamanic Staff",
+        "support_status": "partial",
+        "tooltip_text": [],
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Unique/set record is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "attribute_requirements": {},
+        "base_item_id": "item_base:equippable:3:5",
+        "bonus_text": [],
+        "canonical_id": "set_item:98",
+        "class_restrictions": [],
+        "classification": "armor",
+        "consumer_safe_fields": {
+          "display_name": "Halvar's Stand",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Halvar's Stand",
+        "equipment_slot": "boots",
+        "implicit_ids": [],
+        "implicit_links": [
+          {
+            "base_item_id": "item_base:equippable:3:5",
+            "implicit_index": 0,
+            "modifier_type": "ADDED",
+            "property": "Armour"
+          },
+          {
+            "base_item_id": "item_base:equippable:3:5",
+            "implicit_index": 1,
+            "modifier_type": "INCREASED",
+            "property": "Movespeed"
+          },
+          {
+            "base_item_id": "item_base:equippable:3:5",
+            "implicit_index": 2,
+            "modifier_type": "ADDED",
+            "property": "ColdResistance"
+          }
+        ],
+        "item_category": "equipment",
+        "item_type": "boots",
+        "level_requirement": 45,
+        "lore_text": "When Morditas\u2019 army closed in on him, Halvar asked the mountain to bury them together.",
+        "mastery_restrictions": [],
+        "modifier_references": [
+          {
+            "modifier_id": "set_item_modifier_set_item:98:0",
+            "property": "FreezeRateMultiplier",
+            "property_path": "ADDED.FreezeRateMultiplier",
+            "source_record_id": "set_item:98:modifier:0"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:98:1",
+            "property": "ManaEfficiency",
+            "property_path": "ADDED.ManaEfficiency",
+            "source_record_id": "set_item:98:modifier:1"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:98:2",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Fire.Void.Necrotic",
+            "source_record_id": "set_item:98:modifier:2"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:98:3",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Poison",
+            "source_record_id": "set_item:98:modifier:3"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:98:4",
+            "property": "Movespeed",
+            "property_path": "INCREASED.Movespeed",
+            "source_record_id": "set_item:98:modifier:4"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:98:0",
+            "modifier_type": "ADDED",
+            "property": "FreezeRateMultiplier",
+            "property_path": "ADDED.FreezeRateMultiplier",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "FreezeRateMultiplier"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:98:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 2.0,
+            "value_min": 1.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:98:1",
+            "modifier_type": "ADDED",
+            "property": "ManaEfficiency",
+            "property_path": "ADDED.ManaEfficiency",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 1,
+                "property": "ManaEfficiency"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:98:modifier:1",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 1,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.1,
+            "value_min": 0.05
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:98:2",
+            "modifier_type": "ADDED",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Fire.Void.Necrotic",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 2,
+                "property": "PlayerProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:98:modifier:2",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 2,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Fire",
+              "Void",
+              "Necrotic"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.7,
+            "value_min": 0.35
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:98:3",
+            "modifier_type": "ADDED",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Poison",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 3,
+                "property": "PlayerProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:98:modifier:3",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 3,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Poison"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.4,
+            "value_min": 0.2
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:98:4",
+            "modifier_type": "INCREASED",
+            "property": "Movespeed",
+            "property_path": "INCREASED.Movespeed",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 4,
+                "property": "Movespeed"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:98:modifier:4",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 4,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.18,
+            "value_min": 0.12
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_item_modifier_set_item:98:0",
+              "property": "FreezeRateMultiplier",
+              "property_path": "ADDED.FreezeRateMultiplier",
+              "source_record_id": "set_item:98:modifier:0"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:98:1",
+              "property": "ManaEfficiency",
+              "property_path": "ADDED.ManaEfficiency",
+              "source_record_id": "set_item:98:modifier:1"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:98:2",
+              "property": "PlayerProperty",
+              "property_path": "ADDED.PlayerProperty.Fire.Void.Necrotic",
+              "source_record_id": "set_item:98:modifier:2"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:98:3",
+              "property": "PlayerProperty",
+              "property_path": "ADDED.PlayerProperty.Poison",
+              "source_record_id": "set_item:98:modifier:3"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:98:4",
+              "property": "Movespeed",
+              "property_path": "INCREASED.Movespeed",
+              "source_record_id": "set_item:98:modifier:4"
+            }
+          ]
+        },
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_unique_set_export",
+          "notes": [
+            "Generated from extracted unique/set data; tooltip text is not inferred as mechanics."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "id": 98,
+            "name": "Halvars Stand"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_item:98",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+          "source_type": "set_item"
+        },
+        "raw_reference": {
+          "baseType": "BOOTS",
+          "id": 98,
+          "name": "Halvars Stand",
+          "resolutionStatus": "resolved",
+          "resolvedBaseItem": {
+            "baseTypeID": 3,
+            "displayName": "Boots",
+            "name": "Boots",
+            "subType": {
+              "displayName": "",
+              "levelRequirement": 45,
+              "name": "Heoborean Boots",
+              "subTypeID": 5
+            },
+            "type": "BOOTS"
+          },
+          "subTypes": [
+            5
+          ]
+        },
+        "requirements": {
+          "attributes": {},
+          "class": null,
+          "level": 45,
+          "mastery": null
+        },
+        "set_group_display_name": null,
+        "set_group_id": "set:7",
+        "set_id": "set:7",
+        "slot": "boots",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+        "source_id": "set_item:98",
+        "special_mechanic_classification": "partial_modifier",
+        "special_mechanic_notes": [
+          "Structured modifier rows exist but remain partial until value normalization is solved."
+        ],
+        "stable_calculable": false,
+        "subtype": "Heoborean Boots",
+        "support_status": "partial",
+        "tooltip_text": [],
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Unique/set record is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "attribute_requirements": {},
+        "base_item_id": "item_base:equippable:22:7",
+        "bonus_text": [],
+        "canonical_id": "set_item:99",
+        "class_restrictions": [],
+        "classification": "accessory",
+        "consumer_safe_fields": {
+          "display_name": "Last Gift of the Mountain",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Last Gift of the Mountain",
+        "equipment_slot": "relic",
+        "implicit_ids": [],
+        "implicit_links": [
+          {
+            "base_item_id": "item_base:equippable:22:7",
+            "implicit_index": 0,
+            "modifier_type": "ADDED",
+            "property": "Attunement"
+          },
+          {
+            "base_item_id": "item_base:equippable:22:7",
+            "implicit_index": 1,
+            "modifier_type": "ADDED",
+            "property": "AllResistances"
+          }
+        ],
+        "item_category": "equipment",
+        "item_type": "relic",
+        "level_requirement": 42,
+        "lore_text": "The mountain was sad to lose a friend as true as Halvar.",
+        "mastery_restrictions": [],
+        "modifier_references": [
+          {
+            "modifier_id": "set_item_modifier_set_item:99:0",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Physical.Cold.Void.Necrotic",
+            "source_record_id": "set_item:99:modifier:0"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:99:1",
+            "property": "IncreasedStunChance",
+            "property_path": "ADDED.IncreasedStunChance.Spell",
+            "source_record_id": "set_item:99:modifier:1"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:99:2",
+            "property": "AilmentChance",
+            "property_path": "ADDED.AilmentChance.Spell",
+            "source_record_id": "set_item:99:modifier:2"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:99:3",
+            "property": "AilmentChance",
+            "property_path": "ADDED.AilmentChance.Spell",
+            "source_record_id": "set_item:99:modifier:3"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:99:4",
+            "property": "Health",
+            "property_path": "ADDED.Health",
+            "source_record_id": "set_item:99:modifier:4"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:99:0",
+            "modifier_type": "ADDED",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Physical.Cold.Void.Necrotic",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "PlayerProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:99:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Physical",
+              "Cold",
+              "Void",
+              "Necrotic"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.7,
+            "value_min": 0.35
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:99:1",
+            "modifier_type": "ADDED",
+            "property": "IncreasedStunChance",
+            "property_path": "ADDED.IncreasedStunChance.Spell",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 1,
+                "property": "IncreasedStunChance"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:99:modifier:1",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 1,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Spell"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.6,
+            "value_min": 0.3
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:99:2",
+            "modifier_type": "ADDED",
+            "property": "AilmentChance",
+            "property_path": "ADDED.AilmentChance.Spell",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 2,
+                "property": "AilmentChance"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:99:modifier:2",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 2,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Spell"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 1.5,
+            "value_min": 0.75
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:99:3",
+            "modifier_type": "ADDED",
+            "property": "AilmentChance",
+            "property_path": "ADDED.AilmentChance.Spell",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 3,
+                "property": "AilmentChance"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:99:modifier:3",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 3,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Spell"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 1.0,
+            "value_min": 0.5
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:99:4",
+            "modifier_type": "ADDED",
+            "property": "Health",
+            "property_path": "ADDED.Health",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 4,
+                "property": "Health"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:99:modifier:4",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 4,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 60.0,
+            "value_min": 20.0
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_item_modifier_set_item:99:0",
+              "property": "PlayerProperty",
+              "property_path": "ADDED.PlayerProperty.Physical.Cold.Void.Necrotic",
+              "source_record_id": "set_item:99:modifier:0"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:99:1",
+              "property": "IncreasedStunChance",
+              "property_path": "ADDED.IncreasedStunChance.Spell",
+              "source_record_id": "set_item:99:modifier:1"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:99:2",
+              "property": "AilmentChance",
+              "property_path": "ADDED.AilmentChance.Spell",
+              "source_record_id": "set_item:99:modifier:2"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:99:3",
+              "property": "AilmentChance",
+              "property_path": "ADDED.AilmentChance.Spell",
+              "source_record_id": "set_item:99:modifier:3"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:99:4",
+              "property": "Health",
+              "property_path": "ADDED.Health",
+              "source_record_id": "set_item:99:modifier:4"
+            }
+          ]
+        },
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_unique_set_export",
+          "notes": [
+            "Generated from extracted unique/set data; tooltip text is not inferred as mechanics."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "id": 99,
+            "name": "Last Gift of the Mountain"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_item:99",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+          "source_type": "set_item"
+        },
+        "raw_reference": {
+          "baseType": "RELIC",
+          "id": 99,
+          "name": "Last Gift of the Mountain",
+          "resolutionStatus": "resolved",
+          "resolvedBaseItem": {
+            "baseTypeID": 22,
+            "displayName": "Relic",
+            "name": "Relic",
+            "subType": {
+              "displayName": "",
+              "levelRequirement": 35,
+              "name": "Overgrowth Bloom",
+              "subTypeID": 7
+            },
+            "type": "RELIC"
+          },
+          "subTypes": [
+            7
+          ]
+        },
+        "requirements": {
+          "attributes": {},
+          "class": null,
+          "level": 42,
+          "mastery": null
+        },
+        "set_group_display_name": null,
+        "set_group_id": "set:7",
+        "set_id": "set:7",
+        "slot": "relic",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+        "source_id": "set_item:99",
+        "special_mechanic_classification": "partial_modifier",
+        "special_mechanic_notes": [
+          "Structured modifier rows exist but remain partial until value normalization is solved."
+        ],
+        "stable_calculable": false,
+        "subtype": "Overgrowth Bloom",
+        "support_status": "partial",
+        "tooltip_text": [],
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Unique/set record is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "attribute_requirements": {},
+        "base_item_id": "item_base:equippable:10:6",
+        "bonus_text": [
+          "+3 Melee Lightning Damage for Minions"
+        ],
+        "canonical_id": "set_item:100",
+        "class_restrictions": [],
+        "classification": "weapon",
+        "consumer_safe_fields": {
+          "display_name": "Pebbles' Femur",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Pebbles' Femur",
+        "equipment_slot": "wand",
+        "implicit_ids": [],
+        "implicit_links": [
+          {
+            "base_item_id": "item_base:equippable:10:6",
+            "implicit_index": 0,
+            "modifier_type": "ADDED",
+            "property": "Damage"
+          },
+          {
+            "base_item_id": "item_base:equippable:10:6",
+            "implicit_index": 1,
+            "modifier_type": "ADDED",
+            "property": "WardRetention"
+          },
+          {
+            "base_item_id": "item_base:equippable:10:6",
+            "implicit_index": 2,
+            "modifier_type": "ADDED",
+            "property": "ManaCost"
+          }
+        ],
+        "item_category": "equipment",
+        "item_type": "wand",
+        "level_requirement": 30,
+        "lore_text": "Feeding Pebbles was one of my favorite things to do. -Traveling Merchant",
+        "mastery_restrictions": [],
+        "modifier_references": [
+          {
+            "modifier_id": "set_item_modifier_set_item:100:0",
+            "property": "Damage",
+            "property_path": "INCREASED.Damage.Melee.Minion",
+            "source_record_id": "set_item:100:modifier:0"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:100:1",
+            "property": "Damage",
+            "property_path": "ADDED.Damage.Lightning.Melee.Minion",
+            "source_record_id": "set_item:100:modifier:1"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:100:2",
+            "property": "Intelligence",
+            "property_path": "ADDED.Intelligence",
+            "source_record_id": "set_item:100:modifier:2"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:100:3",
+            "property": "LightningResistance",
+            "property_path": "ADDED.LightningResistance",
+            "source_record_id": "set_item:100:modifier:3"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:100:0",
+            "modifier_type": "INCREASED",
+            "property": "Damage",
+            "property_path": "INCREASED.Damage.Melee.Minion",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "Damage"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:100:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Melee",
+              "Minion"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 1.2,
+            "value_min": 0.8
+          },
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": true,
+            "modifier_id": "set_item_modifier_set_item:100:1",
+            "modifier_type": "ADDED",
+            "property": "Damage",
+            "property_path": "ADDED.Damage.Lightning.Melee.Minion",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 1,
+                "property": "Damage"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:100:modifier:1",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Lightning",
+              "Melee",
+              "Minion"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 3.0,
+            "value_min": 3.0
+          },
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:100:2",
+            "modifier_type": "ADDED",
+            "property": "Intelligence",
+            "property_path": "ADDED.Intelligence",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 2,
+                "property": "Intelligence"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:100:modifier:2",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 3.0,
+            "value_min": 3.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:100:3",
+            "modifier_type": "ADDED",
+            "property": "LightningResistance",
+            "property_path": "ADDED.LightningResistance",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 3,
+                "property": "LightningResistance"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:100:modifier:3",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 1,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.42,
+            "value_min": 0.24
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_item_modifier_set_item:100:0",
+              "property": "Damage",
+              "property_path": "INCREASED.Damage.Melee.Minion",
+              "source_record_id": "set_item:100:modifier:0"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:100:1",
+              "property": "Damage",
+              "property_path": "ADDED.Damage.Lightning.Melee.Minion",
+              "source_record_id": "set_item:100:modifier:1"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:100:2",
+              "property": "Intelligence",
+              "property_path": "ADDED.Intelligence",
+              "source_record_id": "set_item:100:modifier:2"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:100:3",
+              "property": "LightningResistance",
+              "property_path": "ADDED.LightningResistance",
+              "source_record_id": "set_item:100:modifier:3"
+            }
+          ]
+        },
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_unique_set_export",
+          "notes": [
+            "Generated from extracted unique/set data; tooltip text is not inferred as mechanics."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "id": 100,
+            "name": "Pebbles Femur"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_item:100",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+          "source_type": "set_item"
+        },
+        "raw_reference": {
+          "baseType": "WAND",
+          "id": 100,
+          "name": "Pebbles Femur",
+          "resolutionStatus": "resolved",
+          "resolvedBaseItem": {
+            "baseTypeID": 10,
+            "displayName": "Wand",
+            "name": "Wands",
+            "subType": {
+              "displayName": "",
+              "levelRequirement": 31,
+              "name": "Ivory Wand",
+              "subTypeID": 6
+            },
+            "type": "WAND"
+          },
+          "subTypes": [
+            6
+          ]
+        },
+        "requirements": {
+          "attributes": {},
+          "class": null,
+          "level": 30,
+          "mastery": null
+        },
+        "set_group_display_name": null,
+        "set_group_id": "set:8",
+        "set_id": "set:8",
+        "slot": "wand",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+        "source_id": "set_item:100",
+        "special_mechanic_classification": "partial_modifier",
+        "special_mechanic_notes": [
+          "Structured modifier rows exist but remain partial until value normalization is solved."
+        ],
+        "stable_calculable": false,
+        "subtype": "Ivory Wand",
+        "support_status": "partial",
+        "tooltip_text": [
+          "+3 Melee Lightning Damage for Minions"
+        ],
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Unique/set record is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "attribute_requirements": {},
+        "base_item_id": "item_base:equippable:22:0",
+        "bonus_text": [
+          "+3 Melee Cold Damage for Minions"
+        ],
+        "canonical_id": "set_item:101",
+        "class_restrictions": [],
+        "classification": "accessory",
+        "consumer_safe_fields": {
+          "display_name": "Pebbles' Collar",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Pebbles' Collar",
+        "equipment_slot": "relic",
+        "implicit_ids": [],
+        "implicit_links": [
+          {
+            "base_item_id": "item_base:equippable:22:0",
+            "implicit_index": 0,
+            "modifier_type": "ADDED",
+            "property": "Mana"
+          }
+        ],
+        "item_category": "equipment",
+        "item_type": "relic",
+        "level_requirement": 12,
+        "lore_text": "The bones in Pebbles' body respond to metal like a magnet. I\u2019m beginning to think I\u2019m in over my head. -Traveling Merchant",
+        "mastery_restrictions": [],
+        "modifier_references": [
+          {
+            "modifier_id": "set_item_modifier_set_item:101:0",
+            "property": "Damage",
+            "property_path": "INCREASED.Damage.Minion",
+            "source_record_id": "set_item:101:modifier:0"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:101:1",
+            "property": "Intelligence",
+            "property_path": "ADDED.Intelligence",
+            "source_record_id": "set_item:101:modifier:1"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:101:2",
+            "property": "ColdResistance",
+            "property_path": "ADDED.ColdResistance",
+            "source_record_id": "set_item:101:modifier:2"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:101:3",
+            "property": "Damage",
+            "property_path": "ADDED.Damage.Cold.Melee.Minion",
+            "source_record_id": "set_item:101:modifier:3"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:101:0",
+            "modifier_type": "INCREASED",
+            "property": "Damage",
+            "property_path": "INCREASED.Damage.Minion",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "Damage"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:101:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Minion"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.42,
+            "value_min": 0.24
+          },
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:101:1",
+            "modifier_type": "ADDED",
+            "property": "Intelligence",
+            "property_path": "ADDED.Intelligence",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 1,
+                "property": "Intelligence"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:101:modifier:1",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 3.0,
+            "value_min": 3.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:101:2",
+            "modifier_type": "ADDED",
+            "property": "ColdResistance",
+            "property_path": "ADDED.ColdResistance",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 2,
+                "property": "ColdResistance"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:101:modifier:2",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 1,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.42,
+            "value_min": 0.24
+          },
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": true,
+            "modifier_id": "set_item_modifier_set_item:101:3",
+            "modifier_type": "ADDED",
+            "property": "Damage",
+            "property_path": "ADDED.Damage.Cold.Melee.Minion",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 3,
+                "property": "Damage"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:101:modifier:3",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Cold",
+              "Melee",
+              "Minion"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 3.0,
+            "value_min": 3.0
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_item_modifier_set_item:101:0",
+              "property": "Damage",
+              "property_path": "INCREASED.Damage.Minion",
+              "source_record_id": "set_item:101:modifier:0"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:101:1",
+              "property": "Intelligence",
+              "property_path": "ADDED.Intelligence",
+              "source_record_id": "set_item:101:modifier:1"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:101:2",
+              "property": "ColdResistance",
+              "property_path": "ADDED.ColdResistance",
+              "source_record_id": "set_item:101:modifier:2"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:101:3",
+              "property": "Damage",
+              "property_path": "ADDED.Damage.Cold.Melee.Minion",
+              "source_record_id": "set_item:101:modifier:3"
+            }
+          ]
+        },
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_unique_set_export",
+          "notes": [
+            "Generated from extracted unique/set data; tooltip text is not inferred as mechanics."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "id": 101,
+            "name": "Pebbles Collar"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_item:101",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+          "source_type": "set_item"
+        },
+        "raw_reference": {
+          "baseType": "RELIC",
+          "id": 101,
+          "name": "Pebbles Collar",
+          "resolutionStatus": "resolved",
+          "resolvedBaseItem": {
+            "baseTypeID": 22,
+            "displayName": "Relic",
+            "name": "Relic",
+            "subType": {
+              "displayName": "Reliquary Text",
+              "levelRequirement": 0,
+              "name": "Mage Relic",
+              "subTypeID": 0
+            },
+            "type": "RELIC"
+          },
+          "subTypes": [
+            0
+          ]
+        },
+        "requirements": {
+          "attributes": {},
+          "class": null,
+          "level": 12,
+          "mastery": null
+        },
+        "set_group_display_name": null,
+        "set_group_id": "set:8",
+        "set_id": "set:8",
+        "slot": "relic",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+        "source_id": "set_item:101",
+        "special_mechanic_classification": "partial_modifier",
+        "special_mechanic_notes": [
+          "Structured modifier rows exist but remain partial until value normalization is solved."
+        ],
+        "stable_calculable": false,
+        "subtype": "Mage Relic",
+        "support_status": "partial",
+        "tooltip_text": [
+          "+3 Melee Cold Damage for Minions"
+        ],
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Unique/set record is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "attribute_requirements": {},
+        "base_item_id": "item_base:equippable:2:0",
+        "bonus_text": [
+          "+3 Melee Fire Damage for Minions"
+        ],
+        "canonical_id": "set_item:102",
+        "class_restrictions": [],
+        "classification": "accessory",
+        "consumer_safe_fields": {
+          "display_name": "Pebbles' Bitemarked Sash",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Pebbles' Bitemarked Sash",
+        "equipment_slot": "belt",
+        "implicit_ids": [],
+        "implicit_links": [
+          {
+            "base_item_id": "item_base:equippable:2:0",
+            "implicit_index": 0,
+            "modifier_type": "ADDED",
+            "property": "PotionSlots"
+          }
+        ],
+        "item_category": "equipment",
+        "item_type": "belt",
+        "level_requirement": 12,
+        "lore_text": "As I lay in the ditch pulling my entrails back into my body, I wonder; who is the pet now?  -Traveling Merchant",
+        "mastery_restrictions": [],
+        "modifier_references": [
+          {
+            "modifier_id": "set_item_modifier_set_item:102:0",
+            "property": "Damage",
+            "property_path": "INCREASED.Damage.Minion",
+            "source_record_id": "set_item:102:modifier:0"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:102:1",
+            "property": "Intelligence",
+            "property_path": "ADDED.Intelligence",
+            "source_record_id": "set_item:102:modifier:1"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:102:2",
+            "property": "FireResistance",
+            "property_path": "ADDED.FireResistance",
+            "source_record_id": "set_item:102:modifier:2"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:102:3",
+            "property": "Damage",
+            "property_path": "ADDED.Damage.Fire.Melee.Minion",
+            "source_record_id": "set_item:102:modifier:3"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:102:0",
+            "modifier_type": "INCREASED",
+            "property": "Damage",
+            "property_path": "INCREASED.Damage.Minion",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "Damage"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:102:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Minion"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.42,
+            "value_min": 0.24
+          },
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:102:1",
+            "modifier_type": "ADDED",
+            "property": "Intelligence",
+            "property_path": "ADDED.Intelligence",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 1,
+                "property": "Intelligence"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:102:modifier:1",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 3.0,
+            "value_min": 3.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:102:2",
+            "modifier_type": "ADDED",
+            "property": "FireResistance",
+            "property_path": "ADDED.FireResistance",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 2,
+                "property": "FireResistance"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:102:modifier:2",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 1,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.42,
+            "value_min": 0.24
+          },
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": true,
+            "modifier_id": "set_item_modifier_set_item:102:3",
+            "modifier_type": "ADDED",
+            "property": "Damage",
+            "property_path": "ADDED.Damage.Fire.Melee.Minion",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 3,
+                "property": "Damage"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:102:modifier:3",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Fire",
+              "Melee",
+              "Minion"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 3.0,
+            "value_min": 3.0
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_item_modifier_set_item:102:0",
+              "property": "Damage",
+              "property_path": "INCREASED.Damage.Minion",
+              "source_record_id": "set_item:102:modifier:0"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:102:1",
+              "property": "Intelligence",
+              "property_path": "ADDED.Intelligence",
+              "source_record_id": "set_item:102:modifier:1"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:102:2",
+              "property": "FireResistance",
+              "property_path": "ADDED.FireResistance",
+              "source_record_id": "set_item:102:modifier:2"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:102:3",
+              "property": "Damage",
+              "property_path": "ADDED.Damage.Fire.Melee.Minion",
+              "source_record_id": "set_item:102:modifier:3"
+            }
+          ]
+        },
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_unique_set_export",
+          "notes": [
+            "Generated from extracted unique/set data; tooltip text is not inferred as mechanics."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "id": 102,
+            "name": "Pebbles Bitemarked Sash"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_item:102",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+          "source_type": "set_item"
+        },
+        "raw_reference": {
+          "baseType": "BELT",
+          "id": 102,
+          "name": "Pebbles Bitemarked Sash",
+          "resolutionStatus": "resolved",
+          "resolvedBaseItem": {
+            "baseTypeID": 2,
+            "displayName": "Belt",
+            "name": "Belts",
+            "subType": {
+              "displayName": "",
+              "levelRequirement": 0,
+              "name": "Sash",
+              "subTypeID": 0
+            },
+            "type": "BELT"
+          },
+          "subTypes": [
+            0
+          ]
+        },
+        "requirements": {
+          "attributes": {},
+          "class": null,
+          "level": 12,
+          "mastery": null
+        },
+        "set_group_display_name": null,
+        "set_group_id": "set:8",
+        "set_id": "set:8",
+        "slot": "belt",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+        "source_id": "set_item:102",
+        "special_mechanic_classification": "partial_modifier",
+        "special_mechanic_notes": [
+          "Structured modifier rows exist but remain partial until value normalization is solved."
+        ],
+        "stable_calculable": false,
+        "subtype": "Sash",
+        "support_status": "partial",
+        "tooltip_text": [
+          "+3 Melee Fire Damage for Minions"
+        ],
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Unique/set record is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "attribute_requirements": {},
+        "base_item_id": "item_base:equippable:9:0",
+        "bonus_text": [],
+        "canonical_id": "set_item:109",
+        "class_restrictions": [],
+        "classification": "weapon",
+        "consumer_safe_fields": {
+          "display_name": "Shard of the Shattered Lance",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Shard of the Shattered Lance",
+        "equipment_slot": "one_handed_sword",
+        "implicit_ids": [],
+        "implicit_links": [
+          {
+            "base_item_id": "item_base:equippable:9:0",
+            "implicit_index": 0,
+            "modifier_type": "ADDED",
+            "property": "Damage"
+          }
+        ],
+        "item_category": "equipment",
+        "item_type": "one_handed_sword",
+        "level_requirement": 68,
+        "lore_text": "Dreams of deicide reflected in ice.",
+        "mastery_restrictions": [],
+        "modifier_references": [
+          {
+            "modifier_id": "set_item_modifier_set_item:109:0",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Physical.Cold.Fire.Poison",
+            "source_record_id": "set_item:109:modifier:0"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:109:1",
+            "property": "Damage",
+            "property_path": "ADDED.Damage.Cold.Melee",
+            "source_record_id": "set_item:109:modifier:1"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:109:2",
+            "property": "Damage",
+            "property_path": "INCREASED.Damage.Cold.Melee",
+            "source_record_id": "set_item:109:modifier:2"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:109:3",
+            "property": "FreezeRateMultiplier",
+            "property_path": "ADDED.FreezeRateMultiplier",
+            "source_record_id": "set_item:109:modifier:3"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:109:4",
+            "property": "HealthRegen",
+            "property_path": "ADDED.HealthRegen",
+            "source_record_id": "set_item:109:modifier:4"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:109:0",
+            "modifier_type": "ADDED",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Physical.Cold.Fire.Poison",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "PlayerProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:109:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Physical",
+              "Cold",
+              "Fire",
+              "Poison"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 1.0,
+            "value_min": 1.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:109:1",
+            "modifier_type": "ADDED",
+            "property": "Damage",
+            "property_path": "ADDED.Damage.Cold.Melee",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 1,
+                "property": "Damage"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:109:modifier:1",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Cold",
+              "Melee"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 85.0,
+            "value_min": 70.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:109:2",
+            "modifier_type": "INCREASED",
+            "property": "Damage",
+            "property_path": "INCREASED.Damage.Cold.Melee",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 2,
+                "property": "Damage"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:109:modifier:2",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 1,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Cold",
+              "Melee"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 1.0,
+            "value_min": 0.7
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:109:3",
+            "modifier_type": "ADDED",
+            "property": "FreezeRateMultiplier",
+            "property_path": "ADDED.FreezeRateMultiplier",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 3,
+                "property": "FreezeRateMultiplier"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:109:modifier:3",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 2,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 1.5,
+            "value_min": 1.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:109:4",
+            "modifier_type": "ADDED",
+            "property": "HealthRegen",
+            "property_path": "ADDED.HealthRegen",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 4,
+                "property": "HealthRegen"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:109:modifier:4",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 3,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 10.0,
+            "value_min": 5.0
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_item_modifier_set_item:109:0",
+              "property": "PlayerProperty",
+              "property_path": "ADDED.PlayerProperty.Physical.Cold.Fire.Poison",
+              "source_record_id": "set_item:109:modifier:0"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:109:1",
+              "property": "Damage",
+              "property_path": "ADDED.Damage.Cold.Melee",
+              "source_record_id": "set_item:109:modifier:1"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:109:2",
+              "property": "Damage",
+              "property_path": "INCREASED.Damage.Cold.Melee",
+              "source_record_id": "set_item:109:modifier:2"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:109:3",
+              "property": "FreezeRateMultiplier",
+              "property_path": "ADDED.FreezeRateMultiplier",
+              "source_record_id": "set_item:109:modifier:3"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:109:4",
+              "property": "HealthRegen",
+              "property_path": "ADDED.HealthRegen",
+              "source_record_id": "set_item:109:modifier:4"
+            }
+          ]
+        },
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_unique_set_export",
+          "notes": [
+            "Generated from extracted unique/set data; tooltip text is not inferred as mechanics."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "id": 109,
+            "name": "Shard of the Shattered Lance"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_item:109",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+          "source_type": "set_item"
+        },
+        "raw_reference": {
+          "baseType": "ONE_HANDED_SWORD",
+          "id": 109,
+          "name": "Shard of the Shattered Lance",
+          "resolutionStatus": "resolved",
+          "resolvedBaseItem": {
+            "baseTypeID": 9,
+            "displayName": "One-Handed Sword",
+            "name": "1H Swords",
+            "subType": {
+              "displayName": "",
+              "levelRequirement": 5,
+              "name": "Broken Sword",
+              "subTypeID": 0
+            },
+            "type": "ONE_HANDED_SWORD"
+          },
+          "subTypes": [
+            0
+          ]
+        },
+        "requirements": {
+          "attributes": {},
+          "class": null,
+          "level": 68,
+          "mastery": null
+        },
+        "set_group_display_name": null,
+        "set_group_id": "set:9",
+        "set_id": "set:9",
+        "slot": "one_handed_sword",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+        "source_id": "set_item:109",
+        "special_mechanic_classification": "partial_modifier",
+        "special_mechanic_notes": [
+          "Structured modifier rows exist but remain partial until value normalization is solved."
+        ],
+        "stable_calculable": false,
+        "subtype": "Broken Sword",
+        "support_status": "partial",
+        "tooltip_text": [],
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Unique/set record is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "attribute_requirements": {},
+        "base_item_id": "item_base:equippable:22:10",
+        "bonus_text": [],
+        "canonical_id": "set_item:110",
+        "class_restrictions": [],
+        "classification": "accessory",
+        "consumer_safe_fields": {
+          "display_name": "Fragments of the Shattered Lance",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Fragments of the Shattered Lance",
+        "equipment_slot": "relic",
+        "implicit_ids": [],
+        "implicit_links": [
+          {
+            "base_item_id": "item_base:equippable:22:10",
+            "implicit_index": 0,
+            "modifier_type": "ADDED",
+            "property": "HealthRegen"
+          }
+        ],
+        "item_category": "equipment",
+        "item_type": "relic",
+        "level_requirement": 65,
+        "lore_text": "Crafted in desperation, seized with ambition.",
+        "mastery_restrictions": [],
+        "modifier_references": [
+          {
+            "modifier_id": "set_item_modifier_set_item:110:0",
+            "property": "HealthRegen",
+            "property_path": "INCREASED.HealthRegen",
+            "source_record_id": "set_item:110:modifier:0"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:110:1",
+            "property": "FreezeRateMultiplier",
+            "property_path": "ADDED.FreezeRateMultiplier",
+            "source_record_id": "set_item:110:modifier:1"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:110:2",
+            "property": "HealthGain",
+            "property_path": "ADDED.HealthGain",
+            "source_record_id": "set_item:110:modifier:2"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:110:3",
+            "property": "Damage",
+            "property_path": "INCREASED.Damage.Cold.Melee",
+            "source_record_id": "set_item:110:modifier:3"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:110:0",
+            "modifier_type": "INCREASED",
+            "property": "HealthRegen",
+            "property_path": "INCREASED.HealthRegen",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "HealthRegen"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:110:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 1.0,
+            "value_min": 0.7
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:110:1",
+            "modifier_type": "ADDED",
+            "property": "FreezeRateMultiplier",
+            "property_path": "ADDED.FreezeRateMultiplier",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 1,
+                "property": "FreezeRateMultiplier"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:110:modifier:1",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 1,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 1.0,
+            "value_min": 0.5
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:110:2",
+            "modifier_type": "ADDED",
+            "property": "HealthGain",
+            "property_path": "ADDED.HealthGain",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 2,
+                "property": "HealthGain"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:110:modifier:2",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 13.0,
+            "value_min": 10.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:110:3",
+            "modifier_type": "INCREASED",
+            "property": "Damage",
+            "property_path": "INCREASED.Damage.Cold.Melee",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 3,
+                "property": "Damage"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:110:modifier:3",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Cold",
+              "Melee"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.7,
+            "value_min": 0.5
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_item_modifier_set_item:110:0",
+              "property": "HealthRegen",
+              "property_path": "INCREASED.HealthRegen",
+              "source_record_id": "set_item:110:modifier:0"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:110:1",
+              "property": "FreezeRateMultiplier",
+              "property_path": "ADDED.FreezeRateMultiplier",
+              "source_record_id": "set_item:110:modifier:1"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:110:2",
+              "property": "HealthGain",
+              "property_path": "ADDED.HealthGain",
+              "source_record_id": "set_item:110:modifier:2"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:110:3",
+              "property": "Damage",
+              "property_path": "INCREASED.Damage.Cold.Melee",
+              "source_record_id": "set_item:110:modifier:3"
+            }
+          ]
+        },
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_unique_set_export",
+          "notes": [
+            "Generated from extracted unique/set data; tooltip text is not inferred as mechanics."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "id": 110,
+            "name": "Fragments of the Shattered Lance"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_item:110",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+          "source_type": "set_item"
+        },
+        "raw_reference": {
+          "baseType": "RELIC",
+          "id": 110,
+          "name": "Fragments of the Shattered Lance",
+          "resolutionStatus": "resolved",
+          "resolvedBaseItem": {
+            "baseTypeID": 22,
+            "displayName": "Relic",
+            "name": "Relic",
+            "subType": {
+              "displayName": "",
+              "levelRequirement": 65,
+              "name": "Splintered Haft",
+              "subTypeID": 10
+            },
+            "type": "RELIC"
+          },
+          "subTypes": [
+            10
+          ]
+        },
+        "requirements": {
+          "attributes": {},
+          "class": null,
+          "level": 65,
+          "mastery": null
+        },
+        "set_group_display_name": null,
+        "set_group_id": "set:9",
+        "set_id": "set:9",
+        "slot": "relic",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+        "source_id": "set_item:110",
+        "special_mechanic_classification": "partial_modifier",
+        "special_mechanic_notes": [
+          "Structured modifier rows exist but remain partial until value normalization is solved."
+        ],
+        "stable_calculable": false,
+        "subtype": "Splintered Haft",
+        "support_status": "partial",
+        "tooltip_text": [],
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Unique/set record is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "attribute_requirements": {},
+        "base_item_id": "item_base:equippable:8:4",
+        "bonus_text": [
+          "Your companions are Enraged when hit by your Storm Totem",
+          "Enrage gives 60% increased attack and cast speed and 35% increased movement speed."
+        ],
+        "canonical_id": "set_item:127",
+        "class_restrictions": [],
+        "classification": "weapon",
+        "consumer_safe_fields": {
+          "display_name": "Boardman's Plank",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Boardman's Plank",
+        "equipment_slot": "one_handed_sceptre",
+        "implicit_ids": [],
+        "implicit_links": [
+          {
+            "base_item_id": "item_base:equippable:8:4",
+            "implicit_index": 0,
+            "modifier_type": "ADDED",
+            "property": "Damage"
+          },
+          {
+            "base_item_id": "item_base:equippable:8:4",
+            "implicit_index": 1,
+            "modifier_type": "ADDED",
+            "property": "Damage"
+          },
+          {
+            "base_item_id": "item_base:equippable:8:4",
+            "implicit_index": 2,
+            "modifier_type": "INCREASED",
+            "property": "Damage"
+          }
+        ],
+        "item_category": "equipment",
+        "item_type": "one_handed_sceptre",
+        "level_requirement": 63,
+        "lore_text": "Unleash the Beast.",
+        "mastery_restrictions": [],
+        "modifier_references": [
+          {
+            "modifier_id": "set_item_modifier_set_item:127:0",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Lightning.Cold.Fire.Spell",
+            "source_record_id": "set_item:127:modifier:0"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:127:1",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Lightning.Poison.Elemental",
+            "source_record_id": "set_item:127:modifier:1"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:127:2",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Lightning.Poison.Elemental",
+            "source_record_id": "set_item:127:modifier:2"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:127:3",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Lightning.Poison.Elemental",
+            "source_record_id": "set_item:127:modifier:3"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:127:0",
+            "modifier_type": "ADDED",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Lightning.Cold.Fire.Spell",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "AbilityProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:127:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Lightning",
+              "Cold",
+              "Fire",
+              "Spell"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.21,
+            "value_min": 0.21
+          },
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": true,
+            "modifier_id": "set_item_modifier_set_item:127:1",
+            "modifier_type": "ADDED",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Lightning.Poison.Elemental",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 1,
+                "property": "AbilityProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:127:modifier:1",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Physical",
+              "Lightning",
+              "Poison",
+              "Elemental"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 1.0,
+            "value_min": 1.0
+          },
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:127:2",
+            "modifier_type": "ADDED",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Lightning.Poison.Elemental",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 2,
+                "property": "AbilityProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:127:modifier:2",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Physical",
+              "Lightning",
+              "Poison",
+              "Elemental"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 21.0,
+            "value_min": 21.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:127:3",
+            "modifier_type": "ADDED",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Lightning.Poison.Elemental",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 3,
+                "property": "AbilityProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:127:modifier:3",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Physical",
+              "Lightning",
+              "Poison",
+              "Elemental"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.75,
+            "value_min": 0.3
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_item_modifier_set_item:127:0",
+              "property": "AbilityProperty",
+              "property_path": "ADDED.AbilityProperty.Lightning.Cold.Fire.Spell",
+              "source_record_id": "set_item:127:modifier:0"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:127:1",
+              "property": "AbilityProperty",
+              "property_path": "ADDED.AbilityProperty.Physical.Lightning.Poison.Elemental",
+              "source_record_id": "set_item:127:modifier:1"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:127:2",
+              "property": "AbilityProperty",
+              "property_path": "ADDED.AbilityProperty.Physical.Lightning.Poison.Elemental",
+              "source_record_id": "set_item:127:modifier:2"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:127:3",
+              "property": "AbilityProperty",
+              "property_path": "ADDED.AbilityProperty.Physical.Lightning.Poison.Elemental",
+              "source_record_id": "set_item:127:modifier:3"
+            }
+          ]
+        },
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_unique_set_export",
+          "notes": [
+            "Generated from extracted unique/set data; tooltip text is not inferred as mechanics."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "id": 127,
+            "name": "Boardman Plank"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_item:127",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+          "source_type": "set_item"
+        },
+        "raw_reference": {
+          "baseType": "ONE_HANDED_SCEPTRE",
+          "id": 127,
+          "name": "Boardman Plank",
+          "resolutionStatus": "resolved",
+          "resolvedBaseItem": {
+            "baseTypeID": 8,
+            "displayName": "Sceptre",
+            "name": "1H Scepter",
+            "subType": {
+              "displayName": "",
+              "levelRequirement": 21,
+              "name": "Oak Sceptre",
+              "subTypeID": 4
+            },
+            "type": "ONE_HANDED_SCEPTRE"
+          },
+          "subTypes": [
+            4
+          ]
+        },
+        "requirements": {
+          "attributes": {},
+          "class": null,
+          "level": 63,
+          "mastery": null
+        },
+        "set_group_display_name": null,
+        "set_group_id": "set:10",
+        "set_id": "set:10",
+        "slot": "one_handed_sceptre",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+        "source_id": "set_item:127",
+        "special_mechanic_classification": "partial_modifier",
+        "special_mechanic_notes": [
+          "Structured modifier rows exist but remain partial until value normalization is solved."
+        ],
+        "stable_calculable": false,
+        "subtype": "Oak Sceptre",
+        "support_status": "partial",
+        "tooltip_text": [
+          "Your companions are Enraged when hit by your Storm Totem",
+          "Enrage gives 60% increased attack and cast speed and 35% increased movement speed."
+        ],
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Unique/set record is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "attribute_requirements": {},
+        "base_item_id": "item_base:equippable:1:29",
+        "bonus_text": [
+          "You are Frenzied for 3 seconds when hit by your Storm Totem",
+          "Frenzy gives 20% increased attack and cast speed.",
+          "[10,21,1]% Increased Area of Storm Totem Aura"
+        ],
+        "canonical_id": "set_item:128",
+        "class_restrictions": [],
+        "classification": "armor",
+        "consumer_safe_fields": {
+          "display_name": "Boardman's Fallacy",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Boardman's Fallacy",
+        "equipment_slot": "body_armor",
+        "implicit_ids": [],
+        "implicit_links": [
+          {
+            "base_item_id": "item_base:equippable:1:29",
+            "implicit_index": 0,
+            "modifier_type": "ADDED",
+            "property": "Armour"
+          },
+          {
+            "base_item_id": "item_base:equippable:1:29",
+            "implicit_index": 1,
+            "modifier_type": "ADDED",
+            "property": "PhysicalResistance"
+          }
+        ],
+        "item_category": "equipment",
+        "item_type": "body_armor",
+        "level_requirement": 63,
+        "lore_text": null,
+        "mastery_restrictions": [],
+        "modifier_references": [
+          {
+            "modifier_id": "set_item_modifier_set_item:128:0",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Lightning.Poison.Elemental",
+            "source_record_id": "set_item:128:modifier:0"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:128:1",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Lightning.Poison.Elemental",
+            "source_record_id": "set_item:128:modifier:1"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:128:2",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Lightning.Poison.Elemental",
+            "source_record_id": "set_item:128:modifier:2"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:128:3",
+            "property": "Health",
+            "property_path": "INCREASED.Health.Minion",
+            "source_record_id": "set_item:128:modifier:3"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:128:4",
+            "property": "HealthRegen",
+            "property_path": "INCREASED.HealthRegen.Minion",
+            "source_record_id": "set_item:128:modifier:4"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:128:5",
+            "property": "Penetration",
+            "property_path": "ADDED.Penetration.Lightning.Minion",
+            "source_record_id": "set_item:128:modifier:5"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:128:0",
+            "modifier_type": "ADDED",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Lightning.Poison.Elemental",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "AbilityProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:128:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Physical",
+              "Lightning",
+              "Poison",
+              "Elemental"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.75,
+            "value_min": 0.3
+          },
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": true,
+            "modifier_id": "set_item_modifier_set_item:128:1",
+            "modifier_type": "ADDED",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Lightning.Poison.Elemental",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 1,
+                "property": "AbilityProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:128:modifier:1",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Physical",
+              "Lightning",
+              "Poison",
+              "Elemental"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 1.0,
+            "value_min": 1.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": true,
+            "modifier_id": "set_item_modifier_set_item:128:2",
+            "modifier_type": "ADDED",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Lightning.Poison.Elemental",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 2,
+                "property": "AbilityProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:128:modifier:2",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 1,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Physical",
+              "Lightning",
+              "Poison",
+              "Elemental"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.21,
+            "value_min": 0.1
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:128:3",
+            "modifier_type": "INCREASED",
+            "property": "Health",
+            "property_path": "INCREASED.Health.Minion",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 3,
+                "property": "Health"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:128:modifier:3",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 2,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Minion"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 3.21,
+            "value_min": 2.21
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:128:4",
+            "modifier_type": "INCREASED",
+            "property": "HealthRegen",
+            "property_path": "INCREASED.HealthRegen.Minion",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 4,
+                "property": "HealthRegen"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:128:modifier:4",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 3,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Minion"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 3.21,
+            "value_min": 2.21
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:128:5",
+            "modifier_type": "ADDED",
+            "property": "Penetration",
+            "property_path": "ADDED.Penetration.Lightning.Minion",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 5,
+                "property": "Penetration"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:128:modifier:5",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 4,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Lightning",
+              "Minion"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.21,
+            "value_min": 0.1
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_item_modifier_set_item:128:0",
+              "property": "AbilityProperty",
+              "property_path": "ADDED.AbilityProperty.Physical.Lightning.Poison.Elemental",
+              "source_record_id": "set_item:128:modifier:0"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:128:1",
+              "property": "AbilityProperty",
+              "property_path": "ADDED.AbilityProperty.Physical.Lightning.Poison.Elemental",
+              "source_record_id": "set_item:128:modifier:1"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:128:2",
+              "property": "AbilityProperty",
+              "property_path": "ADDED.AbilityProperty.Physical.Lightning.Poison.Elemental",
+              "source_record_id": "set_item:128:modifier:2"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:128:3",
+              "property": "Health",
+              "property_path": "INCREASED.Health.Minion",
+              "source_record_id": "set_item:128:modifier:3"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:128:4",
+              "property": "HealthRegen",
+              "property_path": "INCREASED.HealthRegen.Minion",
+              "source_record_id": "set_item:128:modifier:4"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:128:5",
+              "property": "Penetration",
+              "property_path": "ADDED.Penetration.Lightning.Minion",
+              "source_record_id": "set_item:128:modifier:5"
+            }
+          ]
+        },
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_unique_set_export",
+          "notes": [
+            "Generated from extracted unique/set data; tooltip text is not inferred as mechanics."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "id": 128,
+            "name": "Boardman Fallacy"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_item:128",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+          "source_type": "set_item"
+        },
+        "raw_reference": {
+          "baseType": "BODY_ARMOR",
+          "id": 128,
+          "name": "Boardman Fallacy",
+          "resolutionStatus": "resolved",
+          "resolvedBaseItem": {
+            "baseTypeID": 1,
+            "displayName": "Body Armor",
+            "name": "Body Armor",
+            "subType": {
+              "displayName": "",
+              "levelRequirement": 46,
+              "name": "Kolheim Armor",
+              "subTypeID": 29
+            },
+            "type": "BODY_ARMOR"
+          },
+          "subTypes": [
+            29
+          ]
+        },
+        "requirements": {
+          "attributes": {},
+          "class": null,
+          "level": 63,
+          "mastery": null
+        },
+        "set_group_display_name": null,
+        "set_group_id": "set:10",
+        "set_id": "set:10",
+        "slot": "body_armor",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+        "source_id": "set_item:128",
+        "special_mechanic_classification": "partial_modifier",
+        "special_mechanic_notes": [
+          "Structured modifier rows exist but remain partial until value normalization is solved."
+        ],
+        "stable_calculable": false,
+        "subtype": "Kolheim Armor",
+        "support_status": "partial",
+        "tooltip_text": [
+          "You are Frenzied for 3 seconds when hit by your Storm Totem",
+          "Frenzy gives 20% increased attack and cast speed.",
+          "[10,21,1]% Increased Area of Storm Totem Aura"
+        ],
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Unique/set record is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "attribute_requirements": {},
+        "base_item_id": "item_base:equippable:0:30",
+        "bonus_text": [
+          "You gain haste for 3 seconds when hit by your Storm Totem",
+          "Haste gives 30% increased attack and cast speed.",
+          "21% increased minion attack and cast speed",
+          "[10,21,1]% Increased Area of Storm Totem Aura"
+        ],
+        "canonical_id": "set_item:129",
+        "class_restrictions": [],
+        "classification": "armor",
+        "consumer_safe_fields": {
+          "display_name": "Boardman's Legacy",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Boardman's Legacy",
+        "equipment_slot": "helmet",
+        "implicit_ids": [],
+        "implicit_links": [
+          {
+            "base_item_id": "item_base:equippable:0:30",
+            "implicit_index": 0,
+            "modifier_type": "ADDED",
+            "property": "Armour"
+          },
+          {
+            "base_item_id": "item_base:equippable:0:30",
+            "implicit_index": 1,
+            "modifier_type": "INCREASED",
+            "property": "Damage"
+          },
+          {
+            "base_item_id": "item_base:equippable:0:30",
+            "implicit_index": 2,
+            "modifier_type": "INCREASED",
+            "property": "Damage"
+          }
+        ],
+        "item_category": "equipment",
+        "item_type": "helmet",
+        "level_requirement": 63,
+        "lore_text": null,
+        "mastery_restrictions": [],
+        "modifier_references": [
+          {
+            "modifier_id": "set_item_modifier_set_item:129:0",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Lightning.Poison.Elemental",
+            "source_record_id": "set_item:129:modifier:0"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:129:1",
+            "property": "AttackSpeed",
+            "property_path": "INCREASED.AttackSpeed.Minion",
+            "source_record_id": "set_item:129:modifier:1"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:129:2",
+            "property": "CastSpeed",
+            "property_path": "INCREASED.CastSpeed.Minion",
+            "source_record_id": "set_item:129:modifier:2"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:129:3",
+            "property": "DamageTaken",
+            "property_path": "MORE.DamageTaken.Totem",
+            "source_record_id": "set_item:129:modifier:3"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:129:4",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Lightning.Poison.Elemental",
+            "source_record_id": "set_item:129:modifier:4"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:129:5",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Lightning.Poison.Elemental",
+            "source_record_id": "set_item:129:modifier:5"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:129:0",
+            "modifier_type": "ADDED",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Lightning.Poison.Elemental",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "AbilityProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:129:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Physical",
+              "Lightning",
+              "Poison",
+              "Elemental"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.75,
+            "value_min": 0.3
+          },
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": true,
+            "modifier_id": "set_item_modifier_set_item:129:1",
+            "modifier_type": "INCREASED",
+            "property": "AttackSpeed",
+            "property_path": "INCREASED.AttackSpeed.Minion",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 1,
+                "property": "AttackSpeed"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:129:modifier:1",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Minion"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.21,
+            "value_min": 0.21
+          },
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": true,
+            "modifier_id": "set_item_modifier_set_item:129:2",
+            "modifier_type": "INCREASED",
+            "property": "CastSpeed",
+            "property_path": "INCREASED.CastSpeed.Minion",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 2,
+                "property": "CastSpeed"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:129:modifier:2",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Minion"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.21,
+            "value_min": 0.21
+          },
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:129:3",
+            "modifier_type": "MORE",
+            "property": "DamageTaken",
+            "property_path": "MORE.DamageTaken.Totem",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 3,
+                "property": "DamageTaken"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:129:modifier:3",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Totem"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": -0.21,
+            "value_min": -0.21
+          },
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": true,
+            "modifier_id": "set_item_modifier_set_item:129:4",
+            "modifier_type": "ADDED",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Lightning.Poison.Elemental",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 4,
+                "property": "AbilityProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:129:modifier:4",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Physical",
+              "Lightning",
+              "Poison",
+              "Elemental"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 1.0,
+            "value_min": 1.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": true,
+            "modifier_id": "set_item_modifier_set_item:129:5",
+            "modifier_type": "ADDED",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Lightning.Poison.Elemental",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 5,
+                "property": "AbilityProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:129:modifier:5",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 1,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Physical",
+              "Lightning",
+              "Poison",
+              "Elemental"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.21,
+            "value_min": 0.1
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_item_modifier_set_item:129:0",
+              "property": "AbilityProperty",
+              "property_path": "ADDED.AbilityProperty.Physical.Lightning.Poison.Elemental",
+              "source_record_id": "set_item:129:modifier:0"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:129:1",
+              "property": "AttackSpeed",
+              "property_path": "INCREASED.AttackSpeed.Minion",
+              "source_record_id": "set_item:129:modifier:1"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:129:2",
+              "property": "CastSpeed",
+              "property_path": "INCREASED.CastSpeed.Minion",
+              "source_record_id": "set_item:129:modifier:2"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:129:3",
+              "property": "DamageTaken",
+              "property_path": "MORE.DamageTaken.Totem",
+              "source_record_id": "set_item:129:modifier:3"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:129:4",
+              "property": "AbilityProperty",
+              "property_path": "ADDED.AbilityProperty.Physical.Lightning.Poison.Elemental",
+              "source_record_id": "set_item:129:modifier:4"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:129:5",
+              "property": "AbilityProperty",
+              "property_path": "ADDED.AbilityProperty.Physical.Lightning.Poison.Elemental",
+              "source_record_id": "set_item:129:modifier:5"
+            }
+          ]
+        },
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_unique_set_export",
+          "notes": [
+            "Generated from extracted unique/set data; tooltip text is not inferred as mechanics."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "id": 129,
+            "name": "Boardman Legacy"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_item:129",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+          "source_type": "set_item"
+        },
+        "raw_reference": {
+          "baseType": "HELMET",
+          "id": 129,
+          "name": "Boardman Legacy",
+          "resolutionStatus": "resolved",
+          "resolvedBaseItem": {
+            "baseTypeID": 0,
+            "displayName": "Helmet",
+            "name": "Helmets",
+            "subType": {
+              "displayName": "",
+              "levelRequirement": 58,
+              "name": "Darkwolf Pelt",
+              "subTypeID": 30
+            },
+            "type": "HELMET"
+          },
+          "subTypes": [
+            30
+          ]
+        },
+        "requirements": {
+          "attributes": {},
+          "class": null,
+          "level": 63,
+          "mastery": null
+        },
+        "set_group_display_name": null,
+        "set_group_id": "set:10",
+        "set_id": "set:10",
+        "slot": "helmet",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+        "source_id": "set_item:129",
+        "special_mechanic_classification": "partial_modifier",
+        "special_mechanic_notes": [
+          "Structured modifier rows exist but remain partial until value normalization is solved."
+        ],
+        "stable_calculable": false,
+        "subtype": "Darkwolf Pelt",
+        "support_status": "partial",
+        "tooltip_text": [
+          "You gain haste for 3 seconds when hit by your Storm Totem",
+          "Haste gives 30% increased attack and cast speed.",
+          "21% increased minion attack and cast speed",
+          "[10,21,1]% Increased Area of Storm Totem Aura"
+        ],
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Unique/set record is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "attribute_requirements": {},
+        "base_item_id": "item_base:equippable:2:1",
+        "bonus_text": [
+          "[15,20,3]% increased Melee and Throwing Attack Speed for 4 seconds when you use a Potion"
+        ],
+        "canonical_id": "set_item:138",
+        "class_restrictions": [],
+        "classification": "accessory",
+        "consumer_safe_fields": {
+          "display_name": "Zerrick's Guile",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Zerrick's Guile",
+        "equipment_slot": "belt",
+        "implicit_ids": [],
+        "implicit_links": [
+          {
+            "base_item_id": "item_base:equippable:2:1",
+            "implicit_index": 0,
+            "modifier_type": "ADDED",
+            "property": "PotionSlots"
+          }
+        ],
+        "item_category": "equipment",
+        "item_type": "belt",
+        "level_requirement": 49,
+        "lore_text": "Zerrick's humility and reverence for the Nagasa and the Scalebane leaders long kept him in their favour, sealing their demise.",
+        "mastery_restrictions": [],
+        "modifier_references": [
+          {
+            "modifier_id": "set_item_modifier_set_item:138:0",
+            "property": "CritAvoidance",
+            "property_path": "ADDED.CritAvoidance.Potion",
+            "source_record_id": "set_item:138:modifier:0"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:138:1",
+            "property": "DodgeRating",
+            "property_path": "ADDED.DodgeRating",
+            "source_record_id": "set_item:138:modifier:1"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:138:2",
+            "property": "PoisonResistance",
+            "property_path": "ADDED.PoisonResistance.Potion",
+            "source_record_id": "set_item:138:modifier:2"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:138:3",
+            "property": "AttackSpeed",
+            "property_path": "INCREASED.AttackSpeed.Melee.Potion",
+            "source_record_id": "set_item:138:modifier:3"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:138:4",
+            "property": "AttackSpeed",
+            "property_path": "INCREASED.AttackSpeed.Throwing.Potion",
+            "source_record_id": "set_item:138:modifier:4"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:138:0",
+            "modifier_type": "ADDED",
+            "property": "CritAvoidance",
+            "property_path": "ADDED.CritAvoidance.Potion",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "CritAvoidance"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:138:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Potion"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 1.0,
+            "value_min": 1.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:138:1",
+            "modifier_type": "ADDED",
+            "property": "DodgeRating",
+            "property_path": "ADDED.DodgeRating",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 1,
+                "property": "DodgeRating"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:138:modifier:1",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 375.0,
+            "value_min": 125.0
+          },
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:138:2",
+            "modifier_type": "ADDED",
+            "property": "PoisonResistance",
+            "property_path": "ADDED.PoisonResistance.Potion",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 2,
+                "property": "PoisonResistance"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:138:modifier:2",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Potion"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.75,
+            "value_min": 0.75
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": true,
+            "modifier_id": "set_item_modifier_set_item:138:3",
+            "modifier_type": "INCREASED",
+            "property": "AttackSpeed",
+            "property_path": "INCREASED.AttackSpeed.Melee.Potion",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 3,
+                "property": "AttackSpeed"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:138:modifier:3",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 3,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Melee",
+              "Potion"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.2,
+            "value_min": 0.15
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": true,
+            "modifier_id": "set_item_modifier_set_item:138:4",
+            "modifier_type": "INCREASED",
+            "property": "AttackSpeed",
+            "property_path": "INCREASED.AttackSpeed.Throwing.Potion",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 4,
+                "property": "AttackSpeed"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:138:modifier:4",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 3,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Throwing",
+              "Potion"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.2,
+            "value_min": 0.15
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_item_modifier_set_item:138:0",
+              "property": "CritAvoidance",
+              "property_path": "ADDED.CritAvoidance.Potion",
+              "source_record_id": "set_item:138:modifier:0"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:138:1",
+              "property": "DodgeRating",
+              "property_path": "ADDED.DodgeRating",
+              "source_record_id": "set_item:138:modifier:1"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:138:2",
+              "property": "PoisonResistance",
+              "property_path": "ADDED.PoisonResistance.Potion",
+              "source_record_id": "set_item:138:modifier:2"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:138:3",
+              "property": "AttackSpeed",
+              "property_path": "INCREASED.AttackSpeed.Melee.Potion",
+              "source_record_id": "set_item:138:modifier:3"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:138:4",
+              "property": "AttackSpeed",
+              "property_path": "INCREASED.AttackSpeed.Throwing.Potion",
+              "source_record_id": "set_item:138:modifier:4"
+            }
+          ]
+        },
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_unique_set_export",
+          "notes": [
+            "Generated from extracted unique/set data; tooltip text is not inferred as mechanics."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "id": 138,
+            "name": "Zerrick Guile"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_item:138",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+          "source_type": "set_item"
+        },
+        "raw_reference": {
+          "baseType": "BELT",
+          "id": 138,
+          "name": "Zerrick Guile",
+          "resolutionStatus": "resolved",
+          "resolvedBaseItem": {
+            "baseTypeID": 2,
+            "displayName": "Belt",
+            "name": "Belts",
+            "subType": {
+              "displayName": "",
+              "levelRequirement": 9,
+              "name": "Leather Belt",
+              "subTypeID": 1
+            },
+            "type": "BELT"
+          },
+          "subTypes": [
+            1
+          ]
+        },
+        "requirements": {
+          "attributes": {},
+          "class": null,
+          "level": 49,
+          "mastery": null
+        },
+        "set_group_display_name": null,
+        "set_group_id": "set:11",
+        "set_id": "set:11",
+        "slot": "belt",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+        "source_id": "set_item:138",
+        "special_mechanic_classification": "partial_modifier",
+        "special_mechanic_notes": [
+          "Structured modifier rows exist but remain partial until value normalization is solved."
+        ],
+        "stable_calculable": false,
+        "subtype": "Leather Belt",
+        "support_status": "partial",
+        "tooltip_text": [
+          "[15,20,3]% increased Melee and Throwing Attack Speed for 4 seconds when you use a Potion"
+        ],
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Unique/set record is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "attribute_requirements": {},
+        "base_item_id": "item_base:equippable:4:5",
+        "bonus_text": [
+          "Cannot Leech Health from Damage over Time"
+        ],
+        "canonical_id": "set_item:139",
+        "class_restrictions": [],
+        "classification": "armor",
+        "consumer_safe_fields": {
+          "display_name": "Zerrick's Greed",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Zerrick's Greed",
+        "equipment_slot": "gloves",
+        "implicit_ids": [],
+        "implicit_links": [
+          {
+            "base_item_id": "item_base:equippable:4:5",
+            "implicit_index": 0,
+            "modifier_type": "ADDED",
+            "property": "Armour"
+          },
+          {
+            "base_item_id": "item_base:equippable:4:5",
+            "implicit_index": 1,
+            "modifier_type": "ADDED",
+            "property": "Endurance"
+          }
+        ],
+        "item_category": "equipment",
+        "item_type": "gloves",
+        "level_requirement": 57,
+        "lore_text": null,
+        "mastery_restrictions": [],
+        "modifier_references": [
+          {
+            "modifier_id": "set_item_modifier_set_item:139:0",
+            "property": "HealthLeech",
+            "property_path": "ADDED.HealthLeech",
+            "source_record_id": "set_item:139:modifier:0"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:139:1",
+            "property": "Damage",
+            "property_path": "INCREASED.Damage.DoT",
+            "source_record_id": "set_item:139:modifier:1"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:139:2",
+            "property": "DodgeRating",
+            "property_path": "ADDED.DodgeRating",
+            "source_record_id": "set_item:139:modifier:2"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:139:0",
+            "modifier_type": "ADDED",
+            "property": "HealthLeech",
+            "property_path": "ADDED.HealthLeech",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "HealthLeech"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:139:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.4,
+            "value_min": 0.3
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:139:1",
+            "modifier_type": "INCREASED",
+            "property": "Damage",
+            "property_path": "INCREASED.Damage.DoT",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 1,
+                "property": "Damage"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:139:modifier:1",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 1,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "DoT"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 1.3,
+            "value_min": 1.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:139:2",
+            "modifier_type": "ADDED",
+            "property": "DodgeRating",
+            "property_path": "ADDED.DodgeRating",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 2,
+                "property": "DodgeRating"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:139:modifier:2",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 2,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 390.0,
+            "value_min": 130.0
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_item_modifier_set_item:139:0",
+              "property": "HealthLeech",
+              "property_path": "ADDED.HealthLeech",
+              "source_record_id": "set_item:139:modifier:0"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:139:1",
+              "property": "Damage",
+              "property_path": "INCREASED.Damage.DoT",
+              "source_record_id": "set_item:139:modifier:1"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:139:2",
+              "property": "DodgeRating",
+              "property_path": "ADDED.DodgeRating",
+              "source_record_id": "set_item:139:modifier:2"
+            }
+          ]
+        },
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_unique_set_export",
+          "notes": [
+            "Generated from extracted unique/set data; tooltip text is not inferred as mechanics."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "id": 139,
+            "name": "Zerrick Greed"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_item:139",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+          "source_type": "set_item"
+        },
+        "raw_reference": {
+          "baseType": "GLOVES",
+          "id": 139,
+          "name": "Zerrick Greed",
+          "resolutionStatus": "resolved",
+          "resolvedBaseItem": {
+            "baseTypeID": 4,
+            "displayName": "Gloves",
+            "name": "Gloves",
+            "subType": {
+              "displayName": "",
+              "levelRequirement": 45,
+              "name": "Plated Gauntlets",
+              "subTypeID": 5
+            },
+            "type": "GLOVES"
+          },
+          "subTypes": [
+            5
+          ]
+        },
+        "requirements": {
+          "attributes": {},
+          "class": null,
+          "level": 57,
+          "mastery": null
+        },
+        "set_group_display_name": null,
+        "set_group_id": "set:11",
+        "set_id": "set:11",
+        "slot": "gloves",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+        "source_id": "set_item:139",
+        "special_mechanic_classification": "partial_modifier",
+        "special_mechanic_notes": [
+          "Structured modifier rows exist but remain partial until value normalization is solved."
+        ],
+        "stable_calculable": false,
+        "subtype": "Plated Gauntlets",
+        "support_status": "partial",
+        "tooltip_text": [
+          "Cannot Leech Health from Damage over Time"
+        ],
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Unique/set record is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "attribute_requirements": {},
+        "base_item_id": "item_base:equippable:3:4",
+        "bonus_text": [],
+        "canonical_id": "set_item:140",
+        "class_restrictions": [],
+        "classification": "armor",
+        "consumer_safe_fields": {
+          "display_name": "Zerrick's Ambition",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Zerrick's Ambition",
+        "equipment_slot": "boots",
+        "implicit_ids": [],
+        "implicit_links": [
+          {
+            "base_item_id": "item_base:equippable:3:4",
+            "implicit_index": 0,
+            "modifier_type": "ADDED",
+            "property": "Armour"
+          },
+          {
+            "base_item_id": "item_base:equippable:3:4",
+            "implicit_index": 1,
+            "modifier_type": "INCREASED",
+            "property": "Movespeed"
+          }
+        ],
+        "item_category": "equipment",
+        "item_type": "boots",
+        "level_requirement": 52,
+        "lore_text": "In games of power you win or you die",
+        "mastery_restrictions": [],
+        "modifier_references": [
+          {
+            "modifier_id": "set_item_modifier_set_item:140:0",
+            "property": "CriticalMultiplier",
+            "property_path": "ADDED.CriticalMultiplier.Melee.FullLife",
+            "source_record_id": "set_item:140:modifier:0"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:140:1",
+            "property": "CriticalMultiplier",
+            "property_path": "ADDED.CriticalMultiplier.Throwing.FullLife",
+            "source_record_id": "set_item:140:modifier:1"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:140:2",
+            "property": "Movespeed",
+            "property_path": "INCREASED.Movespeed",
+            "source_record_id": "set_item:140:modifier:2"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:140:3",
+            "property": "IncreasedLeechRate",
+            "property_path": "ADDED.IncreasedLeechRate",
+            "source_record_id": "set_item:140:modifier:3"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:140:0",
+            "modifier_type": "ADDED",
+            "property": "CriticalMultiplier",
+            "property_path": "ADDED.CriticalMultiplier.Melee.FullLife",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "CriticalMultiplier"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:140:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Melee",
+              "FullLife"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.5,
+            "value_min": 0.3
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:140:1",
+            "modifier_type": "ADDED",
+            "property": "CriticalMultiplier",
+            "property_path": "ADDED.CriticalMultiplier.Throwing.FullLife",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 1,
+                "property": "CriticalMultiplier"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:140:modifier:1",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 1,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Throwing",
+              "FullLife"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.5,
+            "value_min": 0.3
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:140:2",
+            "modifier_type": "INCREASED",
+            "property": "Movespeed",
+            "property_path": "INCREASED.Movespeed",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 2,
+                "property": "Movespeed"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:140:modifier:2",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 2,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.23,
+            "value_min": 0.15
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:140:3",
+            "modifier_type": "ADDED",
+            "property": "IncreasedLeechRate",
+            "property_path": "ADDED.IncreasedLeechRate",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 3,
+                "property": "IncreasedLeechRate"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:140:modifier:3",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 3,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.35,
+            "value_min": 0.23
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_item_modifier_set_item:140:0",
+              "property": "CriticalMultiplier",
+              "property_path": "ADDED.CriticalMultiplier.Melee.FullLife",
+              "source_record_id": "set_item:140:modifier:0"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:140:1",
+              "property": "CriticalMultiplier",
+              "property_path": "ADDED.CriticalMultiplier.Throwing.FullLife",
+              "source_record_id": "set_item:140:modifier:1"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:140:2",
+              "property": "Movespeed",
+              "property_path": "INCREASED.Movespeed",
+              "source_record_id": "set_item:140:modifier:2"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:140:3",
+              "property": "IncreasedLeechRate",
+              "property_path": "ADDED.IncreasedLeechRate",
+              "source_record_id": "set_item:140:modifier:3"
+            }
+          ]
+        },
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_unique_set_export",
+          "notes": [
+            "Generated from extracted unique/set data; tooltip text is not inferred as mechanics."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "id": 140,
+            "name": "Zerrick Ambition"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_item:140",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+          "source_type": "set_item"
+        },
+        "raw_reference": {
+          "baseType": "BOOTS",
+          "id": 140,
+          "name": "Zerrick Ambition",
+          "resolutionStatus": "resolved",
+          "resolvedBaseItem": {
+            "baseTypeID": 3,
+            "displayName": "Boots",
+            "name": "Boots",
+            "subType": {
+              "displayName": "",
+              "levelRequirement": 30,
+              "name": "Brigandine Boots",
+              "subTypeID": 4
+            },
+            "type": "BOOTS"
+          },
+          "subTypes": [
+            4
+          ]
+        },
+        "requirements": {
+          "attributes": {},
+          "class": null,
+          "level": 52,
+          "mastery": null
+        },
+        "set_group_display_name": null,
+        "set_group_id": "set:11",
+        "set_id": "set:11",
+        "slot": "boots",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+        "source_id": "set_item:140",
+        "special_mechanic_classification": "partial_modifier",
+        "special_mechanic_notes": [
+          "Structured modifier rows exist but remain partial until value normalization is solved."
+        ],
+        "stable_calculable": false,
+        "subtype": "Brigandine Boots",
+        "support_status": "partial",
+        "tooltip_text": [],
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Unique/set record is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "attribute_requirements": {},
+        "base_item_id": "item_base:equippable:8:8",
+        "bonus_text": [],
+        "canonical_id": "set_item:156",
+        "class_restrictions": [],
+        "classification": "weapon",
+        "consumer_safe_fields": {
+          "display_name": "Gaspar's Will",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Gaspar's Will",
+        "equipment_slot": "one_handed_sceptre",
+        "implicit_ids": [],
+        "implicit_links": [
+          {
+            "base_item_id": "item_base:equippable:8:8",
+            "implicit_index": 0,
+            "modifier_type": "ADDED",
+            "property": "Damage"
+          },
+          {
+            "base_item_id": "item_base:equippable:8:8",
+            "implicit_index": 1,
+            "modifier_type": "ADDED",
+            "property": "Damage"
+          }
+        ],
+        "item_category": "equipment",
+        "item_type": "one_handed_sceptre",
+        "level_requirement": 75,
+        "lore_text": "I failed to protect. I failed to lead. Destruction is all that is left.",
+        "mastery_restrictions": [],
+        "modifier_references": [
+          {
+            "modifier_id": "set_item_modifier_set_item:156:0",
+            "property": "Damage",
+            "property_path": "ADDED.Damage.Void.Spell",
+            "source_record_id": "set_item:156:modifier:0"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:156:1",
+            "property": "AilmentChance",
+            "property_path": "ADDED.AilmentChance.Void.Spell",
+            "source_record_id": "set_item:156:modifier:1"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:156:2",
+            "property": "CastSpeed",
+            "property_path": "INCREASED.CastSpeed.Fire",
+            "source_record_id": "set_item:156:modifier:2"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:156:3",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Cold.Melee",
+            "source_record_id": "set_item:156:modifier:3"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:156:0",
+            "modifier_type": "ADDED",
+            "property": "Damage",
+            "property_path": "ADDED.Damage.Void.Spell",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "Damage"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:156:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Void",
+              "Spell"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 7.0,
+            "value_min": 7.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:156:1",
+            "modifier_type": "ADDED",
+            "property": "AilmentChance",
+            "property_path": "ADDED.AilmentChance.Void.Spell",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 1,
+                "property": "AilmentChance"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:156:modifier:1",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Void",
+              "Spell"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 2.45,
+            "value_min": 1.35
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:156:2",
+            "modifier_type": "INCREASED",
+            "property": "CastSpeed",
+            "property_path": "INCREASED.CastSpeed.Fire",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 2,
+                "property": "CastSpeed"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:156:modifier:2",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 1,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Fire"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.28,
+            "value_min": 0.14
+          },
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:156:3",
+            "modifier_type": "ADDED",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Cold.Melee",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 3,
+                "property": "AbilityProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:156:modifier:3",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Physical",
+              "Cold",
+              "Melee"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 1.0,
+            "value_min": 1.0
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_item_modifier_set_item:156:0",
+              "property": "Damage",
+              "property_path": "ADDED.Damage.Void.Spell",
+              "source_record_id": "set_item:156:modifier:0"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:156:1",
+              "property": "AilmentChance",
+              "property_path": "ADDED.AilmentChance.Void.Spell",
+              "source_record_id": "set_item:156:modifier:1"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:156:2",
+              "property": "CastSpeed",
+              "property_path": "INCREASED.CastSpeed.Fire",
+              "source_record_id": "set_item:156:modifier:2"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:156:3",
+              "property": "AbilityProperty",
+              "property_path": "ADDED.AbilityProperty.Physical.Cold.Melee",
+              "source_record_id": "set_item:156:modifier:3"
+            }
+          ]
+        },
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_unique_set_export",
+          "notes": [
+            "Generated from extracted unique/set data; tooltip text is not inferred as mechanics."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "id": 156,
+            "name": "Gaspar Will"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_item:156",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+          "source_type": "set_item"
+        },
+        "raw_reference": {
+          "baseType": "ONE_HANDED_SCEPTRE",
+          "id": 156,
+          "name": "Gaspar Will",
+          "resolutionStatus": "resolved",
+          "resolvedBaseItem": {
+            "baseTypeID": 8,
+            "displayName": "Sceptre",
+            "name": "1H Scepter",
+            "subType": {
+              "displayName": "",
+              "levelRequirement": 75,
+              "name": "Obsidian Sceptre",
+              "subTypeID": 8
+            },
+            "type": "ONE_HANDED_SCEPTRE"
+          },
+          "subTypes": [
+            8
+          ]
+        },
+        "requirements": {
+          "attributes": {},
+          "class": null,
+          "level": 75,
+          "mastery": null
+        },
+        "set_group_display_name": null,
+        "set_group_id": "set:12",
+        "set_id": "set:12",
+        "slot": "one_handed_sceptre",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+        "source_id": "set_item:156",
+        "special_mechanic_classification": "partial_modifier",
+        "special_mechanic_notes": [
+          "Structured modifier rows exist but remain partial until value normalization is solved."
+        ],
+        "stable_calculable": false,
+        "subtype": "Obsidian Sceptre",
+        "support_status": "partial",
+        "tooltip_text": [],
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Unique/set record is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "attribute_requirements": {},
+        "base_item_id": "item_base:equippable:1:3",
+        "bonus_text": [],
+        "canonical_id": "set_item:157",
+        "class_restrictions": [],
+        "classification": "armor",
+        "consumer_safe_fields": {
+          "display_name": "Gaspar's Acuity",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Gaspar's Acuity",
+        "equipment_slot": "body_armor",
+        "implicit_ids": [],
+        "implicit_links": [
+          {
+            "base_item_id": "item_base:equippable:1:3",
+            "implicit_index": 0,
+            "modifier_type": "ADDED",
+            "property": "Armour"
+          },
+          {
+            "base_item_id": "item_base:equippable:1:3",
+            "implicit_index": 1,
+            "modifier_type": "ADDED",
+            "property": "Damage"
+          }
+        ],
+        "item_category": "equipment",
+        "item_type": "body_armor",
+        "level_requirement": 72,
+        "lore_text": "Knowledge without power is nothing but informed futility.",
+        "mastery_restrictions": [],
+        "modifier_references": [
+          {
+            "modifier_id": "set_item_modifier_set_item:157:0",
+            "property": "VoidResistance",
+            "property_path": "ADDED.VoidResistance",
+            "source_record_id": "set_item:157:modifier:0"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:157:1",
+            "property": "AilmentChance",
+            "property_path": "ADDED.AilmentChance.Void.Spell",
+            "source_record_id": "set_item:157:modifier:1"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:157:2",
+            "property": "CastSpeed",
+            "property_path": "INCREASED.CastSpeed.Lightning",
+            "source_record_id": "set_item:157:modifier:2"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:157:3",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Cold.Melee",
+            "source_record_id": "set_item:157:modifier:3"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:157:4",
+            "property": "LightningResistance",
+            "property_path": "ADDED.LightningResistance",
+            "source_record_id": "set_item:157:modifier:4"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:157:0",
+            "modifier_type": "ADDED",
+            "property": "VoidResistance",
+            "property_path": "ADDED.VoidResistance",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "VoidResistance"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:157:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.45,
+            "value_min": 0.35
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:157:1",
+            "modifier_type": "ADDED",
+            "property": "AilmentChance",
+            "property_path": "ADDED.AilmentChance.Void.Spell",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 1,
+                "property": "AilmentChance"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:157:modifier:1",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 1,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Void",
+              "Spell"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 3.45,
+            "value_min": 2.35
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:157:2",
+            "modifier_type": "INCREASED",
+            "property": "CastSpeed",
+            "property_path": "INCREASED.CastSpeed.Lightning",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 2,
+                "property": "CastSpeed"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:157:modifier:2",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 2,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Lightning"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.12,
+            "value_min": 0.07
+          },
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:157:3",
+            "modifier_type": "ADDED",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Cold.Melee",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 3,
+                "property": "AbilityProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:157:modifier:3",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Physical",
+              "Cold",
+              "Melee"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 1.0,
+            "value_min": 1.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:157:4",
+            "modifier_type": "ADDED",
+            "property": "LightningResistance",
+            "property_path": "ADDED.LightningResistance",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 4,
+                "property": "LightningResistance"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:157:modifier:4",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 3,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.45,
+            "value_min": 0.35
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_item_modifier_set_item:157:0",
+              "property": "VoidResistance",
+              "property_path": "ADDED.VoidResistance",
+              "source_record_id": "set_item:157:modifier:0"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:157:1",
+              "property": "AilmentChance",
+              "property_path": "ADDED.AilmentChance.Void.Spell",
+              "source_record_id": "set_item:157:modifier:1"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:157:2",
+              "property": "CastSpeed",
+              "property_path": "INCREASED.CastSpeed.Lightning",
+              "source_record_id": "set_item:157:modifier:2"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:157:3",
+              "property": "AbilityProperty",
+              "property_path": "ADDED.AbilityProperty.Physical.Cold.Melee",
+              "source_record_id": "set_item:157:modifier:3"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:157:4",
+              "property": "LightningResistance",
+              "property_path": "ADDED.LightningResistance",
+              "source_record_id": "set_item:157:modifier:4"
+            }
+          ]
+        },
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_unique_set_export",
+          "notes": [
+            "Generated from extracted unique/set data; tooltip text is not inferred as mechanics."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "id": 157,
+            "name": "Gaspar Acuity"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_item:157",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+          "source_type": "set_item"
+        },
+        "raw_reference": {
+          "baseType": "BODY_ARMOR",
+          "id": 157,
+          "name": "Gaspar Acuity",
+          "resolutionStatus": "resolved",
+          "resolvedBaseItem": {
+            "baseTypeID": 1,
+            "displayName": "Body Armor",
+            "name": "Body Armor",
+            "subType": {
+              "displayName": "Noble Raiment",
+              "levelRequirement": 23,
+              "name": "Red Leather Armor",
+              "subTypeID": 3
+            },
+            "type": "BODY_ARMOR"
+          },
+          "subTypes": [
+            3
+          ]
+        },
+        "requirements": {
+          "attributes": {},
+          "class": null,
+          "level": 72,
+          "mastery": null
+        },
+        "set_group_display_name": null,
+        "set_group_id": "set:12",
+        "set_id": "set:12",
+        "slot": "body_armor",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+        "source_id": "set_item:157",
+        "special_mechanic_classification": "partial_modifier",
+        "special_mechanic_notes": [
+          "Structured modifier rows exist but remain partial until value normalization is solved."
+        ],
+        "stable_calculable": false,
+        "subtype": "Red Leather Armor",
+        "support_status": "partial",
+        "tooltip_text": [],
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Unique/set record is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "attribute_requirements": {},
+        "base_item_id": "item_base:equippable:0:5",
+        "bonus_text": [],
+        "canonical_id": "set_item:158",
+        "class_restrictions": [],
+        "classification": "armor",
+        "consumer_safe_fields": {
+          "display_name": "Gaspar's Insight",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Gaspar's Insight",
+        "equipment_slot": "helmet",
+        "implicit_ids": [],
+        "implicit_links": [
+          {
+            "base_item_id": "item_base:equippable:0:5",
+            "implicit_index": 0,
+            "modifier_type": "ADDED",
+            "property": "Armour"
+          }
+        ],
+        "item_category": "equipment",
+        "item_type": "helmet",
+        "level_requirement": 80,
+        "lore_text": "Among the ruins what is wisdom, but empty platitudes?",
+        "mastery_restrictions": [],
+        "modifier_references": [
+          {
+            "modifier_id": "set_item_modifier_set_item:158:0",
+            "property": "VoidResistance",
+            "property_path": "ADDED.VoidResistance",
+            "source_record_id": "set_item:158:modifier:0"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:158:1",
+            "property": "FreezeRateMultiplier",
+            "property_path": "ADDED.FreezeRateMultiplier",
+            "source_record_id": "set_item:158:modifier:1"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:158:2",
+            "property": "CastSpeed",
+            "property_path": "INCREASED.CastSpeed.Cold",
+            "source_record_id": "set_item:158:modifier:2"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:158:3",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Cold.Melee",
+            "source_record_id": "set_item:158:modifier:3"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:158:4",
+            "property": "ColdResistance",
+            "property_path": "ADDED.ColdResistance",
+            "source_record_id": "set_item:158:modifier:4"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:158:0",
+            "modifier_type": "ADDED",
+            "property": "VoidResistance",
+            "property_path": "ADDED.VoidResistance",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "VoidResistance"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:158:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.45,
+            "value_min": 0.35
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:158:1",
+            "modifier_type": "ADDED",
+            "property": "FreezeRateMultiplier",
+            "property_path": "ADDED.FreezeRateMultiplier",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 1,
+                "property": "FreezeRateMultiplier"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:158:modifier:1",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 1,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 1.85,
+            "value_min": 1.35
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:158:2",
+            "modifier_type": "INCREASED",
+            "property": "CastSpeed",
+            "property_path": "INCREASED.CastSpeed.Cold",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 2,
+                "property": "CastSpeed"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:158:modifier:2",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 2,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Cold"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.12,
+            "value_min": 0.07
+          },
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:158:3",
+            "modifier_type": "ADDED",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Cold.Melee",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 3,
+                "property": "AbilityProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:158:modifier:3",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Physical",
+              "Cold",
+              "Melee"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 1.0,
+            "value_min": 1.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:158:4",
+            "modifier_type": "ADDED",
+            "property": "ColdResistance",
+            "property_path": "ADDED.ColdResistance",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 4,
+                "property": "ColdResistance"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:158:modifier:4",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 3,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.45,
+            "value_min": 0.35
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_item_modifier_set_item:158:0",
+              "property": "VoidResistance",
+              "property_path": "ADDED.VoidResistance",
+              "source_record_id": "set_item:158:modifier:0"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:158:1",
+              "property": "FreezeRateMultiplier",
+              "property_path": "ADDED.FreezeRateMultiplier",
+              "source_record_id": "set_item:158:modifier:1"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:158:2",
+              "property": "CastSpeed",
+              "property_path": "INCREASED.CastSpeed.Cold",
+              "source_record_id": "set_item:158:modifier:2"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:158:3",
+              "property": "AbilityProperty",
+              "property_path": "ADDED.AbilityProperty.Physical.Cold.Melee",
+              "source_record_id": "set_item:158:modifier:3"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:158:4",
+              "property": "ColdResistance",
+              "property_path": "ADDED.ColdResistance",
+              "source_record_id": "set_item:158:modifier:4"
+            }
+          ]
+        },
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_unique_set_export",
+          "notes": [
+            "Generated from extracted unique/set data; tooltip text is not inferred as mechanics."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "id": 158,
+            "name": "Gaspar Insight"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_item:158",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+          "source_type": "set_item"
+        },
+        "raw_reference": {
+          "baseType": "HELMET",
+          "id": 158,
+          "name": "Gaspar Insight",
+          "resolutionStatus": "resolved",
+          "resolvedBaseItem": {
+            "baseTypeID": 0,
+            "displayName": "Helmet",
+            "name": "Helmets",
+            "subType": {
+              "displayName": "Bronze Casque",
+              "levelRequirement": 39,
+              "name": "Bronze Helmet",
+              "subTypeID": 5
+            },
+            "type": "HELMET"
+          },
+          "subTypes": [
+            5
+          ]
+        },
+        "requirements": {
+          "attributes": {},
+          "class": null,
+          "level": 80,
+          "mastery": null
+        },
+        "set_group_display_name": null,
+        "set_group_id": "set:12",
+        "set_id": "set:12",
+        "slot": "helmet",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+        "source_id": "set_item:158",
+        "special_mechanic_classification": "partial_modifier",
+        "special_mechanic_notes": [
+          "Structured modifier rows exist but remain partial until value normalization is solved."
+        ],
+        "stable_calculable": false,
+        "subtype": "Bronze Helmet",
+        "support_status": "partial",
+        "tooltip_text": [],
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Unique/set record is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "attribute_requirements": {},
+        "base_item_id": "item_base:equippable:7:3",
+        "bonus_text": [
+          "+[40,60,0]% to All Resistances for Minions"
+        ],
+        "canonical_id": "set_item:170",
+        "class_restrictions": [],
+        "classification": "weapon",
+        "consumer_safe_fields": {
+          "display_name": "Sinathia's Dying Breath",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Sinathia's Dying Breath",
+        "equipment_slot": "one_handed_maces",
+        "implicit_ids": [],
+        "implicit_links": [
+          {
+            "base_item_id": "item_base:equippable:7:3",
+            "implicit_index": 0,
+            "modifier_type": "ADDED",
+            "property": "Damage"
+          },
+          {
+            "base_item_id": "item_base:equippable:7:3",
+            "implicit_index": 1,
+            "modifier_type": "INCREASED",
+            "property": "Damage"
+          }
+        ],
+        "item_category": "equipment",
+        "item_type": "one_handed_maces",
+        "level_requirement": 60,
+        "lore_text": "As the last dagger plunged into Sinathia's body he uttered a dying curse, sealing the fate of his assassins.",
+        "mastery_restrictions": [],
+        "modifier_references": [
+          {
+            "modifier_id": "set_item_modifier_set_item:170:0",
+            "property": "AllResistances",
+            "property_path": "ADDED.AllResistances.Minion",
+            "source_record_id": "set_item:170:modifier:0"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:170:1",
+            "property": "Damage",
+            "property_path": "INCREASED.Damage.Curse",
+            "source_record_id": "set_item:170:modifier:1"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:170:2",
+            "property": "Damage",
+            "property_path": "ADDED.Damage.Spell.Curse",
+            "source_record_id": "set_item:170:modifier:2"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:170:3",
+            "property": "AllResistances",
+            "property_path": "ADDED.AllResistances",
+            "source_record_id": "set_item:170:modifier:3"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:170:4",
+            "property": "BlockEffectiveness",
+            "property_path": "INCREASED.BlockEffectiveness",
+            "source_record_id": "set_item:170:modifier:4"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": true,
+            "modifier_id": "set_item_modifier_set_item:170:0",
+            "modifier_type": "ADDED",
+            "property": "AllResistances",
+            "property_path": "ADDED.AllResistances.Minion",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "AllResistances"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:170:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Minion"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.6,
+            "value_min": 0.4
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:170:1",
+            "modifier_type": "INCREASED",
+            "property": "Damage",
+            "property_path": "INCREASED.Damage.Curse",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 1,
+                "property": "Damage"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:170:modifier:1",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Curse"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 1.66,
+            "value_min": 0.91
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:170:2",
+            "modifier_type": "ADDED",
+            "property": "Damage",
+            "property_path": "ADDED.Damage.Spell.Curse",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 2,
+                "property": "Damage"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:170:modifier:2",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 1,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Spell",
+              "Curse"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 91.0,
+            "value_min": 66.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:170:3",
+            "modifier_type": "ADDED",
+            "property": "AllResistances",
+            "property_path": "ADDED.AllResistances",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 3,
+                "property": "AllResistances"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:170:modifier:3",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 3,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.33,
+            "value_min": 0.3
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:170:4",
+            "modifier_type": "INCREASED",
+            "property": "BlockEffectiveness",
+            "property_path": "INCREASED.BlockEffectiveness",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 4,
+                "property": "BlockEffectiveness"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:170:modifier:4",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 2,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.19,
+            "value_min": 0.16
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_item_modifier_set_item:170:0",
+              "property": "AllResistances",
+              "property_path": "ADDED.AllResistances.Minion",
+              "source_record_id": "set_item:170:modifier:0"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:170:1",
+              "property": "Damage",
+              "property_path": "INCREASED.Damage.Curse",
+              "source_record_id": "set_item:170:modifier:1"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:170:2",
+              "property": "Damage",
+              "property_path": "ADDED.Damage.Spell.Curse",
+              "source_record_id": "set_item:170:modifier:2"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:170:3",
+              "property": "AllResistances",
+              "property_path": "ADDED.AllResistances",
+              "source_record_id": "set_item:170:modifier:3"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:170:4",
+              "property": "BlockEffectiveness",
+              "property_path": "INCREASED.BlockEffectiveness",
+              "source_record_id": "set_item:170:modifier:4"
+            }
+          ]
+        },
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_unique_set_export",
+          "notes": [
+            "Generated from extracted unique/set data; tooltip text is not inferred as mechanics."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "id": 170,
+            "name": "Unique Skeleton Mace"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_item:170",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+          "source_type": "set_item"
+        },
+        "raw_reference": {
+          "baseType": "ONE_HANDED_MACES",
+          "id": 170,
+          "name": "Unique Skeleton Mace",
+          "resolutionStatus": "resolved",
+          "resolvedBaseItem": {
+            "baseTypeID": 7,
+            "displayName": "One-Handed Mace",
+            "name": "1H Maces",
+            "subType": {
+              "displayName": "",
+              "levelRequirement": 29,
+              "name": "Morning Star",
+              "subTypeID": 3
+            },
+            "type": "ONE_HANDED_MACES"
+          },
+          "subTypes": [
+            3
+          ]
+        },
+        "requirements": {
+          "attributes": {},
+          "class": null,
+          "level": 60,
+          "mastery": null
+        },
+        "set_group_display_name": null,
+        "set_group_id": "set:13",
+        "set_id": "set:13",
+        "slot": "one_handed_maces",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+        "source_id": "set_item:170",
+        "special_mechanic_classification": "partial_modifier",
+        "special_mechanic_notes": [
+          "Structured modifier rows exist but remain partial until value normalization is solved."
+        ],
+        "stable_calculable": false,
+        "subtype": "Morning Star",
+        "support_status": "partial",
+        "tooltip_text": [
+          "+[40,60,0]% to All Resistances for Minions"
+        ],
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Unique/set record is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "attribute_requirements": {},
+        "base_item_id": "item_base:equippable:18:11",
+        "bonus_text": [],
+        "canonical_id": "set_item:171",
+        "class_restrictions": [],
+        "classification": "armor",
+        "consumer_safe_fields": {
+          "display_name": "Sinathia's Resurrection",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Sinathia's Resurrection",
+        "equipment_slot": "shield",
+        "implicit_ids": [],
+        "implicit_links": [
+          {
+            "base_item_id": "item_base:equippable:18:11",
+            "implicit_index": 0,
+            "modifier_type": "ADDED",
+            "property": "BlockChance"
+          },
+          {
+            "base_item_id": "item_base:equippable:18:11",
+            "implicit_index": 1,
+            "modifier_type": "ADDED",
+            "property": "BlockEffectiveness"
+          },
+          {
+            "base_item_id": "item_base:equippable:18:11",
+            "implicit_index": 2,
+            "modifier_type": "ADDED",
+            "property": "Endurance"
+          }
+        ],
+        "item_category": "equipment",
+        "item_type": "shield",
+        "level_requirement": 60,
+        "lore_text": "As the last of his assassins succumbed to their fates, Sinathia stirred within his tomb.",
+        "mastery_restrictions": [],
+        "modifier_references": [
+          {
+            "modifier_id": "set_item_modifier_set_item:171:0",
+            "property": "CastSpeed",
+            "property_path": "INCREASED.CastSpeed.Curse",
+            "source_record_id": "set_item:171:modifier:0"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:171:1",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Fire.Void.Necrotic.Poison",
+            "source_record_id": "set_item:171:modifier:1"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:171:2",
+            "property": "CritAvoidance",
+            "property_path": "ADDED.CritAvoidance.Minion",
+            "source_record_id": "set_item:171:modifier:2"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:171:3",
+            "property": "Health",
+            "property_path": "INCREASED.Health.Minion",
+            "source_record_id": "set_item:171:modifier:3"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:171:4",
+            "property": "BlockChance",
+            "property_path": "ADDED.BlockChance",
+            "source_record_id": "set_item:171:modifier:4"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:171:0",
+            "modifier_type": "INCREASED",
+            "property": "CastSpeed",
+            "property_path": "INCREASED.CastSpeed.Curse",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "CastSpeed"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:171:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Curse"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.36,
+            "value_min": 0.3
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:171:1",
+            "modifier_type": "ADDED",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Fire.Void.Necrotic.Poison",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 1,
+                "property": "AbilityProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:171:modifier:1",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 1,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Fire",
+              "Void",
+              "Necrotic",
+              "Poison"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.46,
+            "value_min": 0.32
+          },
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:171:2",
+            "modifier_type": "ADDED",
+            "property": "CritAvoidance",
+            "property_path": "ADDED.CritAvoidance.Minion",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 2,
+                "property": "CritAvoidance"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:171:modifier:2",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Minion"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 1.0,
+            "value_min": 1.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:171:3",
+            "modifier_type": "INCREASED",
+            "property": "Health",
+            "property_path": "INCREASED.Health.Minion",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 3,
+                "property": "Health"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:171:modifier:3",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 2,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Minion"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 1.66,
+            "value_min": 1.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:171:4",
+            "modifier_type": "ADDED",
+            "property": "BlockChance",
+            "property_path": "ADDED.BlockChance",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 4,
+                "property": "BlockChance"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:171:modifier:4",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 3,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.18,
+            "value_min": 0.12
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_item_modifier_set_item:171:0",
+              "property": "CastSpeed",
+              "property_path": "INCREASED.CastSpeed.Curse",
+              "source_record_id": "set_item:171:modifier:0"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:171:1",
+              "property": "AbilityProperty",
+              "property_path": "ADDED.AbilityProperty.Fire.Void.Necrotic.Poison",
+              "source_record_id": "set_item:171:modifier:1"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:171:2",
+              "property": "CritAvoidance",
+              "property_path": "ADDED.CritAvoidance.Minion",
+              "source_record_id": "set_item:171:modifier:2"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:171:3",
+              "property": "Health",
+              "property_path": "INCREASED.Health.Minion",
+              "source_record_id": "set_item:171:modifier:3"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:171:4",
+              "property": "BlockChance",
+              "property_path": "ADDED.BlockChance",
+              "source_record_id": "set_item:171:modifier:4"
+            }
+          ]
+        },
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_unique_set_export",
+          "notes": [
+            "Generated from extracted unique/set data; tooltip text is not inferred as mechanics."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "id": 171,
+            "name": "Unique Skeleton Shield"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_item:171",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+          "source_type": "set_item"
+        },
+        "raw_reference": {
+          "baseType": "SHIELD",
+          "id": 171,
+          "name": "Unique Skeleton Shield",
+          "resolutionStatus": "resolved",
+          "resolvedBaseItem": {
+            "baseTypeID": 18,
+            "displayName": "Shield",
+            "name": "Shield",
+            "subType": {
+              "displayName": "",
+              "levelRequirement": 59,
+              "name": "Mountain Shield",
+              "subTypeID": 11
+            },
+            "type": "SHIELD"
+          },
+          "subTypes": [
+            11
+          ]
+        },
+        "requirements": {
+          "attributes": {},
+          "class": null,
+          "level": 60,
+          "mastery": null
+        },
+        "set_group_display_name": null,
+        "set_group_id": "set:13",
+        "set_id": "set:13",
+        "slot": "shield",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+        "source_id": "set_item:171",
+        "special_mechanic_classification": "partial_modifier",
+        "special_mechanic_notes": [
+          "Structured modifier rows exist but remain partial until value normalization is solved."
+        ],
+        "stable_calculable": false,
+        "subtype": "Mountain Shield",
+        "support_status": "partial",
+        "tooltip_text": [],
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Unique/set record is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "attribute_requirements": {},
+        "base_item_id": "item_base:equippable:5:3",
+        "bonus_text": [],
+        "canonical_id": "set_item:173",
+        "class_restrictions": [],
+        "classification": "weapon",
+        "consumer_safe_fields": {
+          "display_name": "Ruby Fang Cleaver",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Ruby Fang Cleaver",
+        "equipment_slot": "one_handed_axe",
+        "implicit_ids": [],
+        "implicit_links": [
+          {
+            "base_item_id": "item_base:equippable:5:3",
+            "implicit_index": 0,
+            "modifier_type": "ADDED",
+            "property": "Damage"
+          },
+          {
+            "base_item_id": "item_base:equippable:5:3",
+            "implicit_index": 1,
+            "modifier_type": "ADDED",
+            "property": "AilmentChance"
+          }
+        ],
+        "item_category": "equipment",
+        "item_type": "one_handed_axe",
+        "level_requirement": 55,
+        "lore_text": null,
+        "mastery_restrictions": [],
+        "modifier_references": [
+          {
+            "modifier_id": "set_item_modifier_set_item:173:0",
+            "property": "Damage",
+            "property_path": "ADDED.Damage.Fire.Melee",
+            "source_record_id": "set_item:173:modifier:0"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:173:1",
+            "property": "AilmentChance",
+            "property_path": "ADDED.AilmentChance.Melee",
+            "source_record_id": "set_item:173:modifier:1"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:173:2",
+            "property": "AttackSpeed",
+            "property_path": "INCREASED.AttackSpeed.Melee",
+            "source_record_id": "set_item:173:modifier:2"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:173:3",
+            "property": "IncreasedAilmentEffect",
+            "property_path": "ADDED.IncreasedAilmentEffect.Melee",
+            "source_record_id": "set_item:173:modifier:3"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:173:4",
+            "property": "PoisonResistance",
+            "property_path": "ADDED.PoisonResistance",
+            "source_record_id": "set_item:173:modifier:4"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:173:0",
+            "modifier_type": "ADDED",
+            "property": "Damage",
+            "property_path": "ADDED.Damage.Fire.Melee",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "Damage"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:173:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Fire",
+              "Melee"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 75.0,
+            "value_min": 55.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:173:1",
+            "modifier_type": "ADDED",
+            "property": "AilmentChance",
+            "property_path": "ADDED.AilmentChance.Melee",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 1,
+                "property": "AilmentChance"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:173:modifier:1",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 1,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Melee"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 1.0,
+            "value_min": 0.75
+          },
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:173:2",
+            "modifier_type": "INCREASED",
+            "property": "AttackSpeed",
+            "property_path": "INCREASED.AttackSpeed.Melee",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 2,
+                "property": "AttackSpeed"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:173:modifier:2",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Melee"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.1,
+            "value_min": 0.1
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:173:3",
+            "modifier_type": "ADDED",
+            "property": "IncreasedAilmentEffect",
+            "property_path": "ADDED.IncreasedAilmentEffect.Melee",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 3,
+                "property": "IncreasedAilmentEffect"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:173:modifier:3",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 2,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Melee"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.5,
+            "value_min": 0.35
+          },
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:173:4",
+            "modifier_type": "ADDED",
+            "property": "PoisonResistance",
+            "property_path": "ADDED.PoisonResistance",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 4,
+                "property": "PoisonResistance"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:173:modifier:4",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.75,
+            "value_min": 0.75
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_item_modifier_set_item:173:0",
+              "property": "Damage",
+              "property_path": "ADDED.Damage.Fire.Melee",
+              "source_record_id": "set_item:173:modifier:0"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:173:1",
+              "property": "AilmentChance",
+              "property_path": "ADDED.AilmentChance.Melee",
+              "source_record_id": "set_item:173:modifier:1"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:173:2",
+              "property": "AttackSpeed",
+              "property_path": "INCREASED.AttackSpeed.Melee",
+              "source_record_id": "set_item:173:modifier:2"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:173:3",
+              "property": "IncreasedAilmentEffect",
+              "property_path": "ADDED.IncreasedAilmentEffect.Melee",
+              "source_record_id": "set_item:173:modifier:3"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:173:4",
+              "property": "PoisonResistance",
+              "property_path": "ADDED.PoisonResistance",
+              "source_record_id": "set_item:173:modifier:4"
+            }
+          ]
+        },
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_unique_set_export",
+          "notes": [
+            "Generated from extracted unique/set data; tooltip text is not inferred as mechanics."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "id": 173,
+            "name": "Ruby Fang Cleaver"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_item:173",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+          "source_type": "set_item"
+        },
+        "raw_reference": {
+          "baseType": "ONE_HANDED_AXE",
+          "id": 173,
+          "name": "Ruby Fang Cleaver",
+          "resolutionStatus": "resolved",
+          "resolvedBaseItem": {
+            "baseTypeID": 5,
+            "displayName": "One-Handed Axe",
+            "name": "1H Axes",
+            "subType": {
+              "displayName": "",
+              "levelRequirement": 24,
+              "name": "Battle Axe",
+              "subTypeID": 3
+            },
+            "type": "ONE_HANDED_AXE"
+          },
+          "subTypes": [
+            3
+          ]
+        },
+        "requirements": {
+          "attributes": {},
+          "class": null,
+          "level": 55,
+          "mastery": null
+        },
+        "set_group_display_name": null,
+        "set_group_id": "set:14",
+        "set_id": "set:14",
+        "slot": "one_handed_axe",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+        "source_id": "set_item:173",
+        "special_mechanic_classification": "partial_modifier",
+        "special_mechanic_notes": [
+          "Structured modifier rows exist but remain partial until value normalization is solved."
+        ],
+        "stable_calculable": false,
+        "subtype": "Battle Axe",
+        "support_status": "partial",
+        "tooltip_text": [],
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Unique/set record is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "attribute_requirements": {},
+        "base_item_id": "item_base:equippable:18:13",
+        "bonus_text": [
+          "+[75,100,0]% Chance to Poison on Hit with Fire Skills",
+          "Gain Ruby Venom for 10 seconds on Block",
+          "You can have multiple stacks of Ruby Venom",
+          "15% increased Fire Damage per stack of Ruby Venom",
+          "15% increased Poison Damage per stack of Ruby Venom"
+        ],
+        "canonical_id": "set_item:174",
+        "class_restrictions": [],
+        "classification": "armor",
+        "consumer_safe_fields": {
+          "display_name": "Ruby Fang Aegis",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Ruby Fang Aegis",
+        "equipment_slot": "shield",
+        "implicit_ids": [],
+        "implicit_links": [
+          {
+            "base_item_id": "item_base:equippable:18:13",
+            "implicit_index": 0,
+            "modifier_type": "ADDED",
+            "property": "BlockChance"
+          },
+          {
+            "base_item_id": "item_base:equippable:18:13",
+            "implicit_index": 1,
+            "modifier_type": "ADDED",
+            "property": "BlockEffectiveness"
+          }
+        ],
+        "item_category": "equipment",
+        "item_type": "shield",
+        "level_requirement": 55,
+        "lore_text": null,
+        "mastery_restrictions": [],
+        "modifier_references": [
+          {
+            "modifier_id": "set_item_modifier_set_item:174:0",
+            "property": "AilmentChance",
+            "property_path": "ADDED.AilmentChance.Fire",
+            "source_record_id": "set_item:174:modifier:0"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:174:1",
+            "property": "DamageTaken",
+            "property_path": "MORE.DamageTaken.Poison",
+            "source_record_id": "set_item:174:modifier:1"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:174:2",
+            "property": "FireResistance",
+            "property_path": "ADDED.FireResistance",
+            "source_record_id": "set_item:174:modifier:2"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:174:3",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Physical.Fire.Elemental",
+            "source_record_id": "set_item:174:modifier:3"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": true,
+            "modifier_id": "set_item_modifier_set_item:174:0",
+            "modifier_type": "ADDED",
+            "property": "AilmentChance",
+            "property_path": "ADDED.AilmentChance.Fire",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "AilmentChance"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:174:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Fire"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 1.0,
+            "value_min": 0.75
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:174:1",
+            "modifier_type": "MORE",
+            "property": "DamageTaken",
+            "property_path": "MORE.DamageTaken.Poison",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 1,
+                "property": "DamageTaken"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:174:modifier:1",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 1,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Poison"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": -0.1,
+            "value_min": -0.3
+          },
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:174:2",
+            "modifier_type": "ADDED",
+            "property": "FireResistance",
+            "property_path": "ADDED.FireResistance",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 2,
+                "property": "FireResistance"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:174:modifier:2",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.75,
+            "value_min": 0.75
+          },
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": true,
+            "modifier_id": "set_item_modifier_set_item:174:3",
+            "modifier_type": "ADDED",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Physical.Fire.Elemental",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 3,
+                "property": "PlayerProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:174:modifier:3",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Physical",
+              "Fire",
+              "Elemental"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 1.0,
+            "value_min": 1.0
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_item_modifier_set_item:174:0",
+              "property": "AilmentChance",
+              "property_path": "ADDED.AilmentChance.Fire",
+              "source_record_id": "set_item:174:modifier:0"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:174:1",
+              "property": "DamageTaken",
+              "property_path": "MORE.DamageTaken.Poison",
+              "source_record_id": "set_item:174:modifier:1"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:174:2",
+              "property": "FireResistance",
+              "property_path": "ADDED.FireResistance",
+              "source_record_id": "set_item:174:modifier:2"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:174:3",
+              "property": "PlayerProperty",
+              "property_path": "ADDED.PlayerProperty.Physical.Fire.Elemental",
+              "source_record_id": "set_item:174:modifier:3"
+            }
+          ]
+        },
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_unique_set_export",
+          "notes": [
+            "Generated from extracted unique/set data; tooltip text is not inferred as mechanics."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "id": 174,
+            "name": "Ruby Tower Shield"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_item:174",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+          "source_type": "set_item"
+        },
+        "raw_reference": {
+          "baseType": "SHIELD",
+          "id": 174,
+          "name": "Ruby Tower Shield",
+          "resolutionStatus": "resolved",
+          "resolvedBaseItem": {
+            "baseTypeID": 18,
+            "displayName": "Shield",
+            "name": "Shield",
+            "subType": {
+              "displayName": "",
+              "levelRequirement": 72,
+              "name": "Ironglass Shield",
+              "subTypeID": 13
+            },
+            "type": "SHIELD"
+          },
+          "subTypes": [
+            13
+          ]
+        },
+        "requirements": {
+          "attributes": {},
+          "class": null,
+          "level": 55,
+          "mastery": null
+        },
+        "set_group_display_name": null,
+        "set_group_id": "set:14",
+        "set_id": "set:14",
+        "slot": "shield",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+        "source_id": "set_item:174",
+        "special_mechanic_classification": "partial_modifier",
+        "special_mechanic_notes": [
+          "Structured modifier rows exist but remain partial until value normalization is solved."
+        ],
+        "stable_calculable": false,
+        "subtype": "Ironglass Shield",
+        "support_status": "partial",
+        "tooltip_text": [
+          "+[75,100,0]% Chance to Poison on Hit with Fire Skills",
+          "Gain Ruby Venom for 10 seconds on Block",
+          "You can have multiple stacks of Ruby Venom",
+          "15% increased Fire Damage per stack of Ruby Venom",
+          "15% increased Poison Damage per stack of Ruby Venom"
+        ],
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Unique/set record is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "attribute_requirements": {},
+        "base_item_id": "item_base:equippable:0:57",
+        "bonus_text": [],
+        "canonical_id": "set_item:185",
+        "class_restrictions": [],
+        "classification": "armor",
+        "consumer_safe_fields": {
+          "display_name": "Vilatria's Storm Crown",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Vilatria's Storm Crown",
+        "equipment_slot": "helmet",
+        "implicit_ids": [],
+        "implicit_links": [
+          {
+            "base_item_id": "item_base:equippable:0:57",
+            "implicit_index": 0,
+            "modifier_type": "ADDED",
+            "property": "Armour"
+          },
+          {
+            "base_item_id": "item_base:equippable:0:57",
+            "implicit_index": 1,
+            "modifier_type": "INCREASED",
+            "property": "Damage"
+          }
+        ],
+        "item_category": "equipment",
+        "item_type": "helmet",
+        "level_requirement": 14,
+        "lore_text": "Studying at the great colleges of Welryn and Vul'Kaur, Vilatria perfected the art of Storm Magic. Yet a scholarly life never sated her ambition and she returned to the Lake kingdoms of central Eterra. Without a god to lead them, their lords and elders were proud and open to challenges of force. With the college of Welryn on their doorsteps, they were not unprepared for arcane challengers, but their wards could not protect them from the lightning that tore through the roofs of their halls and smote them in their thrones, and so Vilatria claimed their kingdoms by force.",
+        "mastery_restrictions": [],
+        "modifier_references": [
+          {
+            "modifier_id": "set_item_modifier_set_item:185:0",
+            "property": "LevelOfSkills",
+            "property_path": "ADDED.LevelOfSkills.Lightning.Spell",
+            "source_record_id": "set_item:185:modifier:0"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:185:1",
+            "property": "Penetration",
+            "property_path": "ADDED.Penetration.Lightning",
+            "source_record_id": "set_item:185:modifier:1"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:185:2",
+            "property": "Intelligence",
+            "property_path": "ADDED.Intelligence",
+            "source_record_id": "set_item:185:modifier:2"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:185:3",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Void.Elemental",
+            "source_record_id": "set_item:185:modifier:3"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:185:0",
+            "modifier_type": "ADDED",
+            "property": "LevelOfSkills",
+            "property_path": "ADDED.LevelOfSkills.Lightning.Spell",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "LevelOfSkills"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:185:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Lightning",
+              "Spell"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 1.0,
+            "value_min": 1.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:185:1",
+            "modifier_type": "ADDED",
+            "property": "Penetration",
+            "property_path": "ADDED.Penetration.Lightning",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 1,
+                "property": "Penetration"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:185:modifier:1",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Lightning"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.2,
+            "value_min": 0.12
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:185:2",
+            "modifier_type": "ADDED",
+            "property": "Intelligence",
+            "property_path": "ADDED.Intelligence",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 2,
+                "property": "Intelligence"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:185:modifier:2",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 1,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 8.0,
+            "value_min": 4.0
+          },
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:185:3",
+            "modifier_type": "ADDED",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Void.Elemental",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 3,
+                "property": "PlayerProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:185:modifier:3",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Void",
+              "Elemental"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.01,
+            "value_min": 0.01
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_item_modifier_set_item:185:0",
+              "property": "LevelOfSkills",
+              "property_path": "ADDED.LevelOfSkills.Lightning.Spell",
+              "source_record_id": "set_item:185:modifier:0"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:185:1",
+              "property": "Penetration",
+              "property_path": "ADDED.Penetration.Lightning",
+              "source_record_id": "set_item:185:modifier:1"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:185:2",
+              "property": "Intelligence",
+              "property_path": "ADDED.Intelligence",
+              "source_record_id": "set_item:185:modifier:2"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:185:3",
+              "property": "PlayerProperty",
+              "property_path": "ADDED.PlayerProperty.Void.Elemental",
+              "source_record_id": "set_item:185:modifier:3"
+            }
+          ]
+        },
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_unique_set_export",
+          "notes": [
+            "Generated from extracted unique/set data; tooltip text is not inferred as mechanics."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "id": 185,
+            "name": "Vilatria Storm Crown"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_item:185",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+          "source_type": "set_item"
+        },
+        "raw_reference": {
+          "baseType": "HELMET",
+          "id": 185,
+          "name": "Vilatria Storm Crown",
+          "resolutionStatus": "resolved",
+          "resolvedBaseItem": {
+            "baseTypeID": 0,
+            "displayName": "Helmet",
+            "name": "Helmets",
+            "subType": {
+              "displayName": "",
+              "levelRequirement": 14,
+              "name": "Weathered Crown",
+              "subTypeID": 57
+            },
+            "type": "HELMET"
+          },
+          "subTypes": [
+            57
+          ]
+        },
+        "requirements": {
+          "attributes": {},
+          "class": null,
+          "level": 14,
+          "mastery": null
+        },
+        "set_group_display_name": null,
+        "set_group_id": "set:15",
+        "set_id": "set:15",
+        "slot": "helmet",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+        "source_id": "set_item:185",
+        "special_mechanic_classification": "partial_modifier",
+        "special_mechanic_notes": [
+          "Structured modifier rows exist but remain partial until value normalization is solved."
+        ],
+        "stable_calculable": false,
+        "subtype": "Weathered Crown",
+        "support_status": "partial",
+        "tooltip_text": [],
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Unique/set record is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "attribute_requirements": {},
+        "base_item_id": "item_base:equippable:15:7",
+        "bonus_text": [
+          "Meteor is Converted to Lightning",
+          "Converts meteor's base damage, causing it to no longer scale with fire damage and causing Meteor to count as a lightning spell. Does not affect Shrapnel."
+        ],
+        "canonical_id": "set_item:186",
+        "class_restrictions": [],
+        "classification": "weapon",
+        "consumer_safe_fields": {
+          "display_name": "Vilatria's Downfall",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Vilatria's Downfall",
+        "equipment_slot": "two_handed_staff",
+        "implicit_ids": [],
+        "implicit_links": [
+          {
+            "base_item_id": "item_base:equippable:15:7",
+            "implicit_index": 0,
+            "modifier_type": "ADDED",
+            "property": "Damage"
+          },
+          {
+            "base_item_id": "item_base:equippable:15:7",
+            "implicit_index": 1,
+            "modifier_type": "ADDED",
+            "property": "Damage"
+          },
+          {
+            "base_item_id": "item_base:equippable:15:7",
+            "implicit_index": 2,
+            "modifier_type": "ADDED",
+            "property": "ManaCost"
+          }
+        ],
+        "item_category": "equipment",
+        "item_type": "two_handed_staff",
+        "level_requirement": 46,
+        "lore_text": "In her old age, Vilatria's hubris only grew. Having defeated all her human challengers, the storm queen's mind turned to Lagon, the fabled god of the sea and storms. With her apprentice, she sailed out from the border town of Etendell, along the estuary and out into the Fogrise sea. Lagon was said to dwell beneath the far seas beyond the western isles, yet the journey was quick for Vilatria as she fuelled her sails with winds of magic. Eventually she alighted at night upon a great isle of rock, coral, and ancient shrines. The moon spoke to her from its reflection flickering on the surface of the sea. It spoke with the voice of Lagon, and it spoke with amusement at her challenge, readily accepting, and opening the heavens. Thousands of years have passed and Vilatria is long dead, and her kingdom fractured, but the storms still rage upon the seas around that isle.\r",
+        "mastery_restrictions": [],
+        "modifier_references": [
+          {
+            "modifier_id": "set_item_modifier_set_item:186:0",
+            "property": "Damage",
+            "property_path": "INCREASED.Damage.Lightning",
+            "source_record_id": "set_item:186:modifier:0"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:186:1",
+            "property": "Mana",
+            "property_path": "ADDED.Mana",
+            "source_record_id": "set_item:186:modifier:1"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:186:2",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Lightning.Cold",
+            "source_record_id": "set_item:186:modifier:2"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:186:3",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Physical.Void.Elemental",
+            "source_record_id": "set_item:186:modifier:3"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:186:0",
+            "modifier_type": "INCREASED",
+            "property": "Damage",
+            "property_path": "INCREASED.Damage.Lightning",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "Damage"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:186:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Lightning"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 4.0,
+            "value_min": 2.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:186:1",
+            "modifier_type": "ADDED",
+            "property": "Mana",
+            "property_path": "ADDED.Mana",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 1,
+                "property": "Mana"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:186:modifier:1",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 1,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 200.0,
+            "value_min": 100.0
+          },
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": true,
+            "modifier_id": "set_item_modifier_set_item:186:2",
+            "modifier_type": "ADDED",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Lightning.Cold",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 2,
+                "property": "AbilityProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:186:modifier:2",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Physical",
+              "Lightning",
+              "Cold"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 1.0,
+            "value_min": 1.0
+          },
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:186:3",
+            "modifier_type": "ADDED",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Physical.Void.Elemental",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 3,
+                "property": "PlayerProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:186:modifier:3",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Physical",
+              "Void",
+              "Elemental"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.01,
+            "value_min": 0.01
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_item_modifier_set_item:186:0",
+              "property": "Damage",
+              "property_path": "INCREASED.Damage.Lightning",
+              "source_record_id": "set_item:186:modifier:0"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:186:1",
+              "property": "Mana",
+              "property_path": "ADDED.Mana",
+              "source_record_id": "set_item:186:modifier:1"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:186:2",
+              "property": "AbilityProperty",
+              "property_path": "ADDED.AbilityProperty.Physical.Lightning.Cold",
+              "source_record_id": "set_item:186:modifier:2"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:186:3",
+              "property": "PlayerProperty",
+              "property_path": "ADDED.PlayerProperty.Physical.Void.Elemental",
+              "source_record_id": "set_item:186:modifier:3"
+            }
+          ]
+        },
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_unique_set_export",
+          "notes": [
+            "Generated from extracted unique/set data; tooltip text is not inferred as mechanics."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "id": 186,
+            "name": "Vilatria Downfall"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_item:186",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+          "source_type": "set_item"
+        },
+        "raw_reference": {
+          "baseType": "TWO_HANDED_STAFF",
+          "id": 186,
+          "name": "Vilatria Downfall",
+          "resolutionStatus": "resolved",
+          "resolvedBaseItem": {
+            "baseTypeID": 15,
+            "displayName": "Two-Handed Staff",
+            "name": "2H Staff",
+            "subType": {
+              "displayName": "",
+              "levelRequirement": 50,
+              "name": "Moon Staff",
+              "subTypeID": 7
+            },
+            "type": "TWO_HANDED_STAFF"
+          },
+          "subTypes": [
+            7
+          ]
+        },
+        "requirements": {
+          "attributes": {},
+          "class": null,
+          "level": 46,
+          "mastery": null
+        },
+        "set_group_display_name": null,
+        "set_group_id": "set:15",
+        "set_id": "set:15",
+        "slot": "two_handed_staff",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+        "source_id": "set_item:186",
+        "special_mechanic_classification": "partial_modifier",
+        "special_mechanic_notes": [
+          "Structured modifier rows exist but remain partial until value normalization is solved."
+        ],
+        "stable_calculable": false,
+        "subtype": "Moon Staff",
+        "support_status": "partial",
+        "tooltip_text": [
+          "Meteor is Converted to Lightning",
+          "Converts meteor's base damage, causing it to no longer scale with fire damage and causing Meteor to count as a lightning spell. Does not affect Shrapnel."
+        ],
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Unique/set record is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "attribute_requirements": {},
+        "base_item_id": "item_base:equippable:18:6",
+        "bonus_text": [],
+        "canonical_id": "set_item:193",
+        "class_restrictions": [],
+        "classification": "armor",
+        "consumer_safe_fields": {
+          "display_name": "Corsair's Boarding Shield",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Corsair's Boarding Shield",
+        "equipment_slot": "shield",
+        "implicit_ids": [],
+        "implicit_links": [
+          {
+            "base_item_id": "item_base:equippable:18:6",
+            "implicit_index": 0,
+            "modifier_type": "ADDED",
+            "property": "BlockChance"
+          },
+          {
+            "base_item_id": "item_base:equippable:18:6",
+            "implicit_index": 1,
+            "modifier_type": "ADDED",
+            "property": "BlockEffectiveness"
+          },
+          {
+            "base_item_id": "item_base:equippable:18:6",
+            "implicit_index": 2,
+            "modifier_type": "INCREASED",
+            "property": "Damage"
+          }
+        ],
+        "item_category": "equipment",
+        "item_type": "shield",
+        "level_requirement": 35,
+        "lore_text": "Striking the Dreadnought would be their greatest feat yet, a win to remember that would silence those wishing to surrender to the Empire. However, for the captain freeing the whales was the true reward.",
+        "mastery_restrictions": [],
+        "modifier_references": [
+          {
+            "modifier_id": "set_item_modifier_set_item:193:0",
+            "property": "BlockEffectiveness",
+            "property_path": "ADDED.BlockEffectiveness",
+            "source_record_id": "set_item:193:modifier:0"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:193:1",
+            "property": "NecroticResistance",
+            "property_path": "ADDED.NecroticResistance",
+            "source_record_id": "set_item:193:modifier:1"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:193:2",
+            "property": "Dexterity",
+            "property_path": "ADDED.Dexterity",
+            "source_record_id": "set_item:193:modifier:2"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:193:3",
+            "property": "LevelOfSkills",
+            "property_path": "ADDED.LevelOfSkills.Necrotic.Poison.Elemental",
+            "source_record_id": "set_item:193:modifier:3"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:193:4",
+            "property": "LevelOfSkills",
+            "property_path": "ADDED.LevelOfSkills.Cold.Void.Poison.Elemental.Spell",
+            "source_record_id": "set_item:193:modifier:4"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:193:0",
+            "modifier_type": "ADDED",
+            "property": "BlockEffectiveness",
+            "property_path": "ADDED.BlockEffectiveness",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "BlockEffectiveness"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:193:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 575.0,
+            "value_min": 275.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:193:1",
+            "modifier_type": "ADDED",
+            "property": "NecroticResistance",
+            "property_path": "ADDED.NecroticResistance",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 1,
+                "property": "NecroticResistance"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:193:modifier:1",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.45,
+            "value_min": 0.35
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:193:2",
+            "modifier_type": "ADDED",
+            "property": "Dexterity",
+            "property_path": "ADDED.Dexterity",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 2,
+                "property": "Dexterity"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:193:modifier:2",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 15.0,
+            "value_min": 7.0
+          },
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:193:3",
+            "modifier_type": "ADDED",
+            "property": "LevelOfSkills",
+            "property_path": "ADDED.LevelOfSkills.Necrotic.Poison.Elemental",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 3,
+                "property": "LevelOfSkills"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:193:modifier:3",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Necrotic",
+              "Poison",
+              "Elemental"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 1.0,
+            "value_min": 1.0
+          },
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:193:4",
+            "modifier_type": "ADDED",
+            "property": "LevelOfSkills",
+            "property_path": "ADDED.LevelOfSkills.Cold.Void.Poison.Elemental.Spell",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 4,
+                "property": "LevelOfSkills"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:193:modifier:4",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Cold",
+              "Void",
+              "Poison",
+              "Elemental",
+              "Spell"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 1.0,
+            "value_min": 1.0
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_item_modifier_set_item:193:0",
+              "property": "BlockEffectiveness",
+              "property_path": "ADDED.BlockEffectiveness",
+              "source_record_id": "set_item:193:modifier:0"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:193:1",
+              "property": "NecroticResistance",
+              "property_path": "ADDED.NecroticResistance",
+              "source_record_id": "set_item:193:modifier:1"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:193:2",
+              "property": "Dexterity",
+              "property_path": "ADDED.Dexterity",
+              "source_record_id": "set_item:193:modifier:2"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:193:3",
+              "property": "LevelOfSkills",
+              "property_path": "ADDED.LevelOfSkills.Necrotic.Poison.Elemental",
+              "source_record_id": "set_item:193:modifier:3"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:193:4",
+              "property": "LevelOfSkills",
+              "property_path": "ADDED.LevelOfSkills.Cold.Void.Poison.Elemental.Spell",
+              "source_record_id": "set_item:193:modifier:4"
+            }
+          ]
+        },
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_unique_set_export",
+          "notes": [
+            "Generated from extracted unique/set data; tooltip text is not inferred as mechanics."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "id": 193,
+            "name": "Corsair Boarding Shield"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_item:193",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+          "source_type": "set_item"
+        },
+        "raw_reference": {
+          "baseType": "SHIELD",
+          "id": 193,
+          "name": "Corsair Boarding Shield",
+          "resolutionStatus": "resolved",
+          "resolvedBaseItem": {
+            "baseTypeID": 18,
+            "displayName": "Shield",
+            "name": "Shield",
+            "subType": {
+              "displayName": "",
+              "levelRequirement": 36,
+              "name": "Bandit Shield",
+              "subTypeID": 6
+            },
+            "type": "SHIELD"
+          },
+          "subTypes": [
+            6
+          ]
+        },
+        "requirements": {
+          "attributes": {},
+          "class": null,
+          "level": 35,
+          "mastery": null
+        },
+        "set_group_display_name": null,
+        "set_group_id": "set:16",
+        "set_id": "set:16",
+        "slot": "shield",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+        "source_id": "set_item:193",
+        "special_mechanic_classification": "partial_modifier",
+        "special_mechanic_notes": [
+          "Structured modifier rows exist but remain partial until value normalization is solved."
+        ],
+        "stable_calculable": false,
+        "subtype": "Bandit Shield",
+        "support_status": "partial",
+        "tooltip_text": [],
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Unique/set record is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "attribute_requirements": {},
+        "base_item_id": "item_base:equippable:0:69",
+        "bonus_text": [],
+        "canonical_id": "set_item:194",
+        "class_restrictions": [],
+        "classification": "armor",
+        "consumer_safe_fields": {
+          "display_name": "Corsair's Blood Cowl",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Corsair's Blood Cowl",
+        "equipment_slot": "helmet",
+        "implicit_ids": [],
+        "implicit_links": [
+          {
+            "base_item_id": "item_base:equippable:0:69",
+            "implicit_index": 0,
+            "modifier_type": "ADDED",
+            "property": "Armour"
+          },
+          {
+            "base_item_id": "item_base:equippable:0:69",
+            "implicit_index": 1,
+            "modifier_type": "ADDED",
+            "property": "IncreasedCooldownRecoverySpeed"
+          },
+          {
+            "base_item_id": "item_base:equippable:0:69",
+            "implicit_index": 2,
+            "modifier_type": "ADDED",
+            "property": "IncreasedStunChance"
+          }
+        ],
+        "item_category": "equipment",
+        "item_type": "helmet",
+        "level_requirement": 57,
+        "lore_text": "Standing up to the Empire, not giving in to temptation, the Corsairs of the Scoured Reefs are among the last standing men and women with running blood in their veins.",
+        "mastery_restrictions": [],
+        "modifier_references": [
+          {
+            "modifier_id": "set_item_modifier_set_item:194:0",
+            "property": "IncreasedAilmentEffect",
+            "property_path": "ADDED.IncreasedAilmentEffect",
+            "source_record_id": "set_item:194:modifier:0"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:194:1",
+            "property": "BlockEffectiveness",
+            "property_path": "INCREASED.BlockEffectiveness",
+            "source_record_id": "set_item:194:modifier:1"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:194:2",
+            "property": "IncreasedAilmentDuration",
+            "property_path": "ADDED.IncreasedAilmentDuration",
+            "source_record_id": "set_item:194:modifier:2"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:194:3",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Cold.Void.Poison.Elemental.Spell",
+            "source_record_id": "set_item:194:modifier:3"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:194:4",
+            "property": "IncreasedPotionDropRate",
+            "property_path": "ADDED.IncreasedPotionDropRate",
+            "source_record_id": "set_item:194:modifier:4"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:194:0",
+            "modifier_type": "ADDED",
+            "property": "IncreasedAilmentEffect",
+            "property_path": "ADDED.IncreasedAilmentEffect",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "IncreasedAilmentEffect"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:194:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.35,
+            "value_min": 0.17
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:194:1",
+            "modifier_type": "INCREASED",
+            "property": "BlockEffectiveness",
+            "property_path": "INCREASED.BlockEffectiveness",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 1,
+                "property": "BlockEffectiveness"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:194:modifier:1",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 2,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.35,
+            "value_min": 0.17
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:194:2",
+            "modifier_type": "ADDED",
+            "property": "IncreasedAilmentDuration",
+            "property_path": "ADDED.IncreasedAilmentDuration",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 2,
+                "property": "IncreasedAilmentDuration"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:194:modifier:2",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 3,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.35,
+            "value_min": 0.17
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:194:3",
+            "modifier_type": "ADDED",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Cold.Void.Poison.Elemental.Spell",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 3,
+                "property": "AbilityProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:194:modifier:3",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Cold",
+              "Void",
+              "Poison",
+              "Elemental",
+              "Spell"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.85,
+            "value_min": 0.35
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:194:4",
+            "modifier_type": "ADDED",
+            "property": "IncreasedPotionDropRate",
+            "property_path": "ADDED.IncreasedPotionDropRate",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 4,
+                "property": "IncreasedPotionDropRate"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:194:modifier:4",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 1,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.85,
+            "value_min": 0.35
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_item_modifier_set_item:194:0",
+              "property": "IncreasedAilmentEffect",
+              "property_path": "ADDED.IncreasedAilmentEffect",
+              "source_record_id": "set_item:194:modifier:0"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:194:1",
+              "property": "BlockEffectiveness",
+              "property_path": "INCREASED.BlockEffectiveness",
+              "source_record_id": "set_item:194:modifier:1"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:194:2",
+              "property": "IncreasedAilmentDuration",
+              "property_path": "ADDED.IncreasedAilmentDuration",
+              "source_record_id": "set_item:194:modifier:2"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:194:3",
+              "property": "AbilityProperty",
+              "property_path": "ADDED.AbilityProperty.Cold.Void.Poison.Elemental.Spell",
+              "source_record_id": "set_item:194:modifier:3"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:194:4",
+              "property": "IncreasedPotionDropRate",
+              "property_path": "ADDED.IncreasedPotionDropRate",
+              "source_record_id": "set_item:194:modifier:4"
+            }
+          ]
+        },
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_unique_set_export",
+          "notes": [
+            "Generated from extracted unique/set data; tooltip text is not inferred as mechanics."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "id": 194,
+            "name": "Corsair Blood Cowl"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_item:194",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+          "source_type": "set_item"
+        },
+        "raw_reference": {
+          "baseType": "HELMET",
+          "id": 194,
+          "name": "Corsair Blood Cowl",
+          "resolutionStatus": "resolved",
+          "resolvedBaseItem": {
+            "baseTypeID": 0,
+            "displayName": "Helmet",
+            "name": "Helmets",
+            "subType": {
+              "displayName": "",
+              "levelRequirement": 86,
+              "name": "Gorgonscale Coif",
+              "subTypeID": 69
+            },
+            "type": "HELMET"
+          },
+          "subTypes": [
+            69
+          ]
+        },
+        "requirements": {
+          "attributes": {},
+          "class": null,
+          "level": 57,
+          "mastery": null
+        },
+        "set_group_display_name": null,
+        "set_group_id": "set:16",
+        "set_id": "set:16",
+        "slot": "helmet",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+        "source_id": "set_item:194",
+        "special_mechanic_classification": "partial_modifier",
+        "special_mechanic_notes": [
+          "Structured modifier rows exist but remain partial until value normalization is solved."
+        ],
+        "stable_calculable": false,
+        "subtype": "Gorgonscale Coif",
+        "support_status": "partial",
+        "tooltip_text": [],
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Unique/set record is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "attribute_requirements": {},
+        "base_item_id": "item_base:equippable:6:7",
+        "bonus_text": [],
+        "canonical_id": "set_item:227",
+        "class_restrictions": [],
+        "classification": "weapon",
+        "consumer_safe_fields": {
+          "display_name": "Ferebor's Chisel",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Ferebor's Chisel",
+        "equipment_slot": "one_handed_dagger",
+        "implicit_ids": [],
+        "implicit_links": [
+          {
+            "base_item_id": "item_base:equippable:6:7",
+            "implicit_index": 0,
+            "modifier_type": "ADDED",
+            "property": "Damage"
+          },
+          {
+            "base_item_id": "item_base:equippable:6:7",
+            "implicit_index": 1,
+            "modifier_type": "ADDED",
+            "property": "CriticalChance"
+          },
+          {
+            "base_item_id": "item_base:equippable:6:7",
+            "implicit_index": 2,
+            "modifier_type": "ADDED",
+            "property": "Damage"
+          }
+        ],
+        "item_category": "equipment",
+        "item_type": "one_handed_dagger",
+        "level_requirement": 71,
+        "lore_text": "When Ferebor's collection of totems grew too large, he gathered his creations in a cave while his fellow nomads moved on without him. As the winters passed and his collection grew, other nomads would visit him to trade food and furs for totems crafted to defend their tribes.",
+        "mastery_restrictions": [],
+        "modifier_references": [
+          {
+            "modifier_id": "set_item_modifier_set_item:227:0",
+            "property": "Damage",
+            "property_path": "ADDED.Damage.Physical.Melee.Totem",
+            "source_record_id": "set_item:227:modifier:0"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:227:1",
+            "property": "Damage",
+            "property_path": "ADDED.Damage.Physical.Spell.Totem",
+            "source_record_id": "set_item:227:modifier:1"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:227:2",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Physical.Lightning.Cold.Fire.Necrotic.Elemental",
+            "source_record_id": "set_item:227:modifier:2"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:227:3",
+            "property": "CriticalMultiplier",
+            "property_path": "ADDED.CriticalMultiplier.Totem",
+            "source_record_id": "set_item:227:modifier:3"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:227:4",
+            "property": "Mana",
+            "property_path": "ADDED.Mana",
+            "source_record_id": "set_item:227:modifier:4"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:227:0",
+            "modifier_type": "ADDED",
+            "property": "Damage",
+            "property_path": "ADDED.Damage.Physical.Melee.Totem",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "Damage"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:227:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Physical",
+              "Melee",
+              "Totem"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 15.0,
+            "value_min": 10.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:227:1",
+            "modifier_type": "ADDED",
+            "property": "Damage",
+            "property_path": "ADDED.Damage.Physical.Spell.Totem",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 1,
+                "property": "Damage"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:227:modifier:1",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 1,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Physical",
+              "Spell",
+              "Totem"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 15.0,
+            "value_min": 10.0
+          },
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:227:2",
+            "modifier_type": "ADDED",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Physical.Lightning.Cold.Fire.Necrotic.Elemental",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 2,
+                "property": "PlayerProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:227:modifier:2",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Physical",
+              "Lightning",
+              "Cold",
+              "Fire",
+              "Necrotic",
+              "Elemental"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.01,
+            "value_min": 0.01
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:227:3",
+            "modifier_type": "ADDED",
+            "property": "CriticalMultiplier",
+            "property_path": "ADDED.CriticalMultiplier.Totem",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 3,
+                "property": "CriticalMultiplier"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:227:modifier:3",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 2,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Totem"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.35,
+            "value_min": 0.15
+          },
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:227:4",
+            "modifier_type": "ADDED",
+            "property": "Mana",
+            "property_path": "ADDED.Mana",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 4,
+                "property": "Mana"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:227:modifier:4",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 50.0,
+            "value_min": 50.0
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_item_modifier_set_item:227:0",
+              "property": "Damage",
+              "property_path": "ADDED.Damage.Physical.Melee.Totem",
+              "source_record_id": "set_item:227:modifier:0"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:227:1",
+              "property": "Damage",
+              "property_path": "ADDED.Damage.Physical.Spell.Totem",
+              "source_record_id": "set_item:227:modifier:1"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:227:2",
+              "property": "PlayerProperty",
+              "property_path": "ADDED.PlayerProperty.Physical.Lightning.Cold.Fire.Necrotic.Elemental",
+              "source_record_id": "set_item:227:modifier:2"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:227:3",
+              "property": "CriticalMultiplier",
+              "property_path": "ADDED.CriticalMultiplier.Totem",
+              "source_record_id": "set_item:227:modifier:3"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:227:4",
+              "property": "Mana",
+              "property_path": "ADDED.Mana",
+              "source_record_id": "set_item:227:modifier:4"
+            }
+          ]
+        },
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_unique_set_export",
+          "notes": [
+            "Generated from extracted unique/set data; tooltip text is not inferred as mechanics."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "id": 227,
+            "name": "Ferebors Chisel"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_item:227",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+          "source_type": "set_item"
+        },
+        "raw_reference": {
+          "baseType": "ONE_HANDED_DAGGER",
+          "id": 227,
+          "name": "Ferebors Chisel",
+          "resolutionStatus": "resolved",
+          "resolvedBaseItem": {
+            "baseTypeID": 6,
+            "displayName": "Dagger",
+            "name": "1H Dagger",
+            "subType": {
+              "displayName": "",
+              "levelRequirement": 61,
+              "name": "Rune Dagger",
+              "subTypeID": 7
+            },
+            "type": "ONE_HANDED_DAGGER"
+          },
+          "subTypes": [
+            7
+          ]
+        },
+        "requirements": {
+          "attributes": {},
+          "class": null,
+          "level": 71,
+          "mastery": null
+        },
+        "set_group_display_name": null,
+        "set_group_id": "set:17",
+        "set_id": "set:17",
+        "slot": "one_handed_dagger",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+        "source_id": "set_item:227",
+        "special_mechanic_classification": "partial_modifier",
+        "special_mechanic_notes": [
+          "Structured modifier rows exist but remain partial until value normalization is solved."
+        ],
+        "stable_calculable": false,
+        "subtype": "Rune Dagger",
+        "support_status": "partial",
+        "tooltip_text": [],
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Unique/set record is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "attribute_requirements": {},
+        "base_item_id": "item_base:equippable:21:8",
+        "bonus_text": [],
+        "canonical_id": "set_item:228",
+        "class_restrictions": [],
+        "classification": "accessory",
+        "consumer_safe_fields": {
+          "display_name": "Ferebor's Persistence",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Ferebor's Persistence",
+        "equipment_slot": "ring",
+        "implicit_ids": [],
+        "implicit_links": [
+          {
+            "base_item_id": "item_base:equippable:21:8",
+            "implicit_index": 0,
+            "modifier_type": "ADDED",
+            "property": "NecroticResistance"
+          },
+          {
+            "base_item_id": "item_base:equippable:21:8",
+            "implicit_index": 1,
+            "modifier_type": "ADDED",
+            "property": "WardDecayThreshold"
+          }
+        ],
+        "item_category": "equipment",
+        "item_type": "ring",
+        "level_requirement": 72,
+        "lore_text": "Fifty winters since they first parted, Ferebor's tribe returned to his cave eager to purchase another totem. However, instead of finding the storied totem carver, they were driven away by his creations. Assuming him dead, they paid their respects and moved on, yet the number of totems around the cave continued to grow. Some say Ferebor still dwells there, cut off from the outside but carving totem after totem among the shadows.",
+        "mastery_restrictions": [],
+        "modifier_references": [
+          {
+            "modifier_id": "set_item_modifier_set_item:228:0",
+            "property": "Armour",
+            "property_path": "ADDED.Armour",
+            "source_record_id": "set_item:228:modifier:0"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:228:1",
+            "property": "Armour",
+            "property_path": "ADDED.Armour.Totem",
+            "source_record_id": "set_item:228:modifier:1"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:228:2",
+            "property": "Intelligence",
+            "property_path": "ADDED.Intelligence",
+            "source_record_id": "set_item:228:modifier:2"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:228:3",
+            "property": "HealthRegen",
+            "property_path": "ADDED.HealthRegen",
+            "source_record_id": "set_item:228:modifier:3"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:228:4",
+            "property": "HealthRegen",
+            "property_path": "ADDED.HealthRegen.Totem",
+            "source_record_id": "set_item:228:modifier:4"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:228:0",
+            "modifier_type": "ADDED",
+            "property": "Armour",
+            "property_path": "ADDED.Armour",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "Armour"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:228:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 181.0,
+            "value_min": 100.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:228:1",
+            "modifier_type": "ADDED",
+            "property": "Armour",
+            "property_path": "ADDED.Armour.Totem",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 1,
+                "property": "Armour"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:228:modifier:1",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Totem"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 181.0,
+            "value_min": 100.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:228:2",
+            "modifier_type": "ADDED",
+            "property": "Intelligence",
+            "property_path": "ADDED.Intelligence",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 2,
+                "property": "Intelligence"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:228:modifier:2",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 1,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 18.0,
+            "value_min": 10.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:228:3",
+            "modifier_type": "ADDED",
+            "property": "HealthRegen",
+            "property_path": "ADDED.HealthRegen",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 3,
+                "property": "HealthRegen"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:228:modifier:3",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 2,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 18.0,
+            "value_min": 10.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:228:4",
+            "modifier_type": "ADDED",
+            "property": "HealthRegen",
+            "property_path": "ADDED.HealthRegen.Totem",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 4,
+                "property": "HealthRegen"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:228:modifier:4",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 2,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Totem"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 18.0,
+            "value_min": 10.0
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_item_modifier_set_item:228:0",
+              "property": "Armour",
+              "property_path": "ADDED.Armour",
+              "source_record_id": "set_item:228:modifier:0"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:228:1",
+              "property": "Armour",
+              "property_path": "ADDED.Armour.Totem",
+              "source_record_id": "set_item:228:modifier:1"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:228:2",
+              "property": "Intelligence",
+              "property_path": "ADDED.Intelligence",
+              "source_record_id": "set_item:228:modifier:2"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:228:3",
+              "property": "HealthRegen",
+              "property_path": "ADDED.HealthRegen",
+              "source_record_id": "set_item:228:modifier:3"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:228:4",
+              "property": "HealthRegen",
+              "property_path": "ADDED.HealthRegen.Totem",
+              "source_record_id": "set_item:228:modifier:4"
+            }
+          ]
+        },
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_unique_set_export",
+          "notes": [
+            "Generated from extracted unique/set data; tooltip text is not inferred as mechanics."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "id": 228,
+            "name": "Ferebors Persistence"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_item:228",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+          "source_type": "set_item"
+        },
+        "raw_reference": {
+          "baseType": "RING",
+          "id": 228,
+          "name": "Ferebors Persistence",
+          "resolutionStatus": "resolved",
+          "resolvedBaseItem": {
+            "baseTypeID": 21,
+            "displayName": "Ring",
+            "name": "Ring",
+            "subType": {
+              "displayName": "",
+              "levelRequirement": 66,
+              "name": "Ivory Ring",
+              "subTypeID": 8
+            },
+            "type": "RING"
+          },
+          "subTypes": [
+            8
+          ]
+        },
+        "requirements": {
+          "attributes": {},
+          "class": null,
+          "level": 72,
+          "mastery": null
+        },
+        "set_group_display_name": null,
+        "set_group_id": "set:17",
+        "set_id": "set:17",
+        "slot": "ring",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+        "source_id": "set_item:228",
+        "special_mechanic_classification": "partial_modifier",
+        "special_mechanic_notes": [
+          "Structured modifier rows exist but remain partial until value normalization is solved."
+        ],
+        "stable_calculable": false,
+        "subtype": "Ivory Ring",
+        "support_status": "partial",
+        "tooltip_text": [],
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Unique/set record is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "attribute_requirements": {},
+        "base_item_id": "item_base:equippable:4:4",
+        "bonus_text": [
+          "+[14,24,2] Spell Fire Damage for Damage Over Time Spells"
+        ],
+        "canonical_id": "set_item:260",
+        "class_restrictions": [],
+        "classification": "armor",
+        "consumer_safe_fields": {
+          "display_name": "Lich's Envy",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Lich's Envy",
+        "equipment_slot": "gloves",
+        "implicit_ids": [],
+        "implicit_links": [
+          {
+            "base_item_id": "item_base:equippable:4:4",
+            "implicit_index": 0,
+            "modifier_type": "ADDED",
+            "property": "Armour"
+          },
+          {
+            "base_item_id": "item_base:equippable:4:4",
+            "implicit_index": 1,
+            "modifier_type": "INCREASED",
+            "property": "ManaRegen"
+          }
+        ],
+        "item_category": "equipment",
+        "item_type": "gloves",
+        "level_requirement": 64,
+        "lore_text": null,
+        "mastery_restrictions": [],
+        "modifier_references": [
+          {
+            "modifier_id": "set_item_modifier_set_item:260:0",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Lightning.Void.Necrotic.Poison.Spell",
+            "source_record_id": "set_item:260:modifier:0"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:260:1",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Lightning.Void.Necrotic.Poison.Spell",
+            "source_record_id": "set_item:260:modifier:1"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:260:2",
+            "property": "Damage",
+            "property_path": "ADDED.Damage.Fire.Spell.DoT",
+            "source_record_id": "set_item:260:modifier:2"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:260:3",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Lightning.Void.Necrotic.Poison.Spell",
+            "source_record_id": "set_item:260:modifier:3"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:260:4",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Lightning.Fire.Void.Elemental.Spell",
+            "source_record_id": "set_item:260:modifier:4"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:260:0",
+            "modifier_type": "ADDED",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Lightning.Void.Necrotic.Poison.Spell",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "AbilityProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:260:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Lightning",
+              "Void",
+              "Necrotic",
+              "Poison",
+              "Spell"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 24.0,
+            "value_min": 14.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:260:1",
+            "modifier_type": "ADDED",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Lightning.Void.Necrotic.Poison.Spell",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 1,
+                "property": "AbilityProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:260:modifier:1",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 1,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Lightning",
+              "Void",
+              "Necrotic",
+              "Poison",
+              "Spell"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.48,
+            "value_min": 0.28
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": true,
+            "modifier_id": "set_item_modifier_set_item:260:2",
+            "modifier_type": "ADDED",
+            "property": "Damage",
+            "property_path": "ADDED.Damage.Fire.Spell.DoT",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 2,
+                "property": "Damage"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:260:modifier:2",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 2,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Fire",
+              "Spell",
+              "DoT"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 24.0,
+            "value_min": 14.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:260:3",
+            "modifier_type": "ADDED",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Lightning.Void.Necrotic.Poison.Spell",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 3,
+                "property": "AbilityProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:260:modifier:3",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 3,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Lightning",
+              "Void",
+              "Necrotic",
+              "Poison",
+              "Spell"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": -8.0,
+            "value_min": -14.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:260:4",
+            "modifier_type": "ADDED",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Lightning.Fire.Void.Elemental.Spell",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 4,
+                "property": "AbilityProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:260:modifier:4",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 4,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Physical",
+              "Lightning",
+              "Fire",
+              "Void",
+              "Elemental",
+              "Spell"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": -8.0,
+            "value_min": -14.0
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_item_modifier_set_item:260:0",
+              "property": "AbilityProperty",
+              "property_path": "ADDED.AbilityProperty.Lightning.Void.Necrotic.Poison.Spell",
+              "source_record_id": "set_item:260:modifier:0"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:260:1",
+              "property": "AbilityProperty",
+              "property_path": "ADDED.AbilityProperty.Lightning.Void.Necrotic.Poison.Spell",
+              "source_record_id": "set_item:260:modifier:1"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:260:2",
+              "property": "Damage",
+              "property_path": "ADDED.Damage.Fire.Spell.DoT",
+              "source_record_id": "set_item:260:modifier:2"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:260:3",
+              "property": "AbilityProperty",
+              "property_path": "ADDED.AbilityProperty.Lightning.Void.Necrotic.Poison.Spell",
+              "source_record_id": "set_item:260:modifier:3"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:260:4",
+              "property": "AbilityProperty",
+              "property_path": "ADDED.AbilityProperty.Physical.Lightning.Fire.Void.Elemental.Spell",
+              "source_record_id": "set_item:260:modifier:4"
+            }
+          ]
+        },
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_unique_set_export",
+          "notes": [
+            "Generated from extracted unique/set data; tooltip text is not inferred as mechanics."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "id": 260,
+            "name": "Lichs Envy"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_item:260",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+          "source_type": "set_item"
+        },
+        "raw_reference": {
+          "baseType": "GLOVES",
+          "id": 260,
+          "name": "Lichs Envy",
+          "resolutionStatus": "resolved",
+          "resolvedBaseItem": {
+            "baseTypeID": 4,
+            "displayName": "Gloves",
+            "name": "Gloves",
+            "subType": {
+              "displayName": "",
+              "levelRequirement": 31,
+              "name": "Noble Gloves",
+              "subTypeID": 4
+            },
+            "type": "GLOVES"
+          },
+          "subTypes": [
+            4
+          ]
+        },
+        "requirements": {
+          "attributes": {},
+          "class": null,
+          "level": 64,
+          "mastery": null
+        },
+        "set_group_display_name": null,
+        "set_group_id": "set:18",
+        "set_id": "set:18",
+        "slot": "gloves",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+        "source_id": "set_item:260",
+        "special_mechanic_classification": "partial_modifier",
+        "special_mechanic_notes": [
+          "Structured modifier rows exist but remain partial until value normalization is solved."
+        ],
+        "stable_calculable": false,
+        "subtype": "Noble Gloves",
+        "support_status": "partial",
+        "tooltip_text": [
+          "+[14,24,2] Spell Fire Damage for Damage Over Time Spells"
+        ],
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Unique/set record is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "attribute_requirements": {},
+        "base_item_id": "item_base:equippable:19:11",
+        "bonus_text": [
+          "Dread Shade is Converted to Cold",
+          "This causes it to add and increase Cold Damage instead of Necrotic Damage. This takes priority over the Poison Conversion node on Dread Shade's tree."
+        ],
+        "canonical_id": "set_item:261",
+        "class_restrictions": [],
+        "classification": "accessory",
+        "consumer_safe_fields": {
+          "display_name": "Lich's Scorn",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Lich's Scorn",
+        "equipment_slot": "catalyst",
+        "implicit_ids": [],
+        "implicit_links": [
+          {
+            "base_item_id": "item_base:equippable:19:11",
+            "implicit_index": 0,
+            "modifier_type": "ADDED",
+            "property": "Intelligence"
+          },
+          {
+            "base_item_id": "item_base:equippable:19:11",
+            "implicit_index": 1,
+            "modifier_type": "ADDED",
+            "property": "CriticalChance"
+          },
+          {
+            "base_item_id": "item_base:equippable:19:11",
+            "implicit_index": 2,
+            "modifier_type": "ADDED",
+            "property": "WardRetention"
+          }
+        ],
+        "item_category": "equipment",
+        "item_type": "catalyst",
+        "level_requirement": 63,
+        "lore_text": null,
+        "mastery_restrictions": [],
+        "modifier_references": [
+          {
+            "modifier_id": "set_item_modifier_set_item:261:0",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Lightning.Fire.Void.Elemental.Spell",
+            "source_record_id": "set_item:261:modifier:0"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:261:1",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Lightning.Fire.Void.Elemental.Spell",
+            "source_record_id": "set_item:261:modifier:1"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:261:2",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Lightning.Fire.Void.Elemental.Spell",
+            "source_record_id": "set_item:261:modifier:2"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:261:3",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Lightning.Fire.Void.Elemental.Spell",
+            "source_record_id": "set_item:261:modifier:3"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:261:4",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Lightning.Fire.Void.Elemental.Spell",
+            "source_record_id": "set_item:261:modifier:4"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": true,
+            "modifier_id": "set_item_modifier_set_item:261:0",
+            "modifier_type": "ADDED",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Lightning.Fire.Void.Elemental.Spell",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "AbilityProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:261:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Physical",
+              "Lightning",
+              "Fire",
+              "Void",
+              "Elemental",
+              "Spell"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 1.0,
+            "value_min": 1.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:261:1",
+            "modifier_type": "ADDED",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Lightning.Fire.Void.Elemental.Spell",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 1,
+                "property": "AbilityProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:261:modifier:1",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Physical",
+              "Lightning",
+              "Fire",
+              "Void",
+              "Elemental",
+              "Spell"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.13,
+            "value_min": 0.09
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:261:2",
+            "modifier_type": "ADDED",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Lightning.Fire.Void.Elemental.Spell",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 2,
+                "property": "AbilityProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:261:modifier:2",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 1,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Physical",
+              "Lightning",
+              "Fire",
+              "Void",
+              "Elemental",
+              "Spell"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 1.53,
+            "value_min": 0.93
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:261:3",
+            "modifier_type": "ADDED",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Lightning.Fire.Void.Elemental.Spell",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 3,
+                "property": "AbilityProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:261:modifier:3",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 2,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Physical",
+              "Lightning",
+              "Fire",
+              "Void",
+              "Elemental",
+              "Spell"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 15.0,
+            "value_min": 6.0
+          },
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:261:4",
+            "modifier_type": "ADDED",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Lightning.Fire.Void.Elemental.Spell",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 4,
+                "property": "AbilityProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:261:modifier:4",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Physical",
+              "Lightning",
+              "Fire",
+              "Void",
+              "Elemental",
+              "Spell"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.01,
+            "value_min": 0.01
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_item_modifier_set_item:261:0",
+              "property": "AbilityProperty",
+              "property_path": "ADDED.AbilityProperty.Physical.Lightning.Fire.Void.Elemental.Spell",
+              "source_record_id": "set_item:261:modifier:0"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:261:1",
+              "property": "AbilityProperty",
+              "property_path": "ADDED.AbilityProperty.Physical.Lightning.Fire.Void.Elemental.Spell",
+              "source_record_id": "set_item:261:modifier:1"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:261:2",
+              "property": "AbilityProperty",
+              "property_path": "ADDED.AbilityProperty.Physical.Lightning.Fire.Void.Elemental.Spell",
+              "source_record_id": "set_item:261:modifier:2"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:261:3",
+              "property": "AbilityProperty",
+              "property_path": "ADDED.AbilityProperty.Physical.Lightning.Fire.Void.Elemental.Spell",
+              "source_record_id": "set_item:261:modifier:3"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:261:4",
+              "property": "AbilityProperty",
+              "property_path": "ADDED.AbilityProperty.Physical.Lightning.Fire.Void.Elemental.Spell",
+              "source_record_id": "set_item:261:modifier:4"
+            }
+          ]
+        },
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_unique_set_export",
+          "notes": [
+            "Generated from extracted unique/set data; tooltip text is not inferred as mechanics."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "id": 261,
+            "name": "Lichs Scorn"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_item:261",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+          "source_type": "set_item"
+        },
+        "raw_reference": {
+          "baseType": "CATALYST",
+          "id": 261,
+          "name": "Lichs Scorn",
+          "resolutionStatus": "resolved",
+          "resolvedBaseItem": {
+            "baseTypeID": 19,
+            "displayName": "Off-Hand Catalyst",
+            "name": "Catalyst",
+            "subType": {
+              "displayName": "",
+              "levelRequirement": 74,
+              "name": "Crystal Skull",
+              "subTypeID": 11
+            },
+            "type": "CATALYST"
+          },
+          "subTypes": [
+            11
+          ]
+        },
+        "requirements": {
+          "attributes": {},
+          "class": null,
+          "level": 63,
+          "mastery": null
+        },
+        "set_group_display_name": null,
+        "set_group_id": "set:18",
+        "set_id": "set:18",
+        "slot": "catalyst",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+        "source_id": "set_item:261",
+        "special_mechanic_classification": "partial_modifier",
+        "special_mechanic_notes": [
+          "Structured modifier rows exist but remain partial until value normalization is solved."
+        ],
+        "stable_calculable": false,
+        "subtype": "Crystal Skull",
+        "support_status": "partial",
+        "tooltip_text": [
+          "Dread Shade is Converted to Cold",
+          "This causes it to add and increase Cold Damage instead of Necrotic Damage. This takes priority over the Poison Conversion node on Dread Shade's tree."
+        ],
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Unique/set record is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "attribute_requirements": {},
+        "base_item_id": "item_base:equippable:22:52",
+        "bonus_text": [],
+        "canonical_id": "set_item:451",
+        "class_restrictions": [],
+        "classification": "accessory",
+        "consumer_safe_fields": {
+          "display_name": "Doppelganger's Mimicry",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Doppelganger's Mimicry",
+        "equipment_slot": "relic",
+        "implicit_ids": [],
+        "implicit_links": [
+          {
+            "base_item_id": "item_base:equippable:22:52",
+            "implicit_index": 0,
+            "modifier_type": "INCREASED",
+            "property": "DodgeRating"
+          }
+        ],
+        "item_category": "equipment",
+        "item_type": "relic",
+        "level_requirement": 45,
+        "lore_text": null,
+        "mastery_restrictions": [],
+        "modifier_references": [
+          {
+            "modifier_id": "set_item_modifier_set_item:451:0",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Cold.Void.Poison.Elemental.Spell",
+            "source_record_id": "set_item:451:modifier:0"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:451:1",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Cold.Void.Poison.Elemental.Spell",
+            "source_record_id": "set_item:451:modifier:1"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:451:2",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Cold.Void.Poison.Elemental.Spell",
+            "source_record_id": "set_item:451:modifier:2"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:451:3",
+            "property": "PhysicalResistance",
+            "property_path": "ADDED.PhysicalResistance",
+            "source_record_id": "set_item:451:modifier:3"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:451:0",
+            "modifier_type": "ADDED",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Cold.Void.Poison.Elemental.Spell",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "AbilityProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:451:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Physical",
+              "Cold",
+              "Void",
+              "Poison",
+              "Elemental",
+              "Spell"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.3,
+            "value_min": 0.2
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:451:1",
+            "modifier_type": "ADDED",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Cold.Void.Poison.Elemental.Spell",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 1,
+                "property": "AbilityProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:451:modifier:1",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Physical",
+              "Cold",
+              "Void",
+              "Poison",
+              "Elemental",
+              "Spell"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.09,
+            "value_min": 0.06
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:451:2",
+            "modifier_type": "ADDED",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Cold.Void.Poison.Elemental.Spell",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 2,
+                "property": "AbilityProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:451:modifier:2",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Physical",
+              "Cold",
+              "Void",
+              "Poison",
+              "Elemental",
+              "Spell"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.9,
+            "value_min": 0.6
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:451:3",
+            "modifier_type": "ADDED",
+            "property": "PhysicalResistance",
+            "property_path": "ADDED.PhysicalResistance",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 3,
+                "property": "PhysicalResistance"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:451:modifier:3",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.28,
+            "value_min": 0.14
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_item_modifier_set_item:451:0",
+              "property": "AbilityProperty",
+              "property_path": "ADDED.AbilityProperty.Physical.Cold.Void.Poison.Elemental.Spell",
+              "source_record_id": "set_item:451:modifier:0"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:451:1",
+              "property": "AbilityProperty",
+              "property_path": "ADDED.AbilityProperty.Physical.Cold.Void.Poison.Elemental.Spell",
+              "source_record_id": "set_item:451:modifier:1"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:451:2",
+              "property": "AbilityProperty",
+              "property_path": "ADDED.AbilityProperty.Physical.Cold.Void.Poison.Elemental.Spell",
+              "source_record_id": "set_item:451:modifier:2"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:451:3",
+              "property": "PhysicalResistance",
+              "property_path": "ADDED.PhysicalResistance",
+              "source_record_id": "set_item:451:modifier:3"
+            }
+          ]
+        },
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_unique_set_export",
+          "notes": [
+            "Generated from extracted unique/set data; tooltip text is not inferred as mechanics."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "id": 451,
+            "name": "Doppelgangers Mimicry"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_item:451",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+          "source_type": "set_item"
+        },
+        "raw_reference": {
+          "baseType": "RELIC",
+          "id": 451,
+          "name": "Doppelgangers Mimicry",
+          "resolutionStatus": "resolved",
+          "resolvedBaseItem": {
+            "baseTypeID": 22,
+            "displayName": "Relic",
+            "name": "Relic",
+            "subType": {
+              "displayName": "",
+              "levelRequirement": 55,
+              "name": "Jade Dice",
+              "subTypeID": 52
+            },
+            "type": "RELIC"
+          },
+          "subTypes": [
+            52
+          ]
+        },
+        "requirements": {
+          "attributes": {},
+          "class": null,
+          "level": 45,
+          "mastery": null
+        },
+        "set_group_display_name": null,
+        "set_group_id": "set:19",
+        "set_id": "set:19",
+        "slot": "relic",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+        "source_id": "set_item:451",
+        "special_mechanic_classification": "partial_modifier",
+        "special_mechanic_notes": [
+          "Structured modifier rows exist but remain partial until value normalization is solved."
+        ],
+        "stable_calculable": false,
+        "subtype": "Jade Dice",
+        "support_status": "partial",
+        "tooltip_text": [],
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Unique/set record is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "attribute_requirements": {},
+        "base_item_id": "item_base:equippable:1:48",
+        "bonus_text": [],
+        "canonical_id": "set_item:452",
+        "class_restrictions": [],
+        "classification": "armor",
+        "consumer_safe_fields": {
+          "display_name": "Doppelganger's Deception",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Doppelganger's Deception",
+        "equipment_slot": "body_armor",
+        "implicit_ids": [],
+        "implicit_links": [
+          {
+            "base_item_id": "item_base:equippable:1:48",
+            "implicit_index": 0,
+            "modifier_type": "ADDED",
+            "property": "Armour"
+          },
+          {
+            "base_item_id": "item_base:equippable:1:48",
+            "implicit_index": 1,
+            "modifier_type": "ADDED",
+            "property": "AbilityProperty"
+          }
+        ],
+        "item_category": "equipment",
+        "item_type": "body_armor",
+        "level_requirement": 51,
+        "lore_text": null,
+        "mastery_restrictions": [],
+        "modifier_references": [
+          {
+            "modifier_id": "set_item_modifier_set_item:452:0",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Cold.Void.Poison.Elemental.Spell",
+            "source_record_id": "set_item:452:modifier:0"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:452:1",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Cold.Void.Poison.Elemental.Spell",
+            "source_record_id": "set_item:452:modifier:1"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:452:2",
+            "property": "Health",
+            "property_path": "ADDED.Health",
+            "source_record_id": "set_item:452:modifier:2"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:452:3",
+            "property": "DodgeRating",
+            "property_path": "ADDED.DodgeRating",
+            "source_record_id": "set_item:452:modifier:3"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:452:4",
+            "property": "CritAvoidance",
+            "property_path": "ADDED.CritAvoidance",
+            "source_record_id": "set_item:452:modifier:4"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:452:0",
+            "modifier_type": "ADDED",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Cold.Void.Poison.Elemental.Spell",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "AbilityProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:452:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Physical",
+              "Cold",
+              "Void",
+              "Poison",
+              "Elemental",
+              "Spell"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 1.0,
+            "value_min": 1.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:452:1",
+            "modifier_type": "ADDED",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Cold.Void.Poison.Elemental.Spell",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 1,
+                "property": "AbilityProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:452:modifier:1",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Physical",
+              "Cold",
+              "Void",
+              "Poison",
+              "Elemental",
+              "Spell"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 1.8,
+            "value_min": 1.2
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:452:2",
+            "modifier_type": "ADDED",
+            "property": "Health",
+            "property_path": "ADDED.Health",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 2,
+                "property": "Health"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:452:modifier:2",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 1,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 170.0,
+            "value_min": 120.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:452:3",
+            "modifier_type": "ADDED",
+            "property": "DodgeRating",
+            "property_path": "ADDED.DodgeRating",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 3,
+                "property": "DodgeRating"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:452:modifier:3",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 2,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 210.0,
+            "value_min": 120.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:452:4",
+            "modifier_type": "ADDED",
+            "property": "CritAvoidance",
+            "property_path": "ADDED.CritAvoidance",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 4,
+                "property": "CritAvoidance"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:452:modifier:4",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 3,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.5,
+            "value_min": 0.3
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_item_modifier_set_item:452:0",
+              "property": "AbilityProperty",
+              "property_path": "ADDED.AbilityProperty.Physical.Cold.Void.Poison.Elemental.Spell",
+              "source_record_id": "set_item:452:modifier:0"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:452:1",
+              "property": "AbilityProperty",
+              "property_path": "ADDED.AbilityProperty.Physical.Cold.Void.Poison.Elemental.Spell",
+              "source_record_id": "set_item:452:modifier:1"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:452:2",
+              "property": "Health",
+              "property_path": "ADDED.Health",
+              "source_record_id": "set_item:452:modifier:2"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:452:3",
+              "property": "DodgeRating",
+              "property_path": "ADDED.DodgeRating",
+              "source_record_id": "set_item:452:modifier:3"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:452:4",
+              "property": "CritAvoidance",
+              "property_path": "ADDED.CritAvoidance",
+              "source_record_id": "set_item:452:modifier:4"
+            }
+          ]
+        },
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_unique_set_export",
+          "notes": [
+            "Generated from extracted unique/set data; tooltip text is not inferred as mechanics."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "id": 452,
+            "name": "Doppelgangers Deception"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_item:452",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+          "source_type": "set_item"
+        },
+        "raw_reference": {
+          "baseType": "BODY_ARMOR",
+          "id": 452,
+          "name": "Doppelgangers Deception",
+          "resolutionStatus": "resolved",
+          "resolvedBaseItem": {
+            "baseTypeID": 1,
+            "displayName": "Body Armor",
+            "name": "Body Armor",
+            "subType": {
+              "displayName": "",
+              "levelRequirement": 39,
+              "name": "Umbral Coat",
+              "subTypeID": 48
+            },
+            "type": "BODY_ARMOR"
+          },
+          "subTypes": [
+            48
+          ]
+        },
+        "requirements": {
+          "attributes": {},
+          "class": null,
+          "level": 51,
+          "mastery": null
+        },
+        "set_group_display_name": null,
+        "set_group_id": "set:19",
+        "set_id": "set:19",
+        "slot": "body_armor",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+        "source_id": "set_item:452",
+        "special_mechanic_classification": "partial_modifier",
+        "special_mechanic_notes": [
+          "Structured modifier rows exist but remain partial until value normalization is solved."
+        ],
+        "stable_calculable": false,
+        "subtype": "Umbral Coat",
+        "support_status": "partial",
+        "tooltip_text": [],
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Unique/set record is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "attribute_requirements": {},
+        "base_item_id": "item_base:equippable:0:47",
+        "bonus_text": [
+          "Consuming a Shadow grants a stack of Dusk Shroud"
+        ],
+        "canonical_id": "set_item:453",
+        "class_restrictions": [],
+        "classification": "armor",
+        "consumer_safe_fields": {
+          "display_name": "Doppelganger's Facade",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Doppelganger's Facade",
+        "equipment_slot": "helmet",
+        "implicit_ids": [],
+        "implicit_links": [
+          {
+            "base_item_id": "item_base:equippable:0:47",
+            "implicit_index": 0,
+            "modifier_type": "ADDED",
+            "property": "Armour"
+          },
+          {
+            "base_item_id": "item_base:equippable:0:47",
+            "implicit_index": 1,
+            "modifier_type": "ADDED",
+            "property": "StunAvoidance"
+          }
+        ],
+        "item_category": "equipment",
+        "item_type": "helmet",
+        "level_requirement": 45,
+        "lore_text": null,
+        "mastery_restrictions": [],
+        "modifier_references": [
+          {
+            "modifier_id": "set_item_modifier_set_item:453:0",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Cold.Void.Poison.Elemental.Spell",
+            "source_record_id": "set_item:453:modifier:0"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:453:1",
+            "property": "GlancingBlowChance",
+            "property_path": "ADDED.GlancingBlowChance",
+            "source_record_id": "set_item:453:modifier:1"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:453:2",
+            "property": "Health",
+            "property_path": "INCREASED.Health",
+            "source_record_id": "set_item:453:modifier:2"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:453:3",
+            "property": "DodgeRating",
+            "property_path": "ADDED.DodgeRating",
+            "source_record_id": "set_item:453:modifier:3"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:453:4",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Cold.Void.Poison.Elemental.Spell",
+            "source_record_id": "set_item:453:modifier:4"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:453:0",
+            "modifier_type": "ADDED",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Cold.Void.Poison.Elemental.Spell",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "AbilityProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:453:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Physical",
+              "Cold",
+              "Void",
+              "Poison",
+              "Elemental",
+              "Spell"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 120.0,
+            "value_min": 70.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:453:1",
+            "modifier_type": "ADDED",
+            "property": "GlancingBlowChance",
+            "property_path": "ADDED.GlancingBlowChance",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 1,
+                "property": "GlancingBlowChance"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:453:modifier:1",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.24,
+            "value_min": 0.1
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:453:2",
+            "modifier_type": "INCREASED",
+            "property": "Health",
+            "property_path": "INCREASED.Health",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 2,
+                "property": "Health"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:453:modifier:2",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.14,
+            "value_min": 0.08
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:453:3",
+            "modifier_type": "ADDED",
+            "property": "DodgeRating",
+            "property_path": "ADDED.DodgeRating",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 3,
+                "property": "DodgeRating"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:453:modifier:3",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 110.0,
+            "value_min": 70.0
+          },
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": true,
+            "modifier_id": "set_item_modifier_set_item:453:4",
+            "modifier_type": "ADDED",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Cold.Void.Poison.Elemental.Spell",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 4,
+                "property": "AbilityProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:453:modifier:4",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Physical",
+              "Cold",
+              "Void",
+              "Poison",
+              "Elemental",
+              "Spell"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 1.0,
+            "value_min": 1.0
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_item_modifier_set_item:453:0",
+              "property": "AbilityProperty",
+              "property_path": "ADDED.AbilityProperty.Physical.Cold.Void.Poison.Elemental.Spell",
+              "source_record_id": "set_item:453:modifier:0"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:453:1",
+              "property": "GlancingBlowChance",
+              "property_path": "ADDED.GlancingBlowChance",
+              "source_record_id": "set_item:453:modifier:1"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:453:2",
+              "property": "Health",
+              "property_path": "INCREASED.Health",
+              "source_record_id": "set_item:453:modifier:2"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:453:3",
+              "property": "DodgeRating",
+              "property_path": "ADDED.DodgeRating",
+              "source_record_id": "set_item:453:modifier:3"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:453:4",
+              "property": "AbilityProperty",
+              "property_path": "ADDED.AbilityProperty.Physical.Cold.Void.Poison.Elemental.Spell",
+              "source_record_id": "set_item:453:modifier:4"
+            }
+          ]
+        },
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_unique_set_export",
+          "notes": [
+            "Generated from extracted unique/set data; tooltip text is not inferred as mechanics."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "id": 453,
+            "name": "Doppelgangers Facade"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_item:453",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+          "source_type": "set_item"
+        },
+        "raw_reference": {
+          "baseType": "HELMET",
+          "id": 453,
+          "name": "Doppelgangers Facade",
+          "resolutionStatus": "resolved",
+          "resolvedBaseItem": {
+            "baseTypeID": 0,
+            "displayName": "Helmet",
+            "name": "Helmets",
+            "subType": {
+              "displayName": "",
+              "levelRequirement": 37,
+              "name": "Umbral Hood",
+              "subTypeID": 47
+            },
+            "type": "HELMET"
+          },
+          "subTypes": [
+            47
+          ]
+        },
+        "requirements": {
+          "attributes": {},
+          "class": null,
+          "level": 45,
+          "mastery": null
+        },
+        "set_group_display_name": null,
+        "set_group_id": "set:19",
+        "set_id": "set:19",
+        "slot": "helmet",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+        "source_id": "set_item:453",
+        "special_mechanic_classification": "partial_modifier",
+        "special_mechanic_notes": [
+          "Structured modifier rows exist but remain partial until value normalization is solved."
+        ],
+        "stable_calculable": false,
+        "subtype": "Umbral Hood",
+        "support_status": "partial",
+        "tooltip_text": [
+          "Consuming a Shadow grants a stack of Dusk Shroud"
+        ],
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Unique/set record is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "attribute_requirements": {},
+        "base_item_id": "item_base:equippable:20:18",
+        "bonus_text": [],
+        "canonical_id": "set_item:454",
+        "class_restrictions": [],
+        "classification": "accessory",
+        "consumer_safe_fields": {
+          "display_name": "Abandoned Eyes of the Weaver",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Abandoned Eyes of the Weaver",
+        "equipment_slot": "amulet",
+        "implicit_ids": [],
+        "implicit_links": [
+          {
+            "base_item_id": "item_base:equippable:20:18",
+            "implicit_index": 0,
+            "modifier_type": "ADDED",
+            "property": "Vitality"
+          },
+          {
+            "base_item_id": "item_base:equippable:20:18",
+            "implicit_index": 1,
+            "modifier_type": "ADDED",
+            "property": "Dexterity"
+          }
+        ],
+        "item_category": "equipment",
+        "item_type": "amulet",
+        "level_requirement": 54,
+        "lore_text": "The coalescing Weaver had no more need for mundane eyes",
+        "mastery_restrictions": [],
+        "modifier_references": [
+          {
+            "modifier_id": "set_item_modifier_set_item:454:0",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Cold.Fire.Necrotic.Poison.Melee",
+            "source_record_id": "set_item:454:modifier:0"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:454:1",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Physical.Cold.Fire.Necrotic.Poison.Melee",
+            "source_record_id": "set_item:454:modifier:1"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:454:2",
+            "property": "WardDecayThreshold",
+            "property_path": "ADDED.WardDecayThreshold",
+            "source_record_id": "set_item:454:modifier:2"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:454:3",
+            "property": "LightningResistance",
+            "property_path": "ADDED.LightningResistance",
+            "source_record_id": "set_item:454:modifier:3"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:454:4",
+            "property": "PoisonResistance",
+            "property_path": "ADDED.PoisonResistance",
+            "source_record_id": "set_item:454:modifier:4"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:454:0",
+            "modifier_type": "ADDED",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Cold.Fire.Necrotic.Poison.Melee",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "PlayerProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:454:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Cold",
+              "Fire",
+              "Necrotic",
+              "Poison",
+              "Melee"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.01,
+            "value_min": 0.01
+          },
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:454:1",
+            "modifier_type": "ADDED",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Physical.Cold.Fire.Necrotic.Poison.Melee",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 1,
+                "property": "PlayerProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:454:modifier:1",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Physical",
+              "Cold",
+              "Fire",
+              "Necrotic",
+              "Poison",
+              "Melee"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 1.0,
+            "value_min": 1.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:454:2",
+            "modifier_type": "ADDED",
+            "property": "WardDecayThreshold",
+            "property_path": "ADDED.WardDecayThreshold",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 2,
+                "property": "WardDecayThreshold"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:454:modifier:2",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 300.0,
+            "value_min": 150.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:454:3",
+            "modifier_type": "ADDED",
+            "property": "LightningResistance",
+            "property_path": "ADDED.LightningResistance",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 3,
+                "property": "LightningResistance"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:454:modifier:3",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 2,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.3,
+            "value_min": 0.18
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:454:4",
+            "modifier_type": "ADDED",
+            "property": "PoisonResistance",
+            "property_path": "ADDED.PoisonResistance",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 4,
+                "property": "PoisonResistance"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:454:modifier:4",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 3,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.3,
+            "value_min": 0.18
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_item_modifier_set_item:454:0",
+              "property": "PlayerProperty",
+              "property_path": "ADDED.PlayerProperty.Cold.Fire.Necrotic.Poison.Melee",
+              "source_record_id": "set_item:454:modifier:0"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:454:1",
+              "property": "PlayerProperty",
+              "property_path": "ADDED.PlayerProperty.Physical.Cold.Fire.Necrotic.Poison.Melee",
+              "source_record_id": "set_item:454:modifier:1"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:454:2",
+              "property": "WardDecayThreshold",
+              "property_path": "ADDED.WardDecayThreshold",
+              "source_record_id": "set_item:454:modifier:2"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:454:3",
+              "property": "LightningResistance",
+              "property_path": "ADDED.LightningResistance",
+              "source_record_id": "set_item:454:modifier:3"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:454:4",
+              "property": "PoisonResistance",
+              "property_path": "ADDED.PoisonResistance",
+              "source_record_id": "set_item:454:modifier:4"
+            }
+          ]
+        },
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_unique_set_export",
+          "notes": [
+            "Generated from extracted unique/set data; tooltip text is not inferred as mechanics."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "id": 454,
+            "name": "Abandoned Eyes of the Weaver"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_item:454",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+          "source_type": "set_item"
+        },
+        "raw_reference": {
+          "baseType": "AMULET",
+          "id": 454,
+          "name": "Abandoned Eyes of the Weaver",
+          "resolutionStatus": "resolved",
+          "resolvedBaseItem": {
+            "baseTypeID": 20,
+            "displayName": "Amulet",
+            "name": "Amulet",
+            "subType": {
+              "displayName": "",
+              "levelRequirement": 0,
+              "name": "Spider Eye Amulet",
+              "subTypeID": 18
+            },
+            "type": "AMULET"
+          },
+          "subTypes": [
+            18
+          ]
+        },
+        "requirements": {
+          "attributes": {},
+          "class": null,
+          "level": 54,
+          "mastery": null
+        },
+        "set_group_display_name": null,
+        "set_group_id": "set:20",
+        "set_id": "set:20",
+        "slot": "amulet",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+        "source_id": "set_item:454",
+        "special_mechanic_classification": "partial_modifier",
+        "special_mechanic_notes": [
+          "Structured modifier rows exist but remain partial until value normalization is solved."
+        ],
+        "stable_calculable": false,
+        "subtype": "Spider Eye Amulet",
+        "support_status": "partial",
+        "tooltip_text": [],
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Unique/set record is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "attribute_requirements": {},
+        "base_item_id": "item_base:equippable:21:11",
+        "bonus_text": [],
+        "canonical_id": "set_item:455",
+        "class_restrictions": [],
+        "classification": "accessory",
+        "consumer_safe_fields": {
+          "display_name": "Abandoned Chitin of the Weaver",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Abandoned Chitin of the Weaver",
+        "equipment_slot": "ring",
+        "implicit_ids": [],
+        "implicit_links": [
+          {
+            "base_item_id": "item_base:equippable:21:11",
+            "implicit_index": 0,
+            "modifier_type": "ADDED",
+            "property": "WardDecayThreshold"
+          }
+        ],
+        "item_category": "equipment",
+        "item_type": "ring",
+        "level_requirement": 54,
+        "lore_text": "What was once protection became only a burdensome cage as The Weaver spun a greater form",
+        "mastery_restrictions": [],
+        "modifier_references": [
+          {
+            "modifier_id": "set_item_modifier_set_item:455:0",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Lightning.Cold.Fire.Necrotic.Poison.Melee",
+            "source_record_id": "set_item:455:modifier:0"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:455:1",
+            "property": "Armour",
+            "property_path": "ADDED.Armour",
+            "source_record_id": "set_item:455:modifier:1"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:455:2",
+            "property": "WardRegen",
+            "property_path": "ADDED.WardRegen",
+            "source_record_id": "set_item:455:modifier:2"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:455:3",
+            "property": "Strength",
+            "property_path": "ADDED.Strength",
+            "source_record_id": "set_item:455:modifier:3"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:455:4",
+            "property": "PhysicalResistance",
+            "property_path": "ADDED.PhysicalResistance",
+            "source_record_id": "set_item:455:modifier:4"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:455:0",
+            "modifier_type": "ADDED",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Lightning.Cold.Fire.Necrotic.Poison.Melee",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "PlayerProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:455:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Lightning",
+              "Cold",
+              "Fire",
+              "Necrotic",
+              "Poison",
+              "Melee"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.01,
+            "value_min": 0.01
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:455:1",
+            "modifier_type": "ADDED",
+            "property": "Armour",
+            "property_path": "ADDED.Armour",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 1,
+                "property": "Armour"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:455:modifier:1",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 160.0,
+            "value_min": 120.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:455:2",
+            "modifier_type": "ADDED",
+            "property": "WardRegen",
+            "property_path": "ADDED.WardRegen",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 2,
+                "property": "WardRegen"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:455:modifier:2",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 1,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 30.0,
+            "value_min": 20.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:455:3",
+            "modifier_type": "ADDED",
+            "property": "Strength",
+            "property_path": "ADDED.Strength",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 3,
+                "property": "Strength"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:455:modifier:3",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 2,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 8.0,
+            "value_min": 5.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:455:4",
+            "modifier_type": "ADDED",
+            "property": "PhysicalResistance",
+            "property_path": "ADDED.PhysicalResistance",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 4,
+                "property": "PhysicalResistance"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:455:modifier:4",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 3,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.3,
+            "value_min": 0.18
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_item_modifier_set_item:455:0",
+              "property": "PlayerProperty",
+              "property_path": "ADDED.PlayerProperty.Lightning.Cold.Fire.Necrotic.Poison.Melee",
+              "source_record_id": "set_item:455:modifier:0"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:455:1",
+              "property": "Armour",
+              "property_path": "ADDED.Armour",
+              "source_record_id": "set_item:455:modifier:1"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:455:2",
+              "property": "WardRegen",
+              "property_path": "ADDED.WardRegen",
+              "source_record_id": "set_item:455:modifier:2"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:455:3",
+              "property": "Strength",
+              "property_path": "ADDED.Strength",
+              "source_record_id": "set_item:455:modifier:3"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:455:4",
+              "property": "PhysicalResistance",
+              "property_path": "ADDED.PhysicalResistance",
+              "source_record_id": "set_item:455:modifier:4"
+            }
+          ]
+        },
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_unique_set_export",
+          "notes": [
+            "Generated from extracted unique/set data; tooltip text is not inferred as mechanics."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "id": 455,
+            "name": "Abandoned Chitin of the Weaver"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_item:455",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+          "source_type": "set_item"
+        },
+        "raw_reference": {
+          "baseType": "RING",
+          "id": 455,
+          "name": "Abandoned Chitin of the Weaver",
+          "resolutionStatus": "resolved",
+          "resolvedBaseItem": {
+            "baseTypeID": 21,
+            "displayName": "Ring",
+            "name": "Ring",
+            "subType": {
+              "displayName": "Celestial Ring",
+              "levelRequirement": 52,
+              "name": "Circle of Fortune Ring",
+              "subTypeID": 11
+            },
+            "type": "RING"
+          },
+          "subTypes": [
+            11
+          ]
+        },
+        "requirements": {
+          "attributes": {},
+          "class": null,
+          "level": 54,
+          "mastery": null
+        },
+        "set_group_display_name": null,
+        "set_group_id": "set:20",
+        "set_id": "set:20",
+        "slot": "ring",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+        "source_id": "set_item:455",
+        "special_mechanic_classification": "partial_modifier",
+        "special_mechanic_notes": [
+          "Structured modifier rows exist but remain partial until value normalization is solved."
+        ],
+        "stable_calculable": false,
+        "subtype": "Circle of Fortune Ring",
+        "support_status": "partial",
+        "tooltip_text": [],
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Unique/set record is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "attribute_requirements": {},
+        "base_item_id": "item_base:equippable:9:5",
+        "bonus_text": [
+          "Dancing Strikes is converted to Fire"
+        ],
+        "canonical_id": "set_item:456",
+        "class_restrictions": [],
+        "classification": "weapon",
+        "consumer_safe_fields": {
+          "display_name": "Kuzon's Fury",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Kuzon's Fury",
+        "equipment_slot": "one_handed_sword",
+        "implicit_ids": [],
+        "implicit_links": [
+          {
+            "base_item_id": "item_base:equippable:9:5",
+            "implicit_index": 0,
+            "modifier_type": "ADDED",
+            "property": "Damage"
+          }
+        ],
+        "item_category": "equipment",
+        "item_type": "one_handed_sword",
+        "level_requirement": 49,
+        "lore_text": null,
+        "mastery_restrictions": [],
+        "modifier_references": [
+          {
+            "modifier_id": "set_item_modifier_set_item:456:0",
+            "property": "Damage",
+            "property_path": "ADDED.Damage.Fire.Melee",
+            "source_record_id": "set_item:456:modifier:0"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:456:1",
+            "property": "LevelOfSkills",
+            "property_path": "ADDED.LevelOfSkills.Physical.Necrotic.Poison.Elemental.Spell",
+            "source_record_id": "set_item:456:modifier:1"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:456:2",
+            "property": "LevelOfSkills",
+            "property_path": "ADDED.LevelOfSkills.Lightning.Poison.Elemental.Spell",
+            "source_record_id": "set_item:456:modifier:2"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:456:3",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Lightning.Poison.Elemental.Spell",
+            "source_record_id": "set_item:456:modifier:3"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:456:4",
+            "property": "IncreasedAreaForAreaSkills",
+            "property_path": "ADDED.IncreasedAreaForAreaSkills.Fire.Melee",
+            "source_record_id": "set_item:456:modifier:4"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:456:5",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Fire.Necrotic.Poison.Elemental.Spell",
+            "source_record_id": "set_item:456:modifier:5"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:456:6",
+            "property": "Damage",
+            "property_path": "INCREASED.Damage.Fire",
+            "source_record_id": "set_item:456:modifier:6"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:456:7",
+            "property": "AttackSpeed",
+            "property_path": "INCREASED.AttackSpeed.Melee",
+            "source_record_id": "set_item:456:modifier:7"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:456:0",
+            "modifier_type": "ADDED",
+            "property": "Damage",
+            "property_path": "ADDED.Damage.Fire.Melee",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "Damage"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:456:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Fire",
+              "Melee"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 40.0,
+            "value_min": 40.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:456:1",
+            "modifier_type": "ADDED",
+            "property": "LevelOfSkills",
+            "property_path": "ADDED.LevelOfSkills.Physical.Necrotic.Poison.Elemental.Spell",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 1,
+                "property": "LevelOfSkills"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:456:modifier:1",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Physical",
+              "Necrotic",
+              "Poison",
+              "Elemental",
+              "Spell"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 4.0,
+            "value_min": 2.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:456:2",
+            "modifier_type": "ADDED",
+            "property": "LevelOfSkills",
+            "property_path": "ADDED.LevelOfSkills.Lightning.Poison.Elemental.Spell",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 2,
+                "property": "LevelOfSkills"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:456:modifier:2",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 1,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Lightning",
+              "Poison",
+              "Elemental",
+              "Spell"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 4.0,
+            "value_min": 2.0
+          },
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": true,
+            "modifier_id": "set_item_modifier_set_item:456:3",
+            "modifier_type": "ADDED",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Lightning.Poison.Elemental.Spell",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 3,
+                "property": "AbilityProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:456:modifier:3",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Lightning",
+              "Poison",
+              "Elemental",
+              "Spell"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 1.0,
+            "value_min": 1.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:456:4",
+            "modifier_type": "ADDED",
+            "property": "IncreasedAreaForAreaSkills",
+            "property_path": "ADDED.IncreasedAreaForAreaSkills.Fire.Melee",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 4,
+                "property": "IncreasedAreaForAreaSkills"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:456:modifier:4",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 2,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Fire",
+              "Melee"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.4,
+            "value_min": 0.2
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:456:5",
+            "modifier_type": "ADDED",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Fire.Necrotic.Poison.Elemental.Spell",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 5,
+                "property": "AbilityProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:456:modifier:5",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 3,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Physical",
+              "Fire",
+              "Necrotic",
+              "Poison",
+              "Elemental",
+              "Spell"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.7,
+            "value_min": 0.5
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:456:6",
+            "modifier_type": "INCREASED",
+            "property": "Damage",
+            "property_path": "INCREASED.Damage.Fire",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 6,
+                "property": "Damage"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:456:modifier:6",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 4,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Fire"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 1.2,
+            "value_min": 0.7
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:456:7",
+            "modifier_type": "INCREASED",
+            "property": "AttackSpeed",
+            "property_path": "INCREASED.AttackSpeed.Melee",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 7,
+                "property": "AttackSpeed"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:456:modifier:7",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 5,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Melee"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.17,
+            "value_min": 0.11
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_item_modifier_set_item:456:0",
+              "property": "Damage",
+              "property_path": "ADDED.Damage.Fire.Melee",
+              "source_record_id": "set_item:456:modifier:0"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:456:1",
+              "property": "LevelOfSkills",
+              "property_path": "ADDED.LevelOfSkills.Physical.Necrotic.Poison.Elemental.Spell",
+              "source_record_id": "set_item:456:modifier:1"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:456:2",
+              "property": "LevelOfSkills",
+              "property_path": "ADDED.LevelOfSkills.Lightning.Poison.Elemental.Spell",
+              "source_record_id": "set_item:456:modifier:2"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:456:3",
+              "property": "AbilityProperty",
+              "property_path": "ADDED.AbilityProperty.Lightning.Poison.Elemental.Spell",
+              "source_record_id": "set_item:456:modifier:3"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:456:4",
+              "property": "IncreasedAreaForAreaSkills",
+              "property_path": "ADDED.IncreasedAreaForAreaSkills.Fire.Melee",
+              "source_record_id": "set_item:456:modifier:4"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:456:5",
+              "property": "AbilityProperty",
+              "property_path": "ADDED.AbilityProperty.Physical.Fire.Necrotic.Poison.Elemental.Spell",
+              "source_record_id": "set_item:456:modifier:5"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:456:6",
+              "property": "Damage",
+              "property_path": "INCREASED.Damage.Fire",
+              "source_record_id": "set_item:456:modifier:6"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:456:7",
+              "property": "AttackSpeed",
+              "property_path": "INCREASED.AttackSpeed.Melee",
+              "source_record_id": "set_item:456:modifier:7"
+            }
+          ]
+        },
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_unique_set_export",
+          "notes": [
+            "Generated from extracted unique/set data; tooltip text is not inferred as mechanics."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "id": 456,
+            "name": "Kuzons Fury"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_item:456",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+          "source_type": "set_item"
+        },
+        "raw_reference": {
+          "baseType": "ONE_HANDED_SWORD",
+          "id": 456,
+          "name": "Kuzons Fury",
+          "resolutionStatus": "resolved",
+          "resolvedBaseItem": {
+            "baseTypeID": 9,
+            "displayName": "One-Handed Sword",
+            "name": "1H Swords",
+            "subType": {
+              "displayName": "",
+              "levelRequirement": 30,
+              "name": "Falchion",
+              "subTypeID": 5
+            },
+            "type": "ONE_HANDED_SWORD"
+          },
+          "subTypes": [
+            5
+          ]
+        },
+        "requirements": {
+          "attributes": {},
+          "class": null,
+          "level": 49,
+          "mastery": null
+        },
+        "set_group_display_name": null,
+        "set_group_id": "set:21",
+        "set_id": "set:21",
+        "slot": "one_handed_sword",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+        "source_id": "set_item:456",
+        "special_mechanic_classification": "partial_modifier",
+        "special_mechanic_notes": [
+          "Structured modifier rows exist but remain partial until value normalization is solved."
+        ],
+        "stable_calculable": false,
+        "subtype": "Falchion",
+        "support_status": "partial",
+        "tooltip_text": [
+          "Dancing Strikes is converted to Fire"
+        ],
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Unique/set record is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "attribute_requirements": {},
+        "base_item_id": "item_base:equippable:0:66",
+        "bonus_text": [
+          "Shadow Cascade is converted to Fire"
+        ],
+        "canonical_id": "set_item:457",
+        "class_restrictions": [],
+        "classification": "armor",
+        "consumer_safe_fields": {
+          "display_name": "Kuzon's Guise",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Kuzon's Guise",
+        "equipment_slot": "helmet",
+        "implicit_ids": [],
+        "implicit_links": [
+          {
+            "base_item_id": "item_base:equippable:0:66",
+            "implicit_index": 0,
+            "modifier_type": "ADDED",
+            "property": "Armour"
+          },
+          {
+            "base_item_id": "item_base:equippable:0:66",
+            "implicit_index": 1,
+            "modifier_type": "ADDED",
+            "property": "PoisonResistance"
+          },
+          {
+            "base_item_id": "item_base:equippable:0:66",
+            "implicit_index": 2,
+            "modifier_type": "ADDED",
+            "property": "FireResistance"
+          }
+        ],
+        "item_category": "equipment",
+        "item_type": "helmet",
+        "level_requirement": 49,
+        "lore_text": null,
+        "mastery_restrictions": [],
+        "modifier_references": [
+          {
+            "modifier_id": "set_item_modifier_set_item:457:0",
+            "property": "LevelOfSkills",
+            "property_path": "ADDED.LevelOfSkills.Lightning.Cold.Void.Poison.Elemental",
+            "source_record_id": "set_item:457:modifier:0"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:457:1",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Lightning.Cold.Void.Poison.Elemental",
+            "source_record_id": "set_item:457:modifier:1"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:457:2",
+            "property": "Damage",
+            "property_path": "ADDED.Damage.Fire.Throwing",
+            "source_record_id": "set_item:457:modifier:2"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:457:3",
+            "property": "AilmentChance",
+            "property_path": "ADDED.AilmentChance.Fire",
+            "source_record_id": "set_item:457:modifier:3"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:457:4",
+            "property": "Health",
+            "property_path": "INCREASED.Health",
+            "source_record_id": "set_item:457:modifier:4"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:457:5",
+            "property": "Endurance",
+            "property_path": "ADDED.Endurance",
+            "source_record_id": "set_item:457:modifier:5"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:457:0",
+            "modifier_type": "ADDED",
+            "property": "LevelOfSkills",
+            "property_path": "ADDED.LevelOfSkills.Lightning.Cold.Void.Poison.Elemental",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "LevelOfSkills"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:457:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Lightning",
+              "Cold",
+              "Void",
+              "Poison",
+              "Elemental"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 4.0,
+            "value_min": 2.0
+          },
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": true,
+            "modifier_id": "set_item_modifier_set_item:457:1",
+            "modifier_type": "ADDED",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Lightning.Cold.Void.Poison.Elemental",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 1,
+                "property": "AbilityProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:457:modifier:1",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Lightning",
+              "Cold",
+              "Void",
+              "Poison",
+              "Elemental"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 1.0,
+            "value_min": 1.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:457:2",
+            "modifier_type": "ADDED",
+            "property": "Damage",
+            "property_path": "ADDED.Damage.Fire.Throwing",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 2,
+                "property": "Damage"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:457:modifier:2",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 1,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Fire",
+              "Throwing"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 18.0,
+            "value_min": 12.0
+          },
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:457:3",
+            "modifier_type": "ADDED",
+            "property": "AilmentChance",
+            "property_path": "ADDED.AilmentChance.Fire",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 3,
+                "property": "AilmentChance"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:457:modifier:3",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Fire"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 1.0,
+            "value_min": 1.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:457:4",
+            "modifier_type": "INCREASED",
+            "property": "Health",
+            "property_path": "INCREASED.Health",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 4,
+                "property": "Health"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:457:modifier:4",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 2,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.14,
+            "value_min": 0.07
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:457:5",
+            "modifier_type": "ADDED",
+            "property": "Endurance",
+            "property_path": "ADDED.Endurance",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 5,
+                "property": "Endurance"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:457:modifier:5",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 3,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.12,
+            "value_min": 0.08
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_item_modifier_set_item:457:0",
+              "property": "LevelOfSkills",
+              "property_path": "ADDED.LevelOfSkills.Lightning.Cold.Void.Poison.Elemental",
+              "source_record_id": "set_item:457:modifier:0"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:457:1",
+              "property": "AbilityProperty",
+              "property_path": "ADDED.AbilityProperty.Lightning.Cold.Void.Poison.Elemental",
+              "source_record_id": "set_item:457:modifier:1"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:457:2",
+              "property": "Damage",
+              "property_path": "ADDED.Damage.Fire.Throwing",
+              "source_record_id": "set_item:457:modifier:2"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:457:3",
+              "property": "AilmentChance",
+              "property_path": "ADDED.AilmentChance.Fire",
+              "source_record_id": "set_item:457:modifier:3"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:457:4",
+              "property": "Health",
+              "property_path": "INCREASED.Health",
+              "source_record_id": "set_item:457:modifier:4"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:457:5",
+              "property": "Endurance",
+              "property_path": "ADDED.Endurance",
+              "source_record_id": "set_item:457:modifier:5"
+            }
+          ]
+        },
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_unique_set_export",
+          "notes": [
+            "Generated from extracted unique/set data; tooltip text is not inferred as mechanics."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "id": 457,
+            "name": "Kuzons Guise"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_item:457",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+          "source_type": "set_item"
+        },
+        "raw_reference": {
+          "baseType": "HELMET",
+          "id": 457,
+          "name": "Kuzons Guise",
+          "resolutionStatus": "resolved",
+          "resolvedBaseItem": {
+            "baseTypeID": 0,
+            "displayName": "Helmet",
+            "name": "Helmets",
+            "subType": {
+              "displayName": "",
+              "levelRequirement": 53,
+              "name": "Scalebane Grimace",
+              "subTypeID": 66
+            },
+            "type": "HELMET"
+          },
+          "subTypes": [
+            66
+          ]
+        },
+        "requirements": {
+          "attributes": {},
+          "class": null,
+          "level": 49,
+          "mastery": null
+        },
+        "set_group_display_name": null,
+        "set_group_id": "set:21",
+        "set_id": "set:21",
+        "slot": "helmet",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+        "source_id": "set_item:457",
+        "special_mechanic_classification": "partial_modifier",
+        "special_mechanic_notes": [
+          "Structured modifier rows exist but remain partial until value normalization is solved."
+        ],
+        "stable_calculable": false,
+        "subtype": "Scalebane Grimace",
+        "support_status": "partial",
+        "tooltip_text": [
+          "Shadow Cascade is converted to Fire"
+        ],
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Unique/set record is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "attribute_requirements": {},
+        "base_item_id": "item_base:equippable:2:5",
+        "bonus_text": [],
+        "canonical_id": "set_item:464",
+        "class_restrictions": [],
+        "classification": "accessory",
+        "consumer_safe_fields": {
+          "display_name": "Jormun's Thirst",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Jormun's Thirst",
+        "equipment_slot": "belt",
+        "implicit_ids": [],
+        "implicit_links": [
+          {
+            "base_item_id": "item_base:equippable:2:5",
+            "implicit_index": 0,
+            "modifier_type": "ADDED",
+            "property": "PotionSlots"
+          }
+        ],
+        "item_category": "equipment",
+        "item_type": "belt",
+        "level_requirement": 39,
+        "lore_text": null,
+        "mastery_restrictions": [],
+        "modifier_references": [
+          {
+            "modifier_id": "set_item_modifier_set_item:464:0",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Lightning.Cold.Void.Necrotic.Poison.Melee",
+            "source_record_id": "set_item:464:modifier:0"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:464:1",
+            "property": "PotionSlots",
+            "property_path": "ADDED.PotionSlots",
+            "source_record_id": "set_item:464:modifier:1"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:464:2",
+            "property": "PotionHealth",
+            "property_path": "ADDED.PotionHealth",
+            "source_record_id": "set_item:464:modifier:2"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:464:3",
+            "property": "Health",
+            "property_path": "ADDED.Health",
+            "source_record_id": "set_item:464:modifier:3"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:464:4",
+            "property": "StunAvoidance",
+            "property_path": "ADDED.StunAvoidance",
+            "source_record_id": "set_item:464:modifier:4"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:464:5",
+            "property": "PhysicalResistance",
+            "property_path": "ADDED.PhysicalResistance",
+            "source_record_id": "set_item:464:modifier:5"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:464:0",
+            "modifier_type": "ADDED",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Lightning.Cold.Void.Necrotic.Poison.Melee",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "PlayerProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:464:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Lightning",
+              "Cold",
+              "Void",
+              "Necrotic",
+              "Poison",
+              "Melee"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.4,
+            "value_min": 0.3
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:464:1",
+            "modifier_type": "ADDED",
+            "property": "PotionSlots",
+            "property_path": "ADDED.PotionSlots",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 1,
+                "property": "PotionSlots"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:464:modifier:1",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 5,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 2.0,
+            "value_min": 1.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:464:2",
+            "modifier_type": "ADDED",
+            "property": "PotionHealth",
+            "property_path": "ADDED.PotionHealth",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 2,
+                "property": "PotionHealth"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:464:modifier:2",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 4,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 380.0,
+            "value_min": 250.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:464:3",
+            "modifier_type": "ADDED",
+            "property": "Health",
+            "property_path": "ADDED.Health",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 3,
+                "property": "Health"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:464:modifier:3",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 1,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 140.0,
+            "value_min": 74.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:464:4",
+            "modifier_type": "ADDED",
+            "property": "StunAvoidance",
+            "property_path": "ADDED.StunAvoidance",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 4,
+                "property": "StunAvoidance"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:464:modifier:4",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 2,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 900.0,
+            "value_min": 600.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:464:5",
+            "modifier_type": "ADDED",
+            "property": "PhysicalResistance",
+            "property_path": "ADDED.PhysicalResistance",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 5,
+                "property": "PhysicalResistance"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:464:modifier:5",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 3,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.44,
+            "value_min": 0.22
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_item_modifier_set_item:464:0",
+              "property": "PlayerProperty",
+              "property_path": "ADDED.PlayerProperty.Lightning.Cold.Void.Necrotic.Poison.Melee",
+              "source_record_id": "set_item:464:modifier:0"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:464:1",
+              "property": "PotionSlots",
+              "property_path": "ADDED.PotionSlots",
+              "source_record_id": "set_item:464:modifier:1"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:464:2",
+              "property": "PotionHealth",
+              "property_path": "ADDED.PotionHealth",
+              "source_record_id": "set_item:464:modifier:2"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:464:3",
+              "property": "Health",
+              "property_path": "ADDED.Health",
+              "source_record_id": "set_item:464:modifier:3"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:464:4",
+              "property": "StunAvoidance",
+              "property_path": "ADDED.StunAvoidance",
+              "source_record_id": "set_item:464:modifier:4"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:464:5",
+              "property": "PhysicalResistance",
+              "property_path": "ADDED.PhysicalResistance",
+              "source_record_id": "set_item:464:modifier:5"
+            }
+          ]
+        },
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_unique_set_export",
+          "notes": [
+            "Generated from extracted unique/set data; tooltip text is not inferred as mechanics."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "id": 464,
+            "name": "Jormuns Thirst"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_item:464",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+          "source_type": "set_item"
+        },
+        "raw_reference": {
+          "baseType": "BELT",
+          "id": 464,
+          "name": "Jormuns Thirst",
+          "resolutionStatus": "resolved",
+          "resolvedBaseItem": {
+            "baseTypeID": 2,
+            "displayName": "Belt",
+            "name": "Belts",
+            "subType": {
+              "displayName": "",
+              "levelRequirement": 45,
+              "name": "Nomad Belt",
+              "subTypeID": 5
+            },
+            "type": "BELT"
+          },
+          "subTypes": [
+            5
+          ]
+        },
+        "requirements": {
+          "attributes": {},
+          "class": null,
+          "level": 39,
+          "mastery": null
+        },
+        "set_group_display_name": null,
+        "set_group_id": "set:22",
+        "set_id": "set:22",
+        "slot": "belt",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+        "source_id": "set_item:464",
+        "special_mechanic_classification": "partial_modifier",
+        "special_mechanic_notes": [
+          "Structured modifier rows exist but remain partial until value normalization is solved."
+        ],
+        "stable_calculable": false,
+        "subtype": "Nomad Belt",
+        "support_status": "partial",
+        "tooltip_text": [],
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Unique/set record is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "attribute_requirements": {},
+        "base_item_id": "item_base:equippable:5:3",
+        "bonus_text": [
+          "+[6,10,5] Strength and Dexterity"
+        ],
+        "canonical_id": "set_item:465",
+        "class_restrictions": [],
+        "classification": "weapon",
+        "consumer_safe_fields": {
+          "display_name": "Jormun's Hunger",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Jormun's Hunger",
+        "equipment_slot": "one_handed_axe",
+        "implicit_ids": [],
+        "implicit_links": [
+          {
+            "base_item_id": "item_base:equippable:5:3",
+            "implicit_index": 0,
+            "modifier_type": "ADDED",
+            "property": "Damage"
+          },
+          {
+            "base_item_id": "item_base:equippable:5:3",
+            "implicit_index": 1,
+            "modifier_type": "ADDED",
+            "property": "AilmentChance"
+          }
+        ],
+        "item_category": "equipment",
+        "item_type": "one_handed_axe",
+        "level_requirement": 38,
+        "lore_text": null,
+        "mastery_restrictions": [],
+        "modifier_references": [
+          {
+            "modifier_id": "set_item_modifier_set_item:465:0",
+            "property": "Damage",
+            "property_path": "ADDED.Damage.Melee",
+            "source_record_id": "set_item:465:modifier:0"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:465:1",
+            "property": "AilmentChance",
+            "property_path": "ADDED.AilmentChance.Melee",
+            "source_record_id": "set_item:465:modifier:1"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:465:2",
+            "property": "AilmentChance",
+            "property_path": "ADDED.AilmentChance.Melee",
+            "source_record_id": "set_item:465:modifier:2"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:465:3",
+            "property": "AttackSpeed",
+            "property_path": "INCREASED.AttackSpeed.Melee",
+            "source_record_id": "set_item:465:modifier:3"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:465:4",
+            "property": "HealthLeech",
+            "property_path": "ADDED.HealthLeech.Melee",
+            "source_record_id": "set_item:465:modifier:4"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:465:5",
+            "property": "Strength",
+            "property_path": "ADDED.Strength",
+            "source_record_id": "set_item:465:modifier:5"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:465:6",
+            "property": "Dexterity",
+            "property_path": "ADDED.Dexterity",
+            "source_record_id": "set_item:465:modifier:6"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:465:0",
+            "modifier_type": "ADDED",
+            "property": "Damage",
+            "property_path": "ADDED.Damage.Melee",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "Damage"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:465:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Melee"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 60.0,
+            "value_min": 44.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:465:1",
+            "modifier_type": "ADDED",
+            "property": "AilmentChance",
+            "property_path": "ADDED.AilmentChance.Melee",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 1,
+                "property": "AilmentChance"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:465:modifier:1",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 1,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Melee"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.4,
+            "value_min": 0.2
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:465:2",
+            "modifier_type": "ADDED",
+            "property": "AilmentChance",
+            "property_path": "ADDED.AilmentChance.Melee",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 2,
+                "property": "AilmentChance"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:465:modifier:2",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 2,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Melee"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 1.3,
+            "value_min": 0.8
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:465:3",
+            "modifier_type": "INCREASED",
+            "property": "AttackSpeed",
+            "property_path": "INCREASED.AttackSpeed.Melee",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 3,
+                "property": "AttackSpeed"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:465:modifier:3",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 3,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Melee"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.28,
+            "value_min": 0.16
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:465:4",
+            "modifier_type": "ADDED",
+            "property": "HealthLeech",
+            "property_path": "ADDED.HealthLeech.Melee",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 4,
+                "property": "HealthLeech"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:465:modifier:4",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 4,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Melee"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 1.2,
+            "value_min": 0.6
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": true,
+            "modifier_id": "set_item_modifier_set_item:465:5",
+            "modifier_type": "ADDED",
+            "property": "Strength",
+            "property_path": "ADDED.Strength",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 5,
+                "property": "Strength"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:465:modifier:5",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 5,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 10.0,
+            "value_min": 6.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": true,
+            "modifier_id": "set_item_modifier_set_item:465:6",
+            "modifier_type": "ADDED",
+            "property": "Dexterity",
+            "property_path": "ADDED.Dexterity",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 6,
+                "property": "Dexterity"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:465:modifier:6",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 5,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 10.0,
+            "value_min": 6.0
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_item_modifier_set_item:465:0",
+              "property": "Damage",
+              "property_path": "ADDED.Damage.Melee",
+              "source_record_id": "set_item:465:modifier:0"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:465:1",
+              "property": "AilmentChance",
+              "property_path": "ADDED.AilmentChance.Melee",
+              "source_record_id": "set_item:465:modifier:1"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:465:2",
+              "property": "AilmentChance",
+              "property_path": "ADDED.AilmentChance.Melee",
+              "source_record_id": "set_item:465:modifier:2"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:465:3",
+              "property": "AttackSpeed",
+              "property_path": "INCREASED.AttackSpeed.Melee",
+              "source_record_id": "set_item:465:modifier:3"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:465:4",
+              "property": "HealthLeech",
+              "property_path": "ADDED.HealthLeech.Melee",
+              "source_record_id": "set_item:465:modifier:4"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:465:5",
+              "property": "Strength",
+              "property_path": "ADDED.Strength",
+              "source_record_id": "set_item:465:modifier:5"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:465:6",
+              "property": "Dexterity",
+              "property_path": "ADDED.Dexterity",
+              "source_record_id": "set_item:465:modifier:6"
+            }
+          ]
+        },
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_unique_set_export",
+          "notes": [
+            "Generated from extracted unique/set data; tooltip text is not inferred as mechanics."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "id": 465,
+            "name": "Jormuns Hunger"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_item:465",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+          "source_type": "set_item"
+        },
+        "raw_reference": {
+          "baseType": "ONE_HANDED_AXE",
+          "id": 465,
+          "name": "Jormuns Hunger",
+          "resolutionStatus": "resolved",
+          "resolvedBaseItem": {
+            "baseTypeID": 5,
+            "displayName": "One-Handed Axe",
+            "name": "1H Axes",
+            "subType": {
+              "displayName": "",
+              "levelRequirement": 24,
+              "name": "Battle Axe",
+              "subTypeID": 3
+            },
+            "type": "ONE_HANDED_AXE"
+          },
+          "subTypes": [
+            3
+          ]
+        },
+        "requirements": {
+          "attributes": {},
+          "class": null,
+          "level": 38,
+          "mastery": null
+        },
+        "set_group_display_name": null,
+        "set_group_id": "set:22",
+        "set_id": "set:22",
+        "slot": "one_handed_axe",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+        "source_id": "set_item:465",
+        "special_mechanic_classification": "partial_modifier",
+        "special_mechanic_notes": [
+          "Structured modifier rows exist but remain partial until value normalization is solved."
+        ],
+        "stable_calculable": false,
+        "subtype": "Battle Axe",
+        "support_status": "partial",
+        "tooltip_text": [
+          "+[6,10,5] Strength and Dexterity"
+        ],
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Unique/set record is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "attribute_requirements": {},
+        "base_item_id": "item_base:equippable:9:6",
+        "bonus_text": [],
+        "canonical_id": "set_item:466",
+        "class_restrictions": [],
+        "classification": "weapon",
+        "consumer_safe_fields": {
+          "display_name": "Jormun's Feast",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Jormun's Feast",
+        "equipment_slot": "one_handed_sword",
+        "implicit_ids": [],
+        "implicit_links": [
+          {
+            "base_item_id": "item_base:equippable:9:6",
+            "implicit_index": 0,
+            "modifier_type": "ADDED",
+            "property": "Damage"
+          }
+        ],
+        "item_category": "equipment",
+        "item_type": "one_handed_sword",
+        "level_requirement": 42,
+        "lore_text": null,
+        "mastery_restrictions": [],
+        "modifier_references": [
+          {
+            "modifier_id": "set_item_modifier_set_item:466:0",
+            "property": "Damage",
+            "property_path": "ADDED.Damage.Melee",
+            "source_record_id": "set_item:466:modifier:0"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:466:1",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Physical.Lightning.Cold.Void.Necrotic.Poison.Melee",
+            "source_record_id": "set_item:466:modifier:1"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:466:2",
+            "property": "CriticalChance",
+            "property_path": "ADDED.CriticalChance.Melee",
+            "source_record_id": "set_item:466:modifier:2"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:466:3",
+            "property": "AttackSpeed",
+            "property_path": "INCREASED.AttackSpeed.Melee",
+            "source_record_id": "set_item:466:modifier:3"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:466:0",
+            "modifier_type": "ADDED",
+            "property": "Damage",
+            "property_path": "ADDED.Damage.Melee",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "Damage"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:466:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Melee"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 56.0,
+            "value_min": 40.0
+          },
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:466:1",
+            "modifier_type": "ADDED",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Physical.Lightning.Cold.Void.Necrotic.Poison.Melee",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 1,
+                "property": "PlayerProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:466:modifier:1",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Physical",
+              "Lightning",
+              "Cold",
+              "Void",
+              "Necrotic",
+              "Poison",
+              "Melee"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.07,
+            "value_min": 0.07
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:466:2",
+            "modifier_type": "ADDED",
+            "property": "CriticalChance",
+            "property_path": "ADDED.CriticalChance.Melee",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 2,
+                "property": "CriticalChance"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:466:modifier:2",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 1,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Melee"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.08,
+            "value_min": 0.04
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:466:3",
+            "modifier_type": "INCREASED",
+            "property": "AttackSpeed",
+            "property_path": "INCREASED.AttackSpeed.Melee",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 3,
+                "property": "AttackSpeed"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:466:modifier:3",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 2,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Melee"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.24,
+            "value_min": 0.12
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_item_modifier_set_item:466:0",
+              "property": "Damage",
+              "property_path": "ADDED.Damage.Melee",
+              "source_record_id": "set_item:466:modifier:0"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:466:1",
+              "property": "PlayerProperty",
+              "property_path": "ADDED.PlayerProperty.Physical.Lightning.Cold.Void.Necrotic.Poison.Melee",
+              "source_record_id": "set_item:466:modifier:1"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:466:2",
+              "property": "CriticalChance",
+              "property_path": "ADDED.CriticalChance.Melee",
+              "source_record_id": "set_item:466:modifier:2"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:466:3",
+              "property": "AttackSpeed",
+              "property_path": "INCREASED.AttackSpeed.Melee",
+              "source_record_id": "set_item:466:modifier:3"
+            }
+          ]
+        },
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_unique_set_export",
+          "notes": [
+            "Generated from extracted unique/set data; tooltip text is not inferred as mechanics."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "id": 466,
+            "name": "Jormuns Feast"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_item:466",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+          "source_type": "set_item"
+        },
+        "raw_reference": {
+          "baseType": "ONE_HANDED_SWORD",
+          "id": 466,
+          "name": "Jormuns Feast",
+          "resolutionStatus": "resolved",
+          "resolvedBaseItem": {
+            "baseTypeID": 9,
+            "displayName": "One-Handed Sword",
+            "name": "1H Swords",
+            "subType": {
+              "displayName": "",
+              "levelRequirement": 50,
+              "name": "Longsword",
+              "subTypeID": 6
+            },
+            "type": "ONE_HANDED_SWORD"
+          },
+          "subTypes": [
+            6
+          ]
+        },
+        "requirements": {
+          "attributes": {},
+          "class": null,
+          "level": 42,
+          "mastery": null
+        },
+        "set_group_display_name": null,
+        "set_group_id": "set:22",
+        "set_id": "set:22",
+        "slot": "one_handed_sword",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+        "source_id": "set_item:466",
+        "special_mechanic_classification": "partial_modifier",
+        "special_mechanic_notes": [
+          "Structured modifier rows exist but remain partial until value normalization is solved."
+        ],
+        "stable_calculable": false,
+        "subtype": "Longsword",
+        "support_status": "partial",
+        "tooltip_text": [],
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Unique/set record is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "attribute_requirements": {},
+        "base_item_id": "item_base:equippable:21:1",
+        "bonus_text": [],
+        "canonical_id": "set_item:467",
+        "class_restrictions": [],
+        "classification": "accessory",
+        "consumer_safe_fields": {
+          "display_name": "Keplahan's Pyrolith",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Keplahan's Pyrolith",
+        "equipment_slot": "ring",
+        "implicit_ids": [],
+        "implicit_links": [
+          {
+            "base_item_id": "item_base:equippable:21:1",
+            "implicit_index": 0,
+            "modifier_type": "ADDED",
+            "property": "FireResistance"
+          },
+          {
+            "base_item_id": "item_base:equippable:21:1",
+            "implicit_index": 1,
+            "modifier_type": "INCREASED",
+            "property": "Damage"
+          }
+        ],
+        "item_category": "equipment",
+        "item_type": "ring",
+        "level_requirement": 50,
+        "lore_text": "Elder Keplahan found the stillness of runes lifeless and unworth of pursuit. To him, true magic thrived only in motion, in the fire between change and creation.",
+        "mastery_restrictions": [],
+        "modifier_references": [
+          {
+            "modifier_id": "set_item_modifier_set_item:467:0",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Lightning.Cold.Fire.Poison",
+            "source_record_id": "set_item:467:modifier:0"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:467:1",
+            "property": "Damage",
+            "property_path": "INCREASED.Damage.Fire",
+            "source_record_id": "set_item:467:modifier:1"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:467:2",
+            "property": "Intelligence",
+            "property_path": "ADDED.Intelligence",
+            "source_record_id": "set_item:467:modifier:2"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:467:3",
+            "property": "WardRegen",
+            "property_path": "ADDED.WardRegen",
+            "source_record_id": "set_item:467:modifier:3"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:467:4",
+            "property": "CriticalMultiplier",
+            "property_path": "ADDED.CriticalMultiplier",
+            "source_record_id": "set_item:467:modifier:4"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:467:0",
+            "modifier_type": "ADDED",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Lightning.Cold.Fire.Poison",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "AbilityProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:467:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Lightning",
+              "Cold",
+              "Fire",
+              "Poison"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 1.0,
+            "value_min": 1.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:467:1",
+            "modifier_type": "INCREASED",
+            "property": "Damage",
+            "property_path": "INCREASED.Damage.Fire",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 1,
+                "property": "Damage"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:467:modifier:1",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Fire"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.6,
+            "value_min": 0.3
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:467:2",
+            "modifier_type": "ADDED",
+            "property": "Intelligence",
+            "property_path": "ADDED.Intelligence",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 2,
+                "property": "Intelligence"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:467:modifier:2",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 12.0,
+            "value_min": 6.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:467:3",
+            "modifier_type": "ADDED",
+            "property": "WardRegen",
+            "property_path": "ADDED.WardRegen",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 3,
+                "property": "WardRegen"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:467:modifier:3",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 40.0,
+            "value_min": 20.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:467:4",
+            "modifier_type": "ADDED",
+            "property": "CriticalMultiplier",
+            "property_path": "ADDED.CriticalMultiplier",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 4,
+                "property": "CriticalMultiplier"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:467:modifier:4",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.3,
+            "value_min": 0.15
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_item_modifier_set_item:467:0",
+              "property": "AbilityProperty",
+              "property_path": "ADDED.AbilityProperty.Lightning.Cold.Fire.Poison",
+              "source_record_id": "set_item:467:modifier:0"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:467:1",
+              "property": "Damage",
+              "property_path": "INCREASED.Damage.Fire",
+              "source_record_id": "set_item:467:modifier:1"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:467:2",
+              "property": "Intelligence",
+              "property_path": "ADDED.Intelligence",
+              "source_record_id": "set_item:467:modifier:2"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:467:3",
+              "property": "WardRegen",
+              "property_path": "ADDED.WardRegen",
+              "source_record_id": "set_item:467:modifier:3"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:467:4",
+              "property": "CriticalMultiplier",
+              "property_path": "ADDED.CriticalMultiplier",
+              "source_record_id": "set_item:467:modifier:4"
+            }
+          ]
+        },
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_unique_set_export",
+          "notes": [
+            "Generated from extracted unique/set data; tooltip text is not inferred as mechanics."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "id": 467,
+            "name": "Keplahans Pyrolith"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_item:467",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+          "source_type": "set_item"
+        },
+        "raw_reference": {
+          "baseType": "RING",
+          "id": 467,
+          "name": "Keplahans Pyrolith",
+          "resolutionStatus": "resolved",
+          "resolvedBaseItem": {
+            "baseTypeID": 21,
+            "displayName": "Ring",
+            "name": "Ring",
+            "subType": {
+              "displayName": "",
+              "levelRequirement": 62,
+              "name": "Ruby Ring",
+              "subTypeID": 1
+            },
+            "type": "RING"
+          },
+          "subTypes": [
+            1
+          ]
+        },
+        "requirements": {
+          "attributes": {},
+          "class": null,
+          "level": 50,
+          "mastery": null
+        },
+        "set_group_display_name": null,
+        "set_group_id": "set:23",
+        "set_id": "set:23",
+        "slot": "ring",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+        "source_id": "set_item:467",
+        "special_mechanic_classification": "partial_modifier",
+        "special_mechanic_notes": [
+          "Structured modifier rows exist but remain partial until value normalization is solved."
+        ],
+        "stable_calculable": false,
+        "subtype": "Ruby Ring",
+        "support_status": "partial",
+        "tooltip_text": [],
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Unique/set record is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "attribute_requirements": {},
+        "base_item_id": "item_base:equippable:21:2",
+        "bonus_text": [],
+        "canonical_id": "set_item:468",
+        "class_restrictions": [],
+        "classification": "accessory",
+        "consumer_safe_fields": {
+          "display_name": "Keplahan's Cryolith",
+          "special_mechanic_classification": "partial_modifier",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Keplahan's Cryolith",
+        "equipment_slot": "ring",
+        "implicit_ids": [],
+        "implicit_links": [
+          {
+            "base_item_id": "item_base:equippable:21:2",
+            "implicit_index": 0,
+            "modifier_type": "ADDED",
+            "property": "Mana"
+          },
+          {
+            "base_item_id": "item_base:equippable:21:2",
+            "implicit_index": 1,
+            "modifier_type": "INCREASED",
+            "property": "ManaRegen"
+          }
+        ],
+        "item_category": "equipment",
+        "item_type": "ring",
+        "level_requirement": 50,
+        "lore_text": "Beneath the cold shimmer of the stars, Elder Keplahan burned with envy. His own travels would one day cease, yet the heavens would wander forever.",
+        "mastery_restrictions": [],
+        "modifier_references": [
+          {
+            "modifier_id": "set_item_modifier_set_item:468:0",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Lightning.Cold.Fire.Poison",
+            "source_record_id": "set_item:468:modifier:0"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:468:1",
+            "property": "Damage",
+            "property_path": "INCREASED.Damage.Cold",
+            "source_record_id": "set_item:468:modifier:1"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:468:2",
+            "property": "Dexterity",
+            "property_path": "ADDED.Dexterity",
+            "source_record_id": "set_item:468:modifier:2"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:468:3",
+            "property": "Health",
+            "property_path": "ADDED.Health",
+            "source_record_id": "set_item:468:modifier:3"
+          },
+          {
+            "modifier_id": "set_item_modifier_set_item:468:4",
+            "property": "CriticalChance",
+            "property_path": "INCREASED.CriticalChance",
+            "source_record_id": "set_item:468:modifier:4"
+          }
+        ],
+        "modifier_rows": [
+          {
+            "can_roll": null,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:468:0",
+            "modifier_type": "ADDED",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Lightning.Cold.Fire.Poison",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 0,
+                "property": "AbilityProperty"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:468:modifier:0",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": null,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Lightning",
+              "Cold",
+              "Fire",
+              "Poison"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 1.0,
+            "value_min": 1.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:468:1",
+            "modifier_type": "INCREASED",
+            "property": "Damage",
+            "property_path": "INCREASED.Damage.Cold",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 1,
+                "property": "Damage"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:468:modifier:1",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "Cold"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.6,
+            "value_min": 0.3
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:468:2",
+            "modifier_type": "ADDED",
+            "property": "Dexterity",
+            "property_path": "ADDED.Dexterity",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 2,
+                "property": "Dexterity"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:468:modifier:2",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 12.0,
+            "value_min": 6.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:468:3",
+            "modifier_type": "ADDED",
+            "property": "Health",
+            "property_path": "ADDED.Health",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 3,
+                "property": "Health"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:468:modifier:3",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 84.0,
+            "value_min": 60.0
+          },
+          {
+            "can_roll": true,
+            "extra_tag": 0,
+            "hide_in_tooltip": null,
+            "modifier_id": "set_item_modifier_set_item:468:4",
+            "modifier_type": "INCREASED",
+            "property": "CriticalChance",
+            "property_path": "INCREASED.CriticalChance",
+            "provenance": {
+              "extraction_method": "last_epoch_unique_set_export",
+              "notes": [
+                "Value scale remains source-preserved; stable normalization is deferred."
+              ],
+              "patch_version": null,
+              "raw_reference": {
+                "modifier_index": 4,
+                "property": "CriticalChance"
+              },
+              "schema_version": "v2.unique_set.1",
+              "source_id": "set_item:468:modifier:4",
+              "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+              "source_type": "set_item_modifier"
+            },
+            "roll_id": 0,
+            "special_tag": 0,
+            "stable_calculable": false,
+            "support_status": "partial",
+            "tags": [
+              "None"
+            ],
+            "trust_level": "generated_from_game_data",
+            "value_max": 0.5,
+            "value_min": 0.25
+          }
+        ],
+        "normalized_fields": {
+          "modifier_references": [
+            {
+              "modifier_id": "set_item_modifier_set_item:468:0",
+              "property": "AbilityProperty",
+              "property_path": "ADDED.AbilityProperty.Lightning.Cold.Fire.Poison",
+              "source_record_id": "set_item:468:modifier:0"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:468:1",
+              "property": "Damage",
+              "property_path": "INCREASED.Damage.Cold",
+              "source_record_id": "set_item:468:modifier:1"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:468:2",
+              "property": "Dexterity",
+              "property_path": "ADDED.Dexterity",
+              "source_record_id": "set_item:468:modifier:2"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:468:3",
+              "property": "Health",
+              "property_path": "ADDED.Health",
+              "source_record_id": "set_item:468:modifier:3"
+            },
+            {
+              "modifier_id": "set_item_modifier_set_item:468:4",
+              "property": "CriticalChance",
+              "property_path": "INCREASED.CriticalChance",
+              "source_record_id": "set_item:468:modifier:4"
+            }
+          ]
+        },
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_unique_set_export",
+          "notes": [
+            "Generated from extracted unique/set data; tooltip text is not inferred as mechanics."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "id": 468,
+            "name": "Keplahans Cryolith"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_item:468",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+          "source_type": "set_item"
+        },
+        "raw_reference": {
+          "baseType": "RING",
+          "id": 468,
+          "name": "Keplahans Cryolith",
+          "resolutionStatus": "resolved",
+          "resolvedBaseItem": {
+            "baseTypeID": 21,
+            "displayName": "Ring",
+            "name": "Ring",
+            "subType": {
+              "displayName": "",
+              "levelRequirement": 40,
+              "name": "Sapphire Ring",
+              "subTypeID": 2
+            },
+            "type": "RING"
+          },
+          "subTypes": [
+            2
+          ]
+        },
+        "requirements": {
+          "attributes": {},
+          "class": null,
+          "level": 50,
+          "mastery": null
+        },
+        "set_group_display_name": null,
+        "set_group_id": "set:23",
+        "set_id": "set:23",
+        "slot": "ring",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+        "source_id": "set_item:468",
+        "special_mechanic_classification": "partial_modifier",
+        "special_mechanic_notes": [
+          "Structured modifier rows exist but remain partial until value normalization is solved."
+        ],
+        "stable_calculable": false,
+        "subtype": "Sapphire Ring",
+        "support_status": "partial",
+        "tooltip_text": [],
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Unique/set record is not stable planner-consumed in Phase 5."
+        ]
+      }
+    ],
+    "sets": [
+      {
+        "bonus_ids": [
+          "set_bonus:1:0",
+          "set_bonus:1:1",
+          "set_bonus:1:2"
+        ],
+        "bonus_modifier_references": [
+          {
+            "modifier_id": "set_bonus_modifier_set_bonus:1:1:0",
+            "property": "IncreasedAilmentEffect",
+            "property_path": "ADDED.IncreasedAilmentEffect.special:39",
+            "source_record_id": "set_bonus:1:1:modifier:0"
+          }
+        ],
+        "bonus_text": [
+          "+100% Chance to apply Damned on hit with Necrotic Spells",
+          "Damned deals necrotic damage over time and reduces health regen by 20%. An enemy can have multiple stacks of Damned at once.",
+          "+30% Mana Efficiency with Necrotic Spells"
+        ],
+        "canonical_id": "set:1",
+        "consumer_safe_fields": {
+          "display_name": "Isadora's",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Isadora's",
+        "item_ids": [
+          "set_item:16",
+          "set_item:26",
+          "set_item:5"
+        ],
+        "normalized_fields": {},
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set item and set bonus data."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "setId": "1"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_group:1",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_group"
+        },
+        "raw_reference": {
+          "setId": "1"
+        },
+        "set_group_display_name": "Isadora's",
+        "set_group_id": "set:1",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_group:1",
+        "special_mechanic_classification": "partial_modifier",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set group is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "bonus_ids": [
+          "set_bonus:2:0",
+          "set_bonus:2:1"
+        ],
+        "bonus_modifier_references": [
+          {
+            "modifier_id": "set_bonus_modifier_set_bonus:2:0:0",
+            "property": "CastSpeed",
+            "property_path": "INCREASED.CastSpeed.Elemental",
+            "source_record_id": "set_bonus:2:0:modifier:0"
+          }
+        ],
+        "bonus_text": [
+          "+2 to Fire Spells\n+2 to Lightning Spells\n+2 to Cold Spells"
+        ],
+        "canonical_id": "set:2",
+        "consumer_safe_fields": {
+          "display_name": "The Invoker's",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "The Invoker's",
+        "item_ids": [
+          "set_item:57",
+          "set_item:63",
+          "set_item:64"
+        ],
+        "normalized_fields": {},
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set item and set bonus data."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "setId": "2"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_group:2",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_group"
+        },
+        "raw_reference": {
+          "setId": "2"
+        },
+        "set_group_display_name": "The Invoker's",
+        "set_group_id": "set:2",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_group:2",
+        "special_mechanic_classification": "partial_modifier",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set group is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "bonus_ids": [
+          "set_bonus:3:0",
+          "set_bonus:3:1"
+        ],
+        "bonus_modifier_references": [],
+        "bonus_text": [
+          "Your bees cannot be damaged for 4 seconds after being summoned",
+          "Summon the Queen Bee",
+          "The Queen Bee is a powerful minion and grants Frenzy and Haste to other bees"
+        ],
+        "canonical_id": "set:3",
+        "consumer_safe_fields": {
+          "display_name": "Apiarist's",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Apiarist's",
+        "item_ids": [
+          "set_item:77",
+          "set_item:78",
+          "set_item:79"
+        ],
+        "normalized_fields": {},
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set item and set bonus data."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "setId": "3"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_group:3",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_group"
+        },
+        "raw_reference": {
+          "setId": "3"
+        },
+        "set_group_display_name": "Apiarist's",
+        "set_group_id": "set:3",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_group:3",
+        "special_mechanic_classification": "text_only_effect",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set group is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "bonus_ids": [
+          "set_bonus:4:0",
+          "set_bonus:4:1"
+        ],
+        "bonus_modifier_references": [
+          {
+            "modifier_id": "set_bonus_modifier_set_bonus:4:1:0",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Cold.Fire.Void.Poison.Elemental",
+            "source_record_id": "set_bonus:4:1:modifier:0"
+          }
+        ],
+        "bonus_text": [
+          "+3 to Forge Strike\n+3 to Smelter's Wrath"
+        ],
+        "canonical_id": "set:4",
+        "consumer_safe_fields": {
+          "display_name": "Sunforged",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Sunforged",
+        "item_ids": [
+          "set_item:85",
+          "set_item:86",
+          "set_item:87"
+        ],
+        "normalized_fields": {},
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set item and set bonus data."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "setId": "4"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_group:4",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_group"
+        },
+        "raw_reference": {
+          "setId": "4"
+        },
+        "set_group_display_name": "Sunforged",
+        "set_group_id": "set:4",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_group:4",
+        "special_mechanic_classification": "partial_modifier",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set group is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "bonus_ids": [
+          "set_bonus:5:0",
+          "set_bonus:5:1"
+        ],
+        "bonus_modifier_references": [
+          {
+            "modifier_id": "set_bonus_modifier_set_bonus:5:0:0",
+            "property": "IncreasedAilmentEffect",
+            "property_path": "ADDED.IncreasedAilmentEffect.special:9",
+            "source_record_id": "set_bonus:5:0:modifier:0"
+          },
+          {
+            "modifier_id": "set_bonus_modifier_set_bonus:5:1:0",
+            "property": "DamagePerStackOfAilment",
+            "property_path": "MORE.DamagePerStackOfAilment.Void.special:9",
+            "source_record_id": "set_bonus:5:1:modifier:0"
+          }
+        ],
+        "bonus_text": [],
+        "canonical_id": "set:5",
+        "consumer_safe_fields": {
+          "display_name": "Forgotten Knight",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Forgotten Knight",
+        "item_ids": [
+          "set_item:88",
+          "set_item:89",
+          "set_item:90"
+        ],
+        "normalized_fields": {},
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set item and set bonus data."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "setId": "5"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_group:5",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_group"
+        },
+        "raw_reference": {
+          "setId": "5"
+        },
+        "set_group_display_name": "Forgotten Knight",
+        "set_group_id": "set:5",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_group:5",
+        "special_mechanic_classification": "partial_modifier",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set group is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "bonus_ids": [
+          "set_bonus:6:0",
+          "set_bonus:6:1"
+        ],
+        "bonus_modifier_references": [
+          {
+            "modifier_id": "set_bonus_modifier_set_bonus:6:0:0",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Physical.Lightning.Melee",
+            "source_record_id": "set_bonus:6:0:modifier:0"
+          },
+          {
+            "modifier_id": "set_bonus_modifier_set_bonus:6:1:0",
+            "property": "Strength",
+            "property_path": "ADDED.Strength",
+            "source_record_id": "set_bonus:6:1:modifier:0"
+          }
+        ],
+        "bonus_text": [],
+        "canonical_id": "set:6",
+        "consumer_safe_fields": {
+          "display_name": "The Last Bear's",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "The Last Bear's",
+        "item_ids": [
+          "set_item:94",
+          "set_item:95",
+          "set_item:96"
+        ],
+        "normalized_fields": {},
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set item and set bonus data."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "setId": "6"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_group:6",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_group"
+        },
+        "raw_reference": {
+          "setId": "6"
+        },
+        "set_group_display_name": "The Last Bear's",
+        "set_group_id": "set:6",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_group:6",
+        "special_mechanic_classification": "partial_modifier",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set group is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "bonus_ids": [
+          "set_bonus:7:0",
+          "set_bonus:7:1",
+          "set_bonus:7:2",
+          "set_bonus:7:3"
+        ],
+        "bonus_modifier_references": [
+          {
+            "modifier_id": "set_bonus_modifier_set_bonus:7:0:0",
+            "property": "Damage",
+            "property_path": "ADDED.Damage.Cold.Spell",
+            "source_record_id": "set_bonus:7:0:modifier:0"
+          },
+          {
+            "modifier_id": "set_bonus_modifier_set_bonus:7:1:0",
+            "property": "Damage",
+            "property_path": "ADDED.Damage.Physical.Spell",
+            "source_record_id": "set_bonus:7:1:modifier:0"
+          },
+          {
+            "modifier_id": "set_bonus_modifier_set_bonus:7:2:0",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Cold.Poison",
+            "source_record_id": "set_bonus:7:2:modifier:0"
+          },
+          {
+            "modifier_id": "set_bonus_modifier_set_bonus:7:3:0",
+            "property": "LevelOfSkills",
+            "property_path": "ADDED.LevelOfSkills.Physical.Void.Poison.Elemental.special:1",
+            "source_record_id": "set_bonus:7:3:modifier:0"
+          }
+        ],
+        "bonus_text": [],
+        "canonical_id": "set:7",
+        "consumer_safe_fields": {
+          "display_name": "Halvar's",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Halvar's",
+        "item_ids": [
+          "set_item:97",
+          "set_item:98",
+          "set_item:99"
+        ],
+        "normalized_fields": {},
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set item and set bonus data."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "setId": "7"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_group:7",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_group"
+        },
+        "raw_reference": {
+          "setId": "7"
+        },
+        "set_group_display_name": "Halvar's",
+        "set_group_id": "set:7",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_group:7",
+        "special_mechanic_classification": "partial_modifier",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set group is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "bonus_ids": [
+          "set_bonus:8:0",
+          "set_bonus:8:1"
+        ],
+        "bonus_modifier_references": [
+          {
+            "modifier_id": "set_bonus_modifier_set_bonus:8:0:0",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Cold.Fire.Void.Elemental.special:3",
+            "source_record_id": "set_bonus:8:0:modifier:0"
+          }
+        ],
+        "bonus_text": [
+          "Your Summon Skeletons' spells and attacks deal +42 fire, cold or lightning damage. The element selected is your lowest elemental resistance."
+        ],
+        "canonical_id": "set:8",
+        "consumer_safe_fields": {
+          "display_name": "Pebbles'",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Pebbles'",
+        "item_ids": [
+          "set_item:100",
+          "set_item:101",
+          "set_item:102"
+        ],
+        "normalized_fields": {},
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set item and set bonus data."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "setId": "8"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_group:8",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_group"
+        },
+        "raw_reference": {
+          "setId": "8"
+        },
+        "set_group_display_name": "Pebbles'",
+        "set_group_id": "set:8",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_group:8",
+        "special_mechanic_classification": "partial_modifier",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set group is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "bonus_ids": [
+          "set_bonus:9:0"
+        ],
+        "bonus_modifier_references": [
+          {
+            "modifier_id": "set_bonus_modifier_set_bonus:9:0:0",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Cold.Poison.Elemental",
+            "source_record_id": "set_bonus:9:0:modifier:0"
+          }
+        ],
+        "bonus_text": [],
+        "canonical_id": "set:9",
+        "consumer_safe_fields": {
+          "display_name": "Shattered Lance",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Shattered Lance",
+        "item_ids": [
+          "set_item:109",
+          "set_item:110"
+        ],
+        "normalized_fields": {},
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set item and set bonus data."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "setId": "9"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_group:9",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_group"
+        },
+        "raw_reference": {
+          "setId": "9"
+        },
+        "set_group_display_name": "Shattered Lance",
+        "set_group_id": "set:9",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_group:9",
+        "special_mechanic_classification": "partial_modifier",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set group is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "bonus_ids": [
+          "set_bonus:10:0",
+          "set_bonus:10:1",
+          "set_bonus:10:2"
+        ],
+        "bonus_modifier_references": [],
+        "bonus_text": [
+          "Limited to One Active Companion",
+          "Storm Totem can hit allies to grant 21 health",
+          "Health granted is not affected by minion healing effectiveness",
+          "Storm Totem can hit allies to grant 21 ward"
+        ],
+        "canonical_id": "set:10",
+        "consumer_safe_fields": {
+          "display_name": "Boardman's",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Boardman's",
+        "item_ids": [
+          "set_item:127",
+          "set_item:128",
+          "set_item:129"
+        ],
+        "normalized_fields": {},
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set item and set bonus data."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "setId": "10"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_group:10",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_group"
+        },
+        "raw_reference": {
+          "setId": "10"
+        },
+        "set_group_display_name": "Boardman's",
+        "set_group_id": "set:10",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_group:10",
+        "special_mechanic_classification": "text_only_effect",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set group is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "bonus_ids": [
+          "set_bonus:11:0",
+          "set_bonus:11:1",
+          "set_bonus:11:2"
+        ],
+        "bonus_modifier_references": [
+          {
+            "modifier_id": "set_bonus_modifier_set_bonus:11:1:0",
+            "property": "IncreasedPotionDropRate",
+            "property_path": "ADDED.IncreasedPotionDropRate",
+            "source_record_id": "set_bonus:11:1:modifier:0"
+          }
+        ],
+        "bonus_text": [
+          "Potions no longer heal you, but instead grant +54 necrotic damage to melee and throwing attacks and mark you for death for 4 seconds.",
+          "Mark for Death is a curse that reduces all resistances by 25%.",
+          "18% less Poison and Necrotic Damage Taken",
+          "Multiplicative with other modifiers"
+        ],
+        "canonical_id": "set:11",
+        "consumer_safe_fields": {
+          "display_name": "Zerrick's",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Zerrick's",
+        "item_ids": [
+          "set_item:138",
+          "set_item:139",
+          "set_item:140"
+        ],
+        "normalized_fields": {},
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set item and set bonus data."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "setId": "11"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_group:11",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_group"
+        },
+        "raw_reference": {
+          "setId": "11"
+        },
+        "set_group_display_name": "Zerrick's",
+        "set_group_id": "set:11",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_group:11",
+        "special_mechanic_classification": "partial_modifier",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set group is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "bonus_ids": [
+          "set_bonus:12:0",
+          "set_bonus:12:1",
+          "set_bonus:12:2"
+        ],
+        "bonus_modifier_references": [
+          {
+            "modifier_id": "set_bonus_modifier_set_bonus:12:0:0",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Cold.Melee.special:4",
+            "source_record_id": "set_bonus:12:0:modifier:0"
+          },
+          {
+            "modifier_id": "set_bonus_modifier_set_bonus:12:1:0",
+            "property": "GlobalConditionalDamage",
+            "property_path": "MORE.GlobalConditionalDamage.Void.special:4",
+            "source_record_id": "set_bonus:12:1:modifier:0"
+          },
+          {
+            "modifier_id": "set_bonus_modifier_set_bonus:12:2:0",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Physical.Cold.Melee",
+            "source_record_id": "set_bonus:12:2:modifier:0"
+          }
+        ],
+        "bonus_text": [],
+        "canonical_id": "set:12",
+        "consumer_safe_fields": {
+          "display_name": "Gaspar's",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Gaspar's",
+        "item_ids": [
+          "set_item:156",
+          "set_item:157",
+          "set_item:158"
+        ],
+        "normalized_fields": {},
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set item and set bonus data."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "setId": "12"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_group:12",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_group"
+        },
+        "raw_reference": {
+          "setId": "12"
+        },
+        "set_group_display_name": "Gaspar's",
+        "set_group_id": "set:12",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_group:12",
+        "special_mechanic_classification": "partial_modifier",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set group is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "bonus_ids": [
+          "set_bonus:13:0"
+        ],
+        "bonus_modifier_references": [],
+        "bonus_text": [
+          "+3 to Curse Skills\n+3 to Minion Skills"
+        ],
+        "canonical_id": "set:13",
+        "consumer_safe_fields": {
+          "display_name": "Sinathia's",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Sinathia's",
+        "item_ids": [
+          "set_item:170",
+          "set_item:171"
+        ],
+        "normalized_fields": {},
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set item and set bonus data."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "setId": "13"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_group:13",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_group"
+        },
+        "raw_reference": {
+          "setId": "13"
+        },
+        "set_group_display_name": "Sinathia's",
+        "set_group_id": "set:13",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_group:13",
+        "special_mechanic_classification": "text_only_effect",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set group is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "bonus_ids": [
+          "set_bonus:14:0",
+          "set_bonus:14:1"
+        ],
+        "bonus_modifier_references": [
+          {
+            "modifier_id": "set_bonus_modifier_set_bonus:14:0:0",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Physical.Lightning.Poison.Elemental",
+            "source_record_id": "set_bonus:14:0:modifier:0"
+          },
+          {
+            "modifier_id": "set_bonus_modifier_set_bonus:14:1:0",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Lightning.Cold.Void.Elemental.Melee",
+            "source_record_id": "set_bonus:14:1:modifier:0"
+          }
+        ],
+        "bonus_text": [],
+        "canonical_id": "set:14",
+        "consumer_safe_fields": {
+          "display_name": "Ruby Fang",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Ruby Fang",
+        "item_ids": [
+          "set_item:173",
+          "set_item:174"
+        ],
+        "normalized_fields": {},
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set item and set bonus data."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "setId": "14"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_group:14",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_group"
+        },
+        "raw_reference": {
+          "setId": "14"
+        },
+        "set_group_display_name": "Ruby Fang",
+        "set_group_id": "set:14",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_group:14",
+        "special_mechanic_classification": "partial_modifier",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set group is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "bonus_ids": [
+          "set_bonus:15:0"
+        ],
+        "bonus_modifier_references": [
+          {
+            "modifier_id": "set_bonus_modifier_set_bonus:15:0:0",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Lightning.Void.Elemental",
+            "source_record_id": "set_bonus:15:0:modifier:0"
+          }
+        ],
+        "bonus_text": [],
+        "canonical_id": "set:15",
+        "consumer_safe_fields": {
+          "display_name": "Vilatria's",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Vilatria's",
+        "item_ids": [
+          "set_item:185",
+          "set_item:186"
+        ],
+        "normalized_fields": {},
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set item and set bonus data."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "setId": "15"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_group:15",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_group"
+        },
+        "raw_reference": {
+          "setId": "15"
+        },
+        "set_group_display_name": "Vilatria's",
+        "set_group_id": "set:15",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_group:15",
+        "special_mechanic_classification": "partial_modifier",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set group is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "bonus_ids": [
+          "set_bonus:16:0",
+          "set_bonus:16:1"
+        ],
+        "bonus_modifier_references": [
+          {
+            "modifier_id": "set_bonus_modifier_set_bonus:16:0:0",
+            "property": "PlayerProperty",
+            "property_path": "ADDED.PlayerProperty.Physical.Cold.Void.Elemental",
+            "source_record_id": "set_bonus:16:0:modifier:0"
+          },
+          {
+            "modifier_id": "set_bonus_modifier_set_bonus:16:1:0",
+            "property": "DamageTaken",
+            "property_path": "MORE.DamageTaken.Necrotic.special:6",
+            "source_record_id": "set_bonus:16:1:modifier:0"
+          }
+        ],
+        "bonus_text": [],
+        "canonical_id": "set:16",
+        "consumer_safe_fields": {
+          "display_name": "Corsair's",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Corsair's",
+        "item_ids": [
+          "set_item:193",
+          "set_item:194"
+        ],
+        "normalized_fields": {},
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set item and set bonus data."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "setId": "16"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_group:16",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_group"
+        },
+        "raw_reference": {
+          "setId": "16"
+        },
+        "set_group_display_name": "Corsair's",
+        "set_group_id": "set:16",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_group:16",
+        "special_mechanic_classification": "partial_modifier",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set group is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "bonus_ids": [
+          "set_bonus:17:0"
+        ],
+        "bonus_modifier_references": [
+          {
+            "modifier_id": "set_bonus_modifier_set_bonus:17:0:0",
+            "property": "LevelOfSkills",
+            "property_path": "ADDED.LevelOfSkills.Totem",
+            "source_record_id": "set_bonus:17:0:modifier:0"
+          }
+        ],
+        "bonus_text": [],
+        "canonical_id": "set:17",
+        "consumer_safe_fields": {
+          "display_name": "Ferebor's",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Ferebor's",
+        "item_ids": [
+          "set_item:227",
+          "set_item:228"
+        ],
+        "normalized_fields": {},
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set item and set bonus data."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "setId": "17"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_group:17",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_group"
+        },
+        "raw_reference": {
+          "setId": "17"
+        },
+        "set_group_display_name": "Ferebor's",
+        "set_group_id": "set:17",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_group:17",
+        "special_mechanic_classification": "partial_modifier",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set group is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "bonus_ids": [
+          "set_bonus:18:0"
+        ],
+        "bonus_modifier_references": [
+          {
+            "modifier_id": "set_bonus_modifier_set_bonus:18:0:0",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Lightning.Void.Necrotic.Poison.Spell",
+            "source_record_id": "set_bonus:18:0:modifier:0"
+          }
+        ],
+        "bonus_text": [],
+        "canonical_id": "set:18",
+        "consumer_safe_fields": {
+          "display_name": "Lich's",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Lich's",
+        "item_ids": [
+          "set_item:260",
+          "set_item:261"
+        ],
+        "normalized_fields": {},
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set item and set bonus data."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "setId": "18"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_group:18",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_group"
+        },
+        "raw_reference": {
+          "setId": "18"
+        },
+        "set_group_display_name": "Lich's",
+        "set_group_id": "set:18",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_group:18",
+        "special_mechanic_classification": "partial_modifier",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set group is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "bonus_ids": [
+          "set_bonus:19:0",
+          "set_bonus:19:1"
+        ],
+        "bonus_modifier_references": [],
+        "bonus_text": [
+          "Evade creates a Shadow at your original position",
+          "Traversal skills create 2 Shadows along their path"
+        ],
+        "canonical_id": "set:19",
+        "consumer_safe_fields": {
+          "display_name": "Doppelganger's",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Doppelganger's",
+        "item_ids": [
+          "set_item:451",
+          "set_item:452",
+          "set_item:453"
+        ],
+        "normalized_fields": {},
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set item and set bonus data."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "setId": "19"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_group:19",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_group"
+        },
+        "raw_reference": {
+          "setId": "19"
+        },
+        "set_group_display_name": "Doppelganger's",
+        "set_group_id": "set:19",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_group:19",
+        "special_mechanic_classification": "text_only_effect",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set group is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "bonus_ids": [
+          "set_bonus:20:0"
+        ],
+        "bonus_modifier_references": [],
+        "bonus_text": [
+          "Legendary affixes on equipped Weaver's Will weapons have 50% increased effect"
+        ],
+        "canonical_id": "set:20",
+        "consumer_safe_fields": {
+          "display_name": "Set 20",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Set 20",
+        "item_ids": [
+          "set_item:454",
+          "set_item:455"
+        ],
+        "normalized_fields": {},
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set item and set bonus data."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "setId": "20"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_group:20",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_group"
+        },
+        "raw_reference": {
+          "setId": "20"
+        },
+        "set_group_display_name": "Set 20",
+        "set_group_id": "set:20",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_group:20",
+        "special_mechanic_classification": "text_only_effect",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set group is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "bonus_ids": [
+          "set_bonus:21:0"
+        ],
+        "bonus_modifier_references": [],
+        "bonus_text": [
+          "Throwing a Burning Dagger grants a stack of Dancing Dragon for 4 seconds, which grants 2% increased dodge rating, 4% increased fire damage, and 4% increased area for fire area skills for 4 seconds. This effect can trigger up to 40 times per 4 seconds."
+        ],
+        "canonical_id": "set:21",
+        "consumer_safe_fields": {
+          "display_name": "Kuzon's",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Kuzon's",
+        "item_ids": [
+          "set_item:456",
+          "set_item:457"
+        ],
+        "normalized_fields": {},
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set item and set bonus data."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "setId": "21"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_group:21",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_group"
+        },
+        "raw_reference": {
+          "setId": "21"
+        },
+        "set_group_display_name": "Kuzon's",
+        "set_group_id": "set:21",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_group:21",
+        "special_mechanic_classification": "text_only_effect",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set group is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "bonus_ids": [
+          "set_bonus:22:0",
+          "set_bonus:22:1"
+        ],
+        "bonus_modifier_references": [
+          {
+            "modifier_id": "set_bonus_modifier_set_bonus:22:0:0",
+            "property": "PlayerProperty",
+            "property_path": "MORE.PlayerProperty.Fire.Void.Necrotic.Poison.Melee",
+            "source_record_id": "set_bonus:22:0:modifier:0"
+          },
+          {
+            "modifier_id": "set_bonus_modifier_set_bonus:22:1:0",
+            "property": "CriticalMultiplier",
+            "property_path": "ADDED.CriticalMultiplier",
+            "source_record_id": "set_bonus:22:1:modifier:0"
+          }
+        ],
+        "bonus_text": [],
+        "canonical_id": "set:22",
+        "consumer_safe_fields": {
+          "display_name": "Jormun's",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Jormun's",
+        "item_ids": [
+          "set_item:464",
+          "set_item:465",
+          "set_item:466"
+        ],
+        "normalized_fields": {},
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set item and set bonus data."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "setId": "22"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_group:22",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_group"
+        },
+        "raw_reference": {
+          "setId": "22"
+        },
+        "set_group_display_name": "Jormun's",
+        "set_group_id": "set:22",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_group:22",
+        "special_mechanic_classification": "partial_modifier",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set group is not stable planner-consumed in Phase 5."
+        ]
+      },
+      {
+        "bonus_ids": [
+          "set_bonus:23:0",
+          "set_bonus:23:1"
+        ],
+        "bonus_modifier_references": [
+          {
+            "modifier_id": "set_bonus_modifier_set_bonus:23:1:0",
+            "property": "AbilityProperty",
+            "property_path": "ADDED.AbilityProperty.Lightning.Cold.Fire.Poison.special:11",
+            "source_record_id": "set_bonus:23:1:modifier:0"
+          }
+        ],
+        "bonus_text": [
+          "Volcanic Orbs now orbit you",
+          "Orbiting Volcanic Orbs cannot have their speed reduced by more than 50%"
+        ],
+        "canonical_id": "set:23",
+        "consumer_safe_fields": {
+          "display_name": "Keplahan's",
+          "stable_calculable": false,
+          "support_status": "partial"
+        },
+        "display_name": "Keplahan's",
+        "item_ids": [
+          "set_item:467",
+          "set_item:468"
+        ],
+        "normalized_fields": {},
+        "patch_version": null,
+        "provenance": {
+          "extraction_method": "last_epoch_set_bonus_export",
+          "notes": [
+            "Generated from extracted set item and set bonus data."
+          ],
+          "patch_version": null,
+          "raw_reference": {
+            "setId": "23"
+          },
+          "schema_version": "v2.unique_set.1",
+          "source_id": "set_group:23",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+          "source_type": "set_group"
+        },
+        "raw_reference": {
+          "setId": "23"
+        },
+        "set_group_display_name": "Keplahan's",
+        "set_group_id": "set:23",
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+        "source_id": "set_group:23",
+        "special_mechanic_classification": "partial_modifier",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": [
+          "Set group is not stable planner-consumed in Phase 5."
+        ]
+      }
+    ]
+  },
+  "schema_version": "v2.set_bundle.1",
+  "source_metadata": {
+    "set_bonuses": {
+      "game_build": {
+        "gameAssemblySha256": "d4a68f3f087005f4c16fbcaf3738dd8a80ee017da3c2a0e3ee6fb86ddfc88ae1",
+        "installPath": "D:\\LastEpochTools\\game_files\\current\\1.4.6_22986002",
+        "unity": "6000.0.42f1"
+      },
+      "generated_at": "2026-05-06T00:03:08+00:00",
+      "note": "setIds are binary-derived; mappingConfidence is 'confirmed' for setIds in the SET_NAMES table, 'unknown' for new setIds awaiting a manual table update. bonuses[] is synthesized from tooltipEntries[] in array order (canonical display order); each entry carries a 'kind' discriminant ('description' | 'mod').",
+      "pipeline": "typetree",
+      "pipeline_version": 1,
+      "source": "resources.assets (SetBonusesList, parse_as_dict)",
+      "source_pathid": 270542,
+      "totalGroups": 24
+    },
+    "uniques": {
+      "hidden_count": 3,
+      "hidden_names": [
+        "Egg of the Forgotten",
+        "Heirloom of Light",
+        "Sharktooth Saw"
+      ],
+      "partial_count": 0,
+      "resolved_count": 468,
+      "set_item_count": 59,
+      "total_binary_entries": 471,
+      "unique_count": 409,
+      "unresolved_count": 0
+    }
+  },
+  "source_set_bonuses_path": "D:\\Forge\\last-epoch-data\\exports_json\\set_bonuses.json",
+  "source_uniques_path": "D:\\Forge\\last-epoch-data\\exports_json\\uniques.json",
+  "summary": {
+    "item_type_counts": {
+      "amulet": 3,
+      "belt": 4,
+      "body_armor": 6,
+      "boots": 2,
+      "catalyst": 2,
+      "gloves": 4,
+      "helmet": 9,
+      "one_handed_axe": 2,
+      "one_handed_dagger": 1,
+      "one_handed_maces": 2,
+      "one_handed_sceptre": 2,
+      "one_handed_sword": 4,
+      "relic": 4,
+      "ring": 6,
+      "shield": 4,
+      "two_handed_mace": 1,
+      "two_handed_staff": 2,
+      "wand": 1
+    },
+    "modifier_row_count": 314,
+    "production_consumed": false,
+    "set_bonus_count": 45,
+    "set_bonuses_with_modifier_rows_count": 27,
+    "set_group_count": 23,
+    "set_item_count": 59,
+    "set_items_with_base_links_count": 59,
+    "special_mechanic_classification_counts": {
+      "partial_modifier": 103,
+      "text_only_effect": 24
+    },
+    "stable_calculable_count": 0,
+    "support_status_counts": {
+      "partial": 127
+    },
+    "trust_level_counts": {
+      "generated_from_game_data": 127
+    },
+    "validation_error_count": 0
+  }
+}

--- a/docs/generated/v2_unique_set_unsupported_report.json
+++ b/docs/generated/v2_unique_set_unsupported_report.json
@@ -1,0 +1,3838 @@
+{
+  "metadata": {
+    "experimental": true,
+    "phase": "phase_5_unique_set_infrastructure",
+    "production_consumer": false,
+    "production_safe": false,
+    "read_only": true,
+    "stable_planner_consumed": false,
+    "uses_canonical_contracts": true
+  },
+  "records": [
+    {
+      "canonical_id": "unique:0",
+      "display_name": "Calamity",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:1",
+      "display_name": "Fractured Crown",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:2",
+      "display_name": "Snowblind",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 3
+    },
+    {
+      "canonical_id": "unique:4",
+      "display_name": "Decayed Skull",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 3
+    },
+    {
+      "canonical_id": "unique:8",
+      "display_name": "Doublet of Onos Tull",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:10",
+      "display_name": "Urzil's Pride",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:11",
+      "display_name": "Exsanguinous",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 3
+    },
+    {
+      "canonical_id": "unique:12",
+      "display_name": "Yrun's Wisdom",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:13",
+      "display_name": "Titan Heart",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:18",
+      "display_name": "Chains of Uleros",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 3
+    },
+    {
+      "canonical_id": "unique:19",
+      "display_name": "Mourningfrost",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:20",
+      "display_name": "Stormtide",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:21",
+      "display_name": "Eterra's Path",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 4
+    },
+    {
+      "canonical_id": "unique:22",
+      "display_name": "Keeper's Gloves",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:25",
+      "display_name": "Boulderfists",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:27",
+      "display_name": "Wing Guards",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:28",
+      "display_name": "Beast King",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 4
+    },
+    {
+      "canonical_id": "unique:29",
+      "display_name": "Taste of Blood",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:30",
+      "display_name": "Undisputed",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:31",
+      "display_name": "Tempest Maw",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 3
+    },
+    {
+      "canonical_id": "unique:32",
+      "display_name": "Frozen Ire",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 4
+    },
+    {
+      "canonical_id": "unique:33",
+      "display_name": "Culnivar's Claim",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:34",
+      "display_name": "Humming Bee",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:35",
+      "display_name": "Eye of Reen",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:36",
+      "display_name": "Rainbow Edge",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:37",
+      "display_name": "Cinder Song",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 3
+    },
+    {
+      "canonical_id": "unique:38",
+      "display_name": "Alchemist's Ladle",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:39",
+      "display_name": "Reach of the Grave",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:40",
+      "display_name": "Bone Harvester",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:41",
+      "display_name": "Hammer of Lorent",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:42",
+      "display_name": "Torch Of The Pontifex",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:43",
+      "display_name": "Storm Breaker",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:45",
+      "display_name": "Morditas' Reach",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 3
+    },
+    {
+      "canonical_id": "unique:47",
+      "display_name": "The Last Laugh",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 3
+    },
+    {
+      "canonical_id": "unique:48",
+      "display_name": "Volcanus",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:50",
+      "display_name": "The Slab",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:51",
+      "display_name": "Close Call",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:52",
+      "display_name": "Soul Bastion",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 3
+    },
+    {
+      "canonical_id": "unique:54",
+      "display_name": "Strong Mind",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:55",
+      "display_name": "Bleeding Heart",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:58",
+      "display_name": "The Claw",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 3
+    },
+    {
+      "canonical_id": "unique:59",
+      "display_name": "Death Rattle",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:60",
+      "display_name": "The Fang",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 4
+    },
+    {
+      "canonical_id": "unique:61",
+      "display_name": "Orian's Eye",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:62",
+      "display_name": "Ring of the Third Eye",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:65",
+      "display_name": "Arboreal Circuit",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:66",
+      "display_name": "Hollow Finger",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 4
+    },
+    {
+      "canonical_id": "unique:67",
+      "display_name": "Tome of Elements",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 3
+    },
+    {
+      "canonical_id": "unique:68",
+      "display_name": "Grimoire of Necrotic Elixirs",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 3
+    },
+    {
+      "canonical_id": "unique:70",
+      "display_name": "Soulfire",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 5
+    },
+    {
+      "canonical_id": "unique:72",
+      "display_name": "Orchirian's Petals",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 3
+    },
+    {
+      "canonical_id": "unique:73",
+      "display_name": "Plague Bearer's Staff",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 6
+    },
+    {
+      "canonical_id": "unique:74",
+      "display_name": "Ignivar's Head",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 3
+    },
+    {
+      "canonical_id": "unique:75",
+      "display_name": "The Scavenger",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:81",
+      "display_name": "Ucenui's Sphere",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 4
+    },
+    {
+      "canonical_id": "unique:82",
+      "display_name": "Arek's Bones",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:84",
+      "display_name": "Heirloom of the Last Nomad",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:93",
+      "display_name": "Kermode's Cage",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:105",
+      "display_name": "The Ashen Crown",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:113",
+      "display_name": "Ribbons of Blood",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:114",
+      "display_name": "Frozen Eyes of Formosus",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:115",
+      "display_name": "Last Steps of the Living",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:116",
+      "display_name": "Atrophy",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:119",
+      "display_name": "Bulwark of the Last Abyss",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 4
+    },
+    {
+      "canonical_id": "unique:123",
+      "display_name": "Symbol of Demise",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 4
+    },
+    {
+      "canonical_id": "unique:126",
+      "display_name": "Mortality's Grasp",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:130",
+      "display_name": "Gambler's Fallacy",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:133",
+      "display_name": "Xithara's Conundrum",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 4
+    },
+    {
+      "canonical_id": "unique:137",
+      "display_name": "Uethrin's Stand",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:143",
+      "display_name": "Gladiator's Oath",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:146",
+      "display_name": "Troaka's Teeth",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:150",
+      "display_name": "Sunwreath",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:152",
+      "display_name": "Anchor of Oblivion",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:154",
+      "display_name": "Eye of Storms",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:160",
+      "display_name": "Call of the Tundra",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 3
+    },
+    {
+      "canonical_id": "unique:162",
+      "display_name": "Bhuldar's Wrath",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 3
+    },
+    {
+      "canonical_id": "unique:164",
+      "display_name": "Logi's Hunger",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:165",
+      "display_name": "Serpent's Milk",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:167",
+      "display_name": "Ravens' Rise",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:168",
+      "display_name": "Flight of the First",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 5
+    },
+    {
+      "canonical_id": "unique:172",
+      "display_name": "Herald of the Scurry",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 4
+    },
+    {
+      "canonical_id": "unique:176",
+      "display_name": "Aurora's Time Glass",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:180",
+      "display_name": "Shattered Chains",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:181",
+      "display_name": "Marina's Lost Soul",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:183",
+      "display_name": "Leviathan Carver",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:184",
+      "display_name": "Lethal Concentration",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 4
+    },
+    {
+      "canonical_id": "unique:188",
+      "display_name": "Azurral's Fury",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 5
+    },
+    {
+      "canonical_id": "unique:190",
+      "display_name": "Jasper's Searing Pride",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:192",
+      "display_name": "Fulgurite Shard",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:195",
+      "display_name": "Scales of Eterra",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 4
+    },
+    {
+      "canonical_id": "unique:196",
+      "display_name": "Scales of Eterra",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 4
+    },
+    {
+      "canonical_id": "unique:197",
+      "display_name": "Scales of Eterra",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 4
+    },
+    {
+      "canonical_id": "unique:202",
+      "display_name": "Stormhide Paws",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:205",
+      "display_name": "Curse of Perseverance",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:207",
+      "display_name": "Kelthan Blasting Agent",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:208",
+      "display_name": "Ravenous Void",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 6
+    },
+    {
+      "canonical_id": "unique:209",
+      "display_name": "Aberrant Call",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:211",
+      "display_name": "Throne of Ambition",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5.",
+        "No v2 item base link was established from extracted base identifiers."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 9
+    },
+    {
+      "canonical_id": "unique:212",
+      "display_name": "Eternal Eclipse",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:213",
+      "display_name": "Frostbite Shackles",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:214",
+      "display_name": "Stormcarved Testament",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 5
+    },
+    {
+      "canonical_id": "unique:217",
+      "display_name": "Sacrificial Embrace",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 4
+    },
+    {
+      "canonical_id": "unique:218",
+      "display_name": "Yulia's Path",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:219",
+      "display_name": "Trinity of Flames",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5.",
+        "No v2 item base link was established from extracted base identifiers."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:220",
+      "display_name": "Death's Embrace",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 3
+    },
+    {
+      "canonical_id": "unique:221",
+      "display_name": "Paranoia",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:222",
+      "display_name": "Prismatic Gaze",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 4
+    },
+    {
+      "canonical_id": "unique:223",
+      "display_name": "Chronostasis",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:224",
+      "display_name": "The Judicator",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:225",
+      "display_name": "Aurelis",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:226",
+      "display_name": "Tu'rani's Bident",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 4
+    },
+    {
+      "canonical_id": "unique:229",
+      "display_name": "Roots of Vithrasil",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:230",
+      "display_name": "Usurper's Mandate",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:231",
+      "display_name": "Longshot",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 3
+    },
+    {
+      "canonical_id": "unique:232",
+      "display_name": "Hakar's Phoenix",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 4
+    },
+    {
+      "canonical_id": "unique:233",
+      "display_name": "Snowdrift",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:235",
+      "display_name": "Silvafrond",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 3
+    },
+    {
+      "canonical_id": "unique:238",
+      "display_name": "Julra's Stardial",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:239",
+      "display_name": "Somnia",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:240",
+      "display_name": "Julra's Obsession",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:243",
+      "display_name": "Dragonsong",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 3
+    },
+    {
+      "canonical_id": "unique:246",
+      "display_name": "Singularity",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5.",
+        "No v2 item base link was established from extracted base identifiers."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:248",
+      "display_name": "Flesh of Stone",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:249",
+      "display_name": "Diothaen's Bloody Nib",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:250",
+      "display_name": "Torkrefin's Hunger",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 3
+    },
+    {
+      "canonical_id": "unique:251",
+      "display_name": "Zeurial's Hunt",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 3
+    },
+    {
+      "canonical_id": "unique:252",
+      "display_name": "Pact Severance",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 3
+    },
+    {
+      "canonical_id": "unique:253",
+      "display_name": "Foot of the Mountain",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 4
+    },
+    {
+      "canonical_id": "unique:255",
+      "display_name": "Core of the Mountain",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:256",
+      "display_name": "Peak of the Mountain",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:257",
+      "display_name": "Ashes of Mortality",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:259",
+      "display_name": "Pyre of Affliction",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 7
+    },
+    {
+      "canonical_id": "unique:263",
+      "display_name": "Omen of Thunder",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 3
+    },
+    {
+      "canonical_id": "unique:264",
+      "display_name": "Vaion's Chariot",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 3
+    },
+    {
+      "canonical_id": "unique:265",
+      "display_name": "Soul Gambler's Fallacy",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:267",
+      "display_name": "Ashes of Orchirian",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 4
+    },
+    {
+      "canonical_id": "unique:268",
+      "display_name": "Bloodkeeper's Nest",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 7
+    },
+    {
+      "canonical_id": "unique:269",
+      "display_name": "Scales of Lemniscate",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 4
+    },
+    {
+      "canonical_id": "unique:270",
+      "display_name": "Hive Mind",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 3
+    },
+    {
+      "canonical_id": "unique:271",
+      "display_name": "Gathering Fury",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:272",
+      "display_name": "Aaron's Will",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 4
+    },
+    {
+      "canonical_id": "unique:273",
+      "display_name": "Lament of the Lost Refuge",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 5
+    },
+    {
+      "canonical_id": "unique:274",
+      "display_name": "Branch of Hallows",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 3
+    },
+    {
+      "canonical_id": "unique:275",
+      "display_name": "Unstable Core",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:277",
+      "display_name": "Red Ring of Atlaria",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:280",
+      "display_name": "Telf'un's Mirage",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:281",
+      "display_name": "Vortex Pennant",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:282",
+      "display_name": "Firestarter's Torch",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:283",
+      "display_name": "Rotmind",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:284",
+      "display_name": "The Ghost Maker",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 4
+    },
+    {
+      "canonical_id": "unique:285",
+      "display_name": "Jelkhor's Blast Knife",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 3
+    },
+    {
+      "canonical_id": "unique:286",
+      "display_name": "Fragment of the Enigma",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 3
+    },
+    {
+      "canonical_id": "unique:290",
+      "display_name": "Apostate's Sanctuary",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:292",
+      "display_name": "Apogee of Frozen Light",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 8
+    },
+    {
+      "canonical_id": "unique:293",
+      "display_name": "Swaddling of the Erased",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:294",
+      "display_name": "Font of the Erased",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:295",
+      "display_name": "Cradle of the Erased",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 3
+    },
+    {
+      "canonical_id": "unique:296",
+      "display_name": "Advent of the Erased",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:298",
+      "display_name": "Knowledge of an Erased Mage",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:300",
+      "display_name": "Ambitions of an Erased Acolyte",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:301",
+      "display_name": "Gambit of an Erased Rogue",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:302",
+      "display_name": "Howl of the West Wind",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:303",
+      "display_name": "Cycle of Putrescence",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 3
+    },
+    {
+      "canonical_id": "unique:307",
+      "display_name": "Crest of Unity",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:308",
+      "display_name": "Abacus Rod",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 6
+    },
+    {
+      "canonical_id": "unique:309",
+      "display_name": "Elecoe's Abandon",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:310",
+      "display_name": "Wrongwarp",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 8
+    },
+    {
+      "canonical_id": "unique:311",
+      "display_name": "Transcriber's Graver",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:314",
+      "display_name": "Cleaver Solution",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:315",
+      "display_name": "Dragorath's Claw",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:316",
+      "display_name": "Apex of Thought",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:317",
+      "display_name": "Frey's Retreat",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:318",
+      "display_name": "The Shattered Cycle",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 4
+    },
+    {
+      "canonical_id": "unique:319",
+      "display_name": "Merophage",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:320",
+      "display_name": "Sierpin's Fractal Tree",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:322",
+      "display_name": "The Cuckoo",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:323",
+      "display_name": "Wheel of Torment",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 3
+    },
+    {
+      "canonical_id": "unique:324",
+      "display_name": "Unvar's Rise",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5.",
+        "No v2 item base link was established from extracted base identifiers."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:325",
+      "display_name": "Unvar's Hegemony",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5.",
+        "No v2 item base link was established from extracted base identifiers."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:326",
+      "display_name": "Unvar's Exile",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5.",
+        "No v2 item base link was established from extracted base identifiers."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:327",
+      "display_name": "Communion of the Erased",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 4
+    },
+    {
+      "canonical_id": "unique:328",
+      "display_name": "Stygian Coal",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:330",
+      "display_name": "Spine of Malatros",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 3
+    },
+    {
+      "canonical_id": "unique:331",
+      "display_name": "Vial of Volatile Ice",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:333",
+      "display_name": "Falcon Fists",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:334",
+      "display_name": "Talons of Valor",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:335",
+      "display_name": "Wraithlord's Harbour",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 5
+    },
+    {
+      "canonical_id": "unique:336",
+      "display_name": "Naal's Tooth",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 3
+    },
+    {
+      "canonical_id": "unique:337",
+      "display_name": "Razorfall",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 3
+    },
+    {
+      "canonical_id": "unique:338",
+      "display_name": "Sword Catcher",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:339",
+      "display_name": "Black Blade of Chaos",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:340",
+      "display_name": "Orian's Sun Seal",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:341",
+      "display_name": "Cruelty",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:344",
+      "display_name": "Harbinger's Needle",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5.",
+        "No v2 item base link was established from extracted base identifiers.",
+        "Special behavior is retained for display/debug only."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "text_only_effect",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:347",
+      "display_name": "The Inevitable",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:348",
+      "display_name": "Phantom Grip",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:351",
+      "display_name": "Triboelectra",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 4
+    },
+    {
+      "canonical_id": "unique:355",
+      "display_name": "Aberroth's Command",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 3
+    },
+    {
+      "canonical_id": "unique:356",
+      "display_name": "Stealth",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:358",
+      "display_name": "Null Portent",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:359",
+      "display_name": "Fingers of the Phantom Mire",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 5
+    },
+    {
+      "canonical_id": "unique:360",
+      "display_name": "Carcinization of Momentum",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 3
+    },
+    {
+      "canonical_id": "unique:362",
+      "display_name": "Grim Constitution",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:364",
+      "display_name": "Event Horizon",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 10
+    },
+    {
+      "canonical_id": "unique:366",
+      "display_name": "Flames of Midnight",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 5
+    },
+    {
+      "canonical_id": "unique:367",
+      "display_name": "Celestial Doom",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:368",
+      "display_name": "Mana Guide",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 7
+    },
+    {
+      "canonical_id": "unique:369",
+      "display_name": "Tolmat's Incorrect History of Eterra",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:370",
+      "display_name": "Mantle of the Pale Ox",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:373",
+      "display_name": "Ravager's Dart",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 3
+    },
+    {
+      "canonical_id": "unique:374",
+      "display_name": "Pearls of the Swine",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:375",
+      "display_name": "Pearls of the Swine",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:376",
+      "display_name": "Pearls of the Swine",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:377",
+      "display_name": "Gordian Prism",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 5
+    },
+    {
+      "canonical_id": "unique:378",
+      "display_name": "Crystalwind",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:379",
+      "display_name": "Cocooned Short Sword",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5.",
+        "Special behavior is retained for display/debug only."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "text_only_effect",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:380",
+      "display_name": "Cocooned Cleaver",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5.",
+        "Special behavior is retained for display/debug only."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "text_only_effect",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:381",
+      "display_name": "Cocooned Club",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5.",
+        "Special behavior is retained for display/debug only."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "text_only_effect",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:382",
+      "display_name": "Cocooned Great Sword",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5.",
+        "Special behavior is retained for display/debug only."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "text_only_effect",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:383",
+      "display_name": "Cocooned Great Axe",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5.",
+        "Special behavior is retained for display/debug only."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "text_only_effect",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:384",
+      "display_name": "Cocooned Great Mace",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5.",
+        "Special behavior is retained for display/debug only."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "text_only_effect",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:385",
+      "display_name": "Cocooned Spear",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5.",
+        "Special behavior is retained for display/debug only."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "text_only_effect",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:386",
+      "display_name": "Cocooned Staff",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5.",
+        "Special behavior is retained for display/debug only."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "text_only_effect",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:387",
+      "display_name": "Cocooned Cuirass",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5.",
+        "Special behavior is retained for display/debug only."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "text_only_effect",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:388",
+      "display_name": "Cocooned Dagger",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5.",
+        "Special behavior is retained for display/debug only."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "text_only_effect",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:389",
+      "display_name": "Cocooned Sceptre",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5.",
+        "Special behavior is retained for display/debug only."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "text_only_effect",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:390",
+      "display_name": "Cocooned Wand",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5.",
+        "Special behavior is retained for display/debug only."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "text_only_effect",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:391",
+      "display_name": "Cocooned Bow",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5.",
+        "Special behavior is retained for display/debug only."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "text_only_effect",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:392",
+      "display_name": "Cocooned Quiver",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5.",
+        "Special behavior is retained for display/debug only."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "text_only_effect",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:393",
+      "display_name": "Cocooned Shield",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5.",
+        "Special behavior is retained for display/debug only."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "text_only_effect",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:394",
+      "display_name": "Cocooned Catalyst",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5.",
+        "Special behavior is retained for display/debug only."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "text_only_effect",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:395",
+      "display_name": "Cocooned Relic",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5.",
+        "Special behavior is retained for display/debug only."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "text_only_effect",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:396",
+      "display_name": "Cocooned Ring",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5.",
+        "Special behavior is retained for display/debug only."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "text_only_effect",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:397",
+      "display_name": "Cocooned Amulet",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5.",
+        "Special behavior is retained for display/debug only."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "text_only_effect",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:398",
+      "display_name": "Cocooned Gloves",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5.",
+        "Special behavior is retained for display/debug only."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "text_only_effect",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:399",
+      "display_name": "Cocooned Belt",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5.",
+        "Special behavior is retained for display/debug only."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "text_only_effect",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:400",
+      "display_name": "Cocooned Boots",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5.",
+        "Special behavior is retained for display/debug only."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "text_only_effect",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:401",
+      "display_name": "Cocooned Helmet",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5.",
+        "Special behavior is retained for display/debug only."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "text_only_effect",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:402",
+      "display_name": "Elecoe's Innovation",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:403",
+      "display_name": "Soul of the Mountain",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 4
+    },
+    {
+      "canonical_id": "unique:404",
+      "display_name": "Orian's Descent",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 3
+    },
+    {
+      "canonical_id": "unique:405",
+      "display_name": "Orb Weaver's Fang",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:406",
+      "display_name": "Nest of Nightmares",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:407",
+      "display_name": "Essence Weaver",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 4
+    },
+    {
+      "canonical_id": "unique:408",
+      "display_name": "Weaver's Gift",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 3
+    },
+    {
+      "canonical_id": "unique:409",
+      "display_name": "Inheritance of the Erased",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:410",
+      "display_name": "Unearthed Memories",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 3
+    },
+    {
+      "canonical_id": "unique:411",
+      "display_name": "Countenance of Majasa",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 4
+    },
+    {
+      "canonical_id": "unique:412",
+      "display_name": "Dominance of the Tundra",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:413",
+      "display_name": "Shattered Worlds",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 3
+    },
+    {
+      "canonical_id": "unique:414",
+      "display_name": "Downfall of the Righteous",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 3
+    },
+    {
+      "canonical_id": "unique:415",
+      "display_name": "Immortal Vise",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:417",
+      "display_name": "Clotho's Needle",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 3
+    },
+    {
+      "canonical_id": "unique:418",
+      "display_name": "Scissor of Atropos",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 3
+    },
+    {
+      "canonical_id": "unique:420",
+      "display_name": "Executioner's Tithe",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 9
+    },
+    {
+      "canonical_id": "unique:421",
+      "display_name": "The Land Before",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5.",
+        "No v2 item base link was established from extracted base identifiers."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:422",
+      "display_name": "Lightning in a Bottle",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 4
+    },
+    {
+      "canonical_id": "unique:423",
+      "display_name": "Legends Entwined",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:424",
+      "display_name": "Tyrant's Skull",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 9
+    },
+    {
+      "canonical_id": "unique:425",
+      "display_name": "Wildfire Embers",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 4
+    },
+    {
+      "canonical_id": "unique:426",
+      "display_name": "Thicket of Blinding Light",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:427",
+      "display_name": "Harmony of the First",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:428",
+      "display_name": "Onslaught of Cerata",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:430",
+      "display_name": "Chorus of the Anurok",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 4
+    },
+    {
+      "canonical_id": "unique:431",
+      "display_name": "Carrion of Creation",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 3
+    },
+    {
+      "canonical_id": "unique:432",
+      "display_name": "Horn of the Bone Wisp",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:433",
+      "display_name": "Reliquary Nest",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:434",
+      "display_name": "Mask of Indifference",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:435",
+      "display_name": "Permanence of Primal Knowledge",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 3
+    },
+    {
+      "canonical_id": "unique:437",
+      "display_name": "Primal Cadence",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 3
+    },
+    {
+      "canonical_id": "unique:438",
+      "display_name": "Whetstone Gavel",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:439",
+      "display_name": "Truesight Glass",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:440",
+      "display_name": "Bluefeather Band",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:441",
+      "display_name": "Hydra Arc",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 4
+    },
+    {
+      "canonical_id": "unique:442",
+      "display_name": "Velocyn's Jaw",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:443",
+      "display_name": "Army of Skin",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 5
+    },
+    {
+      "canonical_id": "unique:444",
+      "display_name": "Evolution's End",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 3
+    },
+    {
+      "canonical_id": "unique:445",
+      "display_name": "Spirit Xylem",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:446",
+      "display_name": "Fangs of the Berserker",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:447",
+      "display_name": "Bones of the Ancestral Pack",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 7
+    },
+    {
+      "canonical_id": "unique:449",
+      "display_name": "The Butcher's Crown",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 4
+    },
+    {
+      "canonical_id": "unique:450",
+      "display_name": "Unbroken Charge",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 3
+    },
+    {
+      "canonical_id": "unique:458",
+      "display_name": "Tabi of Dusk and Dawn",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 3
+    },
+    {
+      "canonical_id": "unique:459",
+      "display_name": "Artifice of Devastation",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "unique:460",
+      "display_name": "Laup's Path",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 3
+    },
+    {
+      "canonical_id": "unique:461",
+      "display_name": "Ash Wake",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 5
+    },
+    {
+      "canonical_id": "unique:462",
+      "display_name": "Natural Wrath",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5.",
+        "No v2 item base link was established from extracted base identifiers."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 4
+    },
+    {
+      "canonical_id": "unique:463",
+      "display_name": "Rahyeh's Embrace",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 3
+    },
+    {
+      "canonical_id": "unique:469",
+      "display_name": "Exulis",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "unique:470",
+      "display_name": "Oculus of Ruin",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "unique",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "set:1",
+      "display_name": "Isadora's",
+      "notes": [
+        "Set group is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "set_group",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 3
+    },
+    {
+      "canonical_id": "set:2",
+      "display_name": "The Invoker's",
+      "notes": [
+        "Set group is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "set_group",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "set:3",
+      "display_name": "Apiarist's",
+      "notes": [
+        "Set group is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "set_group",
+      "special_mechanic_classification": "text_only_effect",
+      "support_status": "partial",
+      "text_evidence_count": 3
+    },
+    {
+      "canonical_id": "set:4",
+      "display_name": "Sunforged",
+      "notes": [
+        "Set group is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "set_group",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "set:8",
+      "display_name": "Pebbles'",
+      "notes": [
+        "Set group is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "set_group",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "set:10",
+      "display_name": "Boardman's",
+      "notes": [
+        "Set group is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "set_group",
+      "special_mechanic_classification": "text_only_effect",
+      "support_status": "partial",
+      "text_evidence_count": 4
+    },
+    {
+      "canonical_id": "set:11",
+      "display_name": "Zerrick's",
+      "notes": [
+        "Set group is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "set_group",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 4
+    },
+    {
+      "canonical_id": "set:13",
+      "display_name": "Sinathia's",
+      "notes": [
+        "Set group is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "set_group",
+      "special_mechanic_classification": "text_only_effect",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "set:19",
+      "display_name": "Doppelganger's",
+      "notes": [
+        "Set group is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "set_group",
+      "special_mechanic_classification": "text_only_effect",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "set:20",
+      "display_name": "Set 20",
+      "notes": [
+        "Set group is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "set_group",
+      "special_mechanic_classification": "text_only_effect",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "set:21",
+      "display_name": "Kuzon's",
+      "notes": [
+        "Set group is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "set_group",
+      "special_mechanic_classification": "text_only_effect",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "set:23",
+      "display_name": "Keplahan's",
+      "notes": [
+        "Set group is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "set_group",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "set_item:5",
+      "display_name": "Isadora's Revenge",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "set_item",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "set_item:26",
+      "display_name": "Isadora's Gravechill",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "set_item",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "set_item:77",
+      "display_name": "Apiarist's Smoker",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "set_item",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "set_item:78",
+      "display_name": "Apiarist's Suit",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "set_item",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "set_item:79",
+      "display_name": "Apiarist's Comb",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "set_item",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "set_item:88",
+      "display_name": "Blade of the Forgotten Knight",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "set_item",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "set_item:90",
+      "display_name": "Locket of the Forgotten Knight",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "set_item",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "set_item:100",
+      "display_name": "Pebbles' Femur",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "set_item",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "set_item:101",
+      "display_name": "Pebbles' Collar",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "set_item",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "set_item:102",
+      "display_name": "Pebbles' Bitemarked Sash",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "set_item",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "set_item:127",
+      "display_name": "Boardman's Plank",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "set_item",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "set_item:128",
+      "display_name": "Boardman's Fallacy",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "set_item",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 3
+    },
+    {
+      "canonical_id": "set_item:129",
+      "display_name": "Boardman's Legacy",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "set_item",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 4
+    },
+    {
+      "canonical_id": "set_item:138",
+      "display_name": "Zerrick's Guile",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "set_item",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "set_item:139",
+      "display_name": "Zerrick's Greed",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "set_item",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "set_item:170",
+      "display_name": "Sinathia's Dying Breath",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "set_item",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "set_item:174",
+      "display_name": "Ruby Fang Aegis",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "set_item",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 5
+    },
+    {
+      "canonical_id": "set_item:186",
+      "display_name": "Vilatria's Downfall",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "set_item",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "set_item:260",
+      "display_name": "Lich's Envy",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "set_item",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "set_item:261",
+      "display_name": "Lich's Scorn",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "set_item",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "set_item:453",
+      "display_name": "Doppelganger's Facade",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "set_item",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "set_item:456",
+      "display_name": "Kuzon's Fury",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "set_item",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "set_item:457",
+      "display_name": "Kuzon's Guise",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "set_item",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "set_item:465",
+      "display_name": "Jormun's Hunger",
+      "notes": [
+        "Unique/set record is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "set_item",
+      "special_mechanic_classification": "partial_modifier",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "set_bonus:1:0",
+      "display_name": "Isadora's 2 piece bonus",
+      "notes": [
+        "Set bonus is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "set_bonus",
+      "special_mechanic_classification": "text_only_effect",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "set_bonus:1:2",
+      "display_name": "Isadora's 3 piece bonus",
+      "notes": [
+        "Set bonus is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "set_bonus",
+      "special_mechanic_classification": "text_only_effect",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "set_bonus:2:1",
+      "display_name": "The Invoker's 3 piece bonus",
+      "notes": [
+        "Set bonus is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "set_bonus",
+      "special_mechanic_classification": "text_only_effect",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "set_bonus:3:0",
+      "display_name": "Apiarist's 2 piece bonus",
+      "notes": [
+        "Set bonus is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "set_bonus",
+      "special_mechanic_classification": "text_only_effect",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "set_bonus:3:1",
+      "display_name": "Apiarist's 3 piece bonus",
+      "notes": [
+        "Set bonus is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "set_bonus",
+      "special_mechanic_classification": "text_only_effect",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "set_bonus:4:0",
+      "display_name": "Sunforged 2 piece bonus",
+      "notes": [
+        "Set bonus is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "set_bonus",
+      "special_mechanic_classification": "text_only_effect",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "set_bonus:8:1",
+      "display_name": "Pebbles' 3 piece bonus",
+      "notes": [
+        "Set bonus is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "set_bonus",
+      "special_mechanic_classification": "text_only_effect",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "set_bonus:10:0",
+      "display_name": "Boardman's 1 piece bonus",
+      "notes": [
+        "Set bonus is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "set_bonus",
+      "special_mechanic_classification": "text_only_effect",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "set_bonus:10:1",
+      "display_name": "Boardman's 2 piece bonus",
+      "notes": [
+        "Set bonus is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "set_bonus",
+      "special_mechanic_classification": "text_only_effect",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "set_bonus:10:2",
+      "display_name": "Boardman's 3 piece bonus",
+      "notes": [
+        "Set bonus is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "set_bonus",
+      "special_mechanic_classification": "text_only_effect",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "set_bonus:11:0",
+      "display_name": "Zerrick's 2 piece bonus",
+      "notes": [
+        "Set bonus is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "set_bonus",
+      "special_mechanic_classification": "text_only_effect",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "set_bonus:11:2",
+      "display_name": "Zerrick's 3 piece bonus",
+      "notes": [
+        "Set bonus is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "set_bonus",
+      "special_mechanic_classification": "text_only_effect",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    },
+    {
+      "canonical_id": "set_bonus:13:0",
+      "display_name": "Sinathia's 2 piece bonus",
+      "notes": [
+        "Set bonus is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "set_bonus",
+      "special_mechanic_classification": "text_only_effect",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "set_bonus:19:0",
+      "display_name": "Doppelganger's 2 piece bonus",
+      "notes": [
+        "Set bonus is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "set_bonus",
+      "special_mechanic_classification": "text_only_effect",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "set_bonus:19:1",
+      "display_name": "Doppelganger's 3 piece bonus",
+      "notes": [
+        "Set bonus is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "set_bonus",
+      "special_mechanic_classification": "text_only_effect",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "set_bonus:20:0",
+      "display_name": "set:20 2 piece bonus",
+      "notes": [
+        "Set bonus is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "set_bonus",
+      "special_mechanic_classification": "text_only_effect",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "set_bonus:21:0",
+      "display_name": "Kuzon's 2 piece bonus",
+      "notes": [
+        "Set bonus is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "set_bonus",
+      "special_mechanic_classification": "text_only_effect",
+      "support_status": "partial",
+      "text_evidence_count": 1
+    },
+    {
+      "canonical_id": "set_bonus:23:0",
+      "display_name": "Keplahan's 2 piece bonus",
+      "notes": [
+        "Set bonus is not stable planner-consumed in Phase 5."
+      ],
+      "record_type": "set_bonus",
+      "special_mechanic_classification": "text_only_effect",
+      "support_status": "partial",
+      "text_evidence_count": 2
+    }
+  ],
+  "summary": {
+    "classification_counts": {
+      "partial_modifier": 296,
+      "text_only_effect": 48
+    },
+    "production_consumed": false,
+    "unsupported_or_text_only_count": 344
+  }
+}

--- a/docs/generated/v2_unique_set_validation_report.json
+++ b/docs/generated/v2_unique_set_validation_report.json
@@ -1,0 +1,33 @@
+{
+  "errors": [],
+  "metadata": {
+    "experimental": true,
+    "phase": "phase_5_unique_set_infrastructure",
+    "production_consumer": false,
+    "production_safe": false,
+    "read_only": true,
+    "stable_planner_consumed": false,
+    "uses_canonical_contracts": true
+  },
+  "summary": {
+    "duplicate_set_group_id_count": 0,
+    "duplicate_set_item_id_count": 0,
+    "duplicate_unique_id_count": 0,
+    "error_count": 0,
+    "invalid_trust_level_count": 0,
+    "missing_base_link_count": 0,
+    "missing_provenance_count": 0,
+    "missing_support_status_count": 0,
+    "production_consumed": false,
+    "set_bonus_count": 45,
+    "set_bonus_group_missing_count": 0,
+    "set_group_count": 23,
+    "set_group_link_missing_count": 0,
+    "set_item_count": 59,
+    "stable_calculable_count": 0,
+    "unique_count": 409,
+    "unsupported_stable_calculation_count": 0,
+    "warning_count": 0
+  },
+  "warnings": []
+}

--- a/docs/migration/V2_UNIQUE_SET_MIGRATION.md
+++ b/docs/migration/V2_UNIQUE_SET_MIGRATION.md
@@ -1,0 +1,106 @@
+# v2 Unique and Set Migration
+
+## Purpose
+
+Phase 5 creates read-only canonical unique and set item bundles on top of the v2 contracts and the Phase 4 item base infrastructure. It preserves extracted modifier rows, set membership, base links where available, and text-only/special effect evidence without simulating unique or set mechanics.
+
+This phase does not remap planner behavior, implement special runtime behavior, or mark unique/set records as stable planner inputs.
+
+## Generation Command
+
+```powershell
+.\backend\.venv\Scripts\python.exe backend\scripts\report_v2_unique_set_bundles.py --source-uniques D:\Forge\last-epoch-data\exports_json\uniques.json --source-set-bonuses D:\Forge\last-epoch-data\exports_json\set_bonuses.json --item-base-bundle docs\generated\v2_item_base_bundle.json --unique-output docs\generated\v2_unique_bundle.json --set-output docs\generated\v2_set_bundle.json --validation-output docs\generated\v2_unique_set_validation_report.json --unsupported-output docs\generated\v2_unique_set_unsupported_report.json --markdown-output docs\migration\V2_UNIQUE_SET_MIGRATION.md
+```
+
+## Summary
+
+- Unique count: 409
+- Set group count: 23
+- Set item count: 59
+- Set bonus count: 45
+- Stable-calculable count: 0
+- Validation errors: 0
+- Validation warnings: 0
+- Unsupported/text-only/special behavior records: 344
+- Production consumed: false
+
+## Unique Classification Counts
+
+| Classification | Count |
+| --- | ---: |
+| partial_modifier | 385 |
+| text_only_effect | 24 |
+
+## Set Classification Counts
+
+| Classification | Count |
+| --- | ---: |
+| partial_modifier | 103 |
+| text_only_effect | 24 |
+
+## Unsupported and Text-Only Findings
+
+| Classification | Count |
+| --- | ---: |
+| partial_modifier | 296 |
+| text_only_effect | 48 |
+
+Tooltip and description text is retained as display/debug evidence only. It is not converted into calculated mechanics.
+
+## Example Uniques
+
+| Canonical ID | Display name | Item type | Classification | Modifier rows |
+| --- | --- | --- | --- | ---: |
+| `unique:0` | Calamity | helmet | partial_modifier | 3 |
+| `unique:1` | Fractured Crown | helmet | partial_modifier | 4 |
+| `unique:2` | Snowblind | helmet | partial_modifier | 8 |
+| `unique:3` | Artor's Legacy | helmet | partial_modifier | 5 |
+| `unique:4` | Decayed Skull | helmet | partial_modifier | 7 |
+| `unique:6` | Boneclamor Barbute | helmet | partial_modifier | 5 |
+| `unique:7` | The Kestrel | body_armor | partial_modifier | 5 |
+| `unique:8` | Doublet of Onos Tull | body_armor | partial_modifier | 3 |
+| `unique:9` | Prism Wraps | body_armor | partial_modifier | 4 |
+| `unique:10` | Urzil's Pride | body_armor | partial_modifier | 4 |
+| `unique:11` | Exsanguinous | body_armor | partial_modifier | 6 |
+| `unique:12` | Yrun's Wisdom | body_armor | partial_modifier | 1 |
+| `unique:13` | Titan Heart | body_armor | partial_modifier | 5 |
+| `unique:14` | Valeroot | body_armor | partial_modifier | 6 |
+| `unique:15` | Vipertail | belt | partial_modifier | 5 |
+
+## Example Set Items
+
+| Canonical ID | Display name | Set group | Classification | Modifier rows |
+| --- | --- | --- | --- | ---: |
+| `set_item:5` | Isadora's Revenge | `set:1` | partial_modifier | 4 |
+| `set_item:16` | Isadora's Tomb Binding | `set:1` | partial_modifier | 4 |
+| `set_item:26` | Isadora's Gravechill | `set:1` | partial_modifier | 2 |
+| `set_item:57` | The Invoker's Frozen Heart | `set:2` | partial_modifier | 4 |
+| `set_item:63` | The Invoker's Scorching Grasp | `set:2` | partial_modifier | 4 |
+| `set_item:64` | The Invoker's Static Touch | `set:2` | partial_modifier | 4 |
+| `set_item:77` | Apiarist's Smoker | `set:3` | partial_modifier | 6 |
+| `set_item:78` | Apiarist's Suit | `set:3` | partial_modifier | 9 |
+| `set_item:79` | Apiarist's Comb | `set:3` | partial_modifier | 5 |
+| `set_item:85` | Sunforged Hammer | `set:4` | partial_modifier | 6 |
+| `set_item:86` | Sunforged Cuirass | `set:4` | partial_modifier | 4 |
+| `set_item:87` | Sunforged Greathelm | `set:4` | partial_modifier | 4 |
+| `set_item:88` | Blade of the Forgotten Knight | `set:5` | partial_modifier | 6 |
+| `set_item:89` | Defiance of the Forgotten Knight | `set:5` | partial_modifier | 6 |
+| `set_item:90` | Locket of the Forgotten Knight | `set:5` | partial_modifier | 4 |
+
+## Migration Implications
+
+- Unique and set records are available for experimental lookup and debug inspection.
+- Structured modifier rows remain `partial`; value-scale and modifier normalization are unresolved.
+- Text-only and special behavior remains displayable but is not calculated.
+- Existing planner and `/api/ref/uniques` behavior remain unchanged.
+
+## Deferred
+
+- Runtime simulation for unique and set special mechanics.
+- Stable modifier normalization and value-scale policy.
+- Planner, crafting, stat aggregation, and simulation consumption.
+- Idol, passive, and skill infrastructure.
+
+## Checkpoint 5
+
+Checkpoint 5 is ready for review when generated bundles, validation reports, unsupported report, repository, routes, debug page, and focused tests pass.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -55,6 +55,7 @@ const BackendDebugDashboard = lazy(() => import("@/pages/debug/BackendDebugDashb
 const DataFlowHarness = lazy(() => import("@/pages/debug/DataFlowHarness"));
 const ForgeSafeAffixesDebugPage = lazy(() => import("@/pages/debug/ForgeSafeAffixesDebugPage"));
 const V2ItemsDebugPage = lazy(() => import("@/pages/debug/V2ItemsDebugPage"));
+const V2UniqueSetDebugPage = lazy(() => import("@/pages/debug/V2UniqueSetDebugPage"));
 
 // ---------------------------------------------------------------------------
 // Route alias redirect — preserves the current location's search string so
@@ -258,6 +259,7 @@ export default function App() {
                     <Route path="/debug" element={<Suspense fallback={<PageLoader />}><BackendDebugDashboard /></Suspense>} />
                     <Route path="/debug/forge-safe-affixes" element={<Suspense fallback={<PageLoader />}><ForgeSafeAffixesDebugPage /></Suspense>} />
                     <Route path="/debug/v2-items" element={<Suspense fallback={<PageLoader />}><V2ItemsDebugPage /></Suspense>} />
+                    <Route path="/debug/v2-unique-sets" element={<Suspense fallback={<PageLoader />}><V2UniqueSetDebugPage /></Suspense>} />
                     <Route path="/data-flow" element={<Suspense fallback={<PageLoader />}><DataFlowHarness /></Suspense>} />
                   </>
                 )}

--- a/frontend/src/__tests__/pages/v2-unique-set-debug-page.test.tsx
+++ b/frontend/src/__tests__/pages/v2-unique-set-debug-page.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+
+import V2UniqueSetDebugPage from "@/pages/debug/V2UniqueSetDebugPage";
+
+describe("V2UniqueSetDebugPage", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("renders disabled response clearly", async () => {
+    mockFetch({
+      success: false,
+      error: "v2_unique_set_bundle_missing",
+      message: "v2 unique bundle not found",
+    });
+
+    render(<V2UniqueSetDebugPage />);
+
+    expect(await screen.findByText("Debug endpoint unavailable")).toBeInTheDocument();
+    expect(screen.getByText("v2 unique bundle not found")).toBeInTheDocument();
+  });
+
+  it("renders unique summary and rows", async () => {
+    mockFetch(successPayload());
+
+    render(<V2UniqueSetDebugPage />);
+
+    expect(await screen.findByText("409")).toBeInTheDocument();
+    expect(screen.getByText("23")).toBeInTheDocument();
+    expect(screen.getByText("partial_modifier: 385, text_only_effect: 24")).toBeInTheDocument();
+    expect(screen.getByText("Calamity")).toBeInTheDocument();
+    expect(screen.getByText("unique:0")).toBeInTheDocument();
+    expect(screen.getByText("partial_modifier")).toBeInTheDocument();
+  });
+
+  it("uses controls when loading", async () => {
+    mockFetch(successPayload());
+
+    render(<V2UniqueSetDebugPage />);
+    await screen.findByText("Calamity");
+
+    fireEvent.change(screen.getByLabelText(/Limit/i), { target: { value: "2" } });
+    fireEvent.change(screen.getByLabelText(/Search/i), { target: { value: "calamity" } });
+    fireEvent.change(screen.getByLabelText(/Slot/i), { target: { value: "helmet" } });
+    fireEvent.click(screen.getByRole("button", { name: "Load debug data" }));
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenLastCalledWith("/experimental/v2/uniques?limit=2&q=calamity&slot=helmet");
+    });
+  });
+});
+
+function mockFetch(payload: unknown) {
+  vi.mocked(fetch).mockResolvedValue({
+    json: async () => payload,
+  } as Response);
+}
+
+function successPayload() {
+  return {
+    success: true,
+    experimental: true,
+    read_only: true,
+    production_consumer: false,
+    data_source: "v2_unique_bundle",
+    source_path: "D:\\Forge\\le-the-forge\\docs\\generated\\v2_unique_bundle.json",
+    total_uniques: 409,
+    total_sets: 23,
+    total_set_items: 59,
+    total_set_bonuses: 45,
+    result_count: 1,
+    summary: {
+      special_mechanic_classification_counts: { partial_modifier: 385, text_only_effect: 24 },
+    },
+    records: [
+      {
+        canonical_id: "unique:0",
+        display_name: "Calamity",
+        source_id: "unique:0",
+        source_file: "uniques.json",
+        support_status: "partial",
+        trust_level: "generated_from_game_data",
+        provenance: {
+          source_path: "uniques.json",
+          source_type: "unique",
+          extraction_method: "last_epoch_unique_set_export",
+          schema_version: "v2.unique_set.1",
+          notes: [],
+          raw_reference: {},
+        },
+        item_category: "equipment",
+        item_type: "helmet",
+        equipment_slot: "helmet",
+        slot: "helmet",
+        subtype: "Leather Helmet",
+        classification: "armor",
+        level_requirement: 7,
+        class_restrictions: [],
+        implicit_ids: [],
+        unique_effect_text: [],
+        modifier_references: [{ modifier_id: "unique_modifier:unique:0:0", property: "Damage" }],
+        special_mechanic_classification: "partial_modifier",
+        stable_calculable: false,
+        warnings: [],
+        raw_reference: {},
+        normalized_fields: {},
+        consumer_safe_fields: {},
+      },
+    ],
+  };
+}

--- a/frontend/src/pages/debug/V2UniqueSetDebugPage.tsx
+++ b/frontend/src/pages/debug/V2UniqueSetDebugPage.tsx
@@ -1,0 +1,271 @@
+import { FormEvent, useEffect, useMemo, useState } from "react";
+
+import type { CanonicalSet, CanonicalUnique } from "@/types";
+
+interface V2UniqueSetResponse {
+  success: boolean;
+  experimental?: boolean;
+  read_only?: boolean;
+  production_consumer?: boolean;
+  data_source?: string;
+  source_path?: string;
+  total_uniques?: number;
+  total_sets?: number;
+  total_set_items?: number;
+  total_set_bonuses?: number;
+  result_count?: number;
+  records?: Array<CanonicalUnique | CanonicalSet>;
+  summary?: Record<string, unknown>;
+  error?: string;
+  message?: string;
+}
+
+const DEFAULT_LIMIT = 10;
+
+function buildUrl(kind: "uniques" | "sets", limit: number, query: string, slot: string): string {
+  const params = new URLSearchParams();
+  params.set("limit", String(limit));
+  if (query.trim()) params.set("q", query.trim());
+  if (slot.trim() && kind === "uniques") params.set("slot", slot.trim());
+  return `/experimental/v2/${kind}?${params.toString()}`;
+}
+
+async function fetchV2UniqueSets(kind: "uniques" | "sets", limit: number, query: string, slot: string): Promise<V2UniqueSetResponse> {
+  const response = await fetch(buildUrl(kind, limit, query, slot));
+  const json = await response.json().catch(() => null);
+  if (!json || typeof json !== "object") {
+    return {
+      success: false,
+      error: "invalid_response",
+      message: `Backend returned an unreadable response (${response.status}).`,
+    };
+  }
+  return json as V2UniqueSetResponse;
+}
+
+export default function V2UniqueSetDebugPage() {
+  const [kind, setKind] = useState<"uniques" | "sets">("uniques");
+  const [limit, setLimit] = useState(DEFAULT_LIMIT);
+  const [query, setQuery] = useState("");
+  const [slot, setSlot] = useState("");
+  const [data, setData] = useState<V2UniqueSetResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = async (nextKind = kind, nextLimit = limit, nextQuery = query, nextSlot = slot) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await fetchV2UniqueSets(nextKind, nextLimit, nextQuery, nextSlot);
+      setData(result);
+      if (!result.success) setError(result.message || result.error || "Debug endpoint returned an error.");
+    } catch (err) {
+      setData(null);
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    load("uniques", DEFAULT_LIMIT, "", "");
+    // Initial debug fetch only for this dev-only route.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    load(kind, limit, query, slot);
+  }
+
+  const records = data?.records ?? [];
+  const summary = useMemo(
+    () => [
+      ["Data source", data?.data_source ?? "n/a"],
+      ["Uniques", data?.total_uniques ?? "n/a"],
+      ["Set groups", data?.total_sets ?? "n/a"],
+      ["Set items", data?.total_set_items ?? "n/a"],
+      ["Set bonuses", data?.total_set_bonuses ?? "n/a"],
+      ["Special", summarizeMap(data?.summary, "special_mechanic_classification_counts")],
+      ["Read only", String(data?.read_only ?? false)],
+      ["Production consumer", String(data?.production_consumer ?? false)],
+    ],
+    [data],
+  );
+
+  return (
+    <div className="mx-auto max-w-6xl space-y-6 p-6">
+      <header className="border-b border-[#2a3050] pb-4">
+        <p className="font-mono text-xs uppercase tracking-wide text-[#22d3ee]">
+          Debug / Experimental / Read-only
+        </p>
+        <h1 className="mt-2 font-display text-2xl text-[#f5a623]">
+          v2 unique and set inspection
+        </h1>
+        <p className="mt-2 max-w-3xl text-sm text-gray-400">
+          This page reads v2 unique/set bundles for diagnostics and does not power planner behavior.
+        </p>
+      </header>
+
+      <section className="rounded border border-[#2a3050] bg-[#10152a] p-4">
+        <form onSubmit={handleSubmit} className="flex flex-wrap items-end gap-4">
+          <label className="grid gap-1 text-sm text-gray-300">
+            <span className="text-xs uppercase text-gray-500">Kind</span>
+            <select
+              value={kind}
+              onChange={(event) => setKind(event.target.value as "uniques" | "sets")}
+              className="w-36 rounded border border-[#2a3050] bg-[#0f172a] px-3 py-2 text-gray-100"
+            >
+              <option value="uniques">Uniques</option>
+              <option value="sets">Sets</option>
+            </select>
+          </label>
+          <label className="grid gap-1 text-sm text-gray-300">
+            <span className="text-xs uppercase text-gray-500">Limit</span>
+            <input
+              type="number"
+              min={0}
+              max={50}
+              value={limit}
+              onChange={(event) => setLimit(Number(event.target.value))}
+              className="w-28 rounded border border-[#2a3050] bg-[#0f172a] px-3 py-2 text-gray-100"
+            />
+          </label>
+          <label className="grid gap-1 text-sm text-gray-300">
+            <span className="text-xs uppercase text-gray-500">Search</span>
+            <input
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="optional"
+              className="w-48 rounded border border-[#2a3050] bg-[#0f172a] px-3 py-2 text-gray-100"
+            />
+          </label>
+          <label className="grid gap-1 text-sm text-gray-300">
+            <span className="text-xs uppercase text-gray-500">Slot</span>
+            <input
+              value={slot}
+              onChange={(event) => setSlot(event.target.value)}
+              placeholder="helmet"
+              disabled={kind !== "uniques"}
+              className="w-36 rounded border border-[#2a3050] bg-[#0f172a] px-3 py-2 text-gray-100 disabled:opacity-50"
+            />
+          </label>
+          <button
+            type="submit"
+            className="rounded bg-[#f5a623] px-4 py-2 text-sm font-semibold text-[#10152a] hover:bg-[#f5a623cc]"
+          >
+            Load debug data
+          </button>
+        </form>
+      </section>
+
+      {loading && (
+        <div className="rounded border border-[#2a3050] bg-[#0f172a] p-4 text-sm text-gray-300">
+          Loading debug endpoint...
+        </div>
+      )}
+
+      {!loading && error && (
+        <section className="rounded border border-red-900 bg-red-950/30 p-4">
+          <h2 className="text-sm font-semibold text-red-300">Debug endpoint unavailable</h2>
+          <p className="mt-2 text-sm text-red-100">{error}</p>
+        </section>
+      )}
+
+      {!loading && data?.success && (
+        <>
+          <section className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            {summary.map(([label, value]) => (
+              <div key={label} className="rounded border border-[#2a3050] bg-[#10152a] p-4">
+                <div className="text-xs uppercase text-gray-500">{label}</div>
+                <div className="mt-2 break-words font-mono text-lg text-gray-100">{value}</div>
+              </div>
+            ))}
+          </section>
+
+          <section className="rounded border border-[#2a3050] bg-[#10152a] p-4">
+            <h2 className="text-sm font-semibold text-gray-100">Source</h2>
+            <p className="mt-2 break-all font-mono text-xs text-gray-400">{data.source_path}</p>
+          </section>
+
+          <section className="overflow-hidden rounded border border-[#2a3050] bg-[#10152a]">
+            <div className="border-b border-[#2a3050] p-4">
+              <h2 className="text-sm font-semibold text-gray-100">Records</h2>
+              <p className="mt-1 text-xs text-gray-500">Showing {records.length} records.</p>
+            </div>
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[940px] text-left text-sm">
+                <thead className="bg-[#0f172a] text-xs uppercase text-gray-500">
+                  <tr>
+                    <th className="px-4 py-3">Canonical ID</th>
+                    <th className="px-4 py-3">Name</th>
+                    <th className="px-4 py-3">Support</th>
+                    <th className="px-4 py-3">Trust</th>
+                    <th className="px-4 py-3">Special</th>
+                    <th className="px-4 py-3">Type</th>
+                    <th className="px-4 py-3">Links</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-[#2a3050]">
+                  {records.map((record) => (
+                    <tr key={record.canonical_id}>
+                      <td className="px-4 py-3 font-mono text-[#f5a623]">{record.canonical_id}</td>
+                      <td className="px-4 py-3 text-gray-100">{record.display_name}</td>
+                      <td className="px-4 py-3">{statusBadge(record.support_status)}</td>
+                      <td className="px-4 py-3 text-gray-300">{record.trust_level}</td>
+                      <td className="px-4 py-3">{specialBadge(special(record))}</td>
+                      <td className="px-4 py-3 text-gray-300">{itemType(record)}</td>
+                      <td className="px-4 py-3 font-mono text-gray-300">{linkSummary(record)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+        </>
+      )}
+    </div>
+  );
+}
+
+function summarizeMap(summary: Record<string, unknown> | undefined, key: string): string {
+  const value = summary?.[key];
+  if (!value || typeof value !== "object" || Array.isArray(value)) return "n/a";
+  return Object.entries(value as Record<string, unknown>)
+    .map(([name, count]) => `${name}: ${count}`)
+    .join(", ");
+}
+
+function statusBadge(status: string) {
+  const classes =
+    status === "trusted"
+      ? "border-emerald-700 bg-emerald-950 text-emerald-200"
+      : status === "partial"
+        ? "border-yellow-700 bg-yellow-950 text-yellow-200"
+        : "border-gray-700 bg-gray-900 text-gray-300";
+  return <span className={`inline-flex rounded border px-2 py-1 font-mono text-xs ${classes}`}>{status}</span>;
+}
+
+function specialBadge(value: string) {
+  const classes =
+    value === "partial_modifier"
+      ? "border-cyan-700 bg-cyan-950 text-cyan-200"
+      : value === "text_only_effect"
+        ? "border-purple-700 bg-purple-950 text-purple-200"
+        : "border-gray-700 bg-gray-900 text-gray-300";
+  return <span className={`inline-flex rounded border px-2 py-1 font-mono text-xs ${classes}`}>{value}</span>;
+}
+
+function special(record: CanonicalUnique | CanonicalSet): string {
+  return record.special_mechanic_classification ?? "unknown";
+}
+
+function itemType(record: CanonicalUnique | CanonicalSet): string {
+  return "item_type" in record && record.item_type ? record.item_type : "n/a";
+}
+
+function linkSummary(record: CanonicalUnique | CanonicalSet): number | string {
+  if ("modifier_references" in record && record.modifier_references) return record.modifier_references.length;
+  if ("item_ids" in record && record.item_ids) return `${record.item_ids.length} items`;
+  return "n/a";
+}

--- a/frontend/src/types/canonicalSet.ts
+++ b/frontend/src/types/canonicalSet.ts
@@ -1,14 +1,41 @@
 import type { CanonicalItemBase } from "./canonicalItem";
 import type { CanonicalModifierReference } from "./canonicalModifier";
+import type { UniqueSetSpecialMechanicClassification } from "./canonicalUnique";
 
 export interface CanonicalSetItem extends CanonicalItemBase {
   set_id?: string | null;
+  set_group_id?: string | null;
+  set_group_display_name?: string | null;
   base_item_id?: string | null;
   modifier_references: CanonicalModifierReference[];
+  modifier_rows?: Array<Record<string, unknown>>;
+  tooltip_text?: string[];
+  special_mechanic_classification?: UniqueSetSpecialMechanicClassification;
+  stable_calculable?: boolean;
 }
 
 export interface CanonicalSet extends CanonicalItemBase {
+  set_group_id?: string | null;
+  set_group_display_name?: string | null;
   item_ids: string[];
+  bonus_ids?: string[];
   bonus_modifier_references: CanonicalModifierReference[];
   bonus_text: string[];
+  special_mechanic_classification?: UniqueSetSpecialMechanicClassification;
+  stable_calculable?: boolean;
+}
+
+export interface CanonicalSetBonus {
+  canonical_id: string;
+  display_name: string;
+  set_group_id: string;
+  set_group_display_name?: string | null;
+  required_pieces?: number | null;
+  support_status: string;
+  trust_level: string;
+  description_text: string[];
+  modifier_references: CanonicalModifierReference[];
+  modifier_rows?: Array<Record<string, unknown>>;
+  special_mechanic_classification: UniqueSetSpecialMechanicClassification;
+  stable_calculable?: boolean;
 }

--- a/frontend/src/types/canonicalUnique.ts
+++ b/frontend/src/types/canonicalUnique.ts
@@ -1,8 +1,22 @@
 import type { CanonicalItemBase } from "./canonicalItem";
 import type { CanonicalModifierReference } from "./canonicalModifier";
 
+export type UniqueSetSpecialMechanicClassification =
+  | "trusted_modifier"
+  | "partial_modifier"
+  | "text_only_effect"
+  | "scripted_runtime_behavior"
+  | "unsupported_special_behavior"
+  | "unknown";
+
 export interface CanonicalUnique extends CanonicalItemBase {
   base_item_id?: string | null;
   unique_effect_text: string[];
   modifier_references: CanonicalModifierReference[];
+  modifier_rows?: Array<Record<string, unknown>>;
+  tooltip_text?: string[];
+  special_mechanic_classification?: UniqueSetSpecialMechanicClassification;
+  stable_calculable?: boolean;
+  legendary_type?: string | null;
+  implicit_links?: Array<Record<string, unknown>>;
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -40,9 +40,9 @@ export type { CanonicalIdol } from "./canonicalIdol";
 export type { CanonicalImplicit, CanonicalItemBase } from "./canonicalItem";
 export type { CanonicalModifier, CanonicalModifierReference } from "./canonicalModifier";
 export type { CanonicalPassiveNode, CanonicalPassiveTree } from "./canonicalPassive";
-export type { CanonicalSet, CanonicalSetItem } from "./canonicalSet";
+export type { CanonicalSet, CanonicalSetBonus, CanonicalSetItem } from "./canonicalSet";
 export type { CanonicalSkill, CanonicalSkillTree, CanonicalSkillTreeNode } from "./canonicalSkill";
-export type { CanonicalUnique } from "./canonicalUnique";
+export type { CanonicalUnique, UniqueSetSpecialMechanicClassification } from "./canonicalUnique";
 export type { SourceProvenance } from "./sourceProvenance";
 export {
   SUPPORT_STATUSES,


### PR DESCRIPTION
## Summary

Adds Phase 5 of the v2 trusted data rebuild: unique and set item infrastructure.

This introduces generated v2 unique and set bundles, validation/unsupported reports, a read-only backend repository, experimental unique/set routes, and a debug-only frontend view.

## Added

- v2 unique bundle generation
- v2 set bundle generation
- v2 unique/set validation report
- v2 unique/set unsupported report
- v2 unique/set migration documentation
- read-only `V2UniqueSetRepository`
- experimental v2 unique/set routes:
  - `GET /experimental/v2/uniques`
  - `GET /experimental/v2/uniques/<unique_id>`
  - `GET /experimental/v2/uniques/debug`
  - `GET /experimental/v2/sets`
  - `GET /experimental/v2/sets/<set_id>`
  - `GET /experimental/v2/sets/debug`
- debug-only frontend route:
  - `/debug/v2-unique-sets`
- special mechanic classification badges
- focused backend and frontend tests

## Findings

- Unique count: `409`
- Set group count: `23`
- Set item count: `59`
- Set bonus count: `45`
- Unique modifier rows: `2047`
- Set item/bonus modifier rows: `314`
- `400 / 409` uniques linked to v2 item bases
- `59 / 59` set items linked to v2 item bases
- Unsupported/text-only evidence records: `344`
- Stable-calculable count: `0`
- Validation errors: `0`
- Production consumed: `false`

All unique/set records remain partial. Tooltip/special behavior text is preserved for display/debug only and is not simulated or treated as stable planner-calculable.

## Validation

- v2 unique/set focused tests passed: `8 passed`
- v2 unique/set + item + affix + canonical + production guard tests passed: `38 passed`
- existing experimental forge-safe affix tests passed: `25 passed`
- frontend debug tests passed: `10 passed`
- frontend type-check passed
- backend py_compile passed
- JSON validation passed for all generated reports
- `git diff --check` passed

## Runtime behavior

Production behavior was not changed.

The new v2 unique/set access path is experimental/read-only. Planner, crafting, stat aggregation, simulation, and production routes remain blocked from consuming v2 unique/set data.