### PR TITLE
feat: add v2 class mastery infrastructure

### DIFF
--- a/backend/app/repositories/v2/__init__.py
+++ b/backend/app/repositories/v2/__init__.py
@@ -1,6 +1,7 @@
 """v2 experimental repositories."""
 
 from .affix_repository import V2AffixBundleError, V2AffixRepository
+from .class_mastery_repository import V2ClassMasteryBundleError, V2ClassMasteryRepository
 from .idol_repository import V2IdolBundleError, V2IdolRepository
 from .item_repository import V2ItemBundleError, V2ItemRepository
 from .unique_set_repository import V2UniqueSetBundleError, V2UniqueSetRepository
@@ -8,6 +9,8 @@ from .unique_set_repository import V2UniqueSetBundleError, V2UniqueSetRepository
 __all__ = [
     "V2AffixBundleError",
     "V2AffixRepository",
+    "V2ClassMasteryBundleError",
+    "V2ClassMasteryRepository",
     "V2IdolBundleError",
     "V2IdolRepository",
     "V2ItemBundleError",

--- a/backend/app/repositories/v2/class_mastery_repository.py
+++ b/backend/app/repositories/v2/class_mastery_repository.py
@@ -1,0 +1,175 @@
+"""Read-only v2 class/mastery repository."""
+
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+from app.data_contracts import SupportStatus, TrustLevel, validate_canonical_id
+
+
+class V2ClassMasteryBundleError(ValueError):
+    """Raised when the v2 class/mastery bundle is missing or invalid."""
+
+
+class V2ClassMasteryRepository:
+    """Read-only repository over the generated v2 class/mastery bundle."""
+
+    def __init__(self, bundle_path: str | Path) -> None:
+        self.bundle_path = Path(bundle_path)
+        self._payload: dict[str, Any] | None = None
+        self._classes: tuple[dict[str, Any], ...] = ()
+        self._masteries: tuple[dict[str, Any], ...] = ()
+        self._classes_by_id: dict[str, dict[str, Any]] = {}
+        self._masteries_by_id: dict[str, dict[str, Any]] = {}
+
+    def load(self) -> "V2ClassMasteryRepository":
+        return self.load_payload(_read_json(self.bundle_path, "v2 class/mastery bundle"))
+
+    def load_payload(self, payload: dict[str, Any]) -> "V2ClassMasteryRepository":
+        classes = _records(payload, "classes")
+        masteries = _records(payload, "masteries")
+        self._validate(classes, masteries)
+        self._payload = deepcopy(payload)
+        self._classes = tuple(deepcopy(record) for record in classes)
+        self._masteries = tuple(deepcopy(record) for record in masteries)
+        self._classes_by_id = {record["canonical_id"]: record for record in self._classes}
+        self._masteries_by_id = {record["canonical_id"]: record for record in self._masteries}
+        return self
+
+    def list_classes(self, *, limit: int | None = None, offset: int = 0) -> list[dict[str, Any]]:
+        return _page(self._classes, limit=limit, offset=offset)
+
+    def get_class(self, canonical_id: str) -> dict[str, Any] | None:
+        record = self._classes_by_id.get(canonical_id)
+        return deepcopy(record) if record else None
+
+    def filter_classes(self, *, query: str = "", limit: int | None = None, offset: int = 0) -> list[dict[str, Any]]:
+        records = list(self._classes)
+        if query:
+            needle = query.strip().lower()
+            records = [record for record in records if needle in record["canonical_id"].lower() or needle in str(record.get("display_name", "")).lower()]
+        return _page(tuple(records), limit=limit, offset=offset)
+
+    def list_masteries(self, *, limit: int | None = None, offset: int = 0) -> list[dict[str, Any]]:
+        return _page(self._masteries, limit=limit, offset=offset)
+
+    def get_mastery(self, canonical_id: str) -> dict[str, Any] | None:
+        record = self._masteries_by_id.get(canonical_id)
+        return deepcopy(record) if record else None
+
+    def get_masteries_by_class(self, class_id: str, *, limit: int | None = None, offset: int = 0) -> list[dict[str, Any]]:
+        records = tuple(record for record in self._masteries if record.get("class_id") == class_id)
+        return _page(records, limit=limit, offset=offset)
+
+    def filter_masteries(
+        self,
+        *,
+        query: str = "",
+        class_id: str = "",
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        records = list(self._masteries)
+        if query:
+            needle = query.strip().lower()
+            records = [record for record in records if needle in record["canonical_id"].lower() or needle in str(record.get("display_name", "")).lower()]
+        if class_id:
+            expected = class_id.strip().lower()
+            records = [record for record in records if str(record.get("class_id", "")).lower() == expected]
+        return _page(tuple(records), limit=limit, offset=offset)
+
+    def count_classes(self) -> int:
+        return len(self._classes)
+
+    def count_masteries(self) -> int:
+        return len(self._masteries)
+
+    def debug_summary(self) -> dict[str, Any]:
+        return {
+            "bundle_path": str(self.bundle_path),
+            "class_count": self.count_classes(),
+            "mastery_count": self.count_masteries(),
+            "summary": deepcopy(self._payload.get("summary", {}) if self._payload else {}),
+            "cross_reference": deepcopy(self._payload.get("cross_reference", {}) if self._payload else {}),
+            "production_consumer": False,
+            "production_safe": False,
+        }
+
+    @staticmethod
+    def _validate(classes: list[Any], masteries: list[Any]) -> None:
+        class_ids = _validate_common(classes, "Class")
+        mastery_ids = _validate_common(masteries, "Mastery")
+        for record in classes:
+            canonical_id = record["canonical_id"]
+            if not isinstance(record.get("mastery_ids"), list):
+                raise V2ClassMasteryBundleError(f"Class {canonical_id} has invalid mastery_ids.")
+            for mastery_id in record.get("mastery_ids") or []:
+                if mastery_id not in mastery_ids:
+                    raise V2ClassMasteryBundleError(f"Class {canonical_id} links missing mastery {mastery_id}.")
+        for record in masteries:
+            canonical_id = record["canonical_id"]
+            if record.get("class_id") not in class_ids:
+                raise V2ClassMasteryBundleError(f"Mastery {canonical_id} links missing class {record.get('class_id')}.")
+
+
+def _read_json(path: Path, label: str) -> dict[str, Any]:
+    if not path.exists():
+        raise FileNotFoundError(f"{label} not found: {path}")
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise V2ClassMasteryBundleError(f"Invalid JSON in {label} {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise V2ClassMasteryBundleError(f"{label} must be a JSON object.")
+    return payload
+
+
+def _records(payload: dict[str, Any], key: str) -> list[Any]:
+    records = payload.get("records")
+    if not isinstance(records, dict) or not isinstance(records.get(key), list):
+        raise V2ClassMasteryBundleError(f"v2 class/mastery bundle records.{key} must be a list.")
+    return records[key]
+
+
+def _validate_common(records: list[Any], label: str) -> set[str]:
+    seen: set[str] = set()
+    ids: set[str] = set()
+    for index, record in enumerate(records):
+        if not isinstance(record, dict):
+            raise V2ClassMasteryBundleError(f"{label} record {index} must be an object.")
+        canonical_id = record.get("canonical_id")
+        try:
+            validate_canonical_id(canonical_id)
+        except ValueError as exc:
+            raise V2ClassMasteryBundleError(f"{label} record {index} has invalid canonical_id: {exc}") from exc
+        if canonical_id in seen:
+            raise V2ClassMasteryBundleError(f"Duplicate canonical_id in v2 class/mastery bundle: {canonical_id}")
+        seen.add(canonical_id)
+        ids.add(canonical_id)
+        if not record.get("display_name"):
+            raise V2ClassMasteryBundleError(f"{label} {canonical_id} is missing display_name.")
+        provenance = record.get("provenance")
+        if not isinstance(provenance, dict) or not provenance.get("source_path") or not provenance.get("source_id"):
+            raise V2ClassMasteryBundleError(f"{label} {canonical_id} is missing provenance.")
+        try:
+            status = SupportStatus(str(record.get("support_status")))
+        except ValueError as exc:
+            raise V2ClassMasteryBundleError(f"{label} {canonical_id} has invalid support_status.") from exc
+        try:
+            trust = TrustLevel(str(record.get("trust_level")))
+        except ValueError as exc:
+            raise V2ClassMasteryBundleError(f"{label} {canonical_id} has invalid trust_level.") from exc
+        if record.get("manual_bridge") is True and trust != TrustLevel.MANUAL_BRIDGE:
+            raise V2ClassMasteryBundleError(f"{label} {canonical_id} is a manual bridge without trust_level manual_bridge.")
+        if record.get("stable_calculable") is True or status == SupportStatus.TRUSTED:
+            raise V2ClassMasteryBundleError(f"{label} {canonical_id} is not approved for stable calculation in Phase 7.")
+    return ids
+
+
+def _page(records: tuple[dict[str, Any], ...], *, limit: int | None, offset: int) -> list[dict[str, Any]]:
+    start = max(0, offset)
+    end = None if limit is None else start + max(0, limit)
+    return [deepcopy(record) for record in records[start:end]]

--- a/backend/app/routes/experimental.py
+++ b/backend/app/routes/experimental.py
@@ -13,6 +13,7 @@ from typing import Any
 from flask import Blueprint, current_app, jsonify, request
 
 from app.repositories.v2.affix_repository import V2AffixBundleError, V2AffixRepository
+from app.repositories.v2.class_mastery_repository import V2ClassMasteryBundleError, V2ClassMasteryRepository
 from app.repositories.v2.idol_repository import V2IdolBundleError, V2IdolRepository
 from app.repositories.v2.item_repository import V2ItemBundleError, V2ItemRepository
 from app.repositories.v2.unique_set_repository import V2UniqueSetBundleError, V2UniqueSetRepository
@@ -38,6 +39,7 @@ DEFAULT_V2_UNIQUE_BUNDLE_PATH = ROOT / "docs" / "generated" / "v2_unique_bundle.
 DEFAULT_V2_SET_BUNDLE_PATH = ROOT / "docs" / "generated" / "v2_set_bundle.json"
 DEFAULT_V2_IDOL_BUNDLE_PATH = ROOT / "docs" / "generated" / "v2_idol_bundle.json"
 DEFAULT_V2_IDOL_AFFIX_BUNDLE_PATH = ROOT / "docs" / "generated" / "v2_idol_affix_bundle.json"
+DEFAULT_V2_CLASS_MASTERY_BUNDLE_PATH = ROOT / "docs" / "generated" / "v2_class_mastery_bundle.json"
 
 
 @experimental_bp.route("/forge-safe-affixes", methods=["GET"])
@@ -653,6 +655,85 @@ def v2_idol_debug():
     return jsonify({"success": True, "experimental": True, "read_only": True, "production_consumer": False, "data_source": "v2_idol_bundles", "debug_summary": repository.debug_summary()})
 
 
+@experimental_bp.route("/v2/classes", methods=["GET"])
+def v2_classes():
+    """Query the read-only v2 class bundle."""
+
+    parsed = _parse_v2_class_mastery_query_args()
+    if parsed["errors"]:
+        return jsonify({"success": False, "error": "invalid_query", "message": "; ".join(parsed["errors"])}), 400
+    try:
+        repository = _load_v2_class_mastery_repository()
+    except FileNotFoundError as exc:
+        return jsonify({"success": False, "error": "v2_class_mastery_bundle_missing", "message": str(exc)}), 404
+    except V2ClassMasteryBundleError as exc:
+        return jsonify({"success": False, "error": "v2_class_mastery_bundle_invalid", "message": str(exc)}), 422
+    records = repository.filter_classes(query=parsed["q"], limit=parsed["limit"], offset=parsed["offset"])
+    return jsonify(_v2_class_mastery_response(repository, records, parsed, data_source="v2_class_mastery_bundle", record_kind="classes"))
+
+
+@experimental_bp.route("/v2/classes/debug", methods=["GET"])
+def v2_class_mastery_debug():
+    """Return a debug summary for read-only v2 class/mastery bundle."""
+
+    try:
+        repository = _load_v2_class_mastery_repository()
+    except FileNotFoundError as exc:
+        return jsonify({"success": False, "error": "v2_class_mastery_bundle_missing", "message": str(exc)}), 404
+    except V2ClassMasteryBundleError as exc:
+        return jsonify({"success": False, "error": "v2_class_mastery_bundle_invalid", "message": str(exc)}), 422
+    return jsonify({"success": True, "experimental": True, "read_only": True, "production_consumer": False, "data_source": "v2_class_mastery_bundle", "debug_summary": repository.debug_summary()})
+
+
+@experimental_bp.route("/v2/classes/<path:class_id>", methods=["GET"])
+def v2_class_detail(class_id: str):
+    """Return one v2 class record by canonical ID."""
+
+    try:
+        repository = _load_v2_class_mastery_repository()
+    except FileNotFoundError as exc:
+        return jsonify({"success": False, "error": "v2_class_mastery_bundle_missing", "message": str(exc)}), 404
+    except V2ClassMasteryBundleError as exc:
+        return jsonify({"success": False, "error": "v2_class_mastery_bundle_invalid", "message": str(exc)}), 422
+    record = repository.get_class(class_id)
+    if record is None:
+        return jsonify({"success": False, "error": "class_not_found", "message": f"v2 class not found: {class_id}"}), 404
+    return jsonify({"success": True, "experimental": True, "read_only": True, "production_consumer": False, "data_source": "v2_class_mastery_bundle", "source_path": str(repository.bundle_path), "record": record, "masteries": repository.get_masteries_by_class(class_id)})
+
+
+@experimental_bp.route("/v2/masteries", methods=["GET"])
+def v2_masteries():
+    """Query the read-only v2 mastery records."""
+
+    parsed = _parse_v2_class_mastery_query_args()
+    if parsed["errors"]:
+        return jsonify({"success": False, "error": "invalid_query", "message": "; ".join(parsed["errors"])}), 400
+    try:
+        repository = _load_v2_class_mastery_repository()
+    except FileNotFoundError as exc:
+        return jsonify({"success": False, "error": "v2_class_mastery_bundle_missing", "message": str(exc)}), 404
+    except V2ClassMasteryBundleError as exc:
+        return jsonify({"success": False, "error": "v2_class_mastery_bundle_invalid", "message": str(exc)}), 422
+    records = repository.filter_masteries(query=parsed["q"], class_id=parsed["class_id"], limit=parsed["limit"], offset=parsed["offset"])
+    return jsonify(_v2_class_mastery_response(repository, records, parsed, data_source="v2_class_mastery_bundle", record_kind="masteries"))
+
+
+@experimental_bp.route("/v2/masteries/<path:mastery_id>", methods=["GET"])
+def v2_mastery_detail(mastery_id: str):
+    """Return one v2 mastery record by canonical ID."""
+
+    try:
+        repository = _load_v2_class_mastery_repository()
+    except FileNotFoundError as exc:
+        return jsonify({"success": False, "error": "v2_class_mastery_bundle_missing", "message": str(exc)}), 404
+    except V2ClassMasteryBundleError as exc:
+        return jsonify({"success": False, "error": "v2_class_mastery_bundle_invalid", "message": str(exc)}), 422
+    record = repository.get_mastery(mastery_id)
+    if record is None:
+        return jsonify({"success": False, "error": "mastery_not_found", "message": f"v2 mastery not found: {mastery_id}"}), 404
+    return jsonify({"success": True, "experimental": True, "read_only": True, "production_consumer": False, "data_source": "v2_class_mastery_bundle", "source_path": str(repository.bundle_path), "record": record})
+
+
 def _forge_safe_canonical_affix_catalog(parsed: dict[str, Any], *, detail: bool = False):
     source_path = _configured_export_path()
     if not source_path:
@@ -864,6 +945,13 @@ def _configured_v2_idol_affix_bundle_path() -> Path:
     return DEFAULT_V2_IDOL_AFFIX_BUNDLE_PATH
 
 
+def _configured_v2_class_mastery_bundle_path() -> Path:
+    configured = current_app.config.get("V2_CLASS_MASTERY_BUNDLE_PATH")
+    if configured:
+        return Path(configured)
+    return DEFAULT_V2_CLASS_MASTERY_BUNDLE_PATH
+
+
 def _load_v2_affix_repository() -> V2AffixRepository:
     return V2AffixRepository(_configured_v2_affix_bundle_path()).load()
 
@@ -887,6 +975,10 @@ def _load_v2_idol_repository() -> V2IdolRepository:
         _configured_v2_idol_bundle_path(),
         _configured_v2_idol_affix_bundle_path(),
     ).load()
+
+
+def _load_v2_class_mastery_repository() -> V2ClassMasteryRepository:
+    return V2ClassMasteryRepository(_configured_v2_class_mastery_bundle_path()).load()
 
 
 def _parse_query_args() -> dict[str, Any]:
@@ -950,6 +1042,19 @@ def _parse_v2_idol_query_args() -> dict[str, Any]:
         "idol_type": request.args.get("idol_type") or request.args.get("item_type") or "",
         "class_id": request.args.get("class_id") or "",
         "mastery": request.args.get("mastery") or "",
+        "errors": errors,
+    }
+
+
+def _parse_v2_class_mastery_query_args() -> dict[str, Any]:
+    errors: list[str] = []
+    limit = _parse_non_negative_int("limit", request.args.get("limit"), DEFAULT_LIMIT, errors)
+    offset = _parse_non_negative_int("offset", request.args.get("offset"), 0, errors)
+    return {
+        "limit": min(limit, MAX_LIMIT),
+        "offset": offset,
+        "q": request.args.get("q") or request.args.get("search") or "",
+        "class_id": request.args.get("class_id") or "",
         "errors": errors,
     }
 
@@ -1344,5 +1449,35 @@ def _v2_idol_affix_response(
         "export_policy": "v2_idol_affix_bundle",
         "export_status": "pass" if summary["idol_affix_summary"].get("validation_error_count", 0) == 0 else "blocked",
         "summary": summary["idol_affix_summary"],
+        "records": records,
+    }
+
+
+def _v2_class_mastery_response(
+    repository: V2ClassMasteryRepository,
+    records: list[dict[str, Any]],
+    parsed: dict[str, Any],
+    *,
+    data_source: str,
+    record_kind: str,
+) -> dict[str, Any]:
+    summary = repository.debug_summary()["summary"]
+    return {
+        "success": True,
+        "experimental": True,
+        "read_only": True,
+        "production_consumer": False,
+        "data_source": data_source,
+        "source_path": str(repository.bundle_path),
+        "result_count": len(records),
+        "total_loaded_count": repository.count_classes() if record_kind == "classes" else repository.count_masteries(),
+        "total_classes": repository.count_classes(),
+        "total_masteries": repository.count_masteries(),
+        "query": parsed,
+        "warning_count": 0,
+        "warnings": [],
+        "export_policy": "v2_class_mastery_bundle",
+        "export_status": "pass" if summary.get("validation_error_count", 0) == 0 else "blocked",
+        "summary": summary,
         "records": records,
     }

--- a/backend/scripts/report_v2_class_mastery_bundle.py
+++ b/backend/scripts/report_v2_class_mastery_bundle.py
@@ -1,0 +1,590 @@
+"""Generate the v2 canonical class/mastery bundle."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections import Counter, defaultdict
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "backend"))
+
+from app.data_contracts import SupportStatus, TrustLevel, validate_canonical_id
+
+
+DEFAULT_SOURCE_CLASSES = Path(r"D:\Forge\last-epoch-data\exports_json\classes.json")
+DEFAULT_AFFIX_BUNDLE = ROOT / "docs" / "generated" / "v2_affix_bundle.json"
+DEFAULT_ITEM_BASE_BUNDLE = ROOT / "docs" / "generated" / "v2_item_base_bundle.json"
+DEFAULT_UNIQUE_BUNDLE = ROOT / "docs" / "generated" / "v2_unique_bundle.json"
+DEFAULT_SET_BUNDLE = ROOT / "docs" / "generated" / "v2_set_bundle.json"
+DEFAULT_IDOL_BUNDLE = ROOT / "docs" / "generated" / "v2_idol_bundle.json"
+DEFAULT_IDOL_AFFIX_BUNDLE = ROOT / "docs" / "generated" / "v2_idol_affix_bundle.json"
+DEFAULT_OUTPUT = ROOT / "docs" / "generated" / "v2_class_mastery_bundle.json"
+DEFAULT_VALIDATION_OUTPUT = ROOT / "docs" / "generated" / "v2_class_mastery_validation_report.json"
+DEFAULT_MARKDOWN_OUTPUT = ROOT / "docs" / "migration" / "V2_CLASS_MASTERY_MIGRATION.md"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Build the v2 class/mastery bundle.")
+    parser.add_argument("--source-classes", type=Path, default=DEFAULT_SOURCE_CLASSES)
+    parser.add_argument("--affix-bundle", type=Path, default=DEFAULT_AFFIX_BUNDLE)
+    parser.add_argument("--item-base-bundle", type=Path, default=DEFAULT_ITEM_BASE_BUNDLE)
+    parser.add_argument("--unique-bundle", type=Path, default=DEFAULT_UNIQUE_BUNDLE)
+    parser.add_argument("--set-bundle", type=Path, default=DEFAULT_SET_BUNDLE)
+    parser.add_argument("--idol-bundle", type=Path, default=DEFAULT_IDOL_BUNDLE)
+    parser.add_argument("--idol-affix-bundle", type=Path, default=DEFAULT_IDOL_AFFIX_BUNDLE)
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument("--validation-output", type=Path, default=DEFAULT_VALIDATION_OUTPUT)
+    parser.add_argument("--markdown-output", type=Path, default=DEFAULT_MARKDOWN_OUTPUT)
+    return parser.parse_args()
+
+
+def build_v2_class_mastery_bundle(
+    source_classes: Path,
+    *,
+    reference_bundle_paths: list[Path] | None = None,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    source = _read_json(source_classes, "class source")
+    class_records: list[dict[str, Any]] = []
+    mastery_records: list[dict[str, Any]] = []
+
+    for raw_class in source.get("classes") or []:
+        if not isinstance(raw_class, dict):
+            continue
+        class_id = _class_id(raw_class)
+        mastery_ids: list[str] = []
+        for index, raw_mastery in enumerate(raw_class.get("masteries") or []):
+            if not isinstance(raw_mastery, dict) or index == 0:
+                continue
+            mastery_id = _mastery_id(raw_class, raw_mastery)
+            mastery_ids.append(mastery_id)
+            mastery_records.append(_mastery_record(source_classes, source, raw_class, raw_mastery, index, class_id, mastery_id))
+        class_records.append(_class_record(source_classes, source, raw_class, class_id, mastery_ids))
+
+    cross_reference = collect_class_mastery_cross_references(
+        reference_bundle_paths or [
+            DEFAULT_AFFIX_BUNDLE,
+            DEFAULT_ITEM_BASE_BUNDLE,
+            DEFAULT_UNIQUE_BUNDLE,
+            DEFAULT_SET_BUNDLE,
+            DEFAULT_IDOL_BUNDLE,
+            DEFAULT_IDOL_AFFIX_BUNDLE,
+        ],
+        class_records,
+        mastery_records,
+    )
+    _attach_restriction_coverage(class_records, mastery_records, cross_reference)
+    validation = validate_v2_class_mastery_records(class_records, mastery_records, cross_reference)
+    bundle = {
+        "schema_version": "v2.class_mastery_bundle.1",
+        "generated_on": date.today().isoformat(),
+        "source_classes_path": str(source_classes),
+        "source_metadata": source.get("_meta", {}),
+        "summary": _bundle_summary(class_records, mastery_records, validation, cross_reference),
+        "records": {"classes": class_records, "masteries": mastery_records},
+        "cross_reference": cross_reference,
+        "metadata": _metadata(),
+    }
+    return bundle, validation
+
+
+def validate_v2_class_mastery_records(
+    classes: list[dict[str, Any]],
+    masteries: list[dict[str, Any]],
+    cross_reference: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    errors: list[dict[str, Any]] = []
+    warnings: list[dict[str, Any]] = []
+    class_ids = _validate_common_records(classes, "class", errors)
+    mastery_ids = _validate_common_records(masteries, "mastery", errors)
+
+    for record in classes:
+        canonical_id = record.get("canonical_id")
+        if not isinstance(record.get("mastery_ids"), list):
+            errors.append(_error(canonical_id, "invalid_mastery_links", "Class mastery_ids must be a list."))
+            continue
+        for mastery_id in record.get("mastery_ids") or []:
+            if mastery_id not in mastery_ids:
+                errors.append(_error(canonical_id, "class_links_missing_mastery", f"Class links missing mastery {mastery_id}."))
+        if not isinstance(record.get("known_restriction_labels"), list):
+            errors.append(_error(canonical_id, "invalid_restriction_labels", "known_restriction_labels must be a list."))
+        if record.get("manual_bridge") is True and record.get("trust_level") != TrustLevel.MANUAL_BRIDGE.value:
+            errors.append(_error(canonical_id, "manual_bridge_not_marked", "Manual bridges must use trust_level manual_bridge."))
+        if record.get("stable_calculable") is True:
+            errors.append(_error(canonical_id, "unsupported_stable_calculation", "Classes are not stable-calculable in Phase 7."))
+
+    for record in masteries:
+        canonical_id = record.get("canonical_id")
+        if record.get("class_id") not in class_ids:
+            errors.append(_error(canonical_id, "mastery_parent_missing", f"Mastery parent class is missing: {record.get('class_id')}."))
+        if not isinstance(record.get("known_restriction_labels"), list):
+            errors.append(_error(canonical_id, "invalid_restriction_labels", "known_restriction_labels must be a list."))
+        if record.get("manual_bridge") is True and record.get("trust_level") != TrustLevel.MANUAL_BRIDGE.value:
+            errors.append(_error(canonical_id, "manual_bridge_not_marked", "Manual bridges must use trust_level manual_bridge."))
+        if record.get("stable_calculable") is True:
+            errors.append(_error(canonical_id, "unsupported_stable_calculation", "Masteries are not stable-calculable in Phase 7."))
+
+    for label in (cross_reference or {}).get("unmapped_labels", []):
+        warnings.append(_warning("cross_reference", "unmapped_restriction_label", f"Restriction label did not map to a class/mastery record: {label}."))
+
+    return {
+        "summary": {
+            "class_count": len(classes),
+            "mastery_count": len(masteries),
+            "error_count": len(errors),
+            "warning_count": len(warnings),
+            "duplicate_class_id_count": _count_code(errors, "duplicate_class_id"),
+            "duplicate_mastery_id_count": _count_code(errors, "duplicate_mastery_id"),
+            "missing_provenance_count": _count_code(errors, "missing_provenance"),
+            "missing_support_status_count": _count_code(errors, "missing_support_status"),
+            "invalid_trust_level_count": _count_code(errors, "invalid_trust_level"),
+            "mastery_parent_missing_count": _count_code(errors, "mastery_parent_missing"),
+            "class_links_missing_mastery_count": _count_code(errors, "class_links_missing_mastery"),
+            "manual_bridge_not_marked_count": _count_code(errors, "manual_bridge_not_marked"),
+            "manual_bridge_count": sum(1 for record in [*classes, *masteries] if record.get("trust_level") == TrustLevel.MANUAL_BRIDGE.value),
+            "stable_calculable_count": 0,
+            "production_consumed": False,
+        },
+        "errors": errors,
+        "warnings": warnings,
+        "cross_reference": cross_reference or {},
+        "metadata": _metadata(),
+    }
+
+
+def collect_class_mastery_cross_references(
+    bundle_paths: list[Path],
+    classes: list[dict[str, Any]],
+    masteries: list[dict[str, Any]],
+) -> dict[str, Any]:
+    class_lookup = {_normalize_label(record["display_name"]): record["canonical_id"] for record in classes}
+    mastery_lookup = {_normalize_label(record["display_name"]): record["canonical_id"] for record in masteries}
+    label_counts: Counter[str] = Counter()
+    source_breakdown: dict[str, Counter[str]] = defaultdict(Counter)
+    mapped_labels: dict[str, dict[str, Any]] = {}
+
+    for path in bundle_paths:
+        if not path.exists():
+            continue
+        payload = _read_json(path, "reference bundle")
+        for collection_name, records in (payload.get("records") or {}).items():
+            if not isinstance(records, list):
+                continue
+            source_key = f"{path.name}:{collection_name}"
+            for record in records:
+                if not isinstance(record, dict):
+                    continue
+                for label in _restriction_labels(record):
+                    label_counts[label] += 1
+                    source_breakdown[label][source_key] += 1
+
+    for label, count in sorted(label_counts.items()):
+        normalized = _normalize_label(label)
+        class_id = class_lookup.get(normalized)
+        mastery_id = mastery_lookup.get(normalized)
+        if class_id or mastery_id:
+            mapped_labels[label] = {
+                "label": label,
+                "count": count,
+                "mapped_class_id": class_id,
+                "mapped_mastery_id": mastery_id,
+                "source_breakdown": dict(sorted(source_breakdown[label].items())),
+            }
+
+    return {
+        "restriction_label_count": sum(label_counts.values()),
+        "unique_restriction_label_count": len(label_counts),
+        "mapped_label_count": len(mapped_labels),
+        "unmapped_label_count": len(label_counts) - len(mapped_labels),
+        "labels": [
+            {
+                "label": label,
+                "count": count,
+                "mapped_class_id": mapped_labels.get(label, {}).get("mapped_class_id"),
+                "mapped_mastery_id": mapped_labels.get(label, {}).get("mapped_mastery_id"),
+                "source_breakdown": dict(sorted(source_breakdown[label].items())),
+            }
+            for label, count in sorted(label_counts.items())
+        ],
+        "mapped_labels": list(mapped_labels.values()),
+        "unmapped_labels": [label for label in sorted(label_counts) if label not in mapped_labels],
+    }
+
+
+def render_markdown(bundle: dict[str, Any], validation: dict[str, Any], *, command: str) -> str:
+    summary = bundle["summary"]
+    class_rows = "\n".join(
+        f"| `{record['canonical_id']}` | {record['display_name']} | {len(record['mastery_ids'])} | {', '.join(record['known_restriction_labels']) or 'None'} |"
+        for record in bundle["records"]["classes"]
+    )
+    mastery_rows = "\n".join(
+        f"| `{record['canonical_id']}` | {record['display_name']} | `{record['class_id']}` | {', '.join(record['known_restriction_labels']) or 'None'} |"
+        for record in bundle["records"]["masteries"]
+    )
+    cross_rows = "\n".join(
+        f"| {entry['label']} | {entry['count']} | `{entry.get('mapped_class_id') or ''}` | `{entry.get('mapped_mastery_id') or ''}` |"
+        for entry in bundle["cross_reference"]["labels"]
+    ) or "| None | 0 |  |  |"
+    return f"""# v2 Class and Mastery Migration
+
+## Purpose
+
+Phase 7 creates a read-only canonical class/mastery bundle from the extracted class registry. The bundle is used for diagnostics, validation, and future class/mastery references only.
+
+This phase does not implement passive trees, skill trees, planner remapping, or stable-calculable class behavior.
+
+## Generation Command
+
+```powershell
+{command}
+```
+
+## Summary
+
+- Class count: {summary["class_count"]}
+- Mastery count: {summary["mastery_count"]}
+- Restriction labels found in existing v2 bundles: {summary["unique_restriction_label_count"]}
+- Restriction labels mapped to class/mastery records: {summary["mapped_restriction_label_count"]}
+- Restriction labels unmapped: {summary["unmapped_restriction_label_count"]}
+- Manual bridge count: {summary["manual_bridge_count"]}
+- Stable-calculable count: 0
+- Validation errors: {validation["summary"]["error_count"]}
+- Validation warnings: {validation["summary"]["warning_count"]}
+- Production consumed: false
+
+## Classes
+
+| Canonical ID | Display name | Masteries | Existing restriction labels |
+| --- | --- | ---: | --- |
+{class_rows}
+
+## Masteries
+
+| Canonical ID | Display name | Parent class | Existing restriction labels |
+| --- | --- | --- | --- |
+{mastery_rows}
+
+## Cross-Reference Findings
+
+| Restriction label | Count | Class mapping | Mastery mapping |
+| --- | ---: | --- | --- |
+{cross_rows}
+
+Existing generated v2 affix, item, unique/set, and idol bundles were scanned for class/mastery restriction labels. The scan reports mappings only; it does not rewrite prior bundles.
+
+## Manual Bridge Findings
+
+Manual bridge records: {summary["manual_bridge_count"]}
+
+The extracted class registry provided class and mastery records for this phase, so no manual bridge was needed. If later phases add temporary bridge records, they must use `trust_level: manual_bridge` and explain the source gap in provenance.
+
+## Migration Implications
+
+- Classes and masteries are available for experimental lookup and debug inspection.
+- Records remain `partial` because passives, skills, and modifier normalization are not complete.
+- Restriction labels from prior v2 bundles can now be audited against canonical class/mastery records.
+- Existing planner, crafting, stat aggregation, and simulation behavior remain unchanged.
+
+## Deferred
+
+- Passive tree generation and validation.
+- Skill tree generation and validation.
+- Planner remapping to canonical class/mastery IDs.
+- Stable planner eligibility for class/mastery-linked effects.
+
+## Recommended Next Step
+
+Proceed to Phase 8 passive infrastructure after Checkpoint 7 review.
+"""
+
+
+def write_outputs(bundle: dict[str, Any], validation: dict[str, Any], markdown: str, output: Path, validation_output: Path, markdown_output: Path) -> None:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    validation_output.parent.mkdir(parents=True, exist_ok=True)
+    markdown_output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(bundle, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    validation_output.write_text(json.dumps(validation, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    markdown_output.write_text(markdown, encoding="utf-8")
+
+
+def _class_record(source_path: Path, source: dict[str, Any], raw_class: dict[str, Any], canonical_id: str, mastery_ids: list[str]) -> dict[str, Any]:
+    display_name = _display_name(raw_class)
+    skill_source_ids = _class_skill_source_ids(raw_class)
+    passive_tree_ids = [f"passive_tree:{_slug(raw_class.get('treeID'))}"] if raw_class.get("treeID") else []
+    return {
+        "canonical_id": canonical_id,
+        "display_name": display_name,
+        "source_id": f"class:{raw_class.get('id')}",
+        "source_file": str(source_path),
+        "patch_version": _patch_version(source),
+        "support_status": SupportStatus.PARTIAL.value,
+        "trust_level": TrustLevel.GENERATED_FROM_GAME_DATA.value,
+        "provenance": _provenance(source_path, f"class:{raw_class.get('id')}", "generated_from_game_data", "Extracted class registry record."),
+        "source_class_id": raw_class.get("id"),
+        "source_tree_id": raw_class.get("treeID"),
+        "mastery_ids": mastery_ids,
+        "passive_tree_ids": passive_tree_ids,
+        "skill_ids": skill_source_ids,
+        "linked_skill_source_ids": skill_source_ids,
+        "linked_passive_tree_source_ids": [raw_class.get("treeID")] if raw_class.get("treeID") else [],
+        "known_restriction_labels": [],
+        "base_stats": raw_class.get("stats") or {},
+        "stable_calculable": False,
+        "manual_bridge": False,
+        "warnings": [],
+        "raw_reference": {"source_class_id": raw_class.get("id"), "treeID": raw_class.get("treeID")},
+        "normalized_fields": {"canonical_kind": "class"},
+        "consumer_safe_fields": {"planner_consumed": False, "debug_only": True},
+    }
+
+
+def _mastery_record(
+    source_path: Path,
+    source: dict[str, Any],
+    raw_class: dict[str, Any],
+    raw_mastery: dict[str, Any],
+    source_index: int,
+    class_id: str,
+    mastery_id: str,
+) -> dict[str, Any]:
+    display_name = _display_name(raw_mastery)
+    skill_source_ids = _mastery_skill_source_ids(raw_mastery)
+    return {
+        "canonical_id": mastery_id,
+        "display_name": display_name,
+        "source_id": f"class:{raw_class.get('id')}:mastery:{source_index}",
+        "source_file": str(source_path),
+        "patch_version": _patch_version(source),
+        "support_status": SupportStatus.PARTIAL.value,
+        "trust_level": TrustLevel.GENERATED_FROM_GAME_DATA.value,
+        "provenance": _provenance(source_path, f"class:{raw_class.get('id')}:mastery:{source_index}", "generated_from_game_data", "Extracted mastery entry nested under class registry record."),
+        "source_class_id": raw_class.get("id"),
+        "source_mastery_index": source_index,
+        "source_mastery_id": raw_mastery.get("localizationKey") or raw_mastery.get("name"),
+        "class_id": class_id,
+        "passive_tree_ids": [],
+        "skill_ids": skill_source_ids,
+        "linked_skill_source_ids": skill_source_ids,
+        "linked_passive_tree_source_ids": [],
+        "known_restriction_labels": [],
+        "stable_calculable": False,
+        "manual_bridge": False,
+        "warnings": [],
+        "raw_reference": {
+            "source_class_id": raw_class.get("id"),
+            "source_mastery_index": source_index,
+            "localizationKey": raw_mastery.get("localizationKey"),
+            "masteryAbilityPathId": raw_mastery.get("masteryAbilityPathId"),
+        },
+        "normalized_fields": {"canonical_kind": "mastery"},
+        "consumer_safe_fields": {"planner_consumed": False, "debug_only": True},
+    }
+
+
+def _attach_restriction_coverage(classes: list[dict[str, Any]], masteries: list[dict[str, Any]], cross_reference: dict[str, Any]) -> None:
+    labels_by_class: dict[str, list[str]] = defaultdict(list)
+    labels_by_mastery: dict[str, list[str]] = defaultdict(list)
+    for entry in cross_reference.get("mapped_labels") or []:
+        if entry.get("mapped_class_id"):
+            labels_by_class[entry["mapped_class_id"]].append(entry["label"])
+        if entry.get("mapped_mastery_id"):
+            labels_by_mastery[entry["mapped_mastery_id"]].append(entry["label"])
+    for record in classes:
+        record["known_restriction_labels"] = sorted(labels_by_class.get(record["canonical_id"], []))
+    for record in masteries:
+        record["known_restriction_labels"] = sorted(labels_by_mastery.get(record["canonical_id"], []))
+
+
+def _validate_common_records(records: list[dict[str, Any]], kind: str, errors: list[dict[str, Any]]) -> set[str]:
+    seen: set[str] = set()
+    ids: set[str] = set()
+    for record in records:
+        canonical_id = record.get("canonical_id")
+        try:
+            validate_canonical_id(canonical_id)
+        except ValueError as exc:
+            errors.append(_error(canonical_id, f"invalid_{kind}_id", str(exc)))
+            continue
+        if canonical_id in seen:
+            errors.append(_error(canonical_id, f"duplicate_{kind}_id", f"Duplicate {kind} canonical_id."))
+        seen.add(canonical_id)
+        ids.add(canonical_id)
+        if not record.get("display_name"):
+            errors.append(_error(canonical_id, "missing_display_name", "display_name is required."))
+        provenance = record.get("provenance")
+        if not isinstance(provenance, dict) or not provenance.get("source_path") or not provenance.get("source_id"):
+            errors.append(_error(canonical_id, "missing_provenance", "provenance.source_path and provenance.source_id are required."))
+        if not record.get("support_status"):
+            errors.append(_error(canonical_id, "missing_support_status", "support_status is required."))
+        else:
+            try:
+                SupportStatus(str(record.get("support_status")))
+            except ValueError:
+                errors.append(_error(canonical_id, "invalid_support_status", "support_status is invalid."))
+        try:
+            TrustLevel(str(record.get("trust_level")))
+        except ValueError:
+            errors.append(_error(canonical_id, "invalid_trust_level", "trust_level is invalid."))
+        if record.get("trust_level") in {TrustLevel.GAME_EXTRACTED.value, TrustLevel.GENERATED_FROM_GAME_DATA.value} and not record.get("source_file"):
+            errors.append(_error(canonical_id, "missing_source_reference", "Generated/extracted records require source_file."))
+    return ids
+
+
+def _restriction_labels(record: dict[str, Any]) -> list[str]:
+    labels: list[str] = []
+    for key in ("class_restrictions", "mastery_restrictions"):
+        values = record.get(key)
+        if isinstance(values, list):
+            labels.extend(str(value) for value in values if value not in (None, "", "Any"))
+        elif values not in (None, "", "Any"):
+            labels.append(str(values))
+    return labels
+
+
+def _bundle_summary(classes: list[dict[str, Any]], masteries: list[dict[str, Any]], validation: dict[str, Any], cross_reference: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "class_count": len(classes),
+        "mastery_count": len(masteries),
+        "support_status_counts": dict(Counter(record["support_status"] for record in [*classes, *masteries])),
+        "trust_level_counts": dict(Counter(record["trust_level"] for record in [*classes, *masteries])),
+        "manual_bridge_count": validation["summary"]["manual_bridge_count"],
+        "stable_calculable_count": 0,
+        "unique_restriction_label_count": cross_reference["unique_restriction_label_count"],
+        "mapped_restriction_label_count": cross_reference["mapped_label_count"],
+        "unmapped_restriction_label_count": cross_reference["unmapped_label_count"],
+        "validation_error_count": validation["summary"]["error_count"],
+        "validation_warning_count": validation["summary"]["warning_count"],
+        "production_consumed": False,
+    }
+
+
+def _class_id(raw_class: dict[str, Any]) -> str:
+    return f"class:{_slug(_display_name(raw_class))}"
+
+
+def _mastery_id(raw_class: dict[str, Any], raw_mastery: dict[str, Any]) -> str:
+    return f"mastery:{_slug(_display_name(raw_class))}:{_slug(_display_name(raw_mastery))}"
+
+
+def _display_name(record: dict[str, Any]) -> str:
+    return str(record.get("displayName") or record.get("name") or record.get("localizationKey") or "Unknown")
+
+
+def _class_skill_source_ids(raw_class: dict[str, Any]) -> list[str]:
+    ids: set[int] = set()
+    abilities = raw_class.get("abilities") or {}
+    for value in abilities.get("defaultPathIds") or []:
+        if isinstance(value, int) and value:
+            ids.add(value)
+    for value in abilities.get("knownPathIds") or []:
+        if isinstance(value, int) and value:
+            ids.add(value)
+    for entry in abilities.get("unlockable") or []:
+        if isinstance(entry, dict) and isinstance(entry.get("abilityPathId"), int) and entry.get("abilityPathId"):
+            ids.add(entry["abilityPathId"])
+    return [f"skill_path:{value}" for value in sorted(ids)]
+
+
+def _mastery_skill_source_ids(raw_mastery: dict[str, Any]) -> list[str]:
+    ids: set[int] = set()
+    if isinstance(raw_mastery.get("masteryAbilityPathId"), int) and raw_mastery.get("masteryAbilityPathId"):
+        ids.add(raw_mastery["masteryAbilityPathId"])
+    for value in raw_mastery.get("abilityPathIds") or []:
+        if isinstance(value, int) and value:
+            ids.add(value)
+    return [f"skill_path:{value}" for value in sorted(ids)]
+
+
+def _provenance(source_path: Path, source_id: str, source_type: str, note: str) -> dict[str, Any]:
+    return {
+        "source_path": str(source_path),
+        "source_id": source_id,
+        "source_type": source_type,
+        "extraction_method": "last_epoch_data_export",
+        "notes": [note],
+    }
+
+
+def _patch_version(source: dict[str, Any]) -> str | None:
+    install_path = str((source.get("_meta") or {}).get("game_build", {}).get("installPath") or "")
+    return Path(install_path).name or None
+
+
+def _metadata() -> dict[str, Any]:
+    return {
+        "source": "v2_class_mastery_bundle",
+        "read_only": True,
+        "experimental": True,
+        "production_safe": False,
+        "production_consumed": False,
+    }
+
+
+def _read_json(path: Path, label: str) -> dict[str, Any]:
+    if not path.exists():
+        raise FileNotFoundError(f"{label} not found: {path}")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{label} must be a JSON object: {path}")
+    return payload
+
+
+def _slug(value: Any) -> str:
+    text = str(value or "unknown").strip().lower()
+    text = re.sub(r"[^a-z0-9]+", "_", text)
+    return text.strip("_") or "unknown"
+
+
+def _normalize_label(value: Any) -> str:
+    return _slug(value).replace("_", "")
+
+
+def _error(record_id: Any, code: str, message: str) -> dict[str, Any]:
+    return {"record_id": record_id, "severity": "error", "code": code, "message": message}
+
+
+def _warning(record_id: Any, code: str, message: str) -> dict[str, Any]:
+    return {"record_id": record_id, "severity": "warning", "code": code, "message": message}
+
+
+def _count_code(entries: list[dict[str, Any]], code: str) -> int:
+    return sum(1 for entry in entries if entry.get("code") == code)
+
+
+def main() -> int:
+    args = parse_args()
+    reference_paths = [
+        args.affix_bundle,
+        args.item_base_bundle,
+        args.unique_bundle,
+        args.set_bundle,
+        args.idol_bundle,
+        args.idol_affix_bundle,
+    ]
+    bundle, validation = build_v2_class_mastery_bundle(args.source_classes, reference_bundle_paths=reference_paths)
+    command = (
+        ".\\backend\\.venv\\Scripts\\python.exe backend\\scripts\\report_v2_class_mastery_bundle.py "
+        f"--source-classes {args.source_classes} "
+        f"--affix-bundle {args.affix_bundle} "
+        f"--item-base-bundle {args.item_base_bundle} "
+        f"--unique-bundle {args.unique_bundle} "
+        f"--set-bundle {args.set_bundle} "
+        f"--idol-bundle {args.idol_bundle} "
+        f"--idol-affix-bundle {args.idol_affix_bundle} "
+        f"--output {args.output} "
+        f"--validation-output {args.validation_output} "
+        f"--markdown-output {args.markdown_output}"
+    )
+    write_outputs(bundle, validation, render_markdown(bundle, validation, command=command), args.output, args.validation_output, args.markdown_output)
+    print(json.dumps(bundle["summary"], indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_v2_class_mastery_infrastructure.py
+++ b/backend/tests/test_v2_class_mastery_infrastructure.py
@@ -1,0 +1,189 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from app.repositories.v2.class_mastery_repository import V2ClassMasteryBundleError, V2ClassMasteryRepository
+from scripts.report_v2_class_mastery_bundle import build_v2_class_mastery_bundle, validate_v2_class_mastery_records
+
+
+def test_v2_class_mastery_bundle_generation(tmp_path):
+    source, references = _write_sources(tmp_path)
+
+    bundle, validation = build_v2_class_mastery_bundle(source, reference_bundle_paths=references)
+
+    assert bundle["summary"]["class_count"] == 1
+    assert bundle["summary"]["mastery_count"] == 1
+    assert bundle["summary"]["mapped_restriction_label_count"] == 2
+    assert validation["summary"]["error_count"] == 0
+    class_record = bundle["records"]["classes"][0]
+    mastery_record = bundle["records"]["masteries"][0]
+    assert class_record["canonical_id"] == "class:mage"
+    assert class_record["mastery_ids"] == ["mastery:mage:runemaster"]
+    assert class_record["known_restriction_labels"] == ["Mage"]
+    assert mastery_record["canonical_id"] == "mastery:mage:runemaster"
+    assert mastery_record["class_id"] == "class:mage"
+    assert mastery_record["known_restriction_labels"] == ["Runemaster"]
+    assert class_record["stable_calculable"] is False
+
+
+def test_v2_class_mastery_validation_detects_duplicate_ids(tmp_path):
+    bundle, _validation = _bundle(tmp_path)
+    classes = bundle["records"]["classes"]
+    masteries = bundle["records"]["masteries"]
+    classes.append(dict(classes[0]))
+    masteries.append(dict(masteries[0]))
+
+    report = validate_v2_class_mastery_records(classes, masteries)
+
+    assert report["summary"]["duplicate_class_id_count"] == 1
+    assert report["summary"]["duplicate_mastery_id_count"] == 1
+    with pytest.raises(V2ClassMasteryBundleError, match="Duplicate canonical_id"):
+        V2ClassMasteryRepository("<bundle>").load_payload(bundle)
+
+
+def test_v2_class_mastery_validation_detects_missing_parent_and_class_link(tmp_path):
+    bundle, _validation = _bundle(tmp_path)
+    bundle["records"]["classes"][0]["mastery_ids"] = ["mastery:mage:missing"]
+    bundle["records"]["masteries"][0]["class_id"] = "class:missing"
+
+    report = validate_v2_class_mastery_records(bundle["records"]["classes"], bundle["records"]["masteries"])
+
+    assert report["summary"]["class_links_missing_mastery_count"] == 1
+    assert report["summary"]["mastery_parent_missing_count"] == 1
+    with pytest.raises(V2ClassMasteryBundleError, match="links missing mastery"):
+        V2ClassMasteryRepository("<bundle>").load_payload(bundle)
+
+
+def test_v2_class_mastery_validation_requires_provenance_and_support_status(tmp_path):
+    bundle, _validation = _bundle(tmp_path)
+    bundle["records"]["classes"][0]["provenance"] = {}
+    bundle["records"]["masteries"][0].pop("support_status")
+
+    report = validate_v2_class_mastery_records(bundle["records"]["classes"], bundle["records"]["masteries"])
+
+    assert report["summary"]["missing_provenance_count"] == 1
+    assert report["summary"]["missing_support_status_count"] == 1
+    with pytest.raises(V2ClassMasteryBundleError, match="missing provenance"):
+        V2ClassMasteryRepository("<bundle>").load_payload(bundle)
+
+
+def test_v2_class_mastery_validation_requires_manual_bridge_marking(tmp_path):
+    bundle, _validation = _bundle(tmp_path)
+    bundle["records"]["classes"][0]["manual_bridge"] = True
+
+    report = validate_v2_class_mastery_records(bundle["records"]["classes"], bundle["records"]["masteries"])
+
+    assert report["summary"]["manual_bridge_not_marked_count"] == 1
+    with pytest.raises(V2ClassMasteryBundleError, match="manual bridge"):
+        V2ClassMasteryRepository("<bundle>").load_payload(bundle)
+
+
+def test_v2_class_mastery_repository_lookup_filter_and_debug(tmp_path):
+    bundle, _validation = _bundle(tmp_path)
+    repository = V2ClassMasteryRepository("<bundle>").load_payload(bundle)
+
+    assert repository.count_classes() == 1
+    assert repository.count_masteries() == 1
+    assert repository.get_class("class:mage")["display_name"] == "Mage"
+    assert repository.get_mastery("mastery:mage:runemaster")["display_name"] == "Runemaster"
+    assert repository.filter_classes(query="mage")[0]["canonical_id"] == "class:mage"
+    assert repository.filter_masteries(class_id="class:mage")[0]["canonical_id"] == "mastery:mage:runemaster"
+    assert repository.get_masteries_by_class("class:mage")[0]["canonical_id"] == "mastery:mage:runemaster"
+    assert repository.debug_summary()["production_consumer"] is False
+
+
+def test_v2_class_mastery_routes(app, tmp_path):
+    bundle, _validation = _bundle(tmp_path)
+    path = tmp_path / "v2_class_mastery_bundle.json"
+    path.write_text(json.dumps(bundle), encoding="utf-8")
+    app.config["V2_CLASS_MASTERY_BUNDLE_PATH"] = str(path)
+    client = app.test_client()
+
+    classes = client.get("/experimental/v2/classes?q=mage")
+    assert classes.status_code == 200
+    assert classes.get_json()["records"][0]["canonical_id"] == "class:mage"
+
+    detail = client.get("/experimental/v2/classes/class:mage")
+    assert detail.status_code == 200
+    assert detail.get_json()["masteries"][0]["canonical_id"] == "mastery:mage:runemaster"
+
+    masteries = client.get("/experimental/v2/masteries?class_id=class:mage")
+    assert masteries.status_code == 200
+    assert masteries.get_json()["records"][0]["canonical_id"] == "mastery:mage:runemaster"
+
+    mastery_detail = client.get("/experimental/v2/masteries/mastery:mage:runemaster")
+    assert mastery_detail.status_code == 200
+    assert mastery_detail.get_json()["record"]["class_id"] == "class:mage"
+
+    debug = client.get("/experimental/v2/classes/debug")
+    assert debug.status_code == 200
+    assert debug.get_json()["debug_summary"]["production_safe"] is False
+
+
+def test_v2_class_mastery_bundle_is_not_referenced_by_production_modules():
+    root = Path(__file__).resolve().parents[2]
+    allowed = {
+        root / "backend" / "app" / "routes" / "experimental.py",
+        root / "backend" / "app" / "repositories" / "v2" / "class_mastery_repository.py",
+        root / "backend" / "app" / "repositories" / "v2" / "__init__.py",
+        root / "backend" / "scripts" / "report_v2_class_mastery_bundle.py",
+        Path(__file__).resolve(),
+    }
+    needles = ("v2_class_mastery_bundle.json", "V2ClassMasteryRepository")
+    offenders: list[str] = []
+    for path in (root / "backend" / "app").rglob("*.py"):
+        if path in allowed or "__pycache__" in path.parts:
+            continue
+        text = path.read_text(encoding="utf-8")
+        if any(needle in text for needle in needles):
+            offenders.append(str(path.relative_to(root)))
+
+    assert offenders == []
+
+
+def _bundle(tmp_path: Path) -> tuple[dict, dict]:
+    source, references = _write_sources(tmp_path)
+    return build_v2_class_mastery_bundle(source, reference_bundle_paths=references)
+
+
+def _write_sources(tmp_path: Path) -> tuple[Path, list[Path]]:
+    source = tmp_path / "classes.json"
+    reference = tmp_path / "v2_affix_bundle.json"
+    source.write_text(json.dumps(_source_classes()), encoding="utf-8")
+    reference.write_text(json.dumps(_reference_bundle()), encoding="utf-8")
+    return source, [reference]
+
+
+def _source_classes() -> dict:
+    return {
+        "_meta": {"game_build": {"installPath": "D:\\LastEpochTools\\game_files\\current\\1.4.6_22986002"}},
+        "classes": [
+            {
+                "id": 1,
+                "name": "Mage",
+                "displayName": "Mage",
+                "treeID": "mg-1",
+                "stats": {"baseHealth": 100},
+                "abilities": {"defaultPathIds": [101], "knownPathIds": [102], "unlockable": [{"abilityPathId": 103, "level": 2}]},
+                "masteries": [
+                    {"name": "Mage", "localizationKey": "Class_Mage", "masteryAbilityPathId": 0, "abilityPathIds": []},
+                    {"name": "Runemaster", "localizationKey": "Mastery_Runemaster", "masteryAbilityPathId": 201, "abilityPathIds": [202]},
+                ],
+            }
+        ],
+    }
+
+
+def _reference_bundle() -> dict:
+    return {
+        "records": {
+            "affixes": [
+                {
+                    "canonical_id": "affix:equipment:1",
+                    "class_restrictions": ["Mage"],
+                    "mastery_restrictions": ["Runemaster"],
+                }
+            ]
+        }
+    }

--- a/docs/generated/v2_class_mastery_bundle.json
+++ b/docs/generated/v2_class_mastery_bundle.json
@@ -1,0 +1,1325 @@
+{
+  "cross_reference": {
+    "labels": [
+      {
+        "count": 46,
+        "label": "Acolyte",
+        "mapped_class_id": "class:acolyte",
+        "mapped_mastery_id": null,
+        "source_breakdown": {
+          "v2_idol_bundle.json:idols": 12,
+          "v2_item_base_bundle.json:item_bases": 34
+        }
+      },
+      {
+        "count": 46,
+        "label": "Mage",
+        "mapped_class_id": "class:mage",
+        "mapped_mastery_id": null,
+        "source_breakdown": {
+          "v2_idol_bundle.json:idols": 12,
+          "v2_item_base_bundle.json:item_bases": 34
+        }
+      },
+      {
+        "count": 48,
+        "label": "Primalist",
+        "mapped_class_id": "class:primalist",
+        "mapped_mastery_id": null,
+        "source_breakdown": {
+          "v2_idol_bundle.json:idols": 12,
+          "v2_item_base_bundle.json:item_bases": 36
+        }
+      }
+    ],
+    "mapped_label_count": 3,
+    "mapped_labels": [
+      {
+        "count": 46,
+        "label": "Acolyte",
+        "mapped_class_id": "class:acolyte",
+        "mapped_mastery_id": null,
+        "source_breakdown": {
+          "v2_idol_bundle.json:idols": 12,
+          "v2_item_base_bundle.json:item_bases": 34
+        }
+      },
+      {
+        "count": 46,
+        "label": "Mage",
+        "mapped_class_id": "class:mage",
+        "mapped_mastery_id": null,
+        "source_breakdown": {
+          "v2_idol_bundle.json:idols": 12,
+          "v2_item_base_bundle.json:item_bases": 34
+        }
+      },
+      {
+        "count": 48,
+        "label": "Primalist",
+        "mapped_class_id": "class:primalist",
+        "mapped_mastery_id": null,
+        "source_breakdown": {
+          "v2_idol_bundle.json:idols": 12,
+          "v2_item_base_bundle.json:item_bases": 36
+        }
+      }
+    ],
+    "restriction_label_count": 140,
+    "unique_restriction_label_count": 3,
+    "unmapped_label_count": 0,
+    "unmapped_labels": []
+  },
+  "generated_on": "2026-05-12",
+  "metadata": {
+    "experimental": true,
+    "production_consumed": false,
+    "production_safe": false,
+    "read_only": true,
+    "source": "v2_class_mastery_bundle"
+  },
+  "records": {
+    "classes": [
+      {
+        "base_stats": {
+          "baseAttunement": 1,
+          "baseDexterity": 0,
+          "baseEndurance": 0.20000000298023224,
+          "baseEnduranceThreshold": 0.0,
+          "baseHealth": 100,
+          "baseIntelligence": 0,
+          "baseMana": 50,
+          "baseMoreDoTDamageTaken": -0.15000000596046448,
+          "baseStrength": 2,
+          "baseStunAvoidance": 250,
+          "baseVitality": 0,
+          "enduranceThresholdPerHealth": 0.20000000298023224,
+          "enduranceThresholdPerLevel": 0.0,
+          "healthPerLevel": 10,
+          "healthRegen": 6.0,
+          "healthRegenPerLevel": 0.14000000059604645,
+          "manaPerLevel": 0.5050600171089172,
+          "manaRegen": 8.0,
+          "minionScaling": {
+            "firstLevelForScaling": 26,
+            "lessDamageTakenPerLevel": 0.00800000037997961,
+            "moreDamagePerLevel": 0.00800000037997961
+          },
+          "stunAvoidancePerLevel": 5.0
+        },
+        "canonical_id": "class:primalist",
+        "consumer_safe_fields": {
+          "debug_only": true,
+          "planner_consumed": false
+        },
+        "display_name": "Primalist",
+        "known_restriction_labels": [
+          "Primalist"
+        ],
+        "linked_passive_tree_source_ids": [
+          "pr-1"
+        ],
+        "linked_skill_source_ids": [
+          "skill_path:261142",
+          "skill_path:262531",
+          "skill_path:262552",
+          "skill_path:262952",
+          "skill_path:263498",
+          "skill_path:263704",
+          "skill_path:264453",
+          "skill_path:264461",
+          "skill_path:264551",
+          "skill_path:264562",
+          "skill_path:264730"
+        ],
+        "manual_bridge": false,
+        "mastery_ids": [
+          "mastery:primalist:beastmaster",
+          "mastery:primalist:shaman",
+          "mastery:primalist:druid"
+        ],
+        "normalized_fields": {
+          "canonical_kind": "class"
+        },
+        "passive_tree_ids": [
+          "passive_tree:pr_1"
+        ],
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_data_export",
+          "notes": [
+            "Extracted class registry record."
+          ],
+          "source_id": "class:0",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\classes.json",
+          "source_type": "generated_from_game_data"
+        },
+        "raw_reference": {
+          "source_class_id": 0,
+          "treeID": "pr-1"
+        },
+        "skill_ids": [
+          "skill_path:261142",
+          "skill_path:262531",
+          "skill_path:262552",
+          "skill_path:262952",
+          "skill_path:263498",
+          "skill_path:263704",
+          "skill_path:264453",
+          "skill_path:264461",
+          "skill_path:264551",
+          "skill_path:264562",
+          "skill_path:264730"
+        ],
+        "source_class_id": 0,
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\classes.json",
+        "source_id": "class:0",
+        "source_tree_id": "pr-1",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": []
+      },
+      {
+        "base_stats": {
+          "baseAttunement": 0,
+          "baseDexterity": 0,
+          "baseEndurance": 0.20000000298023224,
+          "baseEnduranceThreshold": 0.0,
+          "baseHealth": 100,
+          "baseIntelligence": 3,
+          "baseMana": 50,
+          "baseMoreDoTDamageTaken": -0.15000000596046448,
+          "baseStrength": 0,
+          "baseStunAvoidance": 250,
+          "baseVitality": 0,
+          "enduranceThresholdPerHealth": 0.20000000298023224,
+          "enduranceThresholdPerLevel": 0.0,
+          "healthPerLevel": 10,
+          "healthRegen": 6.0,
+          "healthRegenPerLevel": 0.14000000059604645,
+          "manaPerLevel": 0.5050600171089172,
+          "manaRegen": 8.0,
+          "minionScaling": {
+            "firstLevelForScaling": 26,
+            "lessDamageTakenPerLevel": 0.00800000037997961,
+            "moreDamagePerLevel": 0.00800000037997961
+          },
+          "stunAvoidancePerLevel": 5.0
+        },
+        "canonical_id": "class:mage",
+        "consumer_safe_fields": {
+          "debug_only": true,
+          "planner_consumed": false
+        },
+        "display_name": "Mage",
+        "known_restriction_labels": [
+          "Mage"
+        ],
+        "linked_passive_tree_source_ids": [
+          "mg-1"
+        ],
+        "linked_skill_source_ids": [
+          "skill_path:261142",
+          "skill_path:261591",
+          "skill_path:262431",
+          "skill_path:262458",
+          "skill_path:262497",
+          "skill_path:262912",
+          "skill_path:262953",
+          "skill_path:263025",
+          "skill_path:263498",
+          "skill_path:264309",
+          "skill_path:264355",
+          "skill_path:264554"
+        ],
+        "manual_bridge": false,
+        "mastery_ids": [
+          "mastery:mage:sorcerer",
+          "mastery:mage:spellblade",
+          "mastery:mage:runemaster"
+        ],
+        "normalized_fields": {
+          "canonical_kind": "class"
+        },
+        "passive_tree_ids": [
+          "passive_tree:mg_1"
+        ],
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_data_export",
+          "notes": [
+            "Extracted class registry record."
+          ],
+          "source_id": "class:1",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\classes.json",
+          "source_type": "generated_from_game_data"
+        },
+        "raw_reference": {
+          "source_class_id": 1,
+          "treeID": "mg-1"
+        },
+        "skill_ids": [
+          "skill_path:261142",
+          "skill_path:261591",
+          "skill_path:262431",
+          "skill_path:262458",
+          "skill_path:262497",
+          "skill_path:262912",
+          "skill_path:262953",
+          "skill_path:263025",
+          "skill_path:263498",
+          "skill_path:264309",
+          "skill_path:264355",
+          "skill_path:264554"
+        ],
+        "source_class_id": 1,
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\classes.json",
+        "source_id": "class:1",
+        "source_tree_id": "mg-1",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": []
+      },
+      {
+        "base_stats": {
+          "baseAttunement": 0,
+          "baseDexterity": 0,
+          "baseEndurance": 0.20000000298023224,
+          "baseEnduranceThreshold": 0.0,
+          "baseHealth": 100,
+          "baseIntelligence": 0,
+          "baseMana": 50,
+          "baseMoreDoTDamageTaken": -0.15000000596046448,
+          "baseStrength": 2,
+          "baseStunAvoidance": 250,
+          "baseVitality": 1,
+          "enduranceThresholdPerHealth": 0.20000000298023224,
+          "enduranceThresholdPerLevel": 0.0,
+          "healthPerLevel": 10,
+          "healthRegen": 6.0,
+          "healthRegenPerLevel": 0.14000000059604645,
+          "manaPerLevel": 0.5050600171089172,
+          "manaRegen": 8.0,
+          "minionScaling": {
+            "firstLevelForScaling": 26,
+            "lessDamageTakenPerLevel": 0.00800000037997961,
+            "moreDamagePerLevel": 0.00800000037997961
+          },
+          "stunAvoidancePerLevel": 5.0
+        },
+        "canonical_id": "class:sentinel",
+        "consumer_safe_fields": {
+          "debug_only": true,
+          "planner_consumed": false
+        },
+        "display_name": "Sentinel",
+        "known_restriction_labels": [],
+        "linked_passive_tree_source_ids": [
+          "kn-1"
+        ],
+        "linked_skill_source_ids": [
+          "skill_path:261142",
+          "skill_path:262625",
+          "skill_path:262850",
+          "skill_path:262951",
+          "skill_path:263498",
+          "skill_path:263800",
+          "skill_path:264164",
+          "skill_path:264241",
+          "skill_path:264735",
+          "skill_path:264807",
+          "skill_path:264881"
+        ],
+        "manual_bridge": false,
+        "mastery_ids": [
+          "mastery:sentinel:void_knight",
+          "mastery:sentinel:forge_guard",
+          "mastery:sentinel:paladin"
+        ],
+        "normalized_fields": {
+          "canonical_kind": "class"
+        },
+        "passive_tree_ids": [
+          "passive_tree:kn_1"
+        ],
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_data_export",
+          "notes": [
+            "Extracted class registry record."
+          ],
+          "source_id": "class:2",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\classes.json",
+          "source_type": "generated_from_game_data"
+        },
+        "raw_reference": {
+          "source_class_id": 2,
+          "treeID": "kn-1"
+        },
+        "skill_ids": [
+          "skill_path:261142",
+          "skill_path:262625",
+          "skill_path:262850",
+          "skill_path:262951",
+          "skill_path:263498",
+          "skill_path:263800",
+          "skill_path:264164",
+          "skill_path:264241",
+          "skill_path:264735",
+          "skill_path:264807",
+          "skill_path:264881"
+        ],
+        "source_class_id": 2,
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\classes.json",
+        "source_id": "class:2",
+        "source_tree_id": "kn-1",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": []
+      },
+      {
+        "base_stats": {
+          "baseAttunement": 0,
+          "baseDexterity": 0,
+          "baseEndurance": 0.20000000298023224,
+          "baseEnduranceThreshold": 0.0,
+          "baseHealth": 100,
+          "baseIntelligence": 2,
+          "baseMana": 50,
+          "baseMoreDoTDamageTaken": -0.15000000596046448,
+          "baseStrength": 0,
+          "baseStunAvoidance": 250,
+          "baseVitality": 1,
+          "enduranceThresholdPerHealth": 0.20000000298023224,
+          "enduranceThresholdPerLevel": 0.0,
+          "healthPerLevel": 10,
+          "healthRegen": 6.0,
+          "healthRegenPerLevel": 0.14000000059604645,
+          "manaPerLevel": 0.5050600171089172,
+          "manaRegen": 8.0,
+          "minionScaling": {
+            "firstLevelForScaling": 26,
+            "lessDamageTakenPerLevel": 0.00800000037997961,
+            "moreDamagePerLevel": 0.00800000037997961
+          },
+          "stunAvoidancePerLevel": 5.0
+        },
+        "canonical_id": "class:acolyte",
+        "consumer_safe_fields": {
+          "debug_only": true,
+          "planner_consumed": false
+        },
+        "display_name": "Acolyte",
+        "known_restriction_labels": [
+          "Acolyte"
+        ],
+        "linked_passive_tree_source_ids": [
+          "ac-1"
+        ],
+        "linked_skill_source_ids": [
+          "skill_path:260926",
+          "skill_path:261142",
+          "skill_path:261173",
+          "skill_path:262645",
+          "skill_path:263035",
+          "skill_path:263498",
+          "skill_path:263799",
+          "skill_path:264444",
+          "skill_path:264458",
+          "skill_path:264675",
+          "skill_path:264863"
+        ],
+        "manual_bridge": false,
+        "mastery_ids": [
+          "mastery:acolyte:necromancer",
+          "mastery:acolyte:lich",
+          "mastery:acolyte:warlock"
+        ],
+        "normalized_fields": {
+          "canonical_kind": "class"
+        },
+        "passive_tree_ids": [
+          "passive_tree:ac_1"
+        ],
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_data_export",
+          "notes": [
+            "Extracted class registry record."
+          ],
+          "source_id": "class:3",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\classes.json",
+          "source_type": "generated_from_game_data"
+        },
+        "raw_reference": {
+          "source_class_id": 3,
+          "treeID": "ac-1"
+        },
+        "skill_ids": [
+          "skill_path:260926",
+          "skill_path:261142",
+          "skill_path:261173",
+          "skill_path:262645",
+          "skill_path:263035",
+          "skill_path:263498",
+          "skill_path:263799",
+          "skill_path:264444",
+          "skill_path:264458",
+          "skill_path:264675",
+          "skill_path:264863"
+        ],
+        "source_class_id": 3,
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\classes.json",
+        "source_id": "class:3",
+        "source_tree_id": "ac-1",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": []
+      },
+      {
+        "base_stats": {
+          "baseAttunement": 0,
+          "baseDexterity": 3,
+          "baseEndurance": 0.20000000298023224,
+          "baseEnduranceThreshold": 0.0,
+          "baseHealth": 100,
+          "baseIntelligence": 0,
+          "baseMana": 50,
+          "baseMoreDoTDamageTaken": -0.15000000596046448,
+          "baseStrength": 0,
+          "baseStunAvoidance": 250,
+          "baseVitality": 0,
+          "enduranceThresholdPerHealth": 0.20000000298023224,
+          "enduranceThresholdPerLevel": 0.0,
+          "healthPerLevel": 10,
+          "healthRegen": 6.0,
+          "healthRegenPerLevel": 0.14000000059604645,
+          "manaPerLevel": 0.5050600171089172,
+          "manaRegen": 8.0,
+          "minionScaling": {
+            "firstLevelForScaling": 26,
+            "lessDamageTakenPerLevel": 0.00800000037997961,
+            "moreDamagePerLevel": 0.00800000037997961
+          },
+          "stunAvoidancePerLevel": 5.0
+        },
+        "canonical_id": "class:rogue",
+        "consumer_safe_fields": {
+          "debug_only": true,
+          "planner_consumed": false
+        },
+        "display_name": "Rogue",
+        "known_restriction_labels": [],
+        "linked_passive_tree_source_ids": [
+          "rg-1"
+        ],
+        "linked_skill_source_ids": [
+          "skill_path:261142",
+          "skill_path:263498",
+          "skill_path:263816",
+          "skill_path:263834",
+          "skill_path:263852",
+          "skill_path:263871",
+          "skill_path:263905",
+          "skill_path:263955",
+          "skill_path:263956",
+          "skill_path:263991",
+          "skill_path:264230"
+        ],
+        "manual_bridge": false,
+        "mastery_ids": [
+          "mastery:rogue:bladedancer",
+          "mastery:rogue:marksman",
+          "mastery:rogue:falconer"
+        ],
+        "normalized_fields": {
+          "canonical_kind": "class"
+        },
+        "passive_tree_ids": [
+          "passive_tree:rg_1"
+        ],
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_data_export",
+          "notes": [
+            "Extracted class registry record."
+          ],
+          "source_id": "class:4",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\classes.json",
+          "source_type": "generated_from_game_data"
+        },
+        "raw_reference": {
+          "source_class_id": 4,
+          "treeID": "rg-1"
+        },
+        "skill_ids": [
+          "skill_path:261142",
+          "skill_path:263498",
+          "skill_path:263816",
+          "skill_path:263834",
+          "skill_path:263852",
+          "skill_path:263871",
+          "skill_path:263905",
+          "skill_path:263955",
+          "skill_path:263956",
+          "skill_path:263991",
+          "skill_path:264230"
+        ],
+        "source_class_id": 4,
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\classes.json",
+        "source_id": "class:4",
+        "source_tree_id": "rg-1",
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": []
+      }
+    ],
+    "masteries": [
+      {
+        "canonical_id": "mastery:primalist:beastmaster",
+        "class_id": "class:primalist",
+        "consumer_safe_fields": {
+          "debug_only": true,
+          "planner_consumed": false
+        },
+        "display_name": "Beastmaster",
+        "known_restriction_labels": [],
+        "linked_passive_tree_source_ids": [],
+        "linked_skill_source_ids": [
+          "skill_path:264437"
+        ],
+        "manual_bridge": false,
+        "normalized_fields": {
+          "canonical_kind": "mastery"
+        },
+        "passive_tree_ids": [],
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_data_export",
+          "notes": [
+            "Extracted mastery entry nested under class registry record."
+          ],
+          "source_id": "class:0:mastery:1",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\classes.json",
+          "source_type": "generated_from_game_data"
+        },
+        "raw_reference": {
+          "localizationKey": "Mastery_Beastmaster",
+          "masteryAbilityPathId": 264437,
+          "source_class_id": 0,
+          "source_mastery_index": 1
+        },
+        "skill_ids": [
+          "skill_path:264437"
+        ],
+        "source_class_id": 0,
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\classes.json",
+        "source_id": "class:0:mastery:1",
+        "source_mastery_id": "Mastery_Beastmaster",
+        "source_mastery_index": 1,
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": []
+      },
+      {
+        "canonical_id": "mastery:primalist:shaman",
+        "class_id": "class:primalist",
+        "consumer_safe_fields": {
+          "debug_only": true,
+          "planner_consumed": false
+        },
+        "display_name": "Shaman",
+        "known_restriction_labels": [],
+        "linked_passive_tree_source_ids": [],
+        "linked_skill_source_ids": [
+          "skill_path:264451"
+        ],
+        "manual_bridge": false,
+        "normalized_fields": {
+          "canonical_kind": "mastery"
+        },
+        "passive_tree_ids": [],
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_data_export",
+          "notes": [
+            "Extracted mastery entry nested under class registry record."
+          ],
+          "source_id": "class:0:mastery:2",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\classes.json",
+          "source_type": "generated_from_game_data"
+        },
+        "raw_reference": {
+          "localizationKey": "Mastery_Shaman",
+          "masteryAbilityPathId": 264451,
+          "source_class_id": 0,
+          "source_mastery_index": 2
+        },
+        "skill_ids": [
+          "skill_path:264451"
+        ],
+        "source_class_id": 0,
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\classes.json",
+        "source_id": "class:0:mastery:2",
+        "source_mastery_id": "Mastery_Shaman",
+        "source_mastery_index": 2,
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": []
+      },
+      {
+        "canonical_id": "mastery:primalist:druid",
+        "class_id": "class:primalist",
+        "consumer_safe_fields": {
+          "debug_only": true,
+          "planner_consumed": false
+        },
+        "display_name": "Druid",
+        "known_restriction_labels": [],
+        "linked_passive_tree_source_ids": [],
+        "linked_skill_source_ids": [
+          "skill_path:264922"
+        ],
+        "manual_bridge": false,
+        "normalized_fields": {
+          "canonical_kind": "mastery"
+        },
+        "passive_tree_ids": [],
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_data_export",
+          "notes": [
+            "Extracted mastery entry nested under class registry record."
+          ],
+          "source_id": "class:0:mastery:3",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\classes.json",
+          "source_type": "generated_from_game_data"
+        },
+        "raw_reference": {
+          "localizationKey": "Mastery_Druid",
+          "masteryAbilityPathId": 264922,
+          "source_class_id": 0,
+          "source_mastery_index": 3
+        },
+        "skill_ids": [
+          "skill_path:264922"
+        ],
+        "source_class_id": 0,
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\classes.json",
+        "source_id": "class:0:mastery:3",
+        "source_mastery_id": "Mastery_Druid",
+        "source_mastery_index": 3,
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": []
+      },
+      {
+        "canonical_id": "mastery:mage:sorcerer",
+        "class_id": "class:mage",
+        "consumer_safe_fields": {
+          "debug_only": true,
+          "planner_consumed": false
+        },
+        "display_name": "Sorcerer",
+        "known_restriction_labels": [],
+        "linked_passive_tree_source_ids": [],
+        "linked_skill_source_ids": [
+          "skill_path:263053"
+        ],
+        "manual_bridge": false,
+        "normalized_fields": {
+          "canonical_kind": "mastery"
+        },
+        "passive_tree_ids": [],
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_data_export",
+          "notes": [
+            "Extracted mastery entry nested under class registry record."
+          ],
+          "source_id": "class:1:mastery:1",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\classes.json",
+          "source_type": "generated_from_game_data"
+        },
+        "raw_reference": {
+          "localizationKey": "Mastery_Sorcerer",
+          "masteryAbilityPathId": 263053,
+          "source_class_id": 1,
+          "source_mastery_index": 1
+        },
+        "skill_ids": [
+          "skill_path:263053"
+        ],
+        "source_class_id": 1,
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\classes.json",
+        "source_id": "class:1:mastery:1",
+        "source_mastery_id": "Mastery_Sorcerer",
+        "source_mastery_index": 1,
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": []
+      },
+      {
+        "canonical_id": "mastery:mage:spellblade",
+        "class_id": "class:mage",
+        "consumer_safe_fields": {
+          "debug_only": true,
+          "planner_consumed": false
+        },
+        "display_name": "Spellblade",
+        "known_restriction_labels": [],
+        "linked_passive_tree_source_ids": [],
+        "linked_skill_source_ids": [
+          "skill_path:264237"
+        ],
+        "manual_bridge": false,
+        "normalized_fields": {
+          "canonical_kind": "mastery"
+        },
+        "passive_tree_ids": [],
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_data_export",
+          "notes": [
+            "Extracted mastery entry nested under class registry record."
+          ],
+          "source_id": "class:1:mastery:2",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\classes.json",
+          "source_type": "generated_from_game_data"
+        },
+        "raw_reference": {
+          "localizationKey": "Mastery_Spellblade",
+          "masteryAbilityPathId": 264237,
+          "source_class_id": 1,
+          "source_mastery_index": 2
+        },
+        "skill_ids": [
+          "skill_path:264237"
+        ],
+        "source_class_id": 1,
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\classes.json",
+        "source_id": "class:1:mastery:2",
+        "source_mastery_id": "Mastery_Spellblade",
+        "source_mastery_index": 2,
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": []
+      },
+      {
+        "canonical_id": "mastery:mage:runemaster",
+        "class_id": "class:mage",
+        "consumer_safe_fields": {
+          "debug_only": true,
+          "planner_consumed": false
+        },
+        "display_name": "Runemaster",
+        "known_restriction_labels": [],
+        "linked_passive_tree_source_ids": [],
+        "linked_skill_source_ids": [
+          "skill_path:264015"
+        ],
+        "manual_bridge": false,
+        "normalized_fields": {
+          "canonical_kind": "mastery"
+        },
+        "passive_tree_ids": [],
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_data_export",
+          "notes": [
+            "Extracted mastery entry nested under class registry record."
+          ],
+          "source_id": "class:1:mastery:3",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\classes.json",
+          "source_type": "generated_from_game_data"
+        },
+        "raw_reference": {
+          "localizationKey": "Mastery_Runemaster",
+          "masteryAbilityPathId": 264015,
+          "source_class_id": 1,
+          "source_mastery_index": 3
+        },
+        "skill_ids": [
+          "skill_path:264015"
+        ],
+        "source_class_id": 1,
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\classes.json",
+        "source_id": "class:1:mastery:3",
+        "source_mastery_id": "Mastery_Runemaster",
+        "source_mastery_index": 3,
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": []
+      },
+      {
+        "canonical_id": "mastery:sentinel:void_knight",
+        "class_id": "class:sentinel",
+        "consumer_safe_fields": {
+          "debug_only": true,
+          "planner_consumed": false
+        },
+        "display_name": "Void Knight",
+        "known_restriction_labels": [],
+        "linked_passive_tree_source_ids": [],
+        "linked_skill_source_ids": [
+          "skill_path:262309"
+        ],
+        "manual_bridge": false,
+        "normalized_fields": {
+          "canonical_kind": "mastery"
+        },
+        "passive_tree_ids": [],
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_data_export",
+          "notes": [
+            "Extracted mastery entry nested under class registry record."
+          ],
+          "source_id": "class:2:mastery:1",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\classes.json",
+          "source_type": "generated_from_game_data"
+        },
+        "raw_reference": {
+          "localizationKey": "Mastery_VoidKnight",
+          "masteryAbilityPathId": 262309,
+          "source_class_id": 2,
+          "source_mastery_index": 1
+        },
+        "skill_ids": [
+          "skill_path:262309"
+        ],
+        "source_class_id": 2,
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\classes.json",
+        "source_id": "class:2:mastery:1",
+        "source_mastery_id": "Mastery_VoidKnight",
+        "source_mastery_index": 1,
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": []
+      },
+      {
+        "canonical_id": "mastery:sentinel:forge_guard",
+        "class_id": "class:sentinel",
+        "consumer_safe_fields": {
+          "debug_only": true,
+          "planner_consumed": false
+        },
+        "display_name": "Forge Guard",
+        "known_restriction_labels": [],
+        "linked_passive_tree_source_ids": [],
+        "linked_skill_source_ids": [
+          "skill_path:262473"
+        ],
+        "manual_bridge": false,
+        "normalized_fields": {
+          "canonical_kind": "mastery"
+        },
+        "passive_tree_ids": [],
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_data_export",
+          "notes": [
+            "Extracted mastery entry nested under class registry record."
+          ],
+          "source_id": "class:2:mastery:2",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\classes.json",
+          "source_type": "generated_from_game_data"
+        },
+        "raw_reference": {
+          "localizationKey": "Mastery_Forge_Guard",
+          "masteryAbilityPathId": 262473,
+          "source_class_id": 2,
+          "source_mastery_index": 2
+        },
+        "skill_ids": [
+          "skill_path:262473"
+        ],
+        "source_class_id": 2,
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\classes.json",
+        "source_id": "class:2:mastery:2",
+        "source_mastery_id": "Mastery_Forge_Guard",
+        "source_mastery_index": 2,
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": []
+      },
+      {
+        "canonical_id": "mastery:sentinel:paladin",
+        "class_id": "class:sentinel",
+        "consumer_safe_fields": {
+          "debug_only": true,
+          "planner_consumed": false
+        },
+        "display_name": "Paladin",
+        "known_restriction_labels": [],
+        "linked_passive_tree_source_ids": [],
+        "linked_skill_source_ids": [
+          "skill_path:262677"
+        ],
+        "manual_bridge": false,
+        "normalized_fields": {
+          "canonical_kind": "mastery"
+        },
+        "passive_tree_ids": [],
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_data_export",
+          "notes": [
+            "Extracted mastery entry nested under class registry record."
+          ],
+          "source_id": "class:2:mastery:3",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\classes.json",
+          "source_type": "generated_from_game_data"
+        },
+        "raw_reference": {
+          "localizationKey": "Mastery_Paladin",
+          "masteryAbilityPathId": 262677,
+          "source_class_id": 2,
+          "source_mastery_index": 3
+        },
+        "skill_ids": [
+          "skill_path:262677"
+        ],
+        "source_class_id": 2,
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\classes.json",
+        "source_id": "class:2:mastery:3",
+        "source_mastery_id": "Mastery_Paladin",
+        "source_mastery_index": 3,
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": []
+      },
+      {
+        "canonical_id": "mastery:acolyte:necromancer",
+        "class_id": "class:acolyte",
+        "consumer_safe_fields": {
+          "debug_only": true,
+          "planner_consumed": false
+        },
+        "display_name": "Necromancer",
+        "known_restriction_labels": [],
+        "linked_passive_tree_source_ids": [],
+        "linked_skill_source_ids": [
+          "skill_path:264462"
+        ],
+        "manual_bridge": false,
+        "normalized_fields": {
+          "canonical_kind": "mastery"
+        },
+        "passive_tree_ids": [],
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_data_export",
+          "notes": [
+            "Extracted mastery entry nested under class registry record."
+          ],
+          "source_id": "class:3:mastery:1",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\classes.json",
+          "source_type": "generated_from_game_data"
+        },
+        "raw_reference": {
+          "localizationKey": "Mastery_Necromancer",
+          "masteryAbilityPathId": 264462,
+          "source_class_id": 3,
+          "source_mastery_index": 1
+        },
+        "skill_ids": [
+          "skill_path:264462"
+        ],
+        "source_class_id": 3,
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\classes.json",
+        "source_id": "class:3:mastery:1",
+        "source_mastery_id": "Mastery_Necromancer",
+        "source_mastery_index": 1,
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": []
+      },
+      {
+        "canonical_id": "mastery:acolyte:lich",
+        "class_id": "class:acolyte",
+        "consumer_safe_fields": {
+          "debug_only": true,
+          "planner_consumed": false
+        },
+        "display_name": "Lich",
+        "known_restriction_labels": [],
+        "linked_passive_tree_source_ids": [],
+        "linked_skill_source_ids": [
+          "skill_path:263788"
+        ],
+        "manual_bridge": false,
+        "normalized_fields": {
+          "canonical_kind": "mastery"
+        },
+        "passive_tree_ids": [],
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_data_export",
+          "notes": [
+            "Extracted mastery entry nested under class registry record."
+          ],
+          "source_id": "class:3:mastery:2",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\classes.json",
+          "source_type": "generated_from_game_data"
+        },
+        "raw_reference": {
+          "localizationKey": "Mastery_Lich",
+          "masteryAbilityPathId": 263788,
+          "source_class_id": 3,
+          "source_mastery_index": 2
+        },
+        "skill_ids": [
+          "skill_path:263788"
+        ],
+        "source_class_id": 3,
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\classes.json",
+        "source_id": "class:3:mastery:2",
+        "source_mastery_id": "Mastery_Lich",
+        "source_mastery_index": 2,
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": []
+      },
+      {
+        "canonical_id": "mastery:acolyte:warlock",
+        "class_id": "class:acolyte",
+        "consumer_safe_fields": {
+          "debug_only": true,
+          "planner_consumed": false
+        },
+        "display_name": "Warlock",
+        "known_restriction_labels": [],
+        "linked_passive_tree_source_ids": [],
+        "linked_skill_source_ids": [
+          "skill_path:264874"
+        ],
+        "manual_bridge": false,
+        "normalized_fields": {
+          "canonical_kind": "mastery"
+        },
+        "passive_tree_ids": [],
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_data_export",
+          "notes": [
+            "Extracted mastery entry nested under class registry record."
+          ],
+          "source_id": "class:3:mastery:3",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\classes.json",
+          "source_type": "generated_from_game_data"
+        },
+        "raw_reference": {
+          "localizationKey": "Mastery_Warlock",
+          "masteryAbilityPathId": 264874,
+          "source_class_id": 3,
+          "source_mastery_index": 3
+        },
+        "skill_ids": [
+          "skill_path:264874"
+        ],
+        "source_class_id": 3,
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\classes.json",
+        "source_id": "class:3:mastery:3",
+        "source_mastery_id": "Mastery_Warlock",
+        "source_mastery_index": 3,
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": []
+      },
+      {
+        "canonical_id": "mastery:rogue:bladedancer",
+        "class_id": "class:rogue",
+        "consumer_safe_fields": {
+          "debug_only": true,
+          "planner_consumed": false
+        },
+        "display_name": "Bladedancer",
+        "known_restriction_labels": [],
+        "linked_passive_tree_source_ids": [],
+        "linked_skill_source_ids": [
+          "skill_path:263841"
+        ],
+        "manual_bridge": false,
+        "normalized_fields": {
+          "canonical_kind": "mastery"
+        },
+        "passive_tree_ids": [],
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_data_export",
+          "notes": [
+            "Extracted mastery entry nested under class registry record."
+          ],
+          "source_id": "class:4:mastery:1",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\classes.json",
+          "source_type": "generated_from_game_data"
+        },
+        "raw_reference": {
+          "localizationKey": "Mastery_Bladedancer",
+          "masteryAbilityPathId": 263841,
+          "source_class_id": 4,
+          "source_mastery_index": 1
+        },
+        "skill_ids": [
+          "skill_path:263841"
+        ],
+        "source_class_id": 4,
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\classes.json",
+        "source_id": "class:4:mastery:1",
+        "source_mastery_id": "Mastery_Bladedancer",
+        "source_mastery_index": 1,
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": []
+      },
+      {
+        "canonical_id": "mastery:rogue:marksman",
+        "class_id": "class:rogue",
+        "consumer_safe_fields": {
+          "debug_only": true,
+          "planner_consumed": false
+        },
+        "display_name": "Marksman",
+        "known_restriction_labels": [],
+        "linked_passive_tree_source_ids": [],
+        "linked_skill_source_ids": [
+          "skill_path:263853"
+        ],
+        "manual_bridge": false,
+        "normalized_fields": {
+          "canonical_kind": "mastery"
+        },
+        "passive_tree_ids": [],
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_data_export",
+          "notes": [
+            "Extracted mastery entry nested under class registry record."
+          ],
+          "source_id": "class:4:mastery:2",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\classes.json",
+          "source_type": "generated_from_game_data"
+        },
+        "raw_reference": {
+          "localizationKey": "Mastery_Marksman",
+          "masteryAbilityPathId": 263853,
+          "source_class_id": 4,
+          "source_mastery_index": 2
+        },
+        "skill_ids": [
+          "skill_path:263853"
+        ],
+        "source_class_id": 4,
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\classes.json",
+        "source_id": "class:4:mastery:2",
+        "source_mastery_id": "Mastery_Marksman",
+        "source_mastery_index": 2,
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": []
+      },
+      {
+        "canonical_id": "mastery:rogue:falconer",
+        "class_id": "class:rogue",
+        "consumer_safe_fields": {
+          "debug_only": true,
+          "planner_consumed": false
+        },
+        "display_name": "Falconer",
+        "known_restriction_labels": [],
+        "linked_passive_tree_source_ids": [],
+        "linked_skill_source_ids": [
+          "skill_path:262328"
+        ],
+        "manual_bridge": false,
+        "normalized_fields": {
+          "canonical_kind": "mastery"
+        },
+        "passive_tree_ids": [],
+        "patch_version": "1.4.6_22986002",
+        "provenance": {
+          "extraction_method": "last_epoch_data_export",
+          "notes": [
+            "Extracted mastery entry nested under class registry record."
+          ],
+          "source_id": "class:4:mastery:3",
+          "source_path": "D:\\Forge\\last-epoch-data\\exports_json\\classes.json",
+          "source_type": "generated_from_game_data"
+        },
+        "raw_reference": {
+          "localizationKey": "Mastery_Falconer",
+          "masteryAbilityPathId": 262328,
+          "source_class_id": 4,
+          "source_mastery_index": 3
+        },
+        "skill_ids": [
+          "skill_path:262328"
+        ],
+        "source_class_id": 4,
+        "source_file": "D:\\Forge\\last-epoch-data\\exports_json\\classes.json",
+        "source_id": "class:4:mastery:3",
+        "source_mastery_id": "Mastery_Falconer",
+        "source_mastery_index": 3,
+        "stable_calculable": false,
+        "support_status": "partial",
+        "trust_level": "generated_from_game_data",
+        "warnings": []
+      }
+    ]
+  },
+  "schema_version": "v2.class_mastery_bundle.1",
+  "source_classes_path": "D:\\Forge\\last-epoch-data\\exports_json\\classes.json",
+  "source_metadata": {
+    "class_count": 5,
+    "decode_failures": 0,
+    "disabled_class_count": 0,
+    "game_build": {
+      "gameAssemblySha256": "d4a68f3f087005f4c16fbcaf3738dd8a80ee017da3c2a0e3ee6fb86ddfc88ae1",
+      "installPath": "D:\\LastEpochTools\\game_files\\current\\1.4.6_22986002",
+      "unity": "6000.0.42f1"
+    },
+    "generated_at": "2026-05-06T00:02:36+00:00",
+    "pipeline": "typetree",
+    "pipeline_version": 1,
+    "source": "resources.assets ('Character Class List', parse_as_dict + PPtr deref)",
+    "source_pathid": 260902
+  },
+  "summary": {
+    "class_count": 5,
+    "manual_bridge_count": 0,
+    "mapped_restriction_label_count": 3,
+    "mastery_count": 15,
+    "production_consumed": false,
+    "stable_calculable_count": 0,
+    "support_status_counts": {
+      "partial": 20
+    },
+    "trust_level_counts": {
+      "generated_from_game_data": 20
+    },
+    "unique_restriction_label_count": 3,
+    "unmapped_restriction_label_count": 0,
+    "validation_error_count": 0,
+    "validation_warning_count": 0
+  }
+}

--- a/docs/generated/v2_class_mastery_validation_report.json
+++ b/docs/generated/v2_class_mastery_validation_report.json
@@ -1,0 +1,99 @@
+{
+  "cross_reference": {
+    "labels": [
+      {
+        "count": 46,
+        "label": "Acolyte",
+        "mapped_class_id": "class:acolyte",
+        "mapped_mastery_id": null,
+        "source_breakdown": {
+          "v2_idol_bundle.json:idols": 12,
+          "v2_item_base_bundle.json:item_bases": 34
+        }
+      },
+      {
+        "count": 46,
+        "label": "Mage",
+        "mapped_class_id": "class:mage",
+        "mapped_mastery_id": null,
+        "source_breakdown": {
+          "v2_idol_bundle.json:idols": 12,
+          "v2_item_base_bundle.json:item_bases": 34
+        }
+      },
+      {
+        "count": 48,
+        "label": "Primalist",
+        "mapped_class_id": "class:primalist",
+        "mapped_mastery_id": null,
+        "source_breakdown": {
+          "v2_idol_bundle.json:idols": 12,
+          "v2_item_base_bundle.json:item_bases": 36
+        }
+      }
+    ],
+    "mapped_label_count": 3,
+    "mapped_labels": [
+      {
+        "count": 46,
+        "label": "Acolyte",
+        "mapped_class_id": "class:acolyte",
+        "mapped_mastery_id": null,
+        "source_breakdown": {
+          "v2_idol_bundle.json:idols": 12,
+          "v2_item_base_bundle.json:item_bases": 34
+        }
+      },
+      {
+        "count": 46,
+        "label": "Mage",
+        "mapped_class_id": "class:mage",
+        "mapped_mastery_id": null,
+        "source_breakdown": {
+          "v2_idol_bundle.json:idols": 12,
+          "v2_item_base_bundle.json:item_bases": 34
+        }
+      },
+      {
+        "count": 48,
+        "label": "Primalist",
+        "mapped_class_id": "class:primalist",
+        "mapped_mastery_id": null,
+        "source_breakdown": {
+          "v2_idol_bundle.json:idols": 12,
+          "v2_item_base_bundle.json:item_bases": 36
+        }
+      }
+    ],
+    "restriction_label_count": 140,
+    "unique_restriction_label_count": 3,
+    "unmapped_label_count": 0,
+    "unmapped_labels": []
+  },
+  "errors": [],
+  "metadata": {
+    "experimental": true,
+    "production_consumed": false,
+    "production_safe": false,
+    "read_only": true,
+    "source": "v2_class_mastery_bundle"
+  },
+  "summary": {
+    "class_count": 5,
+    "class_links_missing_mastery_count": 0,
+    "duplicate_class_id_count": 0,
+    "duplicate_mastery_id_count": 0,
+    "error_count": 0,
+    "invalid_trust_level_count": 0,
+    "manual_bridge_count": 0,
+    "manual_bridge_not_marked_count": 0,
+    "mastery_count": 15,
+    "mastery_parent_missing_count": 0,
+    "missing_provenance_count": 0,
+    "missing_support_status_count": 0,
+    "production_consumed": false,
+    "stable_calculable_count": 0,
+    "warning_count": 0
+  },
+  "warnings": []
+}

--- a/docs/migration/V2_CLASS_MASTERY_MIGRATION.md
+++ b/docs/migration/V2_CLASS_MASTERY_MIGRATION.md
@@ -1,0 +1,90 @@
+# v2 Class and Mastery Migration
+
+## Purpose
+
+Phase 7 creates a read-only canonical class/mastery bundle from the extracted class registry. The bundle is used for diagnostics, validation, and future class/mastery references only.
+
+This phase does not implement passive trees, skill trees, planner remapping, or stable-calculable class behavior.
+
+## Generation Command
+
+```powershell
+.\backend\.venv\Scripts\python.exe backend\scripts\report_v2_class_mastery_bundle.py --source-classes D:\Forge\last-epoch-data\exports_json\classes.json --affix-bundle docs\generated\v2_affix_bundle.json --item-base-bundle docs\generated\v2_item_base_bundle.json --unique-bundle docs\generated\v2_unique_bundle.json --set-bundle docs\generated\v2_set_bundle.json --idol-bundle docs\generated\v2_idol_bundle.json --idol-affix-bundle docs\generated\v2_idol_affix_bundle.json --output docs\generated\v2_class_mastery_bundle.json --validation-output docs\generated\v2_class_mastery_validation_report.json --markdown-output docs\migration\V2_CLASS_MASTERY_MIGRATION.md
+```
+
+## Summary
+
+- Class count: 5
+- Mastery count: 15
+- Restriction labels found in existing v2 bundles: 3
+- Restriction labels mapped to class/mastery records: 3
+- Restriction labels unmapped: 0
+- Manual bridge count: 0
+- Stable-calculable count: 0
+- Validation errors: 0
+- Validation warnings: 0
+- Production consumed: false
+
+## Classes
+
+| Canonical ID | Display name | Masteries | Existing restriction labels |
+| --- | --- | ---: | --- |
+| `class:primalist` | Primalist | 3 | Primalist |
+| `class:mage` | Mage | 3 | Mage |
+| `class:sentinel` | Sentinel | 3 | None |
+| `class:acolyte` | Acolyte | 3 | Acolyte |
+| `class:rogue` | Rogue | 3 | None |
+
+## Masteries
+
+| Canonical ID | Display name | Parent class | Existing restriction labels |
+| --- | --- | --- | --- |
+| `mastery:primalist:beastmaster` | Beastmaster | `class:primalist` | None |
+| `mastery:primalist:shaman` | Shaman | `class:primalist` | None |
+| `mastery:primalist:druid` | Druid | `class:primalist` | None |
+| `mastery:mage:sorcerer` | Sorcerer | `class:mage` | None |
+| `mastery:mage:spellblade` | Spellblade | `class:mage` | None |
+| `mastery:mage:runemaster` | Runemaster | `class:mage` | None |
+| `mastery:sentinel:void_knight` | Void Knight | `class:sentinel` | None |
+| `mastery:sentinel:forge_guard` | Forge Guard | `class:sentinel` | None |
+| `mastery:sentinel:paladin` | Paladin | `class:sentinel` | None |
+| `mastery:acolyte:necromancer` | Necromancer | `class:acolyte` | None |
+| `mastery:acolyte:lich` | Lich | `class:acolyte` | None |
+| `mastery:acolyte:warlock` | Warlock | `class:acolyte` | None |
+| `mastery:rogue:bladedancer` | Bladedancer | `class:rogue` | None |
+| `mastery:rogue:marksman` | Marksman | `class:rogue` | None |
+| `mastery:rogue:falconer` | Falconer | `class:rogue` | None |
+
+## Cross-Reference Findings
+
+| Restriction label | Count | Class mapping | Mastery mapping |
+| --- | ---: | --- | --- |
+| Acolyte | 46 | `class:acolyte` | `` |
+| Mage | 46 | `class:mage` | `` |
+| Primalist | 48 | `class:primalist` | `` |
+
+Existing generated v2 affix, item, unique/set, and idol bundles were scanned for class/mastery restriction labels. The scan reports mappings only; it does not rewrite prior bundles.
+
+## Manual Bridge Findings
+
+Manual bridge records: 0
+
+The extracted class registry provided class and mastery records for this phase, so no manual bridge was needed. If later phases add temporary bridge records, they must use `trust_level: manual_bridge` and explain the source gap in provenance.
+
+## Migration Implications
+
+- Classes and masteries are available for experimental lookup and debug inspection.
+- Records remain `partial` because passives, skills, and modifier normalization are not complete.
+- Restriction labels from prior v2 bundles can now be audited against canonical class/mastery records.
+- Existing planner, crafting, stat aggregation, and simulation behavior remain unchanged.
+
+## Deferred
+
+- Passive tree generation and validation.
+- Skill tree generation and validation.
+- Planner remapping to canonical class/mastery IDs.
+- Stable planner eligibility for class/mastery-linked effects.
+
+## Recommended Next Step
+
+Proceed to Phase 8 passive infrastructure after Checkpoint 7 review.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -57,6 +57,7 @@ const ForgeSafeAffixesDebugPage = lazy(() => import("@/pages/debug/ForgeSafeAffi
 const V2ItemsDebugPage = lazy(() => import("@/pages/debug/V2ItemsDebugPage"));
 const V2UniqueSetDebugPage = lazy(() => import("@/pages/debug/V2UniqueSetDebugPage"));
 const V2IdolsDebugPage = lazy(() => import("@/pages/debug/V2IdolsDebugPage"));
+const V2ClassMasteryDebugPage = lazy(() => import("@/pages/debug/V2ClassMasteryDebugPage"));
 
 // ---------------------------------------------------------------------------
 // Route alias redirect — preserves the current location's search string so
@@ -262,6 +263,7 @@ export default function App() {
                     <Route path="/debug/v2-items" element={<Suspense fallback={<PageLoader />}><V2ItemsDebugPage /></Suspense>} />
                     <Route path="/debug/v2-unique-sets" element={<Suspense fallback={<PageLoader />}><V2UniqueSetDebugPage /></Suspense>} />
                     <Route path="/debug/v2-idols" element={<Suspense fallback={<PageLoader />}><V2IdolsDebugPage /></Suspense>} />
+                    <Route path="/debug/v2-classes" element={<Suspense fallback={<PageLoader />}><V2ClassMasteryDebugPage /></Suspense>} />
                     <Route path="/data-flow" element={<Suspense fallback={<PageLoader />}><DataFlowHarness /></Suspense>} />
                   </>
                 )}

--- a/frontend/src/__tests__/pages/v2-class-mastery-debug-page.test.tsx
+++ b/frontend/src/__tests__/pages/v2-class-mastery-debug-page.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+
+import V2ClassMasteryDebugPage from "@/pages/debug/V2ClassMasteryDebugPage";
+
+describe("V2ClassMasteryDebugPage", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("renders disabled response clearly", async () => {
+    mockFetch({ success: false, error: "v2_class_mastery_bundle_missing", message: "v2 class/mastery bundle not found" });
+
+    render(<V2ClassMasteryDebugPage />);
+
+    expect(await screen.findByText("Debug endpoint unavailable")).toBeInTheDocument();
+    expect(screen.getByText("v2 class/mastery bundle not found")).toBeInTheDocument();
+  });
+
+  it("renders class summary and rows", async () => {
+    mockFetch(successPayload());
+
+    render(<V2ClassMasteryDebugPage />);
+
+    expect(await screen.findByText("5")).toBeInTheDocument();
+    expect(screen.getByText("15")).toBeInTheDocument();
+    expect(screen.getAllByText("Mage").length).toBeGreaterThan(0);
+    expect(screen.getByText("class:mage")).toBeInTheDocument();
+    expect(screen.getByText("3 masteries")).toBeInTheDocument();
+  });
+
+  it("uses controls when loading masteries", async () => {
+    mockFetch(successPayload());
+
+    render(<V2ClassMasteryDebugPage />);
+    await screen.findByText("class:mage");
+
+    fireEvent.change(screen.getByLabelText(/Kind/i), { target: { value: "masteries" } });
+    fireEvent.change(screen.getByLabelText(/Limit/i), { target: { value: "2" } });
+    fireEvent.change(screen.getByLabelText(/Search/i), { target: { value: "rune" } });
+    fireEvent.change(screen.getByLabelText(/Class ID/i), { target: { value: "class:mage" } });
+    fireEvent.click(screen.getByRole("button", { name: "Load debug data" }));
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenLastCalledWith("/experimental/v2/masteries?limit=2&q=rune&class_id=class%3Amage");
+    });
+  });
+});
+
+function mockFetch(payload: unknown) {
+  vi.mocked(fetch).mockResolvedValue({ json: async () => payload } as Response);
+}
+
+function successPayload() {
+  return {
+    success: true,
+    read_only: true,
+    production_consumer: false,
+    data_source: "v2_class_mastery_bundle",
+    source_path: "D:\\Forge\\le-the-forge\\docs\\generated\\v2_class_mastery_bundle.json",
+    total_classes: 5,
+    total_masteries: 15,
+    result_count: 1,
+    summary: {
+      support_status_counts: { partial: 20 },
+      trust_level_counts: { generated_from_game_data: 20 },
+    },
+    records: [
+      {
+        canonical_id: "class:mage",
+        display_name: "Mage",
+        source_id: "class:1",
+        source_file: "classes.json",
+        support_status: "partial",
+        trust_level: "generated_from_game_data",
+        provenance: { source_path: "classes.json" },
+        mastery_ids: ["mastery:mage:sorcerer", "mastery:mage:spellblade", "mastery:mage:runemaster"],
+        passive_tree_ids: ["passive_tree:mg-1"],
+        skill_ids: [],
+        linked_skill_source_ids: [],
+        known_restriction_labels: ["Mage"],
+        stable_calculable: false,
+      },
+    ],
+  };
+}

--- a/frontend/src/pages/debug/V2ClassMasteryDebugPage.tsx
+++ b/frontend/src/pages/debug/V2ClassMasteryDebugPage.tsx
@@ -1,0 +1,193 @@
+import { FormEvent, useEffect, useMemo, useState } from "react";
+
+import type { CanonicalClass, CanonicalMastery } from "@/types";
+
+interface V2ClassMasteryResponse {
+  success: boolean;
+  read_only?: boolean;
+  production_consumer?: boolean;
+  data_source?: string;
+  source_path?: string;
+  total_classes?: number;
+  total_masteries?: number;
+  result_count?: number;
+  records?: Array<CanonicalClass | CanonicalMastery>;
+  summary?: Record<string, unknown>;
+  error?: string;
+  message?: string;
+}
+
+const DEFAULT_LIMIT = 20;
+
+function buildUrl(kind: "classes" | "masteries", limit: number, query: string, classId: string): string {
+  const params = new URLSearchParams();
+  params.set("limit", String(limit));
+  if (query.trim()) params.set("q", query.trim());
+  if (kind === "masteries" && classId.trim()) params.set("class_id", classId.trim());
+  return `/experimental/v2/${kind}?${params.toString()}`;
+}
+
+async function fetchV2ClassMastery(kind: "classes" | "masteries", limit: number, query: string, classId: string): Promise<V2ClassMasteryResponse> {
+  const response = await fetch(buildUrl(kind, limit, query, classId));
+  const json = await response.json().catch(() => null);
+  if (!json || typeof json !== "object") {
+    return { success: false, error: "invalid_response", message: `Backend returned an unreadable response (${response.status}).` };
+  }
+  return json as V2ClassMasteryResponse;
+}
+
+export default function V2ClassMasteryDebugPage() {
+  const [kind, setKind] = useState<"classes" | "masteries">("classes");
+  const [limit, setLimit] = useState(DEFAULT_LIMIT);
+  const [query, setQuery] = useState("");
+  const [classId, setClassId] = useState("");
+  const [data, setData] = useState<V2ClassMasteryResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = async (nextKind = kind, nextLimit = limit, nextQuery = query, nextClassId = classId) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await fetchV2ClassMastery(nextKind, nextLimit, nextQuery, nextClassId);
+      setData(result);
+      if (!result.success) setError(result.message || result.error || "Debug endpoint returned an error.");
+    } catch (err) {
+      setData(null);
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    load("classes", DEFAULT_LIMIT, "", "");
+    // Initial debug fetch only for this dev-only route.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    load(kind, limit, query, classId);
+  }
+
+  const records = data?.records ?? [];
+  const summary = useMemo(
+    () => [
+      ["Data source", data?.data_source ?? "n/a"],
+      ["Classes", data?.total_classes ?? "n/a"],
+      ["Masteries", data?.total_masteries ?? "n/a"],
+      ["Support", summarizeMap(data?.summary, "support_status_counts")],
+      ["Trust", summarizeMap(data?.summary, "trust_level_counts")],
+      ["Read only", String(data?.read_only ?? false)],
+      ["Production consumer", String(data?.production_consumer ?? false)],
+    ],
+    [data],
+  );
+
+  return (
+    <div className="mx-auto max-w-6xl space-y-6 p-6">
+      <header className="border-b border-[#2a3050] pb-4">
+        <p className="font-mono text-xs uppercase tracking-wide text-[#22d3ee]">Debug / Experimental / Read-only</p>
+        <h1 className="mt-2 font-display text-2xl text-[#f5a623]">v2 class and mastery inspection</h1>
+        <p className="mt-2 max-w-3xl text-sm text-gray-400">This page reads v2 class/mastery records for diagnostics and does not power planner behavior.</p>
+      </header>
+
+      <section className="rounded border border-[#2a3050] bg-[#10152a] p-4">
+        <form onSubmit={handleSubmit} className="flex flex-wrap items-end gap-4">
+          <label className="grid gap-1 text-sm text-gray-300">
+            <span className="text-xs uppercase text-gray-500">Kind</span>
+            <select value={kind} onChange={(event) => setKind(event.target.value as "classes" | "masteries")} className="w-36 rounded border border-[#2a3050] bg-[#0f172a] px-3 py-2 text-gray-100">
+              <option value="classes">Classes</option>
+              <option value="masteries">Masteries</option>
+            </select>
+          </label>
+          <label className="grid gap-1 text-sm text-gray-300">
+            <span className="text-xs uppercase text-gray-500">Limit</span>
+            <input type="number" min={0} max={50} value={limit} onChange={(event) => setLimit(Number(event.target.value))} className="w-28 rounded border border-[#2a3050] bg-[#0f172a] px-3 py-2 text-gray-100" />
+          </label>
+          <label className="grid gap-1 text-sm text-gray-300">
+            <span className="text-xs uppercase text-gray-500">Search</span>
+            <input value={query} onChange={(event) => setQuery(event.target.value)} placeholder="optional" className="w-48 rounded border border-[#2a3050] bg-[#0f172a] px-3 py-2 text-gray-100" />
+          </label>
+          <label className="grid gap-1 text-sm text-gray-300">
+            <span className="text-xs uppercase text-gray-500">Class ID</span>
+            <input value={classId} onChange={(event) => setClassId(event.target.value)} placeholder="class:mage" className="w-48 rounded border border-[#2a3050] bg-[#0f172a] px-3 py-2 text-gray-100" />
+          </label>
+          <button type="submit" className="rounded bg-[#f5a623] px-4 py-2 text-sm font-semibold text-[#10152a] hover:bg-[#f5a623cc]">Load debug data</button>
+        </form>
+      </section>
+
+      {loading && <div className="rounded border border-[#2a3050] bg-[#0f172a] p-4 text-sm text-gray-300">Loading debug endpoint...</div>}
+      {!loading && error && (
+        <section className="rounded border border-red-900 bg-red-950/30 p-4">
+          <h2 className="text-sm font-semibold text-red-300">Debug endpoint unavailable</h2>
+          <p className="mt-2 text-sm text-red-100">{error}</p>
+        </section>
+      )}
+      {!loading && data?.success && (
+        <>
+          <section className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            {summary.map(([label, value]) => (
+              <div key={label} className="rounded border border-[#2a3050] bg-[#10152a] p-4">
+                <div className="text-xs uppercase text-gray-500">{label}</div>
+                <div className="mt-2 break-words font-mono text-lg text-gray-100">{value}</div>
+              </div>
+            ))}
+          </section>
+          <section className="overflow-hidden rounded border border-[#2a3050] bg-[#10152a]">
+            <div className="border-b border-[#2a3050] p-4">
+              <h2 className="text-sm font-semibold text-gray-100">Records</h2>
+              <p className="mt-1 text-xs text-gray-500">Showing {records.length} records.</p>
+            </div>
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[900px] text-left text-sm">
+                <thead className="bg-[#0f172a] text-xs uppercase text-gray-500">
+                  <tr>
+                    <th className="px-4 py-3">Canonical ID</th>
+                    <th className="px-4 py-3">Name</th>
+                    <th className="px-4 py-3">Support</th>
+                    <th className="px-4 py-3">Trust</th>
+                    <th className="px-4 py-3">Parent/Links</th>
+                    <th className="px-4 py-3">Restriction Labels</th>
+                    <th className="px-4 py-3">Stable</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-[#2a3050]">
+                  {records.map((record) => (
+                    <tr key={record.canonical_id}>
+                      <td className="px-4 py-3 font-mono text-[#f5a623]">{record.canonical_id}</td>
+                      <td className="px-4 py-3 text-gray-100">{record.display_name}</td>
+                      <td className="px-4 py-3">{statusBadge(record.support_status)}</td>
+                      <td className="px-4 py-3 text-gray-300">{record.trust_level}</td>
+                      <td className="px-4 py-3 font-mono text-gray-300">{linkSummary(record)}</td>
+                      <td className="px-4 py-3 text-gray-300">{record.known_restriction_labels?.join(", ") || "None"}</td>
+                      <td className="px-4 py-3 font-mono text-gray-300">{String(record.stable_calculable ?? false)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+        </>
+      )}
+    </div>
+  );
+}
+
+function summarizeMap(summary: Record<string, unknown> | undefined, key: string): string {
+  const value = summary?.[key];
+  if (!value || typeof value !== "object" || Array.isArray(value)) return "n/a";
+  return Object.entries(value as Record<string, unknown>).map(([name, count]) => `${name}: ${count}`).join(", ");
+}
+
+function statusBadge(status: string) {
+  const classes = status === "partial" ? "border-yellow-700 bg-yellow-950 text-yellow-200" : "border-gray-700 bg-gray-900 text-gray-300";
+  return <span className={`inline-flex rounded border px-2 py-1 font-mono text-xs ${classes}`}>{status}</span>;
+}
+
+function linkSummary(record: CanonicalClass | CanonicalMastery): string {
+  if ("mastery_ids" in record && record.mastery_ids) return `${record.mastery_ids.length} masteries`;
+  if ("class_id" in record && record.class_id) return record.class_id;
+  return "n/a";
+}

--- a/frontend/src/types/canonicalClassMastery.ts
+++ b/frontend/src/types/canonicalClassMastery.ts
@@ -1,13 +1,29 @@
 import type { CanonicalRecord } from "./canonicalBase";
 
 export interface CanonicalClass extends CanonicalRecord {
+  source_class_id?: number | string | null;
+  source_tree_id?: string | null;
   mastery_ids: string[];
   passive_tree_ids: string[];
   skill_ids: string[];
+  linked_skill_source_ids?: string[];
+  linked_passive_tree_source_ids?: string[];
+  known_restriction_labels?: string[];
+  base_stats?: Record<string, unknown>;
+  stable_calculable?: boolean;
+  manual_bridge?: boolean;
 }
 
 export interface CanonicalMastery extends CanonicalRecord {
+  source_class_id?: number | string | null;
+  source_mastery_index?: number | null;
+  source_mastery_id?: string | null;
   class_id?: string | null;
   passive_tree_ids: string[];
   skill_ids: string[];
+  linked_skill_source_ids?: string[];
+  linked_passive_tree_source_ids?: string[];
+  known_restriction_labels?: string[];
+  stable_calculable?: boolean;
+  manual_bridge?: boolean;
 }


### PR DESCRIPTION
## Summary

Adds Phase 7 of the v2 trusted data rebuild: class and mastery infrastructure.

This introduces generated v2 class/mastery data, validation reporting, a read-only backend repository, experimental class/mastery routes, and a debug-only frontend view.

## Added

- v2 class/mastery bundle generation
- v2 class/mastery validation report
- v2 class/mastery migration documentation
- read-only `V2ClassMasteryRepository`
- experimental v2 class/mastery routes:
  - `GET /experimental/v2/classes`
  - `GET /experimental/v2/classes/<class_id>`
  - `GET /experimental/v2/masteries`
  - `GET /experimental/v2/masteries/<mastery_id>`
  - `GET /experimental/v2/classes/debug`
- debug-only frontend route:
  - `/debug/v2-classes`
- class/mastery inspection table with support, trust, linked records, restriction labels, and stable-calculable visibility
- focused backend and frontend tests

## Findings

- Classes: `5`
- Masteries: `15`
- Support status: all `partial`
- Trust level: all `generated_from_game_data`
- Manual bridge count: `0`
- Stable-calculable count: `0`
- Validation errors: `0`
- Validation warnings: `0`
- Production consumed: `false`

## Cross-reference findings

Existing v2 bundles referenced `3` class restriction labels:

- `Acolyte`: `46`
- `Mage`: `46`
- `Primalist`: `48`

All mapped cleanly to v2 class records. No mastery restriction labels were found in existing v2 bundles. No prior bundles were modified.

## Validation

- v2 class/mastery focused tests passed: `8 passed`
- related backend v2/guard tests passed: `54 passed`
- existing experimental Forge-safe tests passed: `25 passed`
- frontend debug tests passed: `16 passed`
- frontend type-check passed
- backend py_compile passed
- JSON validation passed for generated reports
- `git diff --check` passed

## Runtime behavior

Production behavior was not changed.

The new v2 class/mastery access path is experimental/read-only. Planner, crafting, stat aggregation, simulation, and production routes remain unchanged.