### PR TITLE
docs: update v2 skill identity alignment audit

### DIFF
--- a/backend/scripts/report_v2_skill_identity_alignment.py
+++ b/backend/scripts/report_v2_skill_identity_alignment.py
@@ -93,7 +93,7 @@ def _write_markdown(path: Path, report: dict[str, Any], command: str) -> None:
         "",
         "Exact ID matching did not resolve the class/mastery `skill_path:*` references because generated v2 skills use source skill IDs such as `skill:ab0lh`, not numeric path IDs.",
         "",
-        "Raw path matching found references only where the numeric path ID appears somewhere inside raw skill evidence. These are not accepted as a safe bridge unless they are top-level owner identity fields. In the real report, no top-level owner path matches were found.",
+        "Raw path matching now includes upstream `sourceIdentity.skillPath` when present. Those top-level matches are accepted as safe identity evidence. Nested path evidence is still not accepted as a bridge.",
         "",
         "Normalized name matching cannot resolve these references because the class/mastery `skill_path:*` values do not include display names.",
         "",
@@ -117,11 +117,11 @@ def _write_markdown(path: Path, report: dict[str, Any], command: str) -> None:
         "",
         "## Conclusion",
         "",
-        "A deterministic bridge is not safe from the current evidence. Phase 7 `skill_path:*` values should remain unresolved until a source export exposes a top-level owning skill path ID or a separate audited identity table proves the mapping.",
+        "A complete deterministic bridge is still not safe from the current evidence. The enriched upstream export resolves the references that have top-level `sourceIdentity.skillPath` evidence, but remaining unresolved or ambiguous references must stay blocked.",
         "",
         "## Recommended Next Action",
         "",
-        "Before modifier/stat normalization consumes class/mastery skill ownership, add a focused source-export identity alignment task or update the upstream export to include the owning ability path ID on skill records. Do not infer the bridge from nested summoned actor evidence or tooltip text.",
+        "Before modifier/stat normalization consumes class/mastery skill ownership, either resolve the remaining source gaps upstream or carry them as an explicit identity gap. Do not infer the remaining bridge from nested summoned actor evidence or tooltip text.",
         "",
     ]
     path.write_text("\n".join(lines), encoding="utf-8")
