### PR TITLE
docs: audit v2 skill identity alignment

### DIFF
--- a/backend/scripts/report_v2_skill_identity_alignment.py
+++ b/backend/scripts/report_v2_skill_identity_alignment.py
@@ -1,0 +1,450 @@
+"""Audit v2 class/mastery skill references against v2 skill identities.
+
+This is a read-only Phase 9.5 diagnostic. It reports whether class/mastery
+`skill_path:*` references can be deterministically aligned to generated v2 skill
+records without changing runtime behavior or introducing inferred bridges.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from collections import Counter, defaultdict
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_CLASS_MASTERY_BUNDLE = Path("docs/generated/v2_class_mastery_bundle.json")
+DEFAULT_SKILL_BUNDLE = Path("docs/generated/v2_skill_bundle.json")
+DEFAULT_SKILL_TREE_BUNDLE = Path("docs/generated/v2_skill_tree_bundle.json")
+DEFAULT_SOURCE_CLASSES = Path("D:/Forge/last-epoch-data/exports_json/classes.json")
+DEFAULT_SOURCE_SKILLS = Path("D:/Forge/last-epoch-data/exports_json/skills_with_trees.json")
+DEFAULT_OUTPUT = Path("docs/generated/v2_skill_identity_alignment_report.json")
+DEFAULT_MARKDOWN_OUTPUT = Path("docs/migration/V2_SKILL_IDENTITY_ALIGNMENT.md")
+
+PATH_ID_RE = re.compile(r"(?:pathId|PathID|Ability)\D*(\d+)")
+TOP_LEVEL_PATH_FIELDS = {
+    "abilityPathId",
+    "pathId",
+    "sourcePathId",
+    "source_path_id",
+    "skillPathId",
+    "skill_path_id",
+}
+
+
+def _read_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _write_markdown(path: Path, report: dict[str, Any], command: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    summary = report["summary"]
+    fields = report["field_inventory"]
+    lines = [
+        "# v2 Skill Identity Alignment",
+        "",
+        "## Purpose",
+        "",
+        "This Phase 9.5 audit diagnoses the class/mastery to skill identity mismatch reported during Phase 9. It does not create a runtime bridge, change generators, or alter planner behavior.",
+        "",
+        "## Generation Command",
+        "",
+        "```powershell",
+        command,
+        "```",
+        "",
+        "## Summary",
+        "",
+        f"- Total class/mastery skill references: {summary['total_class_mastery_skill_references']}",
+        f"- Total skill records: {summary['total_skill_records']}",
+        f"- Exact ID matches: {summary['exact_id_match_count']}",
+        f"- Exact raw path matches: {summary['exact_path_match_count']}",
+        f"- Top-level path matches: {summary['top_level_path_match_count']}",
+        f"- Nested path-only matches: {summary['nested_path_only_match_count']}",
+        f"- Normalized name matches: {summary['normalized_name_match_count']}",
+        f"- Ambiguous matches: {summary['ambiguous_match_count']}",
+        f"- Unresolved references: {summary['unresolved_reference_count']}",
+        f"- Bridge safe: {str(summary['bridge_safe']).lower()}",
+        f"- Recommended mapping strategy: `{summary['recommended_mapping_strategy']}`",
+        "",
+        "## Field Inventory",
+        "",
+        "Class/mastery records use these fields for skill references:",
+        "",
+        *[f"- `{field}`" for field in fields["class_mastery_skill_reference_fields"]],
+        "",
+        "Skill records expose these source identity fields:",
+        "",
+        *[f"- `{field}`" for field in fields["skill_identity_fields"]],
+        "",
+        "Raw skill records expose these observed path-like fields:",
+        "",
+        *[f"- `{field}`" for field in fields["raw_skill_path_like_fields"][:50]],
+        "",
+        "## What Matched",
+        "",
+        "Exact ID matching did not resolve the class/mastery `skill_path:*` references because generated v2 skills use source skill IDs such as `skill:ab0lh`, not numeric path IDs.",
+        "",
+        "Raw path matching found references only where the numeric path ID appears somewhere inside raw skill evidence. These are not accepted as a safe bridge unless they are top-level owner identity fields. In the real report, no top-level owner path matches were found.",
+        "",
+        "Normalized name matching cannot resolve these references because the class/mastery `skill_path:*` values do not include display names.",
+        "",
+        "## Examples",
+        "",
+        "### Resolved By Safe Identity",
+        "",
+        *(_reference_lines(report["examples"]["resolved_records"]) or ["- None"]),
+        "",
+        "### Nested Path Matches Not Accepted As A Bridge",
+        "",
+        *(_reference_lines(report["examples"]["nested_path_only_records"]) or ["- None"]),
+        "",
+        "### Ambiguous",
+        "",
+        *(_reference_lines(report["examples"]["ambiguous_records"]) or ["- None"]),
+        "",
+        "### Unresolved",
+        "",
+        *_reference_lines(report["examples"]["unresolved_records"]),
+        "",
+        "## Conclusion",
+        "",
+        "A deterministic bridge is not safe from the current evidence. Phase 7 `skill_path:*` values should remain unresolved until a source export exposes a top-level owning skill path ID or a separate audited identity table proves the mapping.",
+        "",
+        "## Recommended Next Action",
+        "",
+        "Before modifier/stat normalization consumes class/mastery skill ownership, add a focused source-export identity alignment task or update the upstream export to include the owning ability path ID on skill records. Do not infer the bridge from nested summoned actor evidence or tooltip text.",
+        "",
+    ]
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def _reference_lines(records: list[dict[str, Any]]) -> list[str]:
+    lines: list[str] = []
+    for record in records:
+        status = record.get("status")
+        reference = record.get("class_mastery_skill_reference")
+        owners = ", ".join(record.get("owners", [])[:3])
+        matches = record.get("candidate_skill_ids") or []
+        suffix = f" -> {', '.join(matches[:3])}" if matches else ""
+        lines.append(f"- `{reference}` ({status}; owners: {owners or 'none'}){suffix}")
+    return lines
+
+
+def _normalize_name(value: Any) -> str:
+    return re.sub(r"[^a-z0-9]+", "", str(value or "").lower())
+
+
+def _class_mastery_skill_references(bundle: dict[str, Any]) -> tuple[dict[str, set[str]], set[str]]:
+    references: dict[str, set[str]] = defaultdict(set)
+    fields: set[str] = set()
+    records = bundle.get("records", {})
+    for kind in ("classes", "masteries"):
+        for record in records.get(kind, []):
+            owner = str(record.get("canonical_id") or record.get("display_name") or kind)
+            for field in ("linked_skill_source_ids", "skill_ids"):
+                values = record.get(field) or []
+                if values:
+                    fields.add(field)
+                for value in values:
+                    if isinstance(value, str) and (value.startswith("skill_path:") or value.startswith("skill:")):
+                        references[value].add(owner)
+    return references, fields
+
+
+def _skill_records(bundle: dict[str, Any]) -> list[dict[str, Any]]:
+    records = bundle.get("records", {})
+    return list(records.get("skills", []))
+
+
+def _raw_skills(source_skills: dict[str, Any]) -> list[dict[str, Any]]:
+    skills = source_skills.get("skills", [])
+    return skills if isinstance(skills, list) else []
+
+
+def _walk_path_ids(value: Any, path: list[str], hits: list[dict[str, Any]], path_fields: set[str]) -> None:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if "path" in key.lower() or "ability" in key.lower():
+                path_fields.add(".".join(path + [str(key)]))
+            _walk_path_ids(child, path + [str(key)], hits, path_fields)
+        return
+    if isinstance(value, list):
+        for index, child in enumerate(value):
+            _walk_path_ids(child, path + [str(index)], hits, path_fields)
+        return
+
+    found: set[str] = set()
+    if isinstance(value, int):
+        found.add(str(value))
+    elif isinstance(value, str):
+        if value.isdigit():
+            found.add(value)
+        found.update(match.group(1) for match in PATH_ID_RE.finditer(value))
+    for path_id in found:
+        field_path = ".".join(path)
+        hits.append(
+            {
+                "path_id": path_id,
+                "field_path": field_path,
+                "top_level_identity": len(path) == 1 and path[0] in TOP_LEVEL_PATH_FIELDS,
+                "value": value,
+            }
+        )
+
+
+def _build_skill_identity_index(skill_records: list[dict[str, Any]], raw_skills: list[dict[str, Any]]) -> dict[str, Any]:
+    by_canonical_id = {skill.get("canonical_id"): skill for skill in skill_records if skill.get("canonical_id")}
+    by_source_id = {
+        f"skill:{skill.get('source_skill_id')}": skill.get("canonical_id")
+        for skill in skill_records
+        if skill.get("source_skill_id")
+    }
+    by_normalized_name: dict[str, set[str]] = defaultdict(set)
+    raw_by_source_id = {raw.get("id"): raw for raw in raw_skills if raw.get("id")}
+    path_matches: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    path_like_fields: set[str] = set()
+
+    for skill in skill_records:
+        canonical_id = skill.get("canonical_id")
+        if not canonical_id:
+            continue
+        for value in (skill.get("display_name"), skill.get("source_skill_id")):
+            normalized = _normalize_name(value)
+            if normalized:
+                by_normalized_name[normalized].add(canonical_id)
+        raw = raw_by_source_id.get(skill.get("source_skill_id"))
+        if raw:
+            raw_tree = raw.get("skillTree") if isinstance(raw.get("skillTree"), dict) else {}
+            for value in (raw.get("name"), raw.get("_mName"), raw_tree.get("ability")):
+                normalized = _normalize_name(value)
+                if normalized:
+                    by_normalized_name[normalized].add(canonical_id)
+            hits: list[dict[str, Any]] = []
+            _walk_path_ids(raw, [], hits, path_like_fields)
+            for hit in hits:
+                path_matches[hit["path_id"]].append(
+                    {
+                        "skill_id": canonical_id,
+                        "source_skill_id": skill.get("source_skill_id"),
+                        "display_name": skill.get("display_name"),
+                        "field_path": hit["field_path"],
+                        "top_level_identity": hit["top_level_identity"],
+                    }
+                )
+
+    return {
+        "by_canonical_id": by_canonical_id,
+        "by_source_id": by_source_id,
+        "by_normalized_name": by_normalized_name,
+        "path_matches": path_matches,
+        "raw_skill_path_like_fields": sorted(path_like_fields),
+    }
+
+
+def _numeric_skill_path(reference: str) -> str | None:
+    if not reference.startswith("skill_path:"):
+        return None
+    value = reference.split(":", 1)[1]
+    return value if value.isdigit() else None
+
+
+def build_report(
+    class_mastery_bundle: dict[str, Any],
+    skill_bundle: dict[str, Any],
+    skill_tree_bundle: dict[str, Any],
+    source_classes: dict[str, Any],
+    source_skills: dict[str, Any],
+) -> dict[str, Any]:
+    references, reference_fields = _class_mastery_skill_references(class_mastery_bundle)
+    skills = _skill_records(skill_bundle)
+    raw_skill_records = _raw_skills(source_skills)
+    index = _build_skill_identity_index(skills, raw_skill_records)
+
+    results: list[dict[str, Any]] = []
+    exact_id_count = 0
+    exact_path_count = 0
+    top_level_path_count = 0
+    normalized_name_count = 0
+    nested_path_only_count = 0
+    ambiguous_count = 0
+    unresolved_count = 0
+    path_context_counter: Counter[str] = Counter()
+
+    for reference in sorted(references):
+        numeric = _numeric_skill_path(reference)
+        exact_id = index["by_source_id"].get(reference)
+        path_hits = index["path_matches"].get(numeric or "", [])
+        path_skill_ids = sorted({hit["skill_id"] for hit in path_hits})
+        top_level_hits = [hit for hit in path_hits if hit.get("top_level_identity")]
+        top_level_skill_ids = sorted({hit["skill_id"] for hit in top_level_hits})
+        normalized_name_hits = sorted(index["by_normalized_name"].get(_normalize_name(reference), set()))
+
+        for hit in path_hits:
+            path_context_counter[hit["field_path"]] += 1
+
+        candidate_ids: set[str] = set()
+        match_methods: list[str] = []
+        if exact_id:
+            candidate_ids.add(exact_id)
+            exact_id_count += 1
+            match_methods.append("exact_id")
+        if path_skill_ids:
+            candidate_ids.update(path_skill_ids)
+            exact_path_count += 1
+            match_methods.append("exact_path")
+        if top_level_skill_ids:
+            top_level_path_count += 1
+            match_methods.append("top_level_path")
+        if normalized_name_hits:
+            candidate_ids.update(normalized_name_hits)
+            normalized_name_count += 1
+            match_methods.append("normalized_name")
+
+        has_safe_identity_match = bool(exact_id or top_level_skill_ids)
+        if len(candidate_ids) > 1:
+            status = "ambiguous"
+            ambiguous_count += 1
+        elif len(candidate_ids) == 1:
+            if has_safe_identity_match:
+                status = "resolved"
+            else:
+                status = "nested_path_match_not_bridge_safe"
+                nested_path_only_count += 1
+        else:
+            status = "unresolved"
+            unresolved_count += 1
+
+        results.append(
+            {
+                "class_mastery_skill_reference": reference,
+                "owners": sorted(references[reference]),
+                "status": status,
+                "match_methods": match_methods,
+                "candidate_skill_ids": sorted(candidate_ids),
+                "exact_id_match": exact_id,
+                "exact_path_matches": path_hits[:10],
+                "normalized_name_matches": normalized_name_hits,
+            }
+        )
+
+    total = len(results)
+    bridge_safe = total > 0 and unresolved_count == 0 and ambiguous_count == 0 and (
+        exact_id_count == total or top_level_path_count == total
+    )
+    if bridge_safe:
+        strategy = "safe_deterministic_bridge_possible"
+    elif exact_path_count:
+        strategy = "do_not_bridge_from_nested_path_evidence"
+    else:
+        strategy = "source_identity_gap_requires_upstream_alignment"
+
+    source_data_missing = unresolved_count > 0 or top_level_path_count == 0
+
+    return {
+        "summary": {
+            "total_class_mastery_skill_references": total,
+            "total_skill_records": len(skills),
+            "exact_id_match_count": exact_id_count,
+            "exact_path_match_count": exact_path_count,
+            "top_level_path_match_count": top_level_path_count,
+            "nested_path_only_match_count": nested_path_only_count,
+            "normalized_name_match_count": normalized_name_count,
+            "ambiguous_match_count": ambiguous_count,
+            "unresolved_reference_count": unresolved_count,
+            "bridge_safe": bridge_safe,
+            "source_data_missing": source_data_missing,
+            "recommended_mapping_strategy": strategy,
+            "production_consumed": False,
+        },
+        "field_inventory": {
+            "class_mastery_skill_reference_fields": sorted(reference_fields),
+            "skill_identity_fields": [
+                "canonical_id",
+                "display_name",
+                "source_skill_id",
+                "raw_reference.source_skill_id",
+                "skill_tree_id",
+            ],
+            "raw_class_skill_reference_fields": [
+                "classes[].abilities.defaultPathIds",
+                "classes[].abilities.knownPathIds",
+                "classes[].abilities.unlockable[].abilityPathId",
+                "classes[].masteries[].masteryAbilityPathId",
+            ],
+            "raw_skill_path_like_fields": index["raw_skill_path_like_fields"],
+            "top_path_match_contexts": [
+                {"field_path": path, "match_count": count} for path, count in path_context_counter.most_common(20)
+            ],
+        },
+        "references": results,
+        "examples": {
+            "resolved_records": [record for record in results if record["status"] == "resolved"][:10],
+            "nested_path_only_records": [
+                record for record in results if record["status"] == "nested_path_match_not_bridge_safe"
+            ][:10],
+            "unresolved_records": [record for record in results if record["status"] == "unresolved"][:10],
+            "ambiguous_records": [record for record in results if record["status"] == "ambiguous"][:10],
+        },
+        "metadata": {
+            "source": "v2_class_mastery_bundle + v2_skill_bundle + source exports",
+            "read_only": True,
+            "experimental": True,
+            "production_safe": False,
+            "generated_on": datetime.now(UTC).date().isoformat(),
+            "source_class_count": len(source_classes.get("classes", [])) if isinstance(source_classes, dict) else None,
+            "source_skill_count": len(raw_skill_records),
+        },
+    }
+
+
+def _command_for_docs(args: argparse.Namespace) -> str:
+    return (
+        ".\\backend\\.venv\\Scripts\\python.exe backend\\scripts\\report_v2_skill_identity_alignment.py "
+        f"--class-mastery-bundle {args.class_mastery_bundle} "
+        f"--skill-bundle {args.skill_bundle} "
+        f"--skill-tree-bundle {args.skill_tree_bundle} "
+        f"--source-classes {args.source_classes} "
+        f"--source-skills {args.source_skills} "
+        f"--output {args.output} "
+        f"--markdown-output {args.markdown_output}"
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--class-mastery-bundle", type=Path, default=DEFAULT_CLASS_MASTERY_BUNDLE)
+    parser.add_argument("--skill-bundle", type=Path, default=DEFAULT_SKILL_BUNDLE)
+    parser.add_argument("--skill-tree-bundle", type=Path, default=DEFAULT_SKILL_TREE_BUNDLE)
+    parser.add_argument("--source-classes", type=Path, default=DEFAULT_SOURCE_CLASSES)
+    parser.add_argument("--source-skills", type=Path, default=DEFAULT_SOURCE_SKILLS)
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument("--markdown-output", type=Path, default=DEFAULT_MARKDOWN_OUTPUT)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    report = build_report(
+        _read_json(args.class_mastery_bundle),
+        _read_json(args.skill_bundle),
+        _read_json(args.skill_tree_bundle),
+        _read_json(args.source_classes),
+        _read_json(args.source_skills),
+    )
+    _write_json(args.output, report)
+    _write_markdown(args.markdown_output, report, _command_for_docs(args))
+    print(json.dumps(report["summary"], indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_v2_skill_identity_alignment.py
+++ b/backend/tests/test_v2_skill_identity_alignment.py
@@ -1,0 +1,128 @@
+from backend.scripts.report_v2_skill_identity_alignment import build_report
+
+
+def _class_bundle(*refs: str) -> dict:
+    return {
+        "records": {
+            "classes": [
+                {
+                    "canonical_id": "class:test",
+                    "linked_skill_source_ids": list(refs),
+                    "skill_ids": list(refs),
+                }
+            ],
+            "masteries": [],
+        }
+    }
+
+
+def _skill_bundle(*skills: dict) -> dict:
+    return {"records": {"skills": list(skills)}}
+
+
+def _skill(canonical_id: str, source_skill_id: str, display_name: str) -> dict:
+    return {
+        "canonical_id": canonical_id,
+        "source_skill_id": source_skill_id,
+        "display_name": display_name,
+        "raw_reference": {"source_skill_id": source_skill_id},
+    }
+
+
+def _source_skills(*skills: dict) -> dict:
+    return {"skills": list(skills)}
+
+
+def test_unresolved_links_are_reported() -> None:
+    report = build_report(
+        _class_bundle("skill_path:100"),
+        _skill_bundle(_skill("skill:abc", "abc", "A Test Skill")),
+        {},
+        {"classes": []},
+        _source_skills({"id": "abc", "name": "A Test Skill"}),
+    )
+
+    assert report["summary"]["total_class_mastery_skill_references"] == 1
+    assert report["summary"]["unresolved_reference_count"] == 1
+    assert report["summary"]["bridge_safe"] is False
+    assert report["references"][0]["status"] == "unresolved"
+
+
+def test_top_level_path_match_can_be_safe_when_complete() -> None:
+    report = build_report(
+        _class_bundle("skill_path:100"),
+        _skill_bundle(_skill("skill:abc", "abc", "A Test Skill")),
+        {},
+        {"classes": []},
+        _source_skills({"id": "abc", "name": "A Test Skill", "abilityPathId": 100}),
+    )
+
+    assert report["summary"]["exact_path_match_count"] == 1
+    assert report["summary"]["top_level_path_match_count"] == 1
+    assert report["summary"]["unresolved_reference_count"] == 0
+    assert report["summary"]["ambiguous_match_count"] == 0
+    assert report["summary"]["bridge_safe"] is True
+
+
+def test_nested_path_match_is_not_bridge_safe() -> None:
+    report = build_report(
+        _class_bundle("skill_path:100"),
+        _skill_bundle(_skill("skill:abc", "abc", "A Test Skill")),
+        {},
+        {"classes": []},
+        _source_skills({"id": "abc", "name": "A Test Skill", "summonedActors": [{"resolvedAbilityPathId": 100}]}),
+    )
+
+    assert report["summary"]["exact_path_match_count"] == 1
+    assert report["summary"]["top_level_path_match_count"] == 0
+    assert report["summary"]["bridge_safe"] is False
+    assert report["summary"]["recommended_mapping_strategy"] == "do_not_bridge_from_nested_path_evidence"
+
+
+def test_ambiguous_mappings_are_not_silently_accepted() -> None:
+    report = build_report(
+        _class_bundle("skill_path:100"),
+        _skill_bundle(
+            _skill("skill:abc", "abc", "A Test Skill"),
+            _skill("skill:def", "def", "Another Skill"),
+        ),
+        {},
+        {"classes": []},
+        _source_skills(
+            {"id": "abc", "name": "A Test Skill", "abilityPathId": 100},
+            {"id": "def", "name": "Another Skill", "abilityPathId": 100},
+        ),
+    )
+
+    assert report["summary"]["ambiguous_match_count"] == 1
+    assert report["summary"]["bridge_safe"] is False
+    assert report["references"][0]["status"] == "ambiguous"
+
+
+def test_exact_source_id_match_is_counted_separately() -> None:
+    report = build_report(
+        _class_bundle("skill:abc"),
+        _skill_bundle(_skill("skill:abc", "abc", "A Test Skill")),
+        {},
+        {"classes": []},
+        _source_skills({"id": "abc", "name": "A Test Skill"}),
+    )
+
+    assert report["summary"]["total_class_mastery_skill_references"] == 1
+    assert report["summary"]["exact_id_match_count"] == 1
+    assert report["summary"]["bridge_safe"] is True
+
+
+def test_metadata_safety_flags() -> None:
+    report = build_report(
+        _class_bundle("skill_path:100"),
+        _skill_bundle(),
+        {},
+        {"classes": []},
+        _source_skills(),
+    )
+
+    assert report["metadata"]["read_only"] is True
+    assert report["metadata"]["experimental"] is True
+    assert report["metadata"]["production_safe"] is False
+    assert report["summary"]["production_consumed"] is False

--- a/docs/generated/v2_skill_identity_alignment_report.json
+++ b/docs/generated/v2_skill_identity_alignment_report.json
@@ -1,0 +1,1558 @@
+{
+  "examples": {
+    "ambiguous_records": [
+      {
+        "candidate_skill_ids": [
+          "skill:sps5l",
+          "skill:sr5t",
+          "skill:srtor",
+          "skill:ss37kl"
+        ],
+        "class_mastery_skill_reference": "skill_path:261142",
+        "exact_id_match": null,
+        "exact_path_matches": [
+          {
+            "display_name": "Summon Raptor",
+            "field_path": "summonedActors.0.abilities.0.resolvedAbilityPathId",
+            "skill_id": "skill:srtor",
+            "source_skill_id": "srtor",
+            "top_level_identity": false
+          },
+          {
+            "display_name": "Summon Raptor",
+            "field_path": "summonedActors.0.abilities.0.abilityResolutionSourcePath.8",
+            "skill_id": "skill:srtor",
+            "source_skill_id": "srtor",
+            "top_level_identity": false
+          },
+          {
+            "display_name": "Summon Raptor",
+            "field_path": "summonedActors.0.abilities.0.damageSources.0.sourcePath.8",
+            "skill_id": "skill:srtor",
+            "source_skill_id": "srtor",
+            "top_level_identity": false
+          },
+          {
+            "display_name": "Summon Skeleton",
+            "field_path": "summonedActors.2.abilities.0.resolvedAbilityPathId",
+            "skill_id": "skill:ss37kl",
+            "source_skill_id": "ss37kl",
+            "top_level_identity": false
+          },
+          {
+            "display_name": "Summon Skeleton",
+            "field_path": "summonedActors.2.abilities.0.abilityResolutionSourcePath.11",
+            "skill_id": "skill:ss37kl",
+            "source_skill_id": "ss37kl",
+            "top_level_identity": false
+          },
+          {
+            "display_name": "Summon Skeleton",
+            "field_path": "summonedActors.2.abilities.0.damageSources.0.sourcePath.11",
+            "skill_id": "skill:ss37kl",
+            "source_skill_id": "ss37kl",
+            "top_level_identity": false
+          },
+          {
+            "display_name": "Summon Skeleton Rogue",
+            "field_path": "summonedActors.2.abilities.0.resolvedAbilityPathId",
+            "skill_id": "skill:sr5t",
+            "source_skill_id": "sr5t",
+            "top_level_identity": false
+          },
+          {
+            "display_name": "Summon Skeleton Rogue",
+            "field_path": "summonedActors.2.abilities.0.abilityResolutionSourcePath.11",
+            "skill_id": "skill:sr5t",
+            "source_skill_id": "sr5t",
+            "top_level_identity": false
+          },
+          {
+            "display_name": "Summon Skeleton Rogue",
+            "field_path": "summonedActors.2.abilities.0.damageSources.0.sourcePath.11",
+            "skill_id": "skill:sr5t",
+            "source_skill_id": "sr5t",
+            "top_level_identity": false
+          },
+          {
+            "display_name": "Summon Squirrel",
+            "field_path": "summonedActors.0.abilities.0.resolvedAbilityPathId",
+            "skill_id": "skill:sps5l",
+            "source_skill_id": "sps5l",
+            "top_level_identity": false
+          }
+        ],
+        "match_methods": [
+          "exact_path"
+        ],
+        "normalized_name_matches": [],
+        "owners": [
+          "class:acolyte",
+          "class:mage",
+          "class:primalist",
+          "class:rogue",
+          "class:sentinel"
+        ],
+        "status": "ambiguous"
+      }
+    ],
+    "nested_path_only_records": [
+      {
+        "candidate_skill_ids": [
+          "skill:fb8fe"
+        ],
+        "class_mastery_skill_reference": "skill_path:264015",
+        "exact_id_match": null,
+        "exact_path_matches": [
+          {
+            "display_name": "Runebolt",
+            "field_path": "skillTree.nodes.28.requirements.0.nodeId",
+            "skill_id": "skill:fb8fe",
+            "source_skill_id": "fb8fe",
+            "top_level_identity": false
+          },
+          {
+            "display_name": "Runebolt",
+            "field_path": "skillTree.nodes.28.effectHints.3.nodeId",
+            "skill_id": "skill:fb8fe",
+            "source_skill_id": "fb8fe",
+            "top_level_identity": false
+          }
+        ],
+        "match_methods": [
+          "exact_path"
+        ],
+        "normalized_name_matches": [],
+        "owners": [
+          "mastery:mage:runemaster"
+        ],
+        "status": "nested_path_match_not_bridge_safe"
+      }
+    ],
+    "resolved_records": [],
+    "unresolved_records": [
+      {
+        "candidate_skill_ids": [],
+        "class_mastery_skill_reference": "skill_path:260926",
+        "exact_id_match": null,
+        "exact_path_matches": [],
+        "match_methods": [],
+        "normalized_name_matches": [],
+        "owners": [
+          "class:acolyte"
+        ],
+        "status": "unresolved"
+      },
+      {
+        "candidate_skill_ids": [],
+        "class_mastery_skill_reference": "skill_path:261173",
+        "exact_id_match": null,
+        "exact_path_matches": [],
+        "match_methods": [],
+        "normalized_name_matches": [],
+        "owners": [
+          "class:acolyte"
+        ],
+        "status": "unresolved"
+      },
+      {
+        "candidate_skill_ids": [],
+        "class_mastery_skill_reference": "skill_path:261591",
+        "exact_id_match": null,
+        "exact_path_matches": [],
+        "match_methods": [],
+        "normalized_name_matches": [],
+        "owners": [
+          "class:mage"
+        ],
+        "status": "unresolved"
+      },
+      {
+        "candidate_skill_ids": [],
+        "class_mastery_skill_reference": "skill_path:262309",
+        "exact_id_match": null,
+        "exact_path_matches": [],
+        "match_methods": [],
+        "normalized_name_matches": [],
+        "owners": [
+          "mastery:sentinel:void_knight"
+        ],
+        "status": "unresolved"
+      },
+      {
+        "candidate_skill_ids": [],
+        "class_mastery_skill_reference": "skill_path:262328",
+        "exact_id_match": null,
+        "exact_path_matches": [],
+        "match_methods": [],
+        "normalized_name_matches": [],
+        "owners": [
+          "mastery:rogue:falconer"
+        ],
+        "status": "unresolved"
+      },
+      {
+        "candidate_skill_ids": [],
+        "class_mastery_skill_reference": "skill_path:262431",
+        "exact_id_match": null,
+        "exact_path_matches": [],
+        "match_methods": [],
+        "normalized_name_matches": [],
+        "owners": [
+          "class:mage"
+        ],
+        "status": "unresolved"
+      },
+      {
+        "candidate_skill_ids": [],
+        "class_mastery_skill_reference": "skill_path:262458",
+        "exact_id_match": null,
+        "exact_path_matches": [],
+        "match_methods": [],
+        "normalized_name_matches": [],
+        "owners": [
+          "class:mage"
+        ],
+        "status": "unresolved"
+      },
+      {
+        "candidate_skill_ids": [],
+        "class_mastery_skill_reference": "skill_path:262473",
+        "exact_id_match": null,
+        "exact_path_matches": [],
+        "match_methods": [],
+        "normalized_name_matches": [],
+        "owners": [
+          "mastery:sentinel:forge_guard"
+        ],
+        "status": "unresolved"
+      },
+      {
+        "candidate_skill_ids": [],
+        "class_mastery_skill_reference": "skill_path:262497",
+        "exact_id_match": null,
+        "exact_path_matches": [],
+        "match_methods": [],
+        "normalized_name_matches": [],
+        "owners": [
+          "class:mage"
+        ],
+        "status": "unresolved"
+      },
+      {
+        "candidate_skill_ids": [],
+        "class_mastery_skill_reference": "skill_path:262531",
+        "exact_id_match": null,
+        "exact_path_matches": [],
+        "match_methods": [],
+        "normalized_name_matches": [],
+        "owners": [
+          "class:primalist"
+        ],
+        "status": "unresolved"
+      }
+    ]
+  },
+  "field_inventory": {
+    "class_mastery_skill_reference_fields": [
+      "linked_skill_source_ids",
+      "skill_ids"
+    ],
+    "raw_class_skill_reference_fields": [
+      "classes[].abilities.defaultPathIds",
+      "classes[].abilities.knownPathIds",
+      "classes[].abilities.unlockable[].abilityPathId",
+      "classes[].masteries[].masteryAbilityPathId"
+    ],
+    "raw_skill_path_like_fields": [
+      "comboAbility",
+      "damageSources.0.pathId",
+      "damageSources.0.sourcePath",
+      "damageSources.1.pathId",
+      "damageSources.1.sourcePath",
+      "damageSources.2.pathId",
+      "damageSources.2.sourcePath",
+      "isZoneAbility",
+      "minionsUseAbility",
+      "mutatorHints.0.pathId",
+      "mutatorHints.0.sourcePath",
+      "mutatorHints.1.pathId",
+      "mutatorHints.1.sourcePath",
+      "mutatorHints.2.pathId",
+      "mutatorHints.2.sourcePath",
+      "sharedCooldownAbilityRefs",
+      "skillTree.ability",
+      "skillTree.nodes.0.effectHints.0.sourcePath",
+      "skillTree.nodes.0.effectHints.1.sourcePath",
+      "skillTree.nodes.0.effectHints.2.sourcePath",
+      "skillTree.nodes.0.effectHints.3.sourcePath",
+      "skillTree.nodes.1.effectHints.0.sourcePath",
+      "skillTree.nodes.1.effectHints.1.sourcePath",
+      "skillTree.nodes.1.effectHints.2.sourcePath",
+      "skillTree.nodes.1.effectHints.3.sourcePath",
+      "skillTree.nodes.1.effectHints.4.sourcePath",
+      "skillTree.nodes.10.effectHints.0.sourcePath",
+      "skillTree.nodes.10.effectHints.1.sourcePath",
+      "skillTree.nodes.10.effectHints.2.sourcePath",
+      "skillTree.nodes.10.effectHints.3.sourcePath",
+      "skillTree.nodes.10.effectHints.4.sourcePath",
+      "skillTree.nodes.10.effectHints.5.sourcePath",
+      "skillTree.nodes.11.effectHints.0.sourcePath",
+      "skillTree.nodes.11.effectHints.1.sourcePath",
+      "skillTree.nodes.11.effectHints.2.sourcePath",
+      "skillTree.nodes.11.effectHints.3.sourcePath",
+      "skillTree.nodes.11.effectHints.4.sourcePath",
+      "skillTree.nodes.11.effectHints.5.sourcePath",
+      "skillTree.nodes.12.effectHints.0.sourcePath",
+      "skillTree.nodes.12.effectHints.1.sourcePath",
+      "skillTree.nodes.12.effectHints.2.sourcePath",
+      "skillTree.nodes.12.effectHints.3.sourcePath",
+      "skillTree.nodes.12.effectHints.4.sourcePath",
+      "skillTree.nodes.13.effectHints.0.sourcePath",
+      "skillTree.nodes.13.effectHints.1.sourcePath",
+      "skillTree.nodes.13.effectHints.2.sourcePath",
+      "skillTree.nodes.13.effectHints.3.sourcePath",
+      "skillTree.nodes.13.effectHints.4.sourcePath",
+      "skillTree.nodes.14.effectHints.0.sourcePath",
+      "skillTree.nodes.14.effectHints.1.sourcePath",
+      "skillTree.nodes.14.effectHints.2.sourcePath",
+      "skillTree.nodes.14.effectHints.3.sourcePath",
+      "skillTree.nodes.14.effectHints.4.sourcePath",
+      "skillTree.nodes.14.effectHints.5.sourcePath",
+      "skillTree.nodes.15.effectHints.0.sourcePath",
+      "skillTree.nodes.15.effectHints.1.sourcePath",
+      "skillTree.nodes.15.effectHints.2.sourcePath",
+      "skillTree.nodes.15.effectHints.3.sourcePath",
+      "skillTree.nodes.15.effectHints.4.sourcePath",
+      "skillTree.nodes.16.effectHints.0.sourcePath",
+      "skillTree.nodes.16.effectHints.1.sourcePath",
+      "skillTree.nodes.16.effectHints.2.sourcePath",
+      "skillTree.nodes.16.effectHints.3.sourcePath",
+      "skillTree.nodes.16.effectHints.4.sourcePath",
+      "skillTree.nodes.16.effectHints.5.sourcePath",
+      "skillTree.nodes.17.effectHints.0.sourcePath",
+      "skillTree.nodes.17.effectHints.1.sourcePath",
+      "skillTree.nodes.17.effectHints.2.sourcePath",
+      "skillTree.nodes.17.effectHints.3.sourcePath",
+      "skillTree.nodes.17.effectHints.4.sourcePath",
+      "skillTree.nodes.18.effectHints.0.sourcePath",
+      "skillTree.nodes.18.effectHints.1.sourcePath",
+      "skillTree.nodes.18.effectHints.2.sourcePath",
+      "skillTree.nodes.18.effectHints.3.sourcePath",
+      "skillTree.nodes.18.effectHints.4.sourcePath",
+      "skillTree.nodes.18.effectHints.5.sourcePath",
+      "skillTree.nodes.19.effectHints.0.sourcePath",
+      "skillTree.nodes.19.effectHints.1.sourcePath",
+      "skillTree.nodes.19.effectHints.2.sourcePath",
+      "skillTree.nodes.19.effectHints.3.sourcePath",
+      "skillTree.nodes.19.effectHints.4.sourcePath",
+      "skillTree.nodes.19.effectHints.5.sourcePath",
+      "skillTree.nodes.2.effectHints.0.sourcePath",
+      "skillTree.nodes.2.effectHints.1.sourcePath",
+      "skillTree.nodes.2.effectHints.2.sourcePath",
+      "skillTree.nodes.2.effectHints.3.sourcePath",
+      "skillTree.nodes.2.effectHints.4.sourcePath",
+      "skillTree.nodes.20.effectHints.0.sourcePath",
+      "skillTree.nodes.20.effectHints.1.sourcePath",
+      "skillTree.nodes.20.effectHints.2.sourcePath",
+      "skillTree.nodes.20.effectHints.3.sourcePath",
+      "skillTree.nodes.20.effectHints.4.sourcePath",
+      "skillTree.nodes.21.effectHints.0.sourcePath",
+      "skillTree.nodes.21.effectHints.1.sourcePath",
+      "skillTree.nodes.21.effectHints.2.sourcePath",
+      "skillTree.nodes.21.effectHints.3.sourcePath",
+      "skillTree.nodes.21.effectHints.4.sourcePath",
+      "skillTree.nodes.21.effectHints.5.sourcePath",
+      "skillTree.nodes.22.effectHints.0.sourcePath",
+      "skillTree.nodes.22.effectHints.1.sourcePath",
+      "skillTree.nodes.22.effectHints.2.sourcePath",
+      "skillTree.nodes.22.effectHints.3.sourcePath",
+      "skillTree.nodes.22.effectHints.4.sourcePath",
+      "skillTree.nodes.22.effectHints.5.sourcePath",
+      "skillTree.nodes.23.effectHints.0.sourcePath",
+      "skillTree.nodes.23.effectHints.1.sourcePath",
+      "skillTree.nodes.23.effectHints.2.sourcePath",
+      "skillTree.nodes.23.effectHints.3.sourcePath",
+      "skillTree.nodes.23.effectHints.4.sourcePath",
+      "skillTree.nodes.23.effectHints.5.sourcePath",
+      "skillTree.nodes.24.effectHints.0.sourcePath",
+      "skillTree.nodes.24.effectHints.1.sourcePath",
+      "skillTree.nodes.24.effectHints.2.sourcePath",
+      "skillTree.nodes.24.effectHints.3.sourcePath",
+      "skillTree.nodes.24.effectHints.4.sourcePath",
+      "skillTree.nodes.24.effectHints.5.sourcePath",
+      "skillTree.nodes.24.effectHints.6.sourcePath",
+      "skillTree.nodes.25.effectHints.0.sourcePath",
+      "skillTree.nodes.25.effectHints.1.sourcePath",
+      "skillTree.nodes.25.effectHints.2.sourcePath",
+      "skillTree.nodes.25.effectHints.3.sourcePath",
+      "skillTree.nodes.25.effectHints.4.sourcePath",
+      "skillTree.nodes.26.effectHints.0.sourcePath",
+      "skillTree.nodes.26.effectHints.1.sourcePath",
+      "skillTree.nodes.26.effectHints.2.sourcePath",
+      "skillTree.nodes.26.effectHints.3.sourcePath",
+      "skillTree.nodes.26.effectHints.4.sourcePath",
+      "skillTree.nodes.26.effectHints.5.sourcePath",
+      "skillTree.nodes.27.effectHints.0.sourcePath",
+      "skillTree.nodes.27.effectHints.1.sourcePath",
+      "skillTree.nodes.27.effectHints.2.sourcePath",
+      "skillTree.nodes.27.effectHints.3.sourcePath",
+      "skillTree.nodes.27.effectHints.4.sourcePath",
+      "skillTree.nodes.28.effectHints.0.sourcePath",
+      "skillTree.nodes.28.effectHints.1.sourcePath",
+      "skillTree.nodes.28.effectHints.2.sourcePath",
+      "skillTree.nodes.28.effectHints.3.sourcePath",
+      "skillTree.nodes.28.effectHints.4.sourcePath",
+      "skillTree.nodes.29.effectHints.0.sourcePath",
+      "skillTree.nodes.29.effectHints.1.sourcePath",
+      "skillTree.nodes.29.effectHints.2.sourcePath",
+      "skillTree.nodes.29.effectHints.3.sourcePath",
+      "skillTree.nodes.29.effectHints.4.sourcePath",
+      "skillTree.nodes.3.effectHints.0.sourcePath",
+      "skillTree.nodes.3.effectHints.1.sourcePath",
+      "skillTree.nodes.3.effectHints.2.sourcePath",
+      "skillTree.nodes.3.effectHints.3.sourcePath",
+      "skillTree.nodes.3.effectHints.4.sourcePath",
+      "skillTree.nodes.30.effectHints.0.sourcePath",
+      "skillTree.nodes.30.effectHints.1.sourcePath",
+      "skillTree.nodes.30.effectHints.2.sourcePath",
+      "skillTree.nodes.30.effectHints.3.sourcePath",
+      "skillTree.nodes.30.effectHints.4.sourcePath",
+      "skillTree.nodes.30.effectHints.5.sourcePath",
+      "skillTree.nodes.31.effectHints.0.sourcePath",
+      "skillTree.nodes.31.effectHints.1.sourcePath",
+      "skillTree.nodes.31.effectHints.2.sourcePath",
+      "skillTree.nodes.31.effectHints.3.sourcePath",
+      "skillTree.nodes.31.effectHints.4.sourcePath",
+      "skillTree.nodes.32.effectHints.0.sourcePath",
+      "skillTree.nodes.32.effectHints.1.sourcePath",
+      "skillTree.nodes.32.effectHints.2.sourcePath",
+      "skillTree.nodes.32.effectHints.3.sourcePath",
+      "skillTree.nodes.32.effectHints.4.sourcePath",
+      "skillTree.nodes.32.effectHints.5.sourcePath",
+      "skillTree.nodes.33.effectHints.0.sourcePath",
+      "skillTree.nodes.33.effectHints.1.sourcePath",
+      "skillTree.nodes.33.effectHints.2.sourcePath",
+      "skillTree.nodes.33.effectHints.3.sourcePath",
+      "skillTree.nodes.34.effectHints.0.sourcePath",
+      "skillTree.nodes.34.effectHints.1.sourcePath",
+      "skillTree.nodes.4.effectHints.0.sourcePath",
+      "skillTree.nodes.4.effectHints.1.sourcePath",
+      "skillTree.nodes.4.effectHints.2.sourcePath",
+      "skillTree.nodes.4.effectHints.3.sourcePath",
+      "skillTree.nodes.4.effectHints.4.sourcePath",
+      "skillTree.nodes.4.effectHints.5.sourcePath",
+      "skillTree.nodes.5.effectHints.0.sourcePath",
+      "skillTree.nodes.5.effectHints.1.sourcePath",
+      "skillTree.nodes.5.effectHints.2.sourcePath",
+      "skillTree.nodes.5.effectHints.3.sourcePath",
+      "skillTree.nodes.5.effectHints.4.sourcePath",
+      "skillTree.nodes.5.effectHints.5.sourcePath",
+      "skillTree.nodes.5.effectHints.6.sourcePath",
+      "skillTree.nodes.6.effectHints.0.sourcePath",
+      "skillTree.nodes.6.effectHints.1.sourcePath",
+      "skillTree.nodes.6.effectHints.2.sourcePath",
+      "skillTree.nodes.6.effectHints.3.sourcePath",
+      "skillTree.nodes.6.effectHints.4.sourcePath",
+      "skillTree.nodes.6.effectHints.5.sourcePath",
+      "skillTree.nodes.7.effectHints.0.sourcePath",
+      "skillTree.nodes.7.effectHints.1.sourcePath",
+      "skillTree.nodes.7.effectHints.2.sourcePath",
+      "skillTree.nodes.7.effectHints.3.sourcePath",
+      "skillTree.nodes.7.effectHints.4.sourcePath",
+      "skillTree.nodes.7.effectHints.5.sourcePath",
+      "skillTree.nodes.8.effectHints.0.sourcePath",
+      "skillTree.nodes.8.effectHints.1.sourcePath",
+      "skillTree.nodes.8.effectHints.2.sourcePath",
+      "skillTree.nodes.8.effectHints.3.sourcePath",
+      "skillTree.nodes.8.effectHints.4.sourcePath",
+      "skillTree.nodes.8.effectHints.5.sourcePath",
+      "skillTree.nodes.9.effectHints.0.sourcePath",
+      "skillTree.nodes.9.effectHints.1.sourcePath",
+      "skillTree.nodes.9.effectHints.2.sourcePath",
+      "skillTree.nodes.9.effectHints.3.sourcePath",
+      "skillTree.nodes.9.effectHints.4.sourcePath",
+      "skillTree.nodes.9.effectHints.5.sourcePath",
+      "summonedActors.0.abilities.0.abilityName",
+      "summonedActors.0.abilities.0.abilityRefKey",
+      "summonedActors.0.abilities.0.abilityResolutionMethod",
+      "summonedActors.0.abilities.0.abilityResolutionSourcePath",
+      "summonedActors.0.abilities.0.abilityResolutionStatus",
+      "summonedActors.0.abilities.0.actorPrefabPath",
+      "summonedActors.0.abilities.0.componentPathId",
+      "summonedActors.0.abilities.0.damageSources.0.pathId",
+      "summonedActors.0.abilities.0.damageSources.0.sourcePath",
+      "summonedActors.0.abilities.0.prefabPath",
+      "summonedActors.0.abilities.0.resolvedAbilityName",
+      "summonedActors.0.abilities.0.resolvedAbilityPathId",
+      "summonedActors.0.abilities.0.sourcePath",
+      "summonedActors.0.abilities.1.abilityName",
+      "summonedActors.0.abilities.1.abilityRefKey",
+      "summonedActors.0.abilities.1.abilityResolutionMethod",
+      "summonedActors.0.abilities.1.abilityResolutionSourcePath",
+      "summonedActors.0.abilities.1.abilityResolutionStatus",
+      "summonedActors.0.abilities.1.actorPrefabPath",
+      "summonedActors.0.abilities.1.componentPathId",
+      "summonedActors.0.abilities.1.damageSources.0.pathId",
+      "summonedActors.0.abilities.1.damageSources.0.sourcePath",
+      "summonedActors.0.abilities.1.prefabPath",
+      "summonedActors.0.abilities.1.resolvedAbilityName",
+      "summonedActors.0.abilities.1.resolvedAbilityPathId",
+      "summonedActors.0.abilities.1.sourcePath",
+      "summonedActors.0.abilities.2.abilityName",
+      "summonedActors.0.abilities.2.abilityRefKey",
+      "summonedActors.0.abilities.2.abilityResolutionMethod",
+      "summonedActors.0.abilities.2.abilityResolutionSourcePath",
+      "summonedActors.0.abilities.2.abilityResolutionStatus",
+      "summonedActors.0.abilities.2.actorPrefabPath",
+      "summonedActors.0.abilities.2.componentPathId",
+      "summonedActors.0.abilities.2.damageSources.0.pathId",
+      "summonedActors.0.abilities.2.damageSources.0.sourcePath",
+      "summonedActors.0.abilities.2.prefabPath",
+      "summonedActors.0.abilities.2.resolvedAbilityName",
+      "summonedActors.0.abilities.2.resolvedAbilityPathId",
+      "summonedActors.0.abilities.2.sourcePath",
+      "summonedActors.0.abilities.3.abilityName",
+      "summonedActors.0.abilities.3.abilityRefKey",
+      "summonedActors.0.abilities.3.abilityResolutionMethod",
+      "summonedActors.0.abilities.3.abilityResolutionSourcePath",
+      "summonedActors.0.abilities.3.abilityResolutionStatus",
+      "summonedActors.0.abilities.3.actorPrefabPath",
+      "summonedActors.0.abilities.3.componentPathId",
+      "summonedActors.0.abilities.3.damageSources.0.pathId",
+      "summonedActors.0.abilities.3.damageSources.0.sourcePath",
+      "summonedActors.0.abilities.3.prefabPath",
+      "summonedActors.0.abilities.3.resolvedAbilityName",
+      "summonedActors.0.abilities.3.resolvedAbilityPathId",
+      "summonedActors.0.abilities.3.sourcePath",
+      "summonedActors.0.abilityEnumerationStatus",
+      "summonedActors.0.actorDataPathId",
+      "summonedActors.0.actorPrefabAssetPath",
+      "summonedActors.0.prefabPath",
+      "summonedActors.0.sourcePath",
+      "summonedActors.0.visualsPath",
+      "summonedActors.1.abilities.0.abilityName",
+      "summonedActors.1.abilities.0.abilityRefKey",
+      "summonedActors.1.abilities.0.abilityResolutionMethod",
+      "summonedActors.1.abilities.0.abilityResolutionSourcePath",
+      "summonedActors.1.abilities.0.abilityResolutionStatus",
+      "summonedActors.1.abilities.0.actorPrefabPath",
+      "summonedActors.1.abilities.0.componentPathId",
+      "summonedActors.1.abilities.0.damageSources.0.pathId",
+      "summonedActors.1.abilities.0.damageSources.0.sourcePath",
+      "summonedActors.1.abilities.0.prefabPath",
+      "summonedActors.1.abilities.0.resolvedAbilityName",
+      "summonedActors.1.abilities.0.resolvedAbilityPathId",
+      "summonedActors.1.abilities.0.sourcePath",
+      "summonedActors.1.abilities.1.abilityName",
+      "summonedActors.1.abilities.1.abilityRefKey",
+      "summonedActors.1.abilities.1.abilityResolutionMethod",
+      "summonedActors.1.abilities.1.abilityResolutionSourcePath",
+      "summonedActors.1.abilities.1.abilityResolutionStatus",
+      "summonedActors.1.abilities.1.actorPrefabPath",
+      "summonedActors.1.abilities.1.componentPathId",
+      "summonedActors.1.abilities.1.damageSources.0.pathId",
+      "summonedActors.1.abilities.1.damageSources.0.sourcePath",
+      "summonedActors.1.abilities.1.prefabPath",
+      "summonedActors.1.abilities.1.resolvedAbilityName",
+      "summonedActors.1.abilities.1.resolvedAbilityPathId",
+      "summonedActors.1.abilities.1.sourcePath",
+      "summonedActors.1.abilities.2.abilityName",
+      "summonedActors.1.abilities.2.abilityRefKey",
+      "summonedActors.1.abilities.2.abilityResolutionMethod",
+      "summonedActors.1.abilities.2.abilityResolutionSourcePath",
+      "summonedActors.1.abilities.2.abilityResolutionStatus",
+      "summonedActors.1.abilities.2.actorPrefabPath",
+      "summonedActors.1.abilities.2.componentPathId",
+      "summonedActors.1.abilities.2.damageSources.0.pathId",
+      "summonedActors.1.abilities.2.damageSources.0.sourcePath",
+      "summonedActors.1.abilities.2.prefabPath",
+      "summonedActors.1.abilities.2.resolvedAbilityName",
+      "summonedActors.1.abilities.2.resolvedAbilityPathId",
+      "summonedActors.1.abilities.2.sourcePath",
+      "summonedActors.1.abilityEnumerationStatus",
+      "summonedActors.1.actorDataPathId",
+      "summonedActors.1.actorPrefabAssetPath",
+      "summonedActors.1.prefabPath",
+      "summonedActors.1.sourcePath",
+      "summonedActors.1.visualsPath",
+      "summonedActors.2.abilities.0.abilityName",
+      "summonedActors.2.abilities.0.abilityRefKey",
+      "summonedActors.2.abilities.0.abilityResolutionMethod",
+      "summonedActors.2.abilities.0.abilityResolutionSourcePath",
+      "summonedActors.2.abilities.0.abilityResolutionStatus",
+      "summonedActors.2.abilities.0.actorPrefabPath",
+      "summonedActors.2.abilities.0.componentPathId",
+      "summonedActors.2.abilities.0.damageSources.0.pathId",
+      "summonedActors.2.abilities.0.damageSources.0.sourcePath",
+      "summonedActors.2.abilities.0.prefabPath",
+      "summonedActors.2.abilities.0.resolvedAbilityName",
+      "summonedActors.2.abilities.0.resolvedAbilityPathId",
+      "summonedActors.2.abilities.0.sourcePath",
+      "summonedActors.2.abilities.1.abilityName",
+      "summonedActors.2.abilities.1.abilityRefKey",
+      "summonedActors.2.abilities.1.abilityResolutionMethod",
+      "summonedActors.2.abilities.1.abilityResolutionSourcePath",
+      "summonedActors.2.abilities.1.abilityResolutionStatus",
+      "summonedActors.2.abilities.1.actorPrefabPath",
+      "summonedActors.2.abilities.1.componentPathId",
+      "summonedActors.2.abilities.1.prefabPath",
+      "summonedActors.2.abilities.1.resolvedAbilityName",
+      "summonedActors.2.abilities.1.resolvedAbilityPathId",
+      "summonedActors.2.abilities.1.sourcePath",
+      "summonedActors.2.abilityEnumerationStatus",
+      "summonedActors.2.actorDataPathId",
+      "summonedActors.2.actorPrefabAssetPath",
+      "summonedActors.2.prefabPath",
+      "summonedActors.2.sourcePath",
+      "summonedActors.2.visualsPath",
+      "summonedActors.3.abilities.0.abilityName",
+      "summonedActors.3.abilities.0.abilityRefKey",
+      "summonedActors.3.abilities.0.abilityResolutionMethod",
+      "summonedActors.3.abilities.0.abilityResolutionSourcePath",
+      "summonedActors.3.abilities.0.abilityResolutionStatus",
+      "summonedActors.3.abilities.0.actorPrefabPath",
+      "summonedActors.3.abilities.0.componentPathId",
+      "summonedActors.3.abilities.0.damageSources.0.pathId",
+      "summonedActors.3.abilities.0.damageSources.0.sourcePath",
+      "summonedActors.3.abilities.0.prefabPath",
+      "summonedActors.3.abilities.0.resolvedAbilityName",
+      "summonedActors.3.abilities.0.resolvedAbilityPathId",
+      "summonedActors.3.abilities.0.sourcePath",
+      "summonedActors.3.abilityEnumerationStatus",
+      "summonedActors.3.actorDataPathId",
+      "summonedActors.3.actorPrefabAssetPath",
+      "summonedActors.3.prefabPath",
+      "summonedActors.3.sourcePath",
+      "summonedActors.3.visualsPath"
+    ],
+    "skill_identity_fields": [
+      "canonical_id",
+      "display_name",
+      "source_skill_id",
+      "raw_reference.source_skill_id",
+      "skill_tree_id"
+    ],
+    "top_path_match_contexts": [
+      {
+        "field_path": "summonedActors.0.abilities.0.resolvedAbilityPathId",
+        "match_count": 2
+      },
+      {
+        "field_path": "summonedActors.0.abilities.0.abilityResolutionSourcePath.8",
+        "match_count": 2
+      },
+      {
+        "field_path": "summonedActors.0.abilities.0.damageSources.0.sourcePath.8",
+        "match_count": 2
+      },
+      {
+        "field_path": "summonedActors.2.abilities.0.resolvedAbilityPathId",
+        "match_count": 2
+      },
+      {
+        "field_path": "summonedActors.2.abilities.0.abilityResolutionSourcePath.11",
+        "match_count": 2
+      },
+      {
+        "field_path": "summonedActors.2.abilities.0.damageSources.0.sourcePath.11",
+        "match_count": 2
+      },
+      {
+        "field_path": "skillTree.nodes.28.requirements.0.nodeId",
+        "match_count": 1
+      },
+      {
+        "field_path": "skillTree.nodes.28.effectHints.3.nodeId",
+        "match_count": 1
+      }
+    ]
+  },
+  "metadata": {
+    "experimental": true,
+    "generated_on": "2026-05-13",
+    "production_safe": false,
+    "read_only": true,
+    "source": "v2_class_mastery_bundle + v2_skill_bundle + source exports",
+    "source_class_count": 5,
+    "source_skill_count": 184
+  },
+  "references": [
+    {
+      "candidate_skill_ids": [],
+      "class_mastery_skill_reference": "skill_path:260926",
+      "exact_id_match": null,
+      "exact_path_matches": [],
+      "match_methods": [],
+      "normalized_name_matches": [],
+      "owners": [
+        "class:acolyte"
+      ],
+      "status": "unresolved"
+    },
+    {
+      "candidate_skill_ids": [
+        "skill:sps5l",
+        "skill:sr5t",
+        "skill:srtor",
+        "skill:ss37kl"
+      ],
+      "class_mastery_skill_reference": "skill_path:261142",
+      "exact_id_match": null,
+      "exact_path_matches": [
+        {
+          "display_name": "Summon Raptor",
+          "field_path": "summonedActors.0.abilities.0.resolvedAbilityPathId",
+          "skill_id": "skill:srtor",
+          "source_skill_id": "srtor",
+          "top_level_identity": false
+        },
+        {
+          "display_name": "Summon Raptor",
+          "field_path": "summonedActors.0.abilities.0.abilityResolutionSourcePath.8",
+          "skill_id": "skill:srtor",
+          "source_skill_id": "srtor",
+          "top_level_identity": false
+        },
+        {
+          "display_name": "Summon Raptor",
+          "field_path": "summonedActors.0.abilities.0.damageSources.0.sourcePath.8",
+          "skill_id": "skill:srtor",
+          "source_skill_id": "srtor",
+          "top_level_identity": false
+        },
+        {
+          "display_name": "Summon Skeleton",
+          "field_path": "summonedActors.2.abilities.0.resolvedAbilityPathId",
+          "skill_id": "skill:ss37kl",
+          "source_skill_id": "ss37kl",
+          "top_level_identity": false
+        },
+        {
+          "display_name": "Summon Skeleton",
+          "field_path": "summonedActors.2.abilities.0.abilityResolutionSourcePath.11",
+          "skill_id": "skill:ss37kl",
+          "source_skill_id": "ss37kl",
+          "top_level_identity": false
+        },
+        {
+          "display_name": "Summon Skeleton",
+          "field_path": "summonedActors.2.abilities.0.damageSources.0.sourcePath.11",
+          "skill_id": "skill:ss37kl",
+          "source_skill_id": "ss37kl",
+          "top_level_identity": false
+        },
+        {
+          "display_name": "Summon Skeleton Rogue",
+          "field_path": "summonedActors.2.abilities.0.resolvedAbilityPathId",
+          "skill_id": "skill:sr5t",
+          "source_skill_id": "sr5t",
+          "top_level_identity": false
+        },
+        {
+          "display_name": "Summon Skeleton Rogue",
+          "field_path": "summonedActors.2.abilities.0.abilityResolutionSourcePath.11",
+          "skill_id": "skill:sr5t",
+          "source_skill_id": "sr5t",
+          "top_level_identity": false
+        },
+        {
+          "display_name": "Summon Skeleton Rogue",
+          "field_path": "summonedActors.2.abilities.0.damageSources.0.sourcePath.11",
+          "skill_id": "skill:sr5t",
+          "source_skill_id": "sr5t",
+          "top_level_identity": false
+        },
+        {
+          "display_name": "Summon Squirrel",
+          "field_path": "summonedActors.0.abilities.0.resolvedAbilityPathId",
+          "skill_id": "skill:sps5l",
+          "source_skill_id": "sps5l",
+          "top_level_identity": false
+        }
+      ],
+      "match_methods": [
+        "exact_path"
+      ],
+      "normalized_name_matches": [],
+      "owners": [
+        "class:acolyte",
+        "class:mage",
+        "class:primalist",
+        "class:rogue",
+        "class:sentinel"
+      ],
+      "status": "ambiguous"
+    },
+    {
+      "candidate_skill_ids": [],
+      "class_mastery_skill_reference": "skill_path:261173",
+      "exact_id_match": null,
+      "exact_path_matches": [],
+      "match_methods": [],
+      "normalized_name_matches": [],
+      "owners": [
+        "class:acolyte"
+      ],
+      "status": "unresolved"
+    },
+    {
+      "candidate_skill_ids": [],
+      "class_mastery_skill_reference": "skill_path:261591",
+      "exact_id_match": null,
+      "exact_path_matches": [],
+      "match_methods": [],
+      "normalized_name_matches": [],
+      "owners": [
+        "class:mage"
+      ],
+      "status": "unresolved"
+    },
+    {
+      "candidate_skill_ids": [],
+      "class_mastery_skill_reference": "skill_path:262309",
+      "exact_id_match": null,
+      "exact_path_matches": [],
+      "match_methods": [],
+      "normalized_name_matches": [],
+      "owners": [
+        "mastery:sentinel:void_knight"
+      ],
+      "status": "unresolved"
+    },
+    {
+      "candidate_skill_ids": [],
+      "class_mastery_skill_reference": "skill_path:262328",
+      "exact_id_match": null,
+      "exact_path_matches": [],
+      "match_methods": [],
+      "normalized_name_matches": [],
+      "owners": [
+        "mastery:rogue:falconer"
+      ],
+      "status": "unresolved"
+    },
+    {
+      "candidate_skill_ids": [],
+      "class_mastery_skill_reference": "skill_path:262431",
+      "exact_id_match": null,
+      "exact_path_matches": [],
+      "match_methods": [],
+      "normalized_name_matches": [],
+      "owners": [
+        "class:mage"
+      ],
+      "status": "unresolved"
+    },
+    {
+      "candidate_skill_ids": [],
+      "class_mastery_skill_reference": "skill_path:262458",
+      "exact_id_match": null,
+      "exact_path_matches": [],
+      "match_methods": [],
+      "normalized_name_matches": [],
+      "owners": [
+        "class:mage"
+      ],
+      "status": "unresolved"
+    },
+    {
+      "candidate_skill_ids": [],
+      "class_mastery_skill_reference": "skill_path:262473",
+      "exact_id_match": null,
+      "exact_path_matches": [],
+      "match_methods": [],
+      "normalized_name_matches": [],
+      "owners": [
+        "mastery:sentinel:forge_guard"
+      ],
+      "status": "unresolved"
+    },
+    {
+      "candidate_skill_ids": [],
+      "class_mastery_skill_reference": "skill_path:262497",
+      "exact_id_match": null,
+      "exact_path_matches": [],
+      "match_methods": [],
+      "normalized_name_matches": [],
+      "owners": [
+        "class:mage"
+      ],
+      "status": "unresolved"
+    },
+    {
+      "candidate_skill_ids": [],
+      "class_mastery_skill_reference": "skill_path:262531",
+      "exact_id_match": null,
+      "exact_path_matches": [],
+      "match_methods": [],
+      "normalized_name_matches": [],
+      "owners": [
+        "class:primalist"
+      ],
+      "status": "unresolved"
+    },
+    {
+      "candidate_skill_ids": [],
+      "class_mastery_skill_reference": "skill_path:262552",
+      "exact_id_match": null,
+      "exact_path_matches": [],
+      "match_methods": [],
+      "normalized_name_matches": [],
+      "owners": [
+        "class:primalist"
+      ],
+      "status": "unresolved"
+    },
+    {
+      "candidate_skill_ids": [],
+      "class_mastery_skill_reference": "skill_path:262625",
+      "exact_id_match": null,
+      "exact_path_matches": [],
+      "match_methods": [],
+      "normalized_name_matches": [],
+      "owners": [
+        "class:sentinel"
+      ],
+      "status": "unresolved"
+    },
+    {
+      "candidate_skill_ids": [],
+      "class_mastery_skill_reference": "skill_path:262645",
+      "exact_id_match": null,
+      "exact_path_matches": [],
+      "match_methods": [],
+      "normalized_name_matches": [],
+      "owners": [
+        "class:acolyte"
+      ],
+      "status": "unresolved"
+    },
+    {
+      "candidate_skill_ids": [],
+      "class_mastery_skill_reference": "skill_path:262677",
+      "exact_id_match": null,
+      "exact_path_matches": [],
+      "match_methods": [],
+      "normalized_name_matches": [],
+      "owners": [
+        "mastery:sentinel:paladin"
+      ],
+      "status": "unresolved"
+    },
+    {
+      "candidate_skill_ids": [],
+      "class_mastery_skill_reference": "skill_path:262850",
+      "exact_id_match": null,
+      "exact_path_matches": [],
+      "match_methods": [],
+      "normalized_name_matches": [],
+      "owners": [
+        "class:sentinel"
+      ],
+      "status": "unresolved"
+    },
+    {
+      "candidate_skill_ids": [],
+      "class_mastery_skill_reference": "skill_path:262912",
+      "exact_id_match": null,
+      "exact_path_matches": [],
+      "match_methods": [],
+      "normalized_name_matches": [],
+      "owners": [
+        "class:mage"
+      ],
+      "status": "unresolved"
+    },
+    {
+      "candidate_skill_ids": [],
+      "class_mastery_skill_reference": "skill_path:262951",
+      "exact_id_match": null,
+      "exact_path_matches": [],
+      "match_methods": [],
+      "normalized_name_matches": [],
+      "owners": [
+        "class:sentinel"
+      ],
+      "status": "unresolved"
+    },
+    {
+      "candidate_skill_ids": [],
+      "class_mastery_skill_reference": "skill_path:262952",
+      "exact_id_match": null,
+      "exact_path_matches": [],
+      "match_methods": [],
+      "normalized_name_matches": [],
+      "owners": [
+        "class:primalist"
+      ],
+      "status": "unresolved"
+    },
+    {
+      "candidate_skill_ids": [],
+      "class_mastery_skill_reference": "skill_path:262953",
+      "exact_id_match": null,
+      "exact_path_matches": [],
+      "match_methods": [],
+      "normalized_name_matches": [],
+      "owners": [
+        "class:mage"
+      ],
+      "status": "unresolved"
+    },
+    {
+      "candidate_skill_ids": [],
+      "class_mastery_skill_reference": "skill_path:263025",
+      "exact_id_match": null,
+      "exact_path_matches": [],
+      "match_methods": [],
+      "normalized_name_matches": [],
+      "owners": [
+        "class:mage"
+      ],
+      "status": "unresolved"
+    },
+    {
+      "candidate_skill_ids": [],
+      "class_mastery_skill_reference": "skill_path:263035",
+      "exact_id_match": null,
+      "exact_path_matches": [],
+      "match_methods": [],
+      "normalized_name_matches": [],
+      "owners": [
+        "class:acolyte"
+      ],
+      "status": "unresolved"
+    },
+    {
+      "candidate_skill_ids": [],
+      "class_mastery_skill_reference": "skill_path:263053",
+      "exact_id_match": null,
+      "exact_path_matches": [],
+      "match_methods": [],
+      "normalized_name_matches": [],
+      "owners": [
+        "mastery:mage:sorcerer"
+      ],
+      "status": "unresolved"
+    },
+    {
+      "candidate_skill_ids": [],
+      "class_mastery_skill_reference": "skill_path:263498",
+      "exact_id_match": null,
+      "exact_path_matches": [],
+      "match_methods": [],
+      "normalized_name_matches": [],
+      "owners": [
+        "class:acolyte",
+        "class:mage",
+        "class:primalist",
+        "class:rogue",
+        "class:sentinel"
+      ],
+      "status": "unresolved"
+    },
+    {
+      "candidate_skill_ids": [],
+      "class_mastery_skill_reference": "skill_path:263704",
+      "exact_id_match": null,
+      "exact_path_matches": [],
+      "match_methods": [],
+      "normalized_name_matches": [],
+      "owners": [
+        "class:primalist"
+      ],
+      "status": "unresolved"
+    },
+    {
+      "candidate_skill_ids": [],
+      "class_mastery_skill_reference": "skill_path:263788",
+      "exact_id_match": null,
+      "exact_path_matches": [],
+      "match_methods": [],
+      "normalized_name_matches": [],
+      "owners": [
+        "mastery:acolyte:lich"
+      ],
+      "status": "unresolved"
+    },
+    {
+      "candidate_skill_ids": [],
+      "class_mastery_skill_reference": "skill_path:263799",
+      "exact_id_match": null,
+      "exact_path_matches": [],
+      "match_methods": [],
+      "normalized_name_matches": [],
+      "owners": [
+        "class:acolyte"
+      ],
+      "status": "unresolved"
+    },
+    {
+      "candidate_skill_ids": [],
+      "class_mastery_skill_reference": "skill_path:263800",
+      "exact_id_match": null,
+      "exact_path_matches": [],
+      "match_methods": [],
+      "normalized_name_matches": [],
+      "owners": [
+        "class:sentinel"
+      ],
+      "status": "unresolved"
+    },
+    {
+      "candidate_skill_ids": [],
+      "class_mastery_skill_reference": "skill_path:263816",
+      "exact_id_match": null,
+      "exact_path_matches": [],
+      "match_methods": [],
+      "normalized_name_matches": [],
+      "owners": [
+        "class:rogue"
+      ],
+      "status": "unresolved"
+    },
+    {
+      "candidate_skill_ids": [],
+      "class_mastery_skill_reference": "skill_path:263834",
+      "exact_id_match": null,
+      "exact_path_matches": [],
+      "match_methods": [],
+      "normalized_name_matches": [],
+      "owners": [
+        "class:rogue"
+      ],
+      "status": "unresolved"
+    },
+    {
+      "candidate_skill_ids": [],
+      "class_mastery_skill_reference": "skill_path:263841",
+      "exact_id_match": null,
+      "exact_path_matches": [],
+      "match_methods": [],
+      "normalized_name_matches": [],
+      "owners": [
+        "mastery:rogue:bladedancer"
+      ],
+      "status": "unresolved"
+    },
+    {
+      "candidate_skill_ids": [],
+      "class_mastery_skill_reference": "skill_path:263852",
+      "exact_id_match": null,
+      "exact_path_matches": [],
+      "match_methods": [],
+      "normalized_name_matches": [],
+      "owners": [
+        "class:rogue"
+      ],
+      "status": "unresolved"
+    },
+    {
+      "candidate_skill_ids": [],
+      "class_mastery_skill_reference": "skill_path:263853",
+      "exact_id_match": null,
+      "exact_path_matches": [],
+      "match_methods": [],
+      "normalized_name_matches": [],
+      "owners": [
+        "mastery:rogue:marksman"
+      ],
+      "status": "unresolved"
+    },
+    {
+      "candidate_skill_ids": [],
+      "class_mastery_skill_reference": "skill_path:263871",
+      "exact_id_match": null,
+      "exact_path_matches": [],
+      "match_methods": [],
+      "normalized_name_matches": [],
+      "owners": [
+        "class:rogue"
+      ],
+      "status": "unresolved"
+    },
+    {
+      "candidate_skill_ids": [],
+      "class_mastery_skill_reference": "skill_path:263905",
+      "exact_id_match": null,
+      "exact_path_matches": [],
+      "match_methods": [],
+      "normalized_name_matches": [],
+      "owners": [
+        "class:rogue"
+      ],
+      "status": "unresolved"
+    },
+    {
+      "candidate_skill_ids": [],
+      "class_mastery_skill_reference": "skill_path:263955",
+      "exact_id_match": null,
+      "exact_path_matches": [],
+      "match_methods": [],
+      "normalized_name_matches": [],
+      "owners": [
+        "class:rogue"
+      ],
+      "status": "unresolved"
+    },
+    {
+      "candidate_skill_ids": [],
+      "class_mastery_skill_reference": "skill_path:263956",
+      "exact_id_match": null,
+      "exact_path_matches": [],
+      "match_methods": [],
+      "normalized_name_matches": [],
+      "owners": [
+        "class:rogue"
+      ],
+      "status": "unresolved"
+    },
+    {
+      "candidate_skill_ids": [],
+      "class_mastery_skill_reference": "skill_path:263991",
+      "exact_id_match": null,
+      "exact_path_matches": [],
+      "match_methods": [],
+      "normalized_name_matches": [],
+      "owners": [
+        "class:rogue"
+      ],
+      "status": "unresolved"
+    },
+    {
+      "candidate_skill_ids": [
+        "skill:fb8fe"
+      ],
+      "class_mastery_skill_reference": "skill_path:264015",
+      "exact_id_match": null,
+      "exact_path_matches": [
+        {
+          "display_name": "Runebolt",
+          "field_path": "skillTree.nodes.28.requirements.0.nodeId",
+          "skill_id": "skill:fb8fe",
+          "source_skill_id": "fb8fe",
+          "top_level_identity": false
+        },
+        {
+          "display_name": "Runebolt",
+          "field_path": "skillTree.nodes.28.effectHints.3.nodeId",
+          "skill_id": "skill:fb8fe",
+          "source_skill_id": "fb8fe",
+          "top_level_identity": false
+        }
+      ],
+      "match_methods": [
+        "exact_path"
+      ],
+      "normalized_name_matches": [],
+      "owners": [
+        "mastery:mage:runemaster"
+      ],
+      "status": "nested_path_match_not_bridge_safe"
+    },
+    {
+      "candidate_skill_ids": [],
+      "class_mastery_skill_reference": "skill_path:264164",
+      "exact_id_match": null,
+      "exact_path_matches": [],
+      "match_methods": [],
+      "normalized_name_matches": [],
+      "owners": [
+        "class:sentinel"
+      ],
+      "status": "unresolved"
+    },
+    {
+      "candidate_skill_ids": [],
+      "class_mastery_skill_reference": "skill_path:264230",
+      "exact_id_match": null,
+      "exact_path_matches": [],
+      "match_methods": [],
+      "normalized_name_matches": [],
+      "owners": [
+        "class:rogue"
+      ],
+      "status": "unresolved"
+    },
+    {
+      "candidate_skill_ids": [],
+      "class_mastery_skill_reference": "skill_path:264237",
+      "exact_id_match": null,
+      "exact_path_matches": [],
+      "match_methods": [],
+      "normalized_name_matches": [],
+      "owners": [
+        "mastery:mage:spellblade"
+      ],
+      "status": "unresolved"
+    },
+    {
+      "candidate_skill_ids": [],
+      "class_mastery_skill_reference": "skill_path:264241",
+      "exact_id_match": null,
+      "exact_path_matches": [],
+      "match_methods": [],
+      "normalized_name_matches": [],
+      "owners": [
+        "class:sentinel"
+      ],
+      "status": "unresolved"
+    },
+    {
+      "candidate_skill_ids": [],
+      "class_mastery_skill_reference": "skill_path:264309",
+      "exact_id_match": null,
+      "exact_path_matches": [],
+      "match_methods": [],
+      "normalized_name_matches": [],
+      "owners": [
+        "class:mage"
+      ],
+      "status": "unresolved"
+    },
+    {
+      "candidate_skill_ids": [],
+      "class_mastery_skill_reference": "skill_path:264355",
+      "exact_id_match": null,
+      "exact_path_matches": [],
+      "match_methods": [],
+      "normalized_name_matches": [],
+      "owners": [
+        "class:mage"
+      ],
+      "status": "unresolved"
+    },
+    {
+      "candidate_skill_ids": [],
+      "class_mastery_skill_reference": "skill_path:264437",
+      "exact_id_match": null,
+      "exact_path_matches": [],
+      "match_methods": [],
+      "normalized_name_matches": [],
+      "owners": [
+        "mastery:primalist:beastmaster"
+      ],
+      "status": "unresolved"
+    },
+    {
+      "candidate_skill_ids": [],
+      "class_mastery_skill_reference": "skill_path:264444",
+      "exact_id_match": null,
+      "exact_path_matches": [],
+      "match_methods": [],
+      "normalized_name_matches": [],
+      "owners": [
+        "class:acolyte"
+      ],
+      "status": "unresolved"
+    },
+    {
+      "candidate_skill_ids": [],
+      "class_mastery_skill_reference": "skill_path:264451",
+      "exact_id_match": null,
+      "exact_path_matches": [],
+      "match_methods": [],
+      "normalized_name_matches": [],
+      "owners": [
+        "mastery:primalist:shaman"
+      ],
+      "status": "unresolved"
+    },
+    {
+      "candidate_skill_ids": [],
+      "class_mastery_skill_reference": "skill_path:264453",
+      "exact_id_match": null,
+      "exact_path_matches": [],
+      "match_methods": [],
+      "normalized_name_matches": [],
+      "owners": [
+        "class:primalist"
+      ],
+      "status": "unresolved"
+    },
+    {
+      "candidate_skill_ids": [],
+      "class_mastery_skill_reference": "skill_path:264458",
+      "exact_id_match": null,
+      "exact_path_matches": [],
+      "match_methods": [],
+      "normalized_name_matches": [],
+      "owners": [
+        "class:acolyte"
+      ],
+      "status": "unresolved"
+    },
+    {
+      "candidate_skill_ids": [],
+      "class_mastery_skill_reference": "skill_path:264461",
+      "exact_id_match": null,
+      "exact_path_matches": [],
+      "match_methods": [],
+      "normalized_name_matches": [],
+      "owners": [
+        "class:primalist"
+      ],
+      "status": "unresolved"
+    },
+    {
+      "candidate_skill_ids": [],
+      "class_mastery_skill_reference": "skill_path:264462",
+      "exact_id_match": null,
+      "exact_path_matches": [],
+      "match_methods": [],
+      "normalized_name_matches": [],
+      "owners": [
+        "mastery:acolyte:necromancer"
+      ],
+      "status": "unresolved"
+    },
+    {
+      "candidate_skill_ids": [],
+      "class_mastery_skill_reference": "skill_path:264551",
+      "exact_id_match": null,
+      "exact_path_matches": [],
+      "match_methods": [],
+      "normalized_name_matches": [],
+      "owners": [
+        "class:primalist"
+      ],
+      "status": "unresolved"
+    },
+    {
+      "candidate_skill_ids": [],
+      "class_mastery_skill_reference": "skill_path:264554",
+      "exact_id_match": null,
+      "exact_path_matches": [],
+      "match_methods": [],
+      "normalized_name_matches": [],
+      "owners": [
+        "class:mage"
+      ],
+      "status": "unresolved"
+    },
+    {
+      "candidate_skill_ids": [],
+      "class_mastery_skill_reference": "skill_path:264562",
+      "exact_id_match": null,
+      "exact_path_matches": [],
+      "match_methods": [],
+      "normalized_name_matches": [],
+      "owners": [
+        "class:primalist"
+      ],
+      "status": "unresolved"
+    },
+    {
+      "candidate_skill_ids": [],
+      "class_mastery_skill_reference": "skill_path:264675",
+      "exact_id_match": null,
+      "exact_path_matches": [],
+      "match_methods": [],
+      "normalized_name_matches": [],
+      "owners": [
+        "class:acolyte"
+      ],
+      "status": "unresolved"
+    },
+    {
+      "candidate_skill_ids": [],
+      "class_mastery_skill_reference": "skill_path:264730",
+      "exact_id_match": null,
+      "exact_path_matches": [],
+      "match_methods": [],
+      "normalized_name_matches": [],
+      "owners": [
+        "class:primalist"
+      ],
+      "status": "unresolved"
+    },
+    {
+      "candidate_skill_ids": [],
+      "class_mastery_skill_reference": "skill_path:264735",
+      "exact_id_match": null,
+      "exact_path_matches": [],
+      "match_methods": [],
+      "normalized_name_matches": [],
+      "owners": [
+        "class:sentinel"
+      ],
+      "status": "unresolved"
+    },
+    {
+      "candidate_skill_ids": [],
+      "class_mastery_skill_reference": "skill_path:264807",
+      "exact_id_match": null,
+      "exact_path_matches": [],
+      "match_methods": [],
+      "normalized_name_matches": [],
+      "owners": [
+        "class:sentinel"
+      ],
+      "status": "unresolved"
+    },
+    {
+      "candidate_skill_ids": [],
+      "class_mastery_skill_reference": "skill_path:264863",
+      "exact_id_match": null,
+      "exact_path_matches": [],
+      "match_methods": [],
+      "normalized_name_matches": [],
+      "owners": [
+        "class:acolyte"
+      ],
+      "status": "unresolved"
+    },
+    {
+      "candidate_skill_ids": [],
+      "class_mastery_skill_reference": "skill_path:264874",
+      "exact_id_match": null,
+      "exact_path_matches": [],
+      "match_methods": [],
+      "normalized_name_matches": [],
+      "owners": [
+        "mastery:acolyte:warlock"
+      ],
+      "status": "unresolved"
+    },
+    {
+      "candidate_skill_ids": [],
+      "class_mastery_skill_reference": "skill_path:264881",
+      "exact_id_match": null,
+      "exact_path_matches": [],
+      "match_methods": [],
+      "normalized_name_matches": [],
+      "owners": [
+        "class:sentinel"
+      ],
+      "status": "unresolved"
+    },
+    {
+      "candidate_skill_ids": [],
+      "class_mastery_skill_reference": "skill_path:264922",
+      "exact_id_match": null,
+      "exact_path_matches": [],
+      "match_methods": [],
+      "normalized_name_matches": [],
+      "owners": [
+        "mastery:primalist:druid"
+      ],
+      "status": "unresolved"
+    }
+  ],
+  "summary": {
+    "ambiguous_match_count": 1,
+    "bridge_safe": false,
+    "exact_id_match_count": 0,
+    "exact_path_match_count": 2,
+    "nested_path_only_match_count": 1,
+    "normalized_name_match_count": 0,
+    "production_consumed": false,
+    "recommended_mapping_strategy": "do_not_bridge_from_nested_path_evidence",
+    "source_data_missing": true,
+    "top_level_path_match_count": 0,
+    "total_class_mastery_skill_references": 63,
+    "total_skill_records": 184,
+    "unresolved_reference_count": 61
+  }
+}

--- a/docs/migration/V2_SKILL_IDENTITY_ALIGNMENT.md
+++ b/docs/migration/V2_SKILL_IDENTITY_ALIGNMENT.md
@@ -1,0 +1,136 @@
+# v2 Skill Identity Alignment
+
+## Purpose
+
+This Phase 9.5 audit diagnoses the class/mastery to skill identity mismatch reported during Phase 9. It does not create a runtime bridge, change generators, or alter planner behavior.
+
+## Generation Command
+
+```powershell
+.\backend\.venv\Scripts\python.exe backend\scripts\report_v2_skill_identity_alignment.py --class-mastery-bundle docs\generated\v2_class_mastery_bundle.json --skill-bundle docs\generated\v2_skill_bundle.json --skill-tree-bundle docs\generated\v2_skill_tree_bundle.json --source-classes D:\Forge\last-epoch-data\exports_json\classes.json --source-skills D:\Forge\last-epoch-data\exports_json\skills_with_trees.json --output docs\generated\v2_skill_identity_alignment_report.json --markdown-output docs\migration\V2_SKILL_IDENTITY_ALIGNMENT.md
+```
+
+## Summary
+
+- Total class/mastery skill references: 63
+- Total skill records: 184
+- Exact ID matches: 0
+- Exact raw path matches: 2
+- Top-level path matches: 0
+- Nested path-only matches: 1
+- Normalized name matches: 0
+- Ambiguous matches: 1
+- Unresolved references: 61
+- Bridge safe: false
+- Recommended mapping strategy: `do_not_bridge_from_nested_path_evidence`
+
+## Field Inventory
+
+Class/mastery records use these fields for skill references:
+
+- `linked_skill_source_ids`
+- `skill_ids`
+
+Skill records expose these source identity fields:
+
+- `canonical_id`
+- `display_name`
+- `source_skill_id`
+- `raw_reference.source_skill_id`
+- `skill_tree_id`
+
+Raw skill records expose these observed path-like fields:
+
+- `comboAbility`
+- `damageSources.0.pathId`
+- `damageSources.0.sourcePath`
+- `damageSources.1.pathId`
+- `damageSources.1.sourcePath`
+- `damageSources.2.pathId`
+- `damageSources.2.sourcePath`
+- `isZoneAbility`
+- `minionsUseAbility`
+- `mutatorHints.0.pathId`
+- `mutatorHints.0.sourcePath`
+- `mutatorHints.1.pathId`
+- `mutatorHints.1.sourcePath`
+- `mutatorHints.2.pathId`
+- `mutatorHints.2.sourcePath`
+- `sharedCooldownAbilityRefs`
+- `skillTree.ability`
+- `skillTree.nodes.0.effectHints.0.sourcePath`
+- `skillTree.nodes.0.effectHints.1.sourcePath`
+- `skillTree.nodes.0.effectHints.2.sourcePath`
+- `skillTree.nodes.0.effectHints.3.sourcePath`
+- `skillTree.nodes.1.effectHints.0.sourcePath`
+- `skillTree.nodes.1.effectHints.1.sourcePath`
+- `skillTree.nodes.1.effectHints.2.sourcePath`
+- `skillTree.nodes.1.effectHints.3.sourcePath`
+- `skillTree.nodes.1.effectHints.4.sourcePath`
+- `skillTree.nodes.10.effectHints.0.sourcePath`
+- `skillTree.nodes.10.effectHints.1.sourcePath`
+- `skillTree.nodes.10.effectHints.2.sourcePath`
+- `skillTree.nodes.10.effectHints.3.sourcePath`
+- `skillTree.nodes.10.effectHints.4.sourcePath`
+- `skillTree.nodes.10.effectHints.5.sourcePath`
+- `skillTree.nodes.11.effectHints.0.sourcePath`
+- `skillTree.nodes.11.effectHints.1.sourcePath`
+- `skillTree.nodes.11.effectHints.2.sourcePath`
+- `skillTree.nodes.11.effectHints.3.sourcePath`
+- `skillTree.nodes.11.effectHints.4.sourcePath`
+- `skillTree.nodes.11.effectHints.5.sourcePath`
+- `skillTree.nodes.12.effectHints.0.sourcePath`
+- `skillTree.nodes.12.effectHints.1.sourcePath`
+- `skillTree.nodes.12.effectHints.2.sourcePath`
+- `skillTree.nodes.12.effectHints.3.sourcePath`
+- `skillTree.nodes.12.effectHints.4.sourcePath`
+- `skillTree.nodes.13.effectHints.0.sourcePath`
+- `skillTree.nodes.13.effectHints.1.sourcePath`
+- `skillTree.nodes.13.effectHints.2.sourcePath`
+- `skillTree.nodes.13.effectHints.3.sourcePath`
+- `skillTree.nodes.13.effectHints.4.sourcePath`
+- `skillTree.nodes.14.effectHints.0.sourcePath`
+- `skillTree.nodes.14.effectHints.1.sourcePath`
+
+## What Matched
+
+Exact ID matching did not resolve the class/mastery `skill_path:*` references because generated v2 skills use source skill IDs such as `skill:ab0lh`, not numeric path IDs.
+
+Raw path matching found references only where the numeric path ID appears somewhere inside raw skill evidence. These are not accepted as a safe bridge unless they are top-level owner identity fields. In the real report, no top-level owner path matches were found.
+
+Normalized name matching cannot resolve these references because the class/mastery `skill_path:*` values do not include display names.
+
+## Examples
+
+### Resolved By Safe Identity
+
+- None
+
+### Nested Path Matches Not Accepted As A Bridge
+
+- `skill_path:264015` (nested_path_match_not_bridge_safe; owners: mastery:mage:runemaster) -> skill:fb8fe
+
+### Ambiguous
+
+- `skill_path:261142` (ambiguous; owners: class:acolyte, class:mage, class:primalist) -> skill:sps5l, skill:sr5t, skill:srtor
+
+### Unresolved
+
+- `skill_path:260926` (unresolved; owners: class:acolyte)
+- `skill_path:261173` (unresolved; owners: class:acolyte)
+- `skill_path:261591` (unresolved; owners: class:mage)
+- `skill_path:262309` (unresolved; owners: mastery:sentinel:void_knight)
+- `skill_path:262328` (unresolved; owners: mastery:rogue:falconer)
+- `skill_path:262431` (unresolved; owners: class:mage)
+- `skill_path:262458` (unresolved; owners: class:mage)
+- `skill_path:262473` (unresolved; owners: mastery:sentinel:forge_guard)
+- `skill_path:262497` (unresolved; owners: class:mage)
+- `skill_path:262531` (unresolved; owners: class:primalist)
+
+## Conclusion
+
+A deterministic bridge is not safe from the current evidence. Phase 7 `skill_path:*` values should remain unresolved until a source export exposes a top-level owning skill path ID or a separate audited identity table proves the mapping.
+
+## Recommended Next Action
+
+Before modifier/stat normalization consumes class/mastery skill ownership, add a focused source-export identity alignment task or update the upstream export to include the owning ability path ID on skill records. Do not infer the bridge from nested summoned actor evidence or tooltip text.


### PR DESCRIPTION
## Summary

Adds a focused Phase 9.5 audit for v2 skill identity alignment.

This investigates the unresolved class/mastery skill reference mismatch found in Phase 9, where Phase 7 exposes `skill_path:*` links but the Phase 9 skill export exposes different source skill IDs.

## Findings

- Total class/mastery skill references: `63`
- Total skill records: `184`
- Exact ID matches: `0`
- Exact raw path matches: `2`
- Top-level path matches: `0`
- Nested path-only matches: `1`
- Normalized name matches: `0`
- Ambiguous matches: `1`
- Unresolved references: `61`
- Source data missing for safe bridge: `true`

## Bridge safety

A deterministic bridge is not safe from the current evidence.

Recommended mapping strategy:

`do_not_bridge_from_nested_path_evidence`

The only non-ambiguous path match was nested inside skill tree/node evidence, not a top-level owning skill identity. The ambiguous path match, `skill_path:261142`, appears through nested summoned actor ability evidence across multiple skills.

## Recommendation

Before any future phase consumes class/mastery skill ownership, either:

1. update the upstream/source export to include a top-level owning ability path ID on skill records, or
2. create a separate audited identity table only if that mapping can be proven from source data.

Do not infer the bridge from nested actor ability references or display names.

## Validation

- Focused tests passed: `6 passed`
- Backend py_compile passed
- JSON validation passed
- `git diff --check` passed

## Runtime behavior

No production planner/runtime behavior was changed.
No class/mastery or skill bundle generation was changed.
This audit only adds reporting, tests, and documentation.