@@ -223,13 +223,34 @@ def _build_skill_identity_index(skill_records: list[dict[str, Any]], raw_skills:
                 by_normalized_name[normalized].add(canonical_id)
         raw = raw_by_source_id.get(skill.get("source_skill_id"))
         if raw:
+            raw_identity = raw.get("sourceIdentity") if isinstance(raw.get("sourceIdentity"), dict) else {}
+            raw_skill_path = raw_identity.get("skillPath")
+            if isinstance(raw_skill_path, str) and raw_skill_path.startswith("skill_path:"):
+                raw_path_id = raw_skill_path.split(":", 1)[1]
+                path_matches[raw_path_id].append(
+                    {
+                        "skill_id": canonical_id,
+                        "source_skill_id": skill.get("source_skill_id"),
+                        "display_name": skill.get("display_name"),
+                        "field_path": "sourceIdentity.skillPath",
+                        "top_level_identity": True,
+                        "identity_source": raw_identity.get("identitySource"),
+                        "identity_confidence": raw_identity.get("identityConfidence"),
+                    }
+                )
+                path_like_fields.add("sourceIdentity.skillPath")
             raw_tree = raw.get("skillTree") if isinstance(raw.get("skillTree"), dict) else {}
             for value in (raw.get("name"), raw.get("_mName"), raw_tree.get("ability")):
                 normalized = _normalize_name(value)
                 if normalized:
                     by_normalized_name[normalized].add(canonical_id)
+            raw_for_nested_scan = {
+                key: value
+                for key, value in raw.items()
+                if key not in {"sourceIdentity", "source_ability_path_id", "source_tree_path_id"}
+            }
             hits: list[dict[str, Any]] = []
-            _walk_path_ids(raw, [], hits, path_like_fields)
+            _walk_path_ids(raw_for_nested_scan, [], hits, path_like_fields)
             for hit in hits:
                 path_matches[hit["path_id"]].append(
                     {
@@ -293,23 +314,28 @@ def build_report(
 
         candidate_ids: set[str] = set()
         match_methods: list[str] = []
+        safe_candidate_ids: set[str] = set()
         if exact_id:
             candidate_ids.add(exact_id)
+            safe_candidate_ids.add(exact_id)
             exact_id_count += 1
             match_methods.append("exact_id")
         if path_skill_ids:
-            candidate_ids.update(path_skill_ids)
             exact_path_count += 1
             match_methods.append("exact_path")
         if top_level_skill_ids:
+            candidate_ids.update(top_level_skill_ids)
+            safe_candidate_ids.update(top_level_skill_ids)
             top_level_path_count += 1
             match_methods.append("top_level_path")
-        if normalized_name_hits:
+        if normalized_name_hits and not safe_candidate_ids:
             candidate_ids.update(normalized_name_hits)
             normalized_name_count += 1
             match_methods.append("normalized_name")
+        if path_skill_ids and not safe_candidate_ids:
+            candidate_ids.update(path_skill_ids)
 
-        has_safe_identity_match = bool(exact_id or top_level_skill_ids)
+        has_safe_identity_match = bool(safe_candidate_ids)
         if len(candidate_ids) > 1:
             status = "ambiguous"
             ambiguous_count += 1
@@ -342,6 +368,8 @@ def build_report(
     )
     if bridge_safe:
         strategy = "safe_deterministic_bridge_possible"
+    elif top_level_path_count:
+        strategy = "top_level_source_identity_partial_unresolved"
     elif exact_path_count:
         strategy = "do_not_bridge_from_nested_path_evidence"
     else:

--- a/backend/tests/test_v2_skill_identity_alignment.py
+++ b/backend/tests/test_v2_skill_identity_alignment.py
@@ -64,6 +64,31 @@ def test_top_level_path_match_can_be_safe_when_complete() -> None:
     assert report["summary"]["bridge_safe"] is True
 
 
+def test_source_identity_skill_path_is_top_level_match() -> None:
+    report = build_report(
+        _class_bundle("skill_path:100"),
+        _skill_bundle(_skill("skill:abc", "abc", "A Test Skill")),
+        {},
+        {"classes": []},
+        _source_skills(
+            {
+                "id": "abc",
+                "name": "A Test Skill",
+                "sourceIdentity": {
+                    "skillPath": "skill_path:100",
+                    "identitySource": "SkillTree.ability PPtr",
+                    "identityConfidence": "top_level_owner_pptr",
+                },
+            }
+        ),
+    )
+
+    assert report["summary"]["exact_path_match_count"] == 1
+    assert report["summary"]["top_level_path_match_count"] == 1
+    assert report["summary"]["bridge_safe"] is True
+    assert report["references"][0]["exact_path_matches"][0]["field_path"] == "sourceIdentity.skillPath"
+
+
 def test_nested_path_match_is_not_bridge_safe() -> None:
     report = build_report(
         _class_bundle("skill_path:100"),

--- a/docs/generated/v2_skill_identity_alignment_report.json
+++ b/docs/generated/v2_skill_identity_alignment_report.json
@@ -96,140 +96,283 @@
         "status": "ambiguous"
       }
     ],
-    "nested_path_only_records": [
+    "nested_path_only_records": [],
+    "resolved_records": [
       {
         "candidate_skill_ids": [
-          "skill:fb8fe"
+          "skill:evade1"
         ],
-        "class_mastery_skill_reference": "skill_path:264015",
+        "class_mastery_skill_reference": "skill_path:260926",
         "exact_id_match": null,
         "exact_path_matches": [
           {
-            "display_name": "Runebolt",
-            "field_path": "skillTree.nodes.28.requirements.0.nodeId",
-            "skill_id": "skill:fb8fe",
-            "source_skill_id": "fb8fe",
-            "top_level_identity": false
-          },
-          {
-            "display_name": "Runebolt",
-            "field_path": "skillTree.nodes.28.effectHints.3.nodeId",
-            "skill_id": "skill:fb8fe",
-            "source_skill_id": "fb8fe",
-            "top_level_identity": false
+            "display_name": "Evade",
+            "field_path": "sourceIdentity.skillPath",
+            "identity_confidence": "top_level_class_ability_pptr",
+            "identity_source": "CharacterClass ability PPtr",
+            "skill_id": "skill:evade1",
+            "source_skill_id": "evade1",
+            "top_level_identity": true
           }
         ],
         "match_methods": [
-          "exact_path"
+          "exact_path",
+          "top_level_path"
         ],
-        "normalized_name_matches": [],
-        "owners": [
-          "mastery:mage:runemaster"
-        ],
-        "status": "nested_path_match_not_bridge_safe"
-      }
-    ],
-    "resolved_records": [],
-    "unresolved_records": [
-      {
-        "candidate_skill_ids": [],
-        "class_mastery_skill_reference": "skill_path:260926",
-        "exact_id_match": null,
-        "exact_path_matches": [],
-        "match_methods": [],
         "normalized_name_matches": [],
         "owners": [
           "class:acolyte"
         ],
-        "status": "unresolved"
+        "status": "resolved"
       },
       {
-        "candidate_skill_ids": [],
+        "candidate_skill_ids": [
+          "skill:bc53"
+        ],
         "class_mastery_skill_reference": "skill_path:261173",
         "exact_id_match": null,
-        "exact_path_matches": [],
-        "match_methods": [],
+        "exact_path_matches": [
+          {
+            "display_name": "Bone Curse",
+            "field_path": "sourceIdentity.skillPath",
+            "identity_confidence": "top_level_owner_pptr",
+            "identity_source": "SkillTree.ability PPtr",
+            "skill_id": "skill:bc53",
+            "source_skill_id": "bc53",
+            "top_level_identity": true
+          }
+        ],
+        "match_methods": [
+          "exact_path",
+          "top_level_path"
+        ],
         "normalized_name_matches": [],
         "owners": [
           "class:acolyte"
         ],
-        "status": "unresolved"
+        "status": "resolved"
       },
       {
-        "candidate_skill_ids": [],
+        "candidate_skill_ids": [
+          "skill:en6"
+        ],
         "class_mastery_skill_reference": "skill_path:261591",
         "exact_id_match": null,
-        "exact_path_matches": [],
-        "match_methods": [],
+        "exact_path_matches": [
+          {
+            "display_name": "Elemental Nova",
+            "field_path": "sourceIdentity.skillPath",
+            "identity_confidence": "top_level_owner_pptr",
+            "identity_source": "SkillTree.ability PPtr",
+            "skill_id": "skill:en6",
+            "source_skill_id": "en6",
+            "top_level_identity": true
+          }
+        ],
+        "match_methods": [
+          "exact_path",
+          "top_level_path"
+        ],
         "normalized_name_matches": [],
         "owners": [
           "class:mage"
         ],
-        "status": "unresolved"
+        "status": "resolved"
       },
       {
-        "candidate_skill_ids": [],
+        "candidate_skill_ids": [
+          "skill:es6ai"
+        ],
         "class_mastery_skill_reference": "skill_path:262309",
         "exact_id_match": null,
-        "exact_path_matches": [],
-        "match_methods": [],
+        "exact_path_matches": [
+          {
+            "display_name": "Erasing Strike",
+            "field_path": "sourceIdentity.skillPath",
+            "identity_confidence": "top_level_owner_pptr",
+            "identity_source": "SkillTree.ability PPtr",
+            "skill_id": "skill:es6ai",
+            "source_skill_id": "es6ai",
+            "top_level_identity": true
+          }
+        ],
+        "match_methods": [
+          "exact_path",
+          "top_level_path"
+        ],
         "normalized_name_matches": [],
         "owners": [
           "mastery:sentinel:void_knight"
         ],
-        "status": "unresolved"
+        "status": "resolved"
       },
       {
-        "candidate_skill_ids": [],
+        "candidate_skill_ids": [
+          "skill:falc0"
+        ],
         "class_mastery_skill_reference": "skill_path:262328",
         "exact_id_match": null,
-        "exact_path_matches": [],
-        "match_methods": [],
+        "exact_path_matches": [
+          {
+            "display_name": "Falconry",
+            "field_path": "sourceIdentity.skillPath",
+            "identity_confidence": "top_level_owner_pptr",
+            "identity_source": "SkillTree.ability PPtr",
+            "skill_id": "skill:falc0",
+            "source_skill_id": "falc0",
+            "top_level_identity": true
+          }
+        ],
+        "match_methods": [
+          "exact_path",
+          "top_level_path"
+        ],
         "normalized_name_matches": [],
         "owners": [
           "mastery:rogue:falconer"
         ],
-        "status": "unresolved"
+        "status": "resolved"
       },
       {
-        "candidate_skill_ids": [],
+        "candidate_skill_ids": [
+          "skill:fi9"
+        ],
         "class_mastery_skill_reference": "skill_path:262431",
         "exact_id_match": null,
-        "exact_path_matches": [],
-        "match_methods": [],
+        "exact_path_matches": [
+          {
+            "display_name": "Fireball",
+            "field_path": "sourceIdentity.skillPath",
+            "identity_confidence": "top_level_owner_pptr",
+            "identity_source": "SkillTree.ability PPtr",
+            "skill_id": "skill:fi9",
+            "source_skill_id": "fi9",
+            "top_level_identity": true
+          }
+        ],
+        "match_methods": [
+          "exact_path",
+          "top_level_path"
+        ],
         "normalized_name_matches": [],
         "owners": [
           "class:mage"
         ],
-        "status": "unresolved"
+        "status": "resolved"
       },
       {
-        "candidate_skill_ids": [],
+        "candidate_skill_ids": [
+          "skill:fw3d"
+        ],
         "class_mastery_skill_reference": "skill_path:262458",
         "exact_id_match": null,
-        "exact_path_matches": [],
-        "match_methods": [],
+        "exact_path_matches": [
+          {
+            "display_name": "Flame Ward",
+            "field_path": "sourceIdentity.skillPath",
+            "identity_confidence": "top_level_owner_pptr",
+            "identity_source": "SkillTree.ability PPtr",
+            "skill_id": "skill:fw3d",
+            "source_skill_id": "fw3d",
+            "top_level_identity": true
+          }
+        ],
+        "match_methods": [
+          "exact_path",
+          "top_level_path"
+        ],
         "normalized_name_matches": [],
         "owners": [
           "class:mage"
         ],
-        "status": "unresolved"
+        "status": "resolved"
       },
       {
-        "candidate_skill_ids": [],
+        "candidate_skill_ids": [
+          "skill:fs3e3"
+        ],
         "class_mastery_skill_reference": "skill_path:262473",
         "exact_id_match": null,
-        "exact_path_matches": [],
-        "match_methods": [],
+        "exact_path_matches": [
+          {
+            "display_name": "Forge Strike",
+            "field_path": "sourceIdentity.skillPath",
+            "identity_confidence": "top_level_owner_pptr",
+            "identity_source": "SkillTree.ability PPtr",
+            "skill_id": "skill:fs3e3",
+            "source_skill_id": "fs3e3",
+            "top_level_identity": true
+          }
+        ],
+        "match_methods": [
+          "exact_path",
+          "top_level_path"
+        ],
         "normalized_name_matches": [],
         "owners": [
           "mastery:sentinel:forge_guard"
         ],
-        "status": "unresolved"
+        "status": "resolved"
       },
       {
-        "candidate_skill_ids": [],
+        "candidate_skill_ids": [
+          "skill:frc87w"
+        ],
         "class_mastery_skill_reference": "skill_path:262497",
+        "exact_id_match": null,
+        "exact_path_matches": [
+          {
+            "display_name": "Frost Claw",
+            "field_path": "sourceIdentity.skillPath",
+            "identity_confidence": "top_level_owner_pptr",
+            "identity_source": "SkillTree.ability PPtr",
+            "skill_id": "skill:frc87w",
+            "source_skill_id": "frc87w",
+            "top_level_identity": true
+          }
+        ],
+        "match_methods": [
+          "exact_path",
+          "top_level_path"
+        ],
+        "normalized_name_matches": [],
+        "owners": [
+          "class:mage"
+        ],
+        "status": "resolved"
+      },
+      {
+        "candidate_skill_ids": [
+          "skill:fl13"
+        ],
+        "class_mastery_skill_reference": "skill_path:262531",
+        "exact_id_match": null,
+        "exact_path_matches": [
+          {
+            "display_name": "Fury Leap",
+            "field_path": "sourceIdentity.skillPath",
+            "identity_confidence": "top_level_owner_pptr",
+            "identity_source": "SkillTree.ability PPtr",
+            "skill_id": "skill:fl13",
+            "source_skill_id": "fl13",
+            "top_level_identity": true
+          }
+        ],
+        "match_methods": [
+          "exact_path",
+          "top_level_path"
+        ],
+        "normalized_name_matches": [],
+        "owners": [
+          "class:primalist"
+        ],
+        "status": "resolved"
+      }
+    ],
+    "unresolved_records": [
+      {
+        "candidate_skill_ids": [],
+        "class_mastery_skill_reference": "skill_path:262953",
         "exact_id_match": null,
         "exact_path_matches": [],
         "match_methods": [],
@@ -241,13 +384,17 @@
       },
       {
         "candidate_skill_ids": [],
-        "class_mastery_skill_reference": "skill_path:262531",
+        "class_mastery_skill_reference": "skill_path:263498",
         "exact_id_match": null,
         "exact_path_matches": [],
         "match_methods": [],
         "normalized_name_matches": [],
         "owners": [
-          "class:primalist"
+          "class:acolyte",
+          "class:mage",
+          "class:primalist",
+          "class:rogue",
+          "class:sentinel"
         ],
         "status": "unresolved"
       }
@@ -473,6 +620,8 @@
       "skillTree.nodes.9.effectHints.3.sourcePath",
       "skillTree.nodes.9.effectHints.4.sourcePath",
       "skillTree.nodes.9.effectHints.5.sourcePath",
+      "sourceIdentity.skillPath",
+      "source_skill_path",
       "summonedActors.0.abilities.0.abilityName",
       "summonedActors.0.abilities.0.abilityRefKey",
       "summonedActors.0.abilities.0.abilityResolutionMethod",
@@ -635,6 +784,10 @@
     ],
     "top_path_match_contexts": [
       {
+        "field_path": "sourceIdentity.skillPath",
+        "match_count": 60
+      },
+      {
         "field_path": "summonedActors.0.abilities.0.resolvedAbilityPathId",
         "match_count": 2
       },
@@ -679,16 +832,31 @@
   },
   "references": [
     {
-      "candidate_skill_ids": [],
+      "candidate_skill_ids": [
+        "skill:evade1"
+      ],
       "class_mastery_skill_reference": "skill_path:260926",
       "exact_id_match": null,
-      "exact_path_matches": [],
-      "match_methods": [],
+      "exact_path_matches": [
+        {
+          "display_name": "Evade",
+          "field_path": "sourceIdentity.skillPath",
+          "identity_confidence": "top_level_class_ability_pptr",
+          "identity_source": "CharacterClass ability PPtr",
+          "skill_id": "skill:evade1",
+          "source_skill_id": "evade1",
+          "top_level_identity": true
+        }
+      ],
+      "match_methods": [
+        "exact_path",
+        "top_level_path"
+      ],
       "normalized_name_matches": [],
       "owners": [
         "class:acolyte"
       ],
-      "status": "unresolved"
+      "status": "resolved"
     },
     {
       "candidate_skill_ids": [
@@ -785,208 +953,463 @@
       "status": "ambiguous"
     },
     {
-      "candidate_skill_ids": [],
+      "candidate_skill_ids": [
+        "skill:bc53"
+      ],
       "class_mastery_skill_reference": "skill_path:261173",
       "exact_id_match": null,
-      "exact_path_matches": [],
-      "match_methods": [],
+      "exact_path_matches": [
+        {
+          "display_name": "Bone Curse",
+          "field_path": "sourceIdentity.skillPath",
+          "identity_confidence": "top_level_owner_pptr",
+          "identity_source": "SkillTree.ability PPtr",
+          "skill_id": "skill:bc53",
+          "source_skill_id": "bc53",
+          "top_level_identity": true
+        }
+      ],
+      "match_methods": [
+        "exact_path",
+        "top_level_path"
+      ],
       "normalized_name_matches": [],
       "owners": [
         "class:acolyte"
       ],
-      "status": "unresolved"
+      "status": "resolved"
     },
     {
-      "candidate_skill_ids": [],
+      "candidate_skill_ids": [
+        "skill:en6"
+      ],
       "class_mastery_skill_reference": "skill_path:261591",
       "exact_id_match": null,
-      "exact_path_matches": [],
-      "match_methods": [],
+      "exact_path_matches": [
+        {
+          "display_name": "Elemental Nova",
+          "field_path": "sourceIdentity.skillPath",
+          "identity_confidence": "top_level_owner_pptr",
+          "identity_source": "SkillTree.ability PPtr",
+          "skill_id": "skill:en6",
+          "source_skill_id": "en6",
+          "top_level_identity": true
+        }
+      ],
+      "match_methods": [
+        "exact_path",
+        "top_level_path"
+      ],
       "normalized_name_matches": [],
       "owners": [
         "class:mage"
       ],
-      "status": "unresolved"
+      "status": "resolved"
     },
     {
-      "candidate_skill_ids": [],
+      "candidate_skill_ids": [
+        "skill:es6ai"
+      ],
       "class_mastery_skill_reference": "skill_path:262309",
       "exact_id_match": null,
-      "exact_path_matches": [],
-      "match_methods": [],
+      "exact_path_matches": [
+        {
+          "display_name": "Erasing Strike",
+          "field_path": "sourceIdentity.skillPath",
+          "identity_confidence": "top_level_owner_pptr",
+          "identity_source": "SkillTree.ability PPtr",
+          "skill_id": "skill:es6ai",
+          "source_skill_id": "es6ai",
+          "top_level_identity": true
+        }
+      ],
+      "match_methods": [
+        "exact_path",
+        "top_level_path"
+      ],
       "normalized_name_matches": [],
       "owners": [
         "mastery:sentinel:void_knight"
       ],
-      "status": "unresolved"
+      "status": "resolved"
     },
     {
-      "candidate_skill_ids": [],
+      "candidate_skill_ids": [
+        "skill:falc0"
+      ],
       "class_mastery_skill_reference": "skill_path:262328",
       "exact_id_match": null,
-      "exact_path_matches": [],
-      "match_methods": [],
+      "exact_path_matches": [
+        {
+          "display_name": "Falconry",
+          "field_path": "sourceIdentity.skillPath",
+          "identity_confidence": "top_level_owner_pptr",
+          "identity_source": "SkillTree.ability PPtr",
+          "skill_id": "skill:falc0",
+          "source_skill_id": "falc0",
+          "top_level_identity": true
+        }
+      ],
+      "match_methods": [
+        "exact_path",
+        "top_level_path"
+      ],
       "normalized_name_matches": [],
       "owners": [
         "mastery:rogue:falconer"
       ],
-      "status": "unresolved"
+      "status": "resolved"
     },
     {
-      "candidate_skill_ids": [],
+      "candidate_skill_ids": [
+        "skill:fi9"
+      ],
       "class_mastery_skill_reference": "skill_path:262431",
       "exact_id_match": null,
-      "exact_path_matches": [],
-      "match_methods": [],
+      "exact_path_matches": [
+        {
+          "display_name": "Fireball",
+          "field_path": "sourceIdentity.skillPath",
+          "identity_confidence": "top_level_owner_pptr",
+          "identity_source": "SkillTree.ability PPtr",
+          "skill_id": "skill:fi9",
+          "source_skill_id": "fi9",
+          "top_level_identity": true
+        }
+      ],
+      "match_methods": [
+        "exact_path",
+        "top_level_path"
+      ],
       "normalized_name_matches": [],
       "owners": [
         "class:mage"
       ],
-      "status": "unresolved"
+      "status": "resolved"
     },
     {
-      "candidate_skill_ids": [],
+      "candidate_skill_ids": [
+        "skill:fw3d"
+      ],
       "class_mastery_skill_reference": "skill_path:262458",
       "exact_id_match": null,
-      "exact_path_matches": [],
-      "match_methods": [],
+      "exact_path_matches": [
+        {
+          "display_name": "Flame Ward",
+          "field_path": "sourceIdentity.skillPath",
+          "identity_confidence": "top_level_owner_pptr",
+          "identity_source": "SkillTree.ability PPtr",
+          "skill_id": "skill:fw3d",
+          "source_skill_id": "fw3d",
+          "top_level_identity": true
+        }
+      ],
+      "match_methods": [
+        "exact_path",
+        "top_level_path"
+      ],
       "normalized_name_matches": [],
       "owners": [
         "class:mage"
       ],
-      "status": "unresolved"
+      "status": "resolved"
     },
     {
-      "candidate_skill_ids": [],
+      "candidate_skill_ids": [
+        "skill:fs3e3"
+      ],
       "class_mastery_skill_reference": "skill_path:262473",
       "exact_id_match": null,
-      "exact_path_matches": [],
-      "match_methods": [],
+      "exact_path_matches": [
+        {
+          "display_name": "Forge Strike",
+          "field_path": "sourceIdentity.skillPath",
+          "identity_confidence": "top_level_owner_pptr",
+          "identity_source": "SkillTree.ability PPtr",
+          "skill_id": "skill:fs3e3",
+          "source_skill_id": "fs3e3",
+          "top_level_identity": true
+        }
+      ],
+      "match_methods": [
+        "exact_path",
+        "top_level_path"
+      ],
       "normalized_name_matches": [],
       "owners": [
         "mastery:sentinel:forge_guard"
       ],
-      "status": "unresolved"
+      "status": "resolved"
     },
     {
-      "candidate_skill_ids": [],
+      "candidate_skill_ids": [
+        "skill:frc87w"
+      ],
       "class_mastery_skill_reference": "skill_path:262497",
       "exact_id_match": null,
-      "exact_path_matches": [],
-      "match_methods": [],
+      "exact_path_matches": [
+        {
+          "display_name": "Frost Claw",
+          "field_path": "sourceIdentity.skillPath",
+          "identity_confidence": "top_level_owner_pptr",
+          "identity_source": "SkillTree.ability PPtr",
+          "skill_id": "skill:frc87w",
+          "source_skill_id": "frc87w",
+          "top_level_identity": true
+        }
+      ],
+      "match_methods": [
+        "exact_path",
+        "top_level_path"
+      ],
       "normalized_name_matches": [],
       "owners": [
         "class:mage"
       ],
-      "status": "unresolved"
+      "status": "resolved"
     },
     {
-      "candidate_skill_ids": [],
+      "candidate_skill_ids": [
+        "skill:fl13"
+      ],
       "class_mastery_skill_reference": "skill_path:262531",
       "exact_id_match": null,
-      "exact_path_matches": [],
-      "match_methods": [],
+      "exact_path_matches": [
+        {
+          "display_name": "Fury Leap",
+          "field_path": "sourceIdentity.skillPath",
+          "identity_confidence": "top_level_owner_pptr",
+          "identity_source": "SkillTree.ability PPtr",
+          "skill_id": "skill:fl13",
+          "source_skill_id": "fl13",
+          "top_level_identity": true
+        }
+      ],
+      "match_methods": [
+        "exact_path",
+        "top_level_path"
+      ],
       "normalized_name_matches": [],
       "owners": [
         "class:primalist"
       ],
-      "status": "unresolved"
+      "status": "resolved"
     },
     {
-      "candidate_skill_ids": [],
+      "candidate_skill_ids": [
+        "skill:ga2st"
+      ],
       "class_mastery_skill_reference": "skill_path:262552",
       "exact_id_match": null,
-      "exact_path_matches": [],
-      "match_methods": [],
+      "exact_path_matches": [
+        {
+          "display_name": "Gathering Storm",
+          "field_path": "sourceIdentity.skillPath",
+          "identity_confidence": "top_level_owner_pptr",
+          "identity_source": "SkillTree.ability PPtr",
+          "skill_id": "skill:ga2st",
+          "source_skill_id": "ga2st",
+          "top_level_identity": true
+        }
+      ],
+      "match_methods": [
+        "exact_path",
+        "top_level_path"
+      ],
       "normalized_name_matches": [],
       "owners": [
         "class:primalist"
       ],
-      "status": "unresolved"
+      "status": "resolved"
     },
     {
-      "candidate_skill_ids": [],
+      "candidate_skill_ids": [
+        "skill:ht16aw"
+      ],
       "class_mastery_skill_reference": "skill_path:262625",
       "exact_id_match": null,
-      "exact_path_matches": [],
-      "match_methods": [],
+      "exact_path_matches": [
+        {
+          "display_name": "Hammer Throw",
+          "field_path": "sourceIdentity.skillPath",
+          "identity_confidence": "top_level_owner_pptr",
+          "identity_source": "SkillTree.ability PPtr",
+          "skill_id": "skill:ht16aw",
+          "source_skill_id": "ht16aw",
+          "top_level_identity": true
+        }
+      ],
+      "match_methods": [
+        "exact_path",
+        "top_level_path"
+      ],
       "normalized_name_matches": [],
       "owners": [
         "class:sentinel"
       ],
-      "status": "unresolved"
+      "status": "resolved"
     },
     {
-      "candidate_skill_ids": [],
+      "candidate_skill_ids": [
+        "skill:ha84"
+      ],
       "class_mastery_skill_reference": "skill_path:262645",
       "exact_id_match": null,
-      "exact_path_matches": [],
-      "match_methods": [],
+      "exact_path_matches": [
+        {
+          "display_name": "Harvest",
+          "field_path": "sourceIdentity.skillPath",
+          "identity_confidence": "top_level_owner_pptr",
+          "identity_source": "SkillTree.ability PPtr",
+          "skill_id": "skill:ha84",
+          "source_skill_id": "ha84",
+          "top_level_identity": true
+        }
+      ],
+      "match_methods": [
+        "exact_path",
+        "top_level_path"
+      ],
       "normalized_name_matches": [],
       "owners": [
         "class:acolyte"
       ],
-      "status": "unresolved"
+      "status": "resolved"
     },
     {
-      "candidate_skill_ids": [],
+      "candidate_skill_ids": [
+        "skill:ah443"
+      ],
       "class_mastery_skill_reference": "skill_path:262677",
       "exact_id_match": null,
-      "exact_path_matches": [],
-      "match_methods": [],
+      "exact_path_matches": [
+        {
+          "display_name": "Holy Aura",
+          "field_path": "sourceIdentity.skillPath",
+          "identity_confidence": "top_level_owner_pptr",
+          "identity_source": "SkillTree.ability PPtr",
+          "skill_id": "skill:ah443",
+          "source_skill_id": "ah443",
+          "top_level_identity": true
+        }
+      ],
+      "match_methods": [
+        "exact_path",
+        "top_level_path"
+      ],
       "normalized_name_matches": [],
       "owners": [
         "mastery:sentinel:paladin"
       ],
-      "status": "unresolved"
+      "status": "resolved"
     },
     {
-      "candidate_skill_ids": [],
+      "candidate_skill_ids": [
+        "skill:javeli"
+      ],
       "class_mastery_skill_reference": "skill_path:262850",
       "exact_id_match": null,
-      "exact_path_matches": [],
-      "match_methods": [],
+      "exact_path_matches": [
+        {
+          "display_name": "Javelin",
+          "field_path": "sourceIdentity.skillPath",
+          "identity_confidence": "top_level_owner_pptr",
+          "identity_source": "SkillTree.ability PPtr",
+          "skill_id": "skill:javeli",
+          "source_skill_id": "javeli",
+          "top_level_identity": true
+        }
+      ],
+      "match_methods": [
+        "exact_path",
+        "top_level_path"
+      ],
       "normalized_name_matches": [],
       "owners": [
         "class:sentinel"
       ],
-      "status": "unresolved"
+      "status": "resolved"
     },
     {
-      "candidate_skill_ids": [],
+      "candidate_skill_ids": [
+        "skill:lb23il"
+      ],
       "class_mastery_skill_reference": "skill_path:262912",
       "exact_id_match": null,
-      "exact_path_matches": [],
-      "match_methods": [],
+      "exact_path_matches": [
+        {
+          "display_name": "Lightning Blast",
+          "field_path": "sourceIdentity.skillPath",
+          "identity_confidence": "top_level_owner_pptr",
+          "identity_source": "SkillTree.ability PPtr",
+          "skill_id": "skill:lb23il",
+          "source_skill_id": "lb23il",
+          "top_level_identity": true
+        }
+      ],
+      "match_methods": [
+        "exact_path",
+        "top_level_path"
+      ],
       "normalized_name_matches": [],
       "owners": [
         "class:mage"
       ],
-      "status": "unresolved"
+      "status": "resolved"
     },
     {
-      "candidate_skill_ids": [],
+      "candidate_skill_ids": [
+        "skill:lu25ng"
+      ],
       "class_mastery_skill_reference": "skill_path:262951",
       "exact_id_match": null,
-      "exact_path_matches": [],
-      "match_methods": [],
+      "exact_path_matches": [
+        {
+          "display_name": "Lunge",
+          "field_path": "sourceIdentity.skillPath",
+          "identity_confidence": "top_level_owner_pptr",
+          "identity_source": "SkillTree.ability PPtr",
+          "skill_id": "skill:lu25ng",
+          "source_skill_id": "lu25ng",
+          "top_level_identity": true
+        }
+      ],
+      "match_methods": [
+        "exact_path",
+        "top_level_path"
+      ],
       "normalized_name_matches": [],
       "owners": [
         "class:sentinel"
       ],
-      "status": "unresolved"
+      "status": "resolved"
     },
     {
-      "candidate_skill_ids": [],
+      "candidate_skill_ids": [
+        "skill:mas54"
+      ],
       "class_mastery_skill_reference": "skill_path:262952",
       "exact_id_match": null,
-      "exact_path_matches": [],
-      "match_methods": [],
+      "exact_path_matches": [
+        {
+          "display_name": "Maelstrom",
+          "field_path": "sourceIdentity.skillPath",
+          "identity_confidence": "top_level_owner_pptr",
+          "identity_source": "SkillTree.ability PPtr",
+          "skill_id": "skill:mas54",
+          "source_skill_id": "mas54",
+          "top_level_identity": true
+        }
+      ],
+      "match_methods": [
+        "exact_path",
+        "top_level_path"
+      ],
       "normalized_name_matches": [],
       "owners": [
         "class:primalist"
       ],
-      "status": "unresolved"
+      "status": "resolved"
     },
     {
       "candidate_skill_ids": [],
@@ -1001,40 +1424,85 @@
       "status": "unresolved"
     },
     {
-      "candidate_skill_ids": [],
+      "candidate_skill_ids": [
+        "skill:ms26"
+      ],
       "class_mastery_skill_reference": "skill_path:263025",
       "exact_id_match": null,
-      "exact_path_matches": [],
-      "match_methods": [],
+      "exact_path_matches": [
+        {
+          "display_name": "Mana Strike",
+          "field_path": "sourceIdentity.skillPath",
+          "identity_confidence": "top_level_owner_pptr",
+          "identity_source": "SkillTree.ability PPtr",
+          "skill_id": "skill:ms26",
+          "source_skill_id": "ms26",
+          "top_level_identity": true
+        }
+      ],
+      "match_methods": [
+        "exact_path",
+        "top_level_path"
+      ],
       "normalized_name_matches": [],
       "owners": [
         "class:mage"
       ],
-      "status": "unresolved"
+      "status": "resolved"
     },
     {
-      "candidate_skill_ids": [],
+      "candidate_skill_ids": [
+        "skill:bp2nk"
+      ],
       "class_mastery_skill_reference": "skill_path:263035",
       "exact_id_match": null,
-      "exact_path_matches": [],
-      "match_methods": [],
+      "exact_path_matches": [
+        {
+          "display_name": "Marrow Shards",
+          "field_path": "sourceIdentity.skillPath",
+          "identity_confidence": "top_level_owner_pptr",
+          "identity_source": "SkillTree.ability PPtr",
+          "skill_id": "skill:bp2nk",
+          "source_skill_id": "bp2nk",
+          "top_level_identity": true
+        }
+      ],
+      "match_methods": [
+        "exact_path",
+        "top_level_path"
+      ],
       "normalized_name_matches": [],
       "owners": [
         "class:acolyte"
       ],
-      "status": "unresolved"
+      "status": "resolved"
     },
     {
-      "candidate_skill_ids": [],
+      "candidate_skill_ids": [
+        "skill:me27"
+      ],
       "class_mastery_skill_reference": "skill_path:263053",
       "exact_id_match": null,
-      "exact_path_matches": [],
-      "match_methods": [],
+      "exact_path_matches": [
+        {
+          "display_name": "Meteor",
+          "field_path": "sourceIdentity.skillPath",
+          "identity_confidence": "top_level_owner_pptr",
+          "identity_source": "SkillTree.ability PPtr",
+          "skill_id": "skill:me27",
+          "source_skill_id": "me27",
+          "top_level_identity": true
+        }
+      ],
+      "match_methods": [
+        "exact_path",
+        "top_level_path"
+      ],
       "normalized_name_matches": [],
       "owners": [
         "mastery:mage:sorcerer"
       ],
-      "status": "unresolved"
+      "status": "resolved"
     },
     {
       "candidate_skill_ids": [],
@@ -1053,176 +1521,386 @@
       "status": "unresolved"
     },
     {
-      "candidate_skill_ids": [],
+      "candidate_skill_ids": [
+        "skill:evade3"
+      ],
       "class_mastery_skill_reference": "skill_path:263704",
       "exact_id_match": null,
-      "exact_path_matches": [],
-      "match_methods": [],
+      "exact_path_matches": [
+        {
+          "display_name": "Evade",
+          "field_path": "sourceIdentity.skillPath",
+          "identity_confidence": "top_level_class_ability_pptr",
+          "identity_source": "CharacterClass ability PPtr",
+          "skill_id": "skill:evade3",
+          "source_skill_id": "evade3",
+          "top_level_identity": true
+        }
+      ],
+      "match_methods": [
+        "exact_path",
+        "top_level_path"
+      ],
       "normalized_name_matches": [],
       "owners": [
         "class:primalist"
       ],
-      "status": "unresolved"
+      "status": "resolved"
     },
     {
-      "candidate_skill_ids": [],
+      "candidate_skill_ids": [
+        "skill:rf1azz"
+      ],
       "class_mastery_skill_reference": "skill_path:263788",
       "exact_id_match": null,
-      "exact_path_matches": [],
-      "match_methods": [],
+      "exact_path_matches": [
+        {
+          "display_name": "Reaper Form",
+          "field_path": "sourceIdentity.skillPath",
+          "identity_confidence": "top_level_owner_pptr",
+          "identity_source": "SkillTree.ability PPtr",
+          "skill_id": "skill:rf1azz",
+          "source_skill_id": "rf1azz",
+          "top_level_identity": true
+        }
+      ],
+      "match_methods": [
+        "exact_path",
+        "top_level_path"
+      ],
       "normalized_name_matches": [],
       "owners": [
         "mastery:acolyte:lich"
       ],
-      "status": "unresolved"
+      "status": "resolved"
     },
     {
-      "candidate_skill_ids": [],
+      "candidate_skill_ids": [
+        "skill:rb31pl"
+      ],
       "class_mastery_skill_reference": "skill_path:263799",
       "exact_id_match": null,
-      "exact_path_matches": [],
-      "match_methods": [],
+      "exact_path_matches": [
+        {
+          "display_name": "Rip Blood",
+          "field_path": "sourceIdentity.skillPath",
+          "identity_confidence": "top_level_owner_pptr",
+          "identity_source": "SkillTree.ability PPtr",
+          "skill_id": "skill:rb31pl",
+          "source_skill_id": "rb31pl",
+          "top_level_identity": true
+        }
+      ],
+      "match_methods": [
+        "exact_path",
+        "top_level_path"
+      ],
       "normalized_name_matches": [],
       "owners": [
         "class:acolyte"
       ],
-      "status": "unresolved"
+      "status": "resolved"
     },
     {
-      "candidate_skill_ids": [],
+      "candidate_skill_ids": [
+        "skill:sndr1"
+      ],
       "class_mastery_skill_reference": "skill_path:263800",
       "exact_id_match": null,
-      "exact_path_matches": [],
-      "match_methods": [],
+      "exact_path_matches": [
+        {
+          "display_name": "Rive",
+          "field_path": "sourceIdentity.skillPath",
+          "identity_confidence": "top_level_owner_pptr",
+          "identity_source": "SkillTree.ability PPtr",
+          "skill_id": "skill:sndr1",
+          "source_skill_id": "sndr1",
+          "top_level_identity": true
+        }
+      ],
+      "match_methods": [
+        "exact_path",
+        "top_level_path"
+      ],
       "normalized_name_matches": [],
       "owners": [
         "class:sentinel"
       ],
-      "status": "unresolved"
+      "status": "resolved"
     },
     {
-      "candidate_skill_ids": [],
+      "candidate_skill_ids": [
+        "skill:aacfl"
+      ],
       "class_mastery_skill_reference": "skill_path:263816",
       "exact_id_match": null,
-      "exact_path_matches": [],
-      "match_methods": [],
+      "exact_path_matches": [
+        {
+          "display_name": "Acid Flask",
+          "field_path": "sourceIdentity.skillPath",
+          "identity_confidence": "top_level_owner_pptr",
+          "identity_source": "SkillTree.ability PPtr",
+          "skill_id": "skill:aacfl",
+          "source_skill_id": "aacfl",
+          "top_level_identity": true
+        }
+      ],
+      "match_methods": [
+        "exact_path",
+        "top_level_path"
+      ],
       "normalized_name_matches": [],
       "owners": [
         "class:rogue"
       ],
-      "status": "unresolved"
+      "status": "resolved"
     },
     {
-      "candidate_skill_ids": [],
+      "candidate_skill_ids": [
+        "skill:cstri"
+      ],
       "class_mastery_skill_reference": "skill_path:263834",
       "exact_id_match": null,
-      "exact_path_matches": [],
-      "match_methods": [],
+      "exact_path_matches": [
+        {
+          "display_name": "Cinder Strike",
+          "field_path": "sourceIdentity.skillPath",
+          "identity_confidence": "top_level_owner_pptr",
+          "identity_source": "SkillTree.ability PPtr",
+          "skill_id": "skill:cstri",
+          "source_skill_id": "cstri",
+          "top_level_identity": true
+        }
+      ],
+      "match_methods": [
+        "exact_path",
+        "top_level_path"
+      ],
       "normalized_name_matches": [],
       "owners": [
         "class:rogue"
       ],
-      "status": "unresolved"
+      "status": "resolved"
     },
     {
-      "candidate_skill_ids": [],
+      "candidate_skill_ids": [
+        "skill:dacn33"
+      ],
       "class_mastery_skill_reference": "skill_path:263841",
       "exact_id_match": null,
-      "exact_path_matches": [],
-      "match_methods": [],
+      "exact_path_matches": [
+        {
+          "display_name": "Dancing Strikes",
+          "field_path": "sourceIdentity.skillPath",
+          "identity_confidence": "top_level_owner_pptr",
+          "identity_source": "SkillTree.ability PPtr",
+          "skill_id": "skill:dacn33",
+          "source_skill_id": "dacn33",
+          "top_level_identity": true
+        }
+      ],
+      "match_methods": [
+        "exact_path",
+        "top_level_path"
+      ],
       "normalized_name_matches": [],
       "owners": [
         "mastery:rogue:bladedancer"
       ],
-      "status": "unresolved"
+      "status": "resolved"
     },
     {
-      "candidate_skill_ids": [],
+      "candidate_skill_ids": [
+        "skill:deeco"
+      ],
       "class_mastery_skill_reference": "skill_path:263852",
       "exact_id_match": null,
-      "exact_path_matches": [],
-      "match_methods": [],
+      "exact_path_matches": [
+        {
+          "display_name": "Decoy",
+          "field_path": "sourceIdentity.skillPath",
+          "identity_confidence": "top_level_owner_pptr",
+          "identity_source": "SkillTree.ability PPtr",
+          "skill_id": "skill:deeco",
+          "source_skill_id": "deeco",
+          "top_level_identity": true
+        }
+      ],
+      "match_methods": [
+        "exact_path",
+        "top_level_path"
+      ],
       "normalized_name_matches": [],
       "owners": [
         "class:rogue"
       ],
-      "status": "unresolved"
+      "status": "resolved"
     },
     {
-      "candidate_skill_ids": [],
+      "candidate_skill_ids": [
+        "skill:detar"
+      ],
       "class_mastery_skill_reference": "skill_path:263853",
       "exact_id_match": null,
-      "exact_path_matches": [],
-      "match_methods": [],
+      "exact_path_matches": [
+        {
+          "display_name": "Detonating Arrow",
+          "field_path": "sourceIdentity.skillPath",
+          "identity_confidence": "top_level_owner_pptr",
+          "identity_source": "SkillTree.ability PPtr",
+          "skill_id": "skill:detar",
+          "source_skill_id": "detar",
+          "top_level_identity": true
+        }
+      ],
+      "match_methods": [
+        "exact_path",
+        "top_level_path"
+      ],
       "normalized_name_matches": [],
       "owners": [
         "mastery:rogue:marksman"
       ],
-      "status": "unresolved"
-    },
-    {
-      "candidate_skill_ids": [],
-      "class_mastery_skill_reference": "skill_path:263871",
-      "exact_id_match": null,
-      "exact_path_matches": [],
-      "match_methods": [],
-      "normalized_name_matches": [],
-      "owners": [
-        "class:rogue"
-      ],
-      "status": "unresolved"
-    },
-    {
-      "candidate_skill_ids": [],
-      "class_mastery_skill_reference": "skill_path:263905",
-      "exact_id_match": null,
-      "exact_path_matches": [],
-      "match_methods": [],
-      "normalized_name_matches": [],
-      "owners": [
-        "class:rogue"
-      ],
-      "status": "unresolved"
-    },
-    {
-      "candidate_skill_ids": [],
-      "class_mastery_skill_reference": "skill_path:263955",
-      "exact_id_match": null,
-      "exact_path_matches": [],
-      "match_methods": [],
-      "normalized_name_matches": [],
-      "owners": [
-        "class:rogue"
-      ],
-      "status": "unresolved"
-    },
-    {
-      "candidate_skill_ids": [],
-      "class_mastery_skill_reference": "skill_path:263956",
-      "exact_id_match": null,
-      "exact_path_matches": [],
-      "match_methods": [],
-      "normalized_name_matches": [],
-      "owners": [
-        "class:rogue"
-      ],
-      "status": "unresolved"
-    },
-    {
-      "candidate_skill_ids": [],
-      "class_mastery_skill_reference": "skill_path:263991",
-      "exact_id_match": null,
-      "exact_path_matches": [],
-      "match_methods": [],
-      "normalized_name_matches": [],
-      "owners": [
-        "class:rogue"
-      ],
-      "status": "unresolved"
+      "status": "resolved"
     },
     {
       "candidate_skill_ids": [
-        "skill:fb8fe"
+        "skill:flur3"
+      ],
+      "class_mastery_skill_reference": "skill_path:263871",
+      "exact_id_match": null,
+      "exact_path_matches": [
+        {
+          "display_name": "Flurry",
+          "field_path": "sourceIdentity.skillPath",
+          "identity_confidence": "top_level_owner_pptr",
+          "identity_source": "SkillTree.ability PPtr",
+          "skill_id": "skill:flur3",
+          "source_skill_id": "flur3",
+          "top_level_identity": true
+        }
+      ],
+      "match_methods": [
+        "exact_path",
+        "top_level_path"
+      ],
+      "normalized_name_matches": [],
+      "owners": [
+        "class:rogue"
+      ],
+      "status": "resolved"
+    },
+    {
+      "candidate_skill_ids": [
+        "skill:pun22"
+      ],
+      "class_mastery_skill_reference": "skill_path:263905",
+      "exact_id_match": null,
+      "exact_path_matches": [
+        {
+          "display_name": "Puncture",
+          "field_path": "sourceIdentity.skillPath",
+          "identity_confidence": "top_level_owner_pptr",
+          "identity_source": "SkillTree.ability PPtr",
+          "skill_id": "skill:pun22",
+          "source_skill_id": "pun22",
+          "top_level_identity": true
+        }
+      ],
+      "match_methods": [
+        "exact_path",
+        "top_level_path"
+      ],
+      "normalized_name_matches": [],
+      "owners": [
+        "class:rogue"
+      ],
+      "status": "resolved"
+    },
+    {
+      "candidate_skill_ids": [
+        "skill:shiif"
+      ],
+      "class_mastery_skill_reference": "skill_path:263955",
+      "exact_id_match": null,
+      "exact_path_matches": [
+        {
+          "display_name": "Shift",
+          "field_path": "sourceIdentity.skillPath",
+          "identity_confidence": "top_level_owner_pptr",
+          "identity_source": "SkillTree.ability PPtr",
+          "skill_id": "skill:shiif",
+          "source_skill_id": "shiif",
+          "top_level_identity": true
+        }
+      ],
+      "match_methods": [
+        "exact_path",
+        "top_level_path"
+      ],
+      "normalized_name_matches": [],
+      "owners": [
+        "class:rogue"
+      ],
+      "status": "resolved"
+    },
+    {
+      "candidate_skill_ids": [
+        "skill:srk21"
+      ],
+      "class_mastery_skill_reference": "skill_path:263956",
+      "exact_id_match": null,
+      "exact_path_matches": [
+        {
+          "display_name": "Shurikens",
+          "field_path": "sourceIdentity.skillPath",
+          "identity_confidence": "top_level_owner_pptr",
+          "identity_source": "SkillTree.ability PPtr",
+          "skill_id": "skill:srk21",
+          "source_skill_id": "srk21",
+          "top_level_identity": true
+        }
+      ],
+      "match_methods": [
+        "exact_path",
+        "top_level_path"
+      ],
+      "normalized_name_matches": [],
+      "owners": [
+        "class:rogue"
+      ],
+      "status": "resolved"
+    },
+    {
+      "candidate_skill_ids": [
+        "skill:evade4"
+      ],
+      "class_mastery_skill_reference": "skill_path:263991",
+      "exact_id_match": null,
+      "exact_path_matches": [
+        {
+          "display_name": "Evade",
+          "field_path": "sourceIdentity.skillPath",
+          "identity_confidence": "top_level_class_ability_pptr",
+          "identity_source": "CharacterClass ability PPtr",
+          "skill_id": "skill:evade4",
+          "source_skill_id": "evade4",
+          "top_level_identity": true
+        }
+      ],
+      "match_methods": [
+        "exact_path",
+        "top_level_path"
+      ],
+      "normalized_name_matches": [],
+      "owners": [
+        "class:rogue"
+      ],
+      "status": "resolved"
+    },
+    {
+      "candidate_skill_ids": [
+        "skill:rn7iv"
       ],
       "class_mastery_skill_reference": "skill_path:264015",
       "exact_id_match": null,
@@ -1240,319 +1918,689 @@
           "skill_id": "skill:fb8fe",
           "source_skill_id": "fb8fe",
           "top_level_identity": false
+        },
+        {
+          "display_name": "Runic Invocation",
+          "field_path": "sourceIdentity.skillPath",
+          "identity_confidence": "top_level_owner_pptr",
+          "identity_source": "SkillTree.ability PPtr",
+          "skill_id": "skill:rn7iv",
+          "source_skill_id": "rn7iv",
+          "top_level_identity": true
         }
       ],
       "match_methods": [
-        "exact_path"
+        "exact_path",
+        "top_level_path"
       ],
       "normalized_name_matches": [],
       "owners": [
         "mastery:mage:runemaster"
       ],
-      "status": "nested_path_match_not_bridge_safe"
+      "status": "resolved"
     },
     {
-      "candidate_skill_ids": [],
+      "candidate_skill_ids": [
+        "skill:evade5"
+      ],
       "class_mastery_skill_reference": "skill_path:264164",
       "exact_id_match": null,
-      "exact_path_matches": [],
-      "match_methods": [],
+      "exact_path_matches": [
+        {
+          "display_name": "Evade",
+          "field_path": "sourceIdentity.skillPath",
+          "identity_confidence": "top_level_class_ability_pptr",
+          "identity_source": "CharacterClass ability PPtr",
+          "skill_id": "skill:evade5",
+          "source_skill_id": "evade5",
+          "top_level_identity": true
+        }
+      ],
+      "match_methods": [
+        "exact_path",
+        "top_level_path"
+      ],
       "normalized_name_matches": [],
       "owners": [
         "class:sentinel"
       ],
-      "status": "unresolved"
+      "status": "resolved"
     },
     {
-      "candidate_skill_ids": [],
+      "candidate_skill_ids": [
+        "skill:sh4re"
+      ],
       "class_mastery_skill_reference": "skill_path:264230",
       "exact_id_match": null,
-      "exact_path_matches": [],
-      "match_methods": [],
+      "exact_path_matches": [
+        {
+          "display_name": "Shadow Rend",
+          "field_path": "sourceIdentity.skillPath",
+          "identity_confidence": "top_level_owner_pptr",
+          "identity_source": "SkillTree.ability PPtr",
+          "skill_id": "skill:sh4re",
+          "source_skill_id": "sh4re",
+          "top_level_identity": true
+        }
+      ],
+      "match_methods": [
+        "exact_path",
+        "top_level_path"
+      ],
       "normalized_name_matches": [],
       "owners": [
         "class:rogue"
       ],
-      "status": "unresolved"
+      "status": "resolved"
     },
     {
-      "candidate_skill_ids": [],
+      "candidate_skill_ids": [
+        "skill:ss3tre"
+      ],
       "class_mastery_skill_reference": "skill_path:264237",
       "exact_id_match": null,
-      "exact_path_matches": [],
-      "match_methods": [],
+      "exact_path_matches": [
+        {
+          "display_name": "Shatter Strike",
+          "field_path": "sourceIdentity.skillPath",
+          "identity_confidence": "top_level_owner_pptr",
+          "identity_source": "SkillTree.ability PPtr",
+          "skill_id": "skill:ss3tre",
+          "source_skill_id": "ss3tre",
+          "top_level_identity": true
+        }
+      ],
+      "match_methods": [
+        "exact_path",
+        "top_level_path"
+      ],
       "normalized_name_matches": [],
       "owners": [
         "mastery:mage:spellblade"
       ],
-      "status": "unresolved"
+      "status": "resolved"
     },
     {
-      "candidate_skill_ids": [],
+      "candidate_skill_ids": [
+        "skill:sb4h"
+      ],
       "class_mastery_skill_reference": "skill_path:264241",
       "exact_id_match": null,
-      "exact_path_matches": [],
-      "match_methods": [],
+      "exact_path_matches": [
+        {
+          "display_name": "Shield Bash",
+          "field_path": "sourceIdentity.skillPath",
+          "identity_confidence": "top_level_owner_pptr",
+          "identity_source": "SkillTree.ability PPtr",
+          "skill_id": "skill:sb4h",
+          "source_skill_id": "sb4h",
+          "top_level_identity": true
+        }
+      ],
+      "match_methods": [
+        "exact_path",
+        "top_level_path"
+      ],
       "normalized_name_matches": [],
       "owners": [
         "class:sentinel"
       ],
-      "status": "unresolved"
+      "status": "resolved"
     },
     {
-      "candidate_skill_ids": [],
+      "candidate_skill_ids": [
+        "skill:sw31a"
+      ],
       "class_mastery_skill_reference": "skill_path:264309",
       "exact_id_match": null,
-      "exact_path_matches": [],
-      "match_methods": [],
+      "exact_path_matches": [
+        {
+          "display_name": "Snap Freeze",
+          "field_path": "sourceIdentity.skillPath",
+          "identity_confidence": "top_level_owner_pptr",
+          "identity_source": "SkillTree.ability PPtr",
+          "skill_id": "skill:sw31a",
+          "source_skill_id": "sw31a",
+          "top_level_identity": true
+        }
+      ],
+      "match_methods": [
+        "exact_path",
+        "top_level_path"
+      ],
       "normalized_name_matches": [],
       "owners": [
         "class:mage"
       ],
-      "status": "unresolved"
+      "status": "resolved"
     },
     {
-      "candidate_skill_ids": [],
+      "candidate_skill_ids": [
+        "skill:st47ic"
+      ],
       "class_mastery_skill_reference": "skill_path:264355",
       "exact_id_match": null,
-      "exact_path_matches": [],
-      "match_methods": [],
+      "exact_path_matches": [
+        {
+          "display_name": "Static",
+          "field_path": "sourceIdentity.skillPath",
+          "identity_confidence": "top_level_owner_pptr",
+          "identity_source": "SkillTree.ability PPtr",
+          "skill_id": "skill:st47ic",
+          "source_skill_id": "st47ic",
+          "top_level_identity": true
+        }
+      ],
+      "match_methods": [
+        "exact_path",
+        "top_level_path"
+      ],
       "normalized_name_matches": [],
       "owners": [
         "class:mage"
       ],
-      "status": "unresolved"
+      "status": "resolved"
     },
     {
-      "candidate_skill_ids": [],
+      "candidate_skill_ids": [
+        "skill:srtor"
+      ],
       "class_mastery_skill_reference": "skill_path:264437",
       "exact_id_match": null,
-      "exact_path_matches": [],
-      "match_methods": [],
+      "exact_path_matches": [
+        {
+          "display_name": "Summon Raptor",
+          "field_path": "sourceIdentity.skillPath",
+          "identity_confidence": "top_level_owner_pptr",
+          "identity_source": "SkillTree.ability PPtr",
+          "skill_id": "skill:srtor",
+          "source_skill_id": "srtor",
+          "top_level_identity": true
+        }
+      ],
+      "match_methods": [
+        "exact_path",
+        "top_level_path"
+      ],
       "normalized_name_matches": [],
       "owners": [
         "mastery:primalist:beastmaster"
       ],
-      "status": "unresolved"
+      "status": "resolved"
     },
     {
-      "candidate_skill_ids": [],
+      "candidate_skill_ids": [
+        "skill:ss37kl"
+      ],
       "class_mastery_skill_reference": "skill_path:264444",
       "exact_id_match": null,
-      "exact_path_matches": [],
-      "match_methods": [],
+      "exact_path_matches": [
+        {
+          "display_name": "Summon Skeleton",
+          "field_path": "sourceIdentity.skillPath",
+          "identity_confidence": "top_level_owner_pptr",
+          "identity_source": "SkillTree.ability PPtr",
+          "skill_id": "skill:ss37kl",
+          "source_skill_id": "ss37kl",
+          "top_level_identity": true
+        }
+      ],
+      "match_methods": [
+        "exact_path",
+        "top_level_path"
+      ],
       "normalized_name_matches": [],
       "owners": [
         "class:acolyte"
       ],
-      "status": "unresolved"
+      "status": "resolved"
     },
     {
-      "candidate_skill_ids": [],
+      "candidate_skill_ids": [
+        "skill:st38ml"
+      ],
       "class_mastery_skill_reference": "skill_path:264451",
       "exact_id_match": null,
-      "exact_path_matches": [],
-      "match_methods": [],
+      "exact_path_matches": [
+        {
+          "display_name": "Summon Storm Totem",
+          "field_path": "sourceIdentity.skillPath",
+          "identity_confidence": "top_level_owner_pptr",
+          "identity_source": "SkillTree.ability PPtr",
+          "skill_id": "skill:st38ml",
+          "source_skill_id": "st38ml",
+          "top_level_identity": true
+        }
+      ],
+      "match_methods": [
+        "exact_path",
+        "top_level_path"
+      ],
       "normalized_name_matches": [],
       "owners": [
         "mastery:primalist:shaman"
       ],
-      "status": "unresolved"
+      "status": "resolved"
     },
     {
-      "candidate_skill_ids": [],
+      "candidate_skill_ids": [
+        "skill:th39"
+      ],
       "class_mastery_skill_reference": "skill_path:264453",
       "exact_id_match": null,
-      "exact_path_matches": [],
-      "match_methods": [],
+      "exact_path_matches": [
+        {
+          "display_name": "Summon Thorn Totem",
+          "field_path": "sourceIdentity.skillPath",
+          "identity_confidence": "top_level_owner_pptr",
+          "identity_source": "SkillTree.ability PPtr",
+          "skill_id": "skill:th39",
+          "source_skill_id": "th39",
+          "top_level_identity": true
+        }
+      ],
+      "match_methods": [
+        "exact_path",
+        "top_level_path"
+      ],
       "normalized_name_matches": [],
       "owners": [
         "class:primalist"
       ],
-      "status": "unresolved"
+      "status": "resolved"
     },
     {
-      "candidate_skill_ids": [],
+      "candidate_skill_ids": [
+        "skill:svz81"
+      ],
       "class_mastery_skill_reference": "skill_path:264458",
       "exact_id_match": null,
-      "exact_path_matches": [],
-      "match_methods": [],
+      "exact_path_matches": [
+        {
+          "display_name": "Summon Volatile Zombie",
+          "field_path": "sourceIdentity.skillPath",
+          "identity_confidence": "top_level_owner_pptr",
+          "identity_source": "SkillTree.ability PPtr",
+          "skill_id": "skill:svz81",
+          "source_skill_id": "svz81",
+          "top_level_identity": true
+        }
+      ],
+      "match_methods": [
+        "exact_path",
+        "top_level_path"
+      ],
       "normalized_name_matches": [],
       "owners": [
         "class:acolyte"
       ],
-      "status": "unresolved"
+      "status": "resolved"
     },
     {
-      "candidate_skill_ids": [],
+      "candidate_skill_ids": [
+        "skill:wo42"
+      ],
       "class_mastery_skill_reference": "skill_path:264461",
       "exact_id_match": null,
-      "exact_path_matches": [],
-      "match_methods": [],
+      "exact_path_matches": [
+        {
+          "display_name": "Summon Wolf",
+          "field_path": "sourceIdentity.skillPath",
+          "identity_confidence": "top_level_owner_pptr",
+          "identity_source": "SkillTree.ability PPtr",
+          "skill_id": "skill:wo42",
+          "source_skill_id": "wo42",
+          "top_level_identity": true
+        }
+      ],
+      "match_methods": [
+        "exact_path",
+        "top_level_path"
+      ],
       "normalized_name_matches": [],
       "owners": [
         "class:primalist"
       ],
-      "status": "unresolved"
+      "status": "resolved"
     },
     {
-      "candidate_skill_ids": [],
+      "candidate_skill_ids": [
+        "skill:sw42ih"
+      ],
       "class_mastery_skill_reference": "skill_path:264462",
       "exact_id_match": null,
-      "exact_path_matches": [],
-      "match_methods": [],
+      "exact_path_matches": [
+        {
+          "display_name": "Summon Wraith",
+          "field_path": "sourceIdentity.skillPath",
+          "identity_confidence": "top_level_owner_pptr",
+          "identity_source": "SkillTree.ability PPtr",
+          "skill_id": "skill:sw42ih",
+          "source_skill_id": "sw42ih",
+          "top_level_identity": true
+        }
+      ],
+      "match_methods": [
+        "exact_path",
+        "top_level_path"
+      ],
       "normalized_name_matches": [],
       "owners": [
         "mastery:acolyte:necromancer"
       ],
-      "status": "unresolved"
+      "status": "resolved"
     },
     {
-      "candidate_skill_ids": [],
+      "candidate_skill_ids": [
+        "skill:sw43"
+      ],
       "class_mastery_skill_reference": "skill_path:264551",
       "exact_id_match": null,
-      "exact_path_matches": [],
-      "match_methods": [],
+      "exact_path_matches": [
+        {
+          "display_name": "Swipe",
+          "field_path": "sourceIdentity.skillPath",
+          "identity_confidence": "top_level_owner_pptr",
+          "identity_source": "SkillTree.ability PPtr",
+          "skill_id": "skill:sw43",
+          "source_skill_id": "sw43",
+          "top_level_identity": true
+        }
+      ],
+      "match_methods": [
+        "exact_path",
+        "top_level_path"
+      ],
       "normalized_name_matches": [],
       "owners": [
         "class:primalist"
       ],
-      "status": "unresolved"
+      "status": "resolved"
     },
     {
-      "candidate_skill_ids": [],
+      "candidate_skill_ids": [
+        "skill:te44"
+      ],
       "class_mastery_skill_reference": "skill_path:264554",
       "exact_id_match": null,
-      "exact_path_matches": [],
-      "match_methods": [],
+      "exact_path_matches": [
+        {
+          "display_name": "Teleport",
+          "field_path": "sourceIdentity.skillPath",
+          "identity_confidence": "top_level_owner_pptr",
+          "identity_source": "SkillTree.ability PPtr",
+          "skill_id": "skill:te44",
+          "source_skill_id": "te44",
+          "top_level_identity": true
+        }
+      ],
+      "match_methods": [
+        "exact_path",
+        "top_level_path"
+      ],
       "normalized_name_matches": [],
       "owners": [
         "class:mage"
       ],
-      "status": "unresolved"
+      "status": "resolved"
     },
     {
-      "candidate_skill_ids": [],
+      "candidate_skill_ids": [
+        "skill:ts85i"
+      ],
       "class_mastery_skill_reference": "skill_path:264562",
       "exact_id_match": null,
-      "exact_path_matches": [],
-      "match_methods": [],
+      "exact_path_matches": [
+        {
+          "display_name": "Tempest Strike",
+          "field_path": "sourceIdentity.skillPath",
+          "identity_confidence": "top_level_owner_pptr",
+          "identity_source": "SkillTree.ability PPtr",
+          "skill_id": "skill:ts85i",
+          "source_skill_id": "ts85i",
+          "top_level_identity": true
+        }
+      ],
+      "match_methods": [
+        "exact_path",
+        "top_level_path"
+      ],
       "normalized_name_matches": [],
       "owners": [
         "class:primalist"
       ],
-      "status": "unresolved"
+      "status": "resolved"
     },
     {
-      "candidate_skill_ids": [],
+      "candidate_skill_ids": [
+        "skill:ts50pl"
+      ],
       "class_mastery_skill_reference": "skill_path:264675",
       "exact_id_match": null,
-      "exact_path_matches": [],
-      "match_methods": [],
+      "exact_path_matches": [
+        {
+          "display_name": "Transplant",
+          "field_path": "sourceIdentity.skillPath",
+          "identity_confidence": "top_level_owner_pptr",
+          "identity_source": "SkillTree.ability PPtr",
+          "skill_id": "skill:ts50pl",
+          "source_skill_id": "ts50pl",
+          "top_level_identity": true
+        }
+      ],
+      "match_methods": [
+        "exact_path",
+        "top_level_path"
+      ],
       "normalized_name_matches": [],
       "owners": [
         "class:acolyte"
       ],
-      "status": "unresolved"
+      "status": "resolved"
     },
     {
-      "candidate_skill_ids": [],
+      "candidate_skill_ids": [
+        "skill:uph41"
+      ],
       "class_mastery_skill_reference": "skill_path:264730",
       "exact_id_match": null,
-      "exact_path_matches": [],
-      "match_methods": [],
+      "exact_path_matches": [
+        {
+          "display_name": "Upheaval",
+          "field_path": "sourceIdentity.skillPath",
+          "identity_confidence": "top_level_owner_pptr",
+          "identity_source": "SkillTree.ability PPtr",
+          "skill_id": "skill:uph41",
+          "source_skill_id": "uph41",
+          "top_level_identity": true
+        }
+      ],
+      "match_methods": [
+        "exact_path",
+        "top_level_path"
+      ],
       "normalized_name_matches": [],
       "owners": [
         "class:primalist"
       ],
-      "status": "unresolved"
+      "status": "resolved"
     },
     {
-      "candidate_skill_ids": [],
+      "candidate_skill_ids": [
+        "skill:gs15de"
+      ],
       "class_mastery_skill_reference": "skill_path:264735",
       "exact_id_match": null,
-      "exact_path_matches": [],
-      "match_methods": [],
+      "exact_path_matches": [
+        {
+          "display_name": "Vengeance",
+          "field_path": "sourceIdentity.skillPath",
+          "identity_confidence": "top_level_owner_pptr",
+          "identity_source": "SkillTree.ability PPtr",
+          "skill_id": "skill:gs15de",
+          "source_skill_id": "gs15de",
+          "top_level_identity": true
+        }
+      ],
+      "match_methods": [
+        "exact_path",
+        "top_level_path"
+      ],
       "normalized_name_matches": [],
       "owners": [
         "class:sentinel"
       ],
-      "status": "unresolved"
+      "status": "resolved"
     },
     {
-      "candidate_skill_ids": [],
+      "candidate_skill_ids": [
+        "skill:v01cv"
+      ],
       "class_mastery_skill_reference": "skill_path:264807",
       "exact_id_match": null,
-      "exact_path_matches": [],
-      "match_methods": [],
+      "exact_path_matches": [
+        {
+          "display_name": "Void Cleave",
+          "field_path": "sourceIdentity.skillPath",
+          "identity_confidence": "top_level_owner_pptr",
+          "identity_source": "SkillTree.ability PPtr",
+          "skill_id": "skill:v01cv",
+          "source_skill_id": "v01cv",
+          "top_level_identity": true
+        }
+      ],
+      "match_methods": [
+        "exact_path",
+        "top_level_path"
+      ],
       "normalized_name_matches": [],
       "owners": [
         "class:sentinel"
       ],
-      "status": "unresolved"
+      "status": "resolved"
     },
     {
-      "candidate_skill_ids": [],
+      "candidate_skill_ids": [
+        "skill:ws54hm"
+      ],
       "class_mastery_skill_reference": "skill_path:264863",
       "exact_id_match": null,
-      "exact_path_matches": [],
-      "match_methods": [],
+      "exact_path_matches": [
+        {
+          "display_name": "Wandering Spirits",
+          "field_path": "sourceIdentity.skillPath",
+          "identity_confidence": "top_level_owner_pptr",
+          "identity_source": "SkillTree.ability PPtr",
+          "skill_id": "skill:ws54hm",
+          "source_skill_id": "ws54hm",
+          "top_level_identity": true
+        }
+      ],
+      "match_methods": [
+        "exact_path",
+        "top_level_path"
+      ],
       "normalized_name_matches": [],
       "owners": [
         "class:acolyte"
       ],
-      "status": "unresolved"
+      "status": "resolved"
     },
     {
-      "candidate_skill_ids": [],
+      "candidate_skill_ids": [
+        "skill:ch0fs"
+      ],
       "class_mastery_skill_reference": "skill_path:264874",
       "exact_id_match": null,
-      "exact_path_matches": [],
-      "match_methods": [],
+      "exact_path_matches": [
+        {
+          "display_name": "Chthonic Fissure",
+          "field_path": "sourceIdentity.skillPath",
+          "identity_confidence": "top_level_owner_pptr",
+          "identity_source": "SkillTree.ability PPtr",
+          "skill_id": "skill:ch0fs",
+          "source_skill_id": "ch0fs",
+          "top_level_identity": true
+        }
+      ],
+      "match_methods": [
+        "exact_path",
+        "top_level_path"
+      ],
       "normalized_name_matches": [],
       "owners": [
         "mastery:acolyte:warlock"
       ],
-      "status": "unresolved"
+      "status": "resolved"
     },
     {
-      "candidate_skill_ids": [],
+      "candidate_skill_ids": [
+        "skill:va53st"
+      ],
       "class_mastery_skill_reference": "skill_path:264881",
       "exact_id_match": null,
-      "exact_path_matches": [],
-      "match_methods": [],
+      "exact_path_matches": [
+        {
+          "display_name": "Warpath",
+          "field_path": "sourceIdentity.skillPath",
+          "identity_confidence": "top_level_owner_pptr",
+          "identity_source": "SkillTree.ability PPtr",
+          "skill_id": "skill:va53st",
+          "source_skill_id": "va53st",
+          "top_level_identity": true
+        }
+      ],
+      "match_methods": [
+        "exact_path",
+        "top_level_path"
+      ],
       "normalized_name_matches": [],
       "owners": [
         "class:sentinel"
       ],
-      "status": "unresolved"
+      "status": "resolved"
     },
     {
-      "candidate_skill_ids": [],
+      "candidate_skill_ids": [
+        "skill:wb8fo"
+      ],
       "class_mastery_skill_reference": "skill_path:264922",
       "exact_id_match": null,
-      "exact_path_matches": [],
-      "match_methods": [],
+      "exact_path_matches": [
+        {
+          "display_name": "Werebear Form",
+          "field_path": "sourceIdentity.skillPath",
+          "identity_confidence": "top_level_owner_pptr",
+          "identity_source": "SkillTree.ability PPtr",
+          "skill_id": "skill:wb8fo",
+          "source_skill_id": "wb8fo",
+          "top_level_identity": true
+        }
+      ],
+      "match_methods": [
+        "exact_path",
+        "top_level_path"
+      ],
       "normalized_name_matches": [],
       "owners": [
         "mastery:primalist:druid"
       ],
-      "status": "unresolved"
+      "status": "resolved"
     }
   ],
   "summary": {
     "ambiguous_match_count": 1,
     "bridge_safe": false,
     "exact_id_match_count": 0,
-    "exact_path_match_count": 2,
-    "nested_path_only_match_count": 1,
+    "exact_path_match_count": 61,
+    "nested_path_only_match_count": 0,
     "normalized_name_match_count": 0,
     "production_consumed": false,
-    "recommended_mapping_strategy": "do_not_bridge_from_nested_path_evidence",
+    "recommended_mapping_strategy": "top_level_source_identity_partial_unresolved",
     "source_data_missing": true,
-    "top_level_path_match_count": 0,
+    "top_level_path_match_count": 60,
     "total_class_mastery_skill_references": 63,
     "total_skill_records": 184,
-    "unresolved_reference_count": 61
+    "unresolved_reference_count": 2
   }
 }

--- a/docs/migration/V2_SKILL_IDENTITY_ALIGNMENT.md
+++ b/docs/migration/V2_SKILL_IDENTITY_ALIGNMENT.md
@@ -15,14 +15,14 @@ This Phase 9.5 audit diagnoses the class/mastery to skill identity mismatch repo
 - Total class/mastery skill references: 63
 - Total skill records: 184
 - Exact ID matches: 0
-- Exact raw path matches: 2
-- Top-level path matches: 0
-- Nested path-only matches: 1
+- Exact raw path matches: 61
+- Top-level path matches: 60
+- Nested path-only matches: 0
 - Normalized name matches: 0
 - Ambiguous matches: 1
-- Unresolved references: 61
+- Unresolved references: 2
 - Bridge safe: false
-- Recommended mapping strategy: `do_not_bridge_from_nested_path_evidence`
+- Recommended mapping strategy: `top_level_source_identity_partial_unresolved`
 
 ## Field Inventory
 
@@ -96,7 +96,7 @@ Raw skill records expose these observed path-like fields:
 
 Exact ID matching did not resolve the class/mastery `skill_path:*` references because generated v2 skills use source skill IDs such as `skill:ab0lh`, not numeric path IDs.
 
-Raw path matching found references only where the numeric path ID appears somewhere inside raw skill evidence. These are not accepted as a safe bridge unless they are top-level owner identity fields. In the real report, no top-level owner path matches were found.
+Raw path matching now includes upstream `sourceIdentity.skillPath` when present. Those top-level matches are accepted as safe identity evidence. Nested path evidence is still not accepted as a bridge.
 
 Normalized name matching cannot resolve these references because the class/mastery `skill_path:*` values do not include display names.
 
@@ -104,11 +104,20 @@ Normalized name matching cannot resolve these references because the class/maste
 
 ### Resolved By Safe Identity
 
-- None
+- `skill_path:260926` (resolved; owners: class:acolyte) -> skill:evade1
+- `skill_path:261173` (resolved; owners: class:acolyte) -> skill:bc53
+- `skill_path:261591` (resolved; owners: class:mage) -> skill:en6
+- `skill_path:262309` (resolved; owners: mastery:sentinel:void_knight) -> skill:es6ai
+- `skill_path:262328` (resolved; owners: mastery:rogue:falconer) -> skill:falc0
+- `skill_path:262431` (resolved; owners: class:mage) -> skill:fi9
+- `skill_path:262458` (resolved; owners: class:mage) -> skill:fw3d
+- `skill_path:262473` (resolved; owners: mastery:sentinel:forge_guard) -> skill:fs3e3
+- `skill_path:262497` (resolved; owners: class:mage) -> skill:frc87w
+- `skill_path:262531` (resolved; owners: class:primalist) -> skill:fl13
 
 ### Nested Path Matches Not Accepted As A Bridge
 
-- `skill_path:264015` (nested_path_match_not_bridge_safe; owners: mastery:mage:runemaster) -> skill:fb8fe
+- None
 
 ### Ambiguous
 
@@ -116,21 +125,13 @@ Normalized name matching cannot resolve these references because the class/maste
 
 ### Unresolved
 
-- `skill_path:260926` (unresolved; owners: class:acolyte)
-- `skill_path:261173` (unresolved; owners: class:acolyte)
-- `skill_path:261591` (unresolved; owners: class:mage)
-- `skill_path:262309` (unresolved; owners: mastery:sentinel:void_knight)
-- `skill_path:262328` (unresolved; owners: mastery:rogue:falconer)
-- `skill_path:262431` (unresolved; owners: class:mage)
-- `skill_path:262458` (unresolved; owners: class:mage)
-- `skill_path:262473` (unresolved; owners: mastery:sentinel:forge_guard)
-- `skill_path:262497` (unresolved; owners: class:mage)
-- `skill_path:262531` (unresolved; owners: class:primalist)
+- `skill_path:262953` (unresolved; owners: class:mage)
+- `skill_path:263498` (unresolved; owners: class:acolyte, class:mage, class:primalist)
 
 ## Conclusion
 
-A deterministic bridge is not safe from the current evidence. Phase 7 `skill_path:*` values should remain unresolved until a source export exposes a top-level owning skill path ID or a separate audited identity table proves the mapping.
+A complete deterministic bridge is still not safe from the current evidence. The enriched upstream export resolves the references that have top-level `sourceIdentity.skillPath` evidence, but remaining unresolved or ambiguous references must stay blocked.
 
 ## Recommended Next Action
 
-Before modifier/stat normalization consumes class/mastery skill ownership, add a focused source-export identity alignment task or update the upstream export to include the owning ability path ID on skill records. Do not infer the bridge from nested summoned actor evidence or tooltip text.
+Before modifier/stat normalization consumes class/mastery skill ownership, either resolve the remaining source gaps upstream or carry them as an explicit identity gap. Do not infer the remaining bridge from nested summoned actor evidence or tooltip text.


### PR DESCRIPTION
## Summary

Updates the v2 skill identity alignment audit to consume the enriched upstream skill source identity export.

This improves safe class/mastery skill reference alignment from 0 top-level matches to 60 / 63 while preserving the unresolved source-data gaps.

## Findings

- Total refs: `63`
- Top-level path matches: `60`
- Exact ID matches: `0`
- Exact raw path matches: `61`
- Nested path-only matches: `0`
- Ambiguous matches: `1`
- Unresolved: `2`
- Bridge safe: `false`

The audit still correctly refuses to accept nested ambiguous evidence for `skill_path:261142`.

## Conclusion

A deterministic full bridge is still not safe, but the available source identity now resolves most class/mastery skill references safely.

Phase 10 may proceed with the explicit restriction that unresolved class/mastery skill ownership remains an identity gap.

## Validation

- focused tests passed
- py_compile passed
- JSON validation passed
- `git diff --check` passed

## Runtime behavior

No production planner/runtime behavior changed.
No planner consumption changed.