### PR TITLE
feat: consolidate v2 backend repositories

### DIFF
--- a/backend/app/repositories/v2/__init__.py
+++ b/backend/app/repositories/v2/__init__.py
@@ -5,6 +5,7 @@ from .class_mastery_repository import V2ClassMasteryBundleError, V2ClassMasteryR
 from .idol_repository import V2IdolBundleError, V2IdolRepository
 from .item_repository import V2ItemBundleError, V2ItemRepository
 from .passive_repository import V2PassiveBundleError, V2PassiveRepository
+from .registry import V2RepositoryDescriptor, V2RepositoryRegistry, default_repository_descriptors
 from .skill_repository import V2SkillBundleError, V2SkillRepository
 from .unique_set_repository import V2UniqueSetBundleError, V2UniqueSetRepository
 
@@ -19,8 +20,11 @@ __all__ = [
     "V2ItemRepository",
     "V2PassiveBundleError",
     "V2PassiveRepository",
+    "V2RepositoryDescriptor",
+    "V2RepositoryRegistry",
     "V2SkillBundleError",
     "V2SkillRepository",
     "V2UniqueSetBundleError",
     "V2UniqueSetRepository",
+    "default_repository_descriptors",
 ]

--- a/backend/app/repositories/v2/paths.py
+++ b/backend/app/repositories/v2/paths.py
@@ -1,0 +1,34 @@
+"""Shared generated artifact paths for read-only v2 repositories."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+GENERATED_DOCS_DIR = REPO_ROOT / "docs" / "generated"
+
+V2_ARTIFACT_PATHS: dict[str, Path] = {
+    "affix_bundle": GENERATED_DOCS_DIR / "v2_affix_bundle.json",
+    "item_base_bundle": GENERATED_DOCS_DIR / "v2_item_base_bundle.json",
+    "item_implicit_bundle": GENERATED_DOCS_DIR / "v2_item_implicit_bundle.json",
+    "unique_bundle": GENERATED_DOCS_DIR / "v2_unique_bundle.json",
+    "set_bundle": GENERATED_DOCS_DIR / "v2_set_bundle.json",
+    "idol_bundle": GENERATED_DOCS_DIR / "v2_idol_bundle.json",
+    "idol_affix_bundle": GENERATED_DOCS_DIR / "v2_idol_affix_bundle.json",
+    "class_mastery_bundle": GENERATED_DOCS_DIR / "v2_class_mastery_bundle.json",
+    "passive_tree_bundle": GENERATED_DOCS_DIR / "v2_passive_tree_bundle.json",
+    "skill_bundle": GENERATED_DOCS_DIR / "v2_skill_bundle.json",
+    "skill_tree_bundle": GENERATED_DOCS_DIR / "v2_skill_tree_bundle.json",
+    "stat_registry": GENERATED_DOCS_DIR / "v2_stat_registry.json",
+    "modifier_registry": GENERATED_DOCS_DIR / "v2_modifier_registry.json",
+    "value_normalization_policy_report": GENERATED_DOCS_DIR / "v2_value_normalization_policy_report.json",
+}
+
+
+def artifact_path(artifact_key: str, *, root: str | Path | None = None) -> Path:
+    """Return an artifact path, optionally rooted at a test workspace."""
+
+    relative_path = V2_ARTIFACT_PATHS[artifact_key].relative_to(REPO_ROOT)
+    if root is None:
+        return V2_ARTIFACT_PATHS[artifact_key]
+    return Path(root) / relative_path

--- a/backend/app/repositories/v2/registry.py
+++ b/backend/app/repositories/v2/registry.py
@@ -1,0 +1,232 @@
+"""Central read-only registry for generated v2 backend repositories."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+from app.normalization.v2 import V2ModifierRegistry, V2StatRegistry
+from app.repositories.v2.affix_repository import V2AffixRepository
+from app.repositories.v2.class_mastery_repository import V2ClassMasteryRepository
+from app.repositories.v2.idol_repository import V2IdolRepository
+from app.repositories.v2.item_repository import V2ItemRepository
+from app.repositories.v2.passive_repository import V2PassiveRepository
+from app.repositories.v2.paths import artifact_path
+from app.repositories.v2.skill_repository import V2SkillRepository
+from app.repositories.v2.unique_set_repository import V2UniqueSetRepository
+
+RepositoryFactory = Callable[[str | Path | None], Any]
+
+
+@dataclass(frozen=True)
+class V2RepositoryDescriptor:
+    domain: str
+    label: str
+    artifact_keys: tuple[str, ...]
+    required_methods: tuple[str, ...]
+    experimental_routes: tuple[str, ...]
+    factory: RepositoryFactory
+
+    def artifact_paths(self, *, root: str | Path | None = None) -> tuple[Path, ...]:
+        return tuple(artifact_path(key, root=root) for key in self.artifact_keys)
+
+
+def default_repository_descriptors() -> tuple[V2RepositoryDescriptor, ...]:
+    """Return the v2 domains currently exposed through read-only loaders."""
+
+    return (
+        V2RepositoryDescriptor(
+            domain="affixes",
+            label="Affixes",
+            artifact_keys=("affix_bundle",),
+            required_methods=("load", "list_affixes", "get_affix", "filter_affixes", "debug_summary"),
+            experimental_routes=("/experimental/v2/affixes", "/experimental/v2/affixes/<affix_id>", "/experimental/v2/affixes/debug"),
+            factory=lambda root=None: V2AffixRepository(artifact_path("affix_bundle", root=root)),
+        ),
+        V2RepositoryDescriptor(
+            domain="items",
+            label="Item bases and implicits",
+            artifact_keys=("item_base_bundle", "item_implicit_bundle"),
+            required_methods=("load", "list_bases", "get_base", "filter_bases", "list_implicits", "get_implicit", "debug_summary"),
+            experimental_routes=("/experimental/v2/items/bases", "/experimental/v2/items/bases/<item_base_id>", "/experimental/v2/items/implicits", "/experimental/v2/items/debug"),
+            factory=lambda root=None: V2ItemRepository(
+                artifact_path("item_base_bundle", root=root),
+                artifact_path("item_implicit_bundle", root=root),
+            ),
+        ),
+        V2RepositoryDescriptor(
+            domain="unique_sets",
+            label="Uniques and sets",
+            artifact_keys=("unique_bundle", "set_bundle"),
+            required_methods=("load", "list_uniques", "get_unique", "filter_uniques", "list_sets", "get_set", "debug_summary"),
+            experimental_routes=("/experimental/v2/uniques", "/experimental/v2/uniques/<unique_id>", "/experimental/v2/sets", "/experimental/v2/sets/<set_id>", "/experimental/v2/uniques/debug", "/experimental/v2/sets/debug"),
+            factory=lambda root=None: V2UniqueSetRepository(
+                artifact_path("unique_bundle", root=root),
+                artifact_path("set_bundle", root=root),
+            ),
+        ),
+        V2RepositoryDescriptor(
+            domain="idols",
+            label="Idols and idol affixes",
+            artifact_keys=("idol_bundle", "idol_affix_bundle"),
+            required_methods=("load", "list_idols", "get_idol", "filter_idols", "list_affixes", "get_affix", "debug_summary"),
+            experimental_routes=("/experimental/v2/idols", "/experimental/v2/idols/<idol_id>", "/experimental/v2/idols/affixes", "/experimental/v2/idols/affixes/<affix_id>", "/experimental/v2/idols/debug"),
+            factory=lambda root=None: V2IdolRepository(
+                artifact_path("idol_bundle", root=root),
+                artifact_path("idol_affix_bundle", root=root),
+            ),
+        ),
+        V2RepositoryDescriptor(
+            domain="classes_masteries",
+            label="Classes and masteries",
+            artifact_keys=("class_mastery_bundle",),
+            required_methods=("load", "list_classes", "get_class", "filter_classes", "list_masteries", "get_mastery", "debug_summary"),
+            experimental_routes=("/experimental/v2/classes", "/experimental/v2/classes/<class_id>", "/experimental/v2/masteries", "/experimental/v2/masteries/<mastery_id>", "/experimental/v2/classes/debug"),
+            factory=lambda root=None: V2ClassMasteryRepository(artifact_path("class_mastery_bundle", root=root)),
+        ),
+        V2RepositoryDescriptor(
+            domain="passives",
+            label="Passive trees",
+            artifact_keys=("passive_tree_bundle",),
+            required_methods=("load", "list_trees", "get_tree", "filter_trees", "get_nodes_by_tree", "get_node", "debug_summary"),
+            experimental_routes=("/experimental/v2/passives", "/experimental/v2/passives/<tree_id>", "/experimental/v2/passives/<tree_id>/nodes/<node_id>", "/experimental/v2/passives/debug"),
+            factory=lambda root=None: V2PassiveRepository(artifact_path("passive_tree_bundle", root=root)),
+        ),
+        V2RepositoryDescriptor(
+            domain="skills",
+            label="Skills and skill trees",
+            artifact_keys=("skill_bundle", "skill_tree_bundle"),
+            required_methods=("load", "list_skills", "filter_skills", "get_skill", "get_tree", "get_tree_by_skill", "get_nodes_by_tree", "get_node", "debug_summary"),
+            experimental_routes=("/experimental/v2/skills", "/experimental/v2/skills/<skill_id>", "/experimental/v2/skills/<skill_id>/tree", "/experimental/v2/skills/trees/<tree_id>", "/experimental/v2/skills/trees/<tree_id>/nodes/<node_id>", "/experimental/v2/skills/debug"),
+            factory=lambda root=None: V2SkillRepository(
+                artifact_path("skill_bundle", root=root),
+                artifact_path("skill_tree_bundle", root=root),
+            ),
+        ),
+        V2RepositoryDescriptor(
+            domain="stats",
+            label="Stat registry",
+            artifact_keys=("stat_registry",),
+            required_methods=("load", "list_stats", "get_stat", "debug_summary"),
+            experimental_routes=("/experimental/v2/stats", "/experimental/v2/stats/<stat_id>"),
+            factory=lambda root=None: V2StatRegistry(artifact_path("stat_registry", root=root)),
+        ),
+        V2RepositoryDescriptor(
+            domain="modifiers",
+            label="Modifier registry",
+            artifact_keys=("modifier_registry",),
+            required_methods=("load", "list_modifiers", "get_modifier", "debug_summary"),
+            experimental_routes=("/experimental/v2/modifiers", "/experimental/v2/modifiers/<modifier_id>", "/experimental/v2/modifiers/debug"),
+            factory=lambda root=None: V2ModifierRegistry(artifact_path("modifier_registry", root=root)),
+        ),
+        V2RepositoryDescriptor(
+            domain="value_policy",
+            label="Value normalization policy",
+            artifact_keys=("value_normalization_policy_report",),
+            required_methods=(),
+            experimental_routes=(),
+            factory=lambda root=None: None,
+        ),
+    )
+
+
+class V2RepositoryRegistry:
+    """Read-only facade for generated v2 repository domains."""
+
+    def __init__(
+        self,
+        *,
+        root: str | Path | None = None,
+        descriptors: tuple[V2RepositoryDescriptor, ...] | None = None,
+    ) -> None:
+        self.root = Path(root) if root is not None else None
+        self._descriptors = {descriptor.domain: descriptor for descriptor in (descriptors or default_repository_descriptors())}
+
+    def list_domains(self) -> list[str]:
+        return sorted(self._descriptors)
+
+    def descriptor(self, domain: str) -> V2RepositoryDescriptor:
+        return self._descriptors[domain]
+
+    def load(self, domain: str) -> Any:
+        descriptor = self.descriptor(domain)
+        repository = descriptor.factory(self.root)
+        if repository is None:
+            return None
+        return repository.load()
+
+    def method_coverage(self, domain: str) -> dict[str, bool]:
+        descriptor = self.descriptor(domain)
+        repository = descriptor.factory(self.root)
+        return {method: hasattr(repository, method) for method in descriptor.required_methods}
+
+    def validate_domain(self, domain: str) -> dict[str, Any]:
+        descriptor = self.descriptor(domain)
+        artifacts = [
+            {
+                "artifact_key": key,
+                "path": str(path),
+                "exists": path.exists(),
+            }
+            for key, path in zip(descriptor.artifact_keys, descriptor.artifact_paths(root=self.root), strict=True)
+        ]
+        missing_artifacts = [artifact for artifact in artifacts if not artifact["exists"]]
+        method_coverage = self.method_coverage(domain)
+        missing_methods = [method for method, present in method_coverage.items() if not present]
+        if missing_artifacts:
+            return {
+                "domain": domain,
+                "label": descriptor.label,
+                "status": "missing_artifacts",
+                "artifacts": artifacts,
+                "missing_artifact_count": len(missing_artifacts),
+                "method_coverage": method_coverage,
+                "missing_methods": missing_methods,
+                "experimental_routes": list(descriptor.experimental_routes),
+                "production_consumed": False,
+                "error": f"Missing v2 generated artifacts for {domain}.",
+            }
+        try:
+            repository = self.load(domain)
+            debug_summary = repository.debug_summary() if repository is not None and hasattr(repository, "debug_summary") else {}
+        except Exception as exc:
+            return {
+                "domain": domain,
+                "label": descriptor.label,
+                "status": "invalid",
+                "artifacts": artifacts,
+                "missing_artifact_count": 0,
+                "method_coverage": method_coverage,
+                "missing_methods": missing_methods,
+                "experimental_routes": list(descriptor.experimental_routes),
+                "production_consumed": False,
+                "error": str(exc),
+            }
+        return {
+            "domain": domain,
+            "label": descriptor.label,
+            "status": "ok",
+            "artifacts": artifacts,
+            "missing_artifact_count": 0,
+            "method_coverage": method_coverage,
+            "missing_methods": missing_methods,
+            "experimental_routes": list(descriptor.experimental_routes),
+            "debug_summary": debug_summary,
+            "production_consumed": False,
+        }
+
+    def validation_status(self) -> dict[str, Any]:
+        domains = [self.validate_domain(domain) for domain in self.list_domains()]
+        missing_count = sum(domain["missing_artifact_count"] for domain in domains)
+        invalid_count = sum(1 for domain in domains if domain["status"] == "invalid")
+        return {
+            "summary": {
+                "repository_domain_count": len(domains),
+                "loaded_repository_count": sum(1 for domain in domains if domain["status"] == "ok"),
+                "missing_artifact_count": missing_count,
+                "invalid_repository_count": invalid_count,
+                "production_consumed": False,
+            },
+            "repositories": domains,
+        }

--- a/backend/scripts/report_v2_backend_repository_layer.py
+++ b/backend/scripts/report_v2_backend_repository_layer.py
@@ -1,0 +1,164 @@
+"""Generate the v2 backend repository layer consolidation report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.repositories.v2.registry import V2RepositoryRegistry
+
+
+def build_v2_backend_repository_report(*, root: str | Path | None = None) -> dict[str, Any]:
+    registry = V2RepositoryRegistry(root=root)
+    validation = registry.validation_status()
+    repositories = validation["repositories"]
+    route_count = sum(len(repository["experimental_routes"]) for repository in repositories)
+    method_count = sum(len(repository["method_coverage"]) for repository in repositories)
+    missing_method_count = sum(len(repository["missing_methods"]) for repository in repositories)
+    domains_with_debug = [
+        repository["domain"]
+        for repository in repositories
+        if repository["status"] == "ok" and repository.get("debug_summary") is not None
+    ]
+    report = {
+        "summary": {
+            "generated_at": datetime.now(UTC).isoformat(),
+            "repository_domain_count": validation["summary"]["repository_domain_count"],
+            "loaded_repository_count": validation["summary"]["loaded_repository_count"],
+            "missing_artifact_count": validation["summary"]["missing_artifact_count"],
+            "invalid_repository_count": validation["summary"]["invalid_repository_count"],
+            "method_coverage_count": method_count,
+            "missing_method_count": missing_method_count,
+            "experimental_route_count": route_count,
+            "debug_summary_domain_count": len(domains_with_debug),
+            "production_consumed": False,
+        },
+        "repositories": repositories,
+        "method_coverage": {
+            repository["domain"]: repository["method_coverage"]
+            for repository in repositories
+        },
+        "experimental_route_coverage": {
+            repository["domain"]: repository["experimental_routes"]
+            for repository in repositories
+        },
+        "missing_artifacts": [
+            {
+                "domain": repository["domain"],
+                "artifact_key": artifact["artifact_key"],
+                "path": artifact["path"],
+            }
+            for repository in repositories
+            for artifact in repository["artifacts"]
+            if not artifact["exists"]
+        ],
+        "metadata": {
+            "source": "generated_v2_backend_repositories",
+            "read_only": True,
+            "experimental": True,
+            "production_safe": False,
+            "production_consumed": False,
+            "planner_consumed": False,
+            "unresolved_skill_identity_bridged": False,
+        },
+    }
+    return report
+
+
+def write_markdown(report: dict[str, Any], output_path: Path) -> None:
+    summary = report["summary"]
+    lines = [
+        "# V2 Backend Repository Layer",
+        "",
+        "## Purpose",
+        "",
+        "This report consolidates the read-only v2 backend repository layer after Phases 3 through 10.5. It documents generated artifact dependencies, loader validation, method coverage, experimental route coverage, and production-consumption safety.",
+        "",
+        "This phase does not remap planner behavior and does not make partial, unsupported, unknown, or source-unit records stable-calculable.",
+        "",
+        "## Summary",
+        "",
+        f"- Repository domains: `{summary['repository_domain_count']}`",
+        f"- Loaded repositories/artifacts: `{summary['loaded_repository_count']}`",
+        f"- Missing artifacts: `{summary['missing_artifact_count']}`",
+        f"- Invalid repositories: `{summary['invalid_repository_count']}`",
+        f"- Missing required methods: `{summary['missing_method_count']}`",
+        f"- Experimental routes documented: `{summary['experimental_route_count']}`",
+        f"- Production consumed: `{str(summary['production_consumed']).lower()}`",
+        "",
+        "## Repository Coverage",
+        "",
+        "| Domain | Status | Artifacts | Missing Methods | Experimental Routes |",
+        "| --- | --- | ---: | ---: | ---: |",
+    ]
+    for repository in report["repositories"]:
+        lines.append(
+            f"| `{repository['domain']}` | `{repository['status']}` | "
+            f"`{len(repository['artifacts'])}` | `{len(repository['missing_methods'])}` | "
+            f"`{len(repository['experimental_routes'])}` |"
+        )
+
+    lines.extend([
+        "",
+        "## Missing Artifacts",
+        "",
+    ])
+    if report["missing_artifacts"]:
+        for artifact in report["missing_artifacts"]:
+            lines.append(f"- `{artifact['domain']}` missing `{artifact['artifact_key']}` at `{artifact['path']}`")
+    else:
+        lines.append("No missing generated artifacts were found.")
+
+    lines.extend([
+        "",
+        "## Route Coverage",
+        "",
+    ])
+    for domain, routes in report["experimental_route_coverage"].items():
+        if not routes:
+            lines.append(f"- `{domain}`: no experimental route; audit/report-only domain.")
+            continue
+        joined = ", ".join(f"`{route}`" for route in routes)
+        lines.append(f"- `{domain}`: {joined}")
+
+    lines.extend([
+        "",
+        "## Safety Notes",
+        "",
+        "- All v2 repositories remain read-only.",
+        "- Production planner, crafting, stat aggregation, simulation, and production reference routes do not consume this registry.",
+        "- The value normalization policy remains audit-only.",
+        "- Remaining skill identity gaps remain unbridged and must not be treated as resolved.",
+        "",
+        "## Recommended Next Step",
+        "",
+        "Proceed to API contract finalization only after this repository layer is reviewed. Planner remapping should remain deferred until value-scale normalization and stable eligibility policy have stronger evidence.",
+    ])
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", default="docs/generated/v2_backend_repository_report.json")
+    parser.add_argument("--markdown-output", default="docs/migration/V2_BACKEND_REPOSITORY_LAYER.md")
+    args = parser.parse_args()
+
+    report = build_v2_backend_repository_report()
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    write_markdown(report, Path(args.markdown_output))
+    print(json.dumps(report["summary"], indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_v2_affix_infrastructure.py
+++ b/backend/tests/test_v2_affix_infrastructure.py
@@ -100,6 +100,8 @@ def test_v2_affix_bundle_is_not_referenced_by_production_modules():
         root / "backend" / "app" / "routes" / "experimental.py",
         root / "backend" / "app" / "repositories" / "v2" / "affix_repository.py",
         root / "backend" / "app" / "repositories" / "v2" / "__init__.py",
+        root / "backend" / "app" / "repositories" / "v2" / "paths.py",
+        root / "backend" / "app" / "repositories" / "v2" / "registry.py",
         root / "backend" / "scripts" / "report_v2_affix_bundle.py",
         Path(__file__).resolve(),
     }

--- a/backend/tests/test_v2_backend_repository_layer.py
+++ b/backend/tests/test_v2_backend_repository_layer.py
@@ -1,0 +1,93 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from app.repositories.v2 import V2RepositoryRegistry
+from scripts.report_v2_backend_repository_layer import build_v2_backend_repository_report
+
+
+def test_v2_repository_registry_loads_all_generated_domains():
+    registry = V2RepositoryRegistry()
+    status = registry.validation_status()
+
+    assert status["summary"]["repository_domain_count"] == 10
+    assert status["summary"]["loaded_repository_count"] == 10
+    assert status["summary"]["missing_artifact_count"] == 0
+    assert status["summary"]["invalid_repository_count"] == 0
+    assert all(repository["production_consumed"] is False for repository in status["repositories"])
+
+
+@pytest.mark.parametrize(
+    "domain, expected_summary_key",
+    [
+        ("affixes", "affix_count"),
+        ("items", "item_base_count"),
+        ("unique_sets", "unique_count"),
+        ("idols", "idol_count"),
+        ("classes_masteries", "class_count"),
+        ("passives", "passive_tree_count"),
+        ("skills", "skill_count"),
+        ("stats", "stat_count"),
+        ("modifiers", "modifier_count"),
+    ],
+)
+def test_v2_repository_registry_exposes_debug_summaries(domain: str, expected_summary_key: str):
+    registry = V2RepositoryRegistry()
+    loaded = registry.validate_domain(domain)
+
+    assert loaded["status"] == "ok"
+    assert loaded["debug_summary"][expected_summary_key] > 0
+    assert loaded["debug_summary"]["production_safe"] is False
+
+
+def test_v2_repository_registry_reports_clear_missing_artifacts(tmp_path):
+    registry = V2RepositoryRegistry(root=tmp_path)
+    status = registry.validate_domain("affixes")
+
+    assert status["status"] == "missing_artifacts"
+    assert status["missing_artifact_count"] == 1
+    assert "Missing v2 generated artifacts for affixes" in status["error"]
+
+
+def test_v2_repository_registry_reports_invalid_bundle_errors(tmp_path):
+    artifact = tmp_path / "docs" / "generated" / "v2_affix_bundle.json"
+    artifact.parent.mkdir(parents=True)
+    artifact.write_text(json.dumps({"records": {"affixes": []}}), encoding="utf-8")
+
+    registry = V2RepositoryRegistry(root=tmp_path)
+    status = registry.validate_domain("affixes")
+
+    assert status["status"] == "invalid"
+    assert "records.affixes must not be empty" in status["error"]
+
+
+def test_v2_backend_repository_report_covers_routes_and_methods():
+    report = build_v2_backend_repository_report()
+
+    assert report["summary"]["repository_domain_count"] == 10
+    assert report["summary"]["missing_artifact_count"] == 0
+    assert report["summary"]["invalid_repository_count"] == 0
+    assert report["summary"]["missing_method_count"] == 0
+    assert report["summary"]["experimental_route_count"] >= 30
+    assert report["metadata"]["production_consumed"] is False
+    assert report["metadata"]["unresolved_skill_identity_bridged"] is False
+
+
+def test_v2_repository_registry_is_not_referenced_by_production_modules():
+    root = Path(__file__).resolve().parents[2]
+    allowed = {
+        root / "backend" / "app" / "repositories" / "v2" / "__init__.py",
+        root / "backend" / "app" / "repositories" / "v2" / "registry.py",
+        root / "backend" / "scripts" / "report_v2_backend_repository_layer.py",
+        Path(__file__).resolve(),
+    }
+    offenders: list[str] = []
+    for path in (root / "backend" / "app").rglob("*.py"):
+        if path in allowed or "__pycache__" in path.parts:
+            continue
+        text = path.read_text(encoding="utf-8")
+        if "V2RepositoryRegistry" in text or "v2_backend_repository_report.json" in text:
+            offenders.append(str(path.relative_to(root)))
+
+    assert offenders == []

--- a/backend/tests/test_v2_class_mastery_infrastructure.py
+++ b/backend/tests/test_v2_class_mastery_infrastructure.py
@@ -127,6 +127,8 @@ def test_v2_class_mastery_bundle_is_not_referenced_by_production_modules():
         root / "backend" / "app" / "routes" / "experimental.py",
         root / "backend" / "app" / "repositories" / "v2" / "class_mastery_repository.py",
         root / "backend" / "app" / "repositories" / "v2" / "__init__.py",
+        root / "backend" / "app" / "repositories" / "v2" / "paths.py",
+        root / "backend" / "app" / "repositories" / "v2" / "registry.py",
         root / "backend" / "scripts" / "report_v2_class_mastery_bundle.py",
         Path(__file__).resolve(),
     }

--- a/backend/tests/test_v2_idol_infrastructure.py
+++ b/backend/tests/test_v2_idol_infrastructure.py
@@ -119,6 +119,8 @@ def test_v2_idol_bundle_is_not_referenced_by_production_modules():
         root / "backend" / "app" / "routes" / "experimental.py",
         root / "backend" / "app" / "repositories" / "v2" / "idol_repository.py",
         root / "backend" / "app" / "repositories" / "v2" / "__init__.py",
+        root / "backend" / "app" / "repositories" / "v2" / "paths.py",
+        root / "backend" / "app" / "repositories" / "v2" / "registry.py",
         root / "backend" / "scripts" / "report_v2_idol_bundles.py",
         Path(__file__).resolve(),
     }

--- a/backend/tests/test_v2_item_infrastructure.py
+++ b/backend/tests/test_v2_item_infrastructure.py
@@ -113,6 +113,8 @@ def test_v2_item_bundle_is_not_referenced_by_production_modules():
         root / "backend" / "app" / "routes" / "experimental.py",
         root / "backend" / "app" / "repositories" / "v2" / "item_repository.py",
         root / "backend" / "app" / "repositories" / "v2" / "__init__.py",
+        root / "backend" / "app" / "repositories" / "v2" / "paths.py",
+        root / "backend" / "app" / "repositories" / "v2" / "registry.py",
         root / "backend" / "scripts" / "report_v2_item_bundles.py",
         Path(__file__).resolve(),
     }

--- a/backend/tests/test_v2_passive_tree_infrastructure.py
+++ b/backend/tests/test_v2_passive_tree_infrastructure.py
@@ -113,6 +113,8 @@ def test_v2_passive_bundle_is_not_referenced_by_production_modules():
         root / "backend" / "app" / "routes" / "experimental.py",
         root / "backend" / "app" / "repositories" / "v2" / "passive_repository.py",
         root / "backend" / "app" / "repositories" / "v2" / "__init__.py",
+        root / "backend" / "app" / "repositories" / "v2" / "paths.py",
+        root / "backend" / "app" / "repositories" / "v2" / "registry.py",
         root / "backend" / "scripts" / "report_v2_passive_tree_bundle.py",
         Path(__file__).resolve(),
     }

--- a/backend/tests/test_v2_skill_tree_infrastructure.py
+++ b/backend/tests/test_v2_skill_tree_infrastructure.py
@@ -136,6 +136,8 @@ def test_v2_skill_bundle_is_not_referenced_by_production_modules():
         root / "backend" / "app" / "routes" / "experimental.py",
         root / "backend" / "app" / "repositories" / "v2" / "skill_repository.py",
         root / "backend" / "app" / "repositories" / "v2" / "__init__.py",
+        root / "backend" / "app" / "repositories" / "v2" / "paths.py",
+        root / "backend" / "app" / "repositories" / "v2" / "registry.py",
         root / "backend" / "scripts" / "report_v2_skill_tree_bundle.py",
         Path(__file__).resolve(),
     }

--- a/backend/tests/test_v2_stat_modifier_normalization.py
+++ b/backend/tests/test_v2_stat_modifier_normalization.py
@@ -99,6 +99,8 @@ def test_v2_modifier_registries_are_not_referenced_by_production_modules():
         root / "backend" / "app" / "normalization" / "v2" / "modifier_registry.py",
         root / "backend" / "app" / "normalization" / "v2" / "stat_registry.py",
         root / "backend" / "app" / "normalization" / "v2" / "__init__.py",
+        root / "backend" / "app" / "repositories" / "v2" / "paths.py",
+        root / "backend" / "app" / "repositories" / "v2" / "registry.py",
         root / "backend" / "scripts" / "report_v2_stat_modifier_normalization.py",
         Path(__file__).resolve(),
     }

--- a/backend/tests/test_v2_unique_set_infrastructure.py
+++ b/backend/tests/test_v2_unique_set_infrastructure.py
@@ -156,6 +156,8 @@ def test_v2_unique_set_bundle_is_not_referenced_by_production_modules():
         root / "backend" / "app" / "routes" / "experimental.py",
         root / "backend" / "app" / "repositories" / "v2" / "unique_set_repository.py",
         root / "backend" / "app" / "repositories" / "v2" / "__init__.py",
+        root / "backend" / "app" / "repositories" / "v2" / "paths.py",
+        root / "backend" / "app" / "repositories" / "v2" / "registry.py",
         root / "backend" / "scripts" / "report_v2_unique_set_bundles.py",
         Path(__file__).resolve(),
     }

--- a/docs/generated/v2_backend_repository_report.json
+++ b/docs/generated/v2_backend_repository_report.json
@@ -1,0 +1,1499 @@
+{
+  "experimental_route_coverage": {
+    "affixes": [
+      "/experimental/v2/affixes",
+      "/experimental/v2/affixes/<affix_id>",
+      "/experimental/v2/affixes/debug"
+    ],
+    "classes_masteries": [
+      "/experimental/v2/classes",
+      "/experimental/v2/classes/<class_id>",
+      "/experimental/v2/masteries",
+      "/experimental/v2/masteries/<mastery_id>",
+      "/experimental/v2/classes/debug"
+    ],
+    "idols": [
+      "/experimental/v2/idols",
+      "/experimental/v2/idols/<idol_id>",
+      "/experimental/v2/idols/affixes",
+      "/experimental/v2/idols/affixes/<affix_id>",
+      "/experimental/v2/idols/debug"
+    ],
+    "items": [
+      "/experimental/v2/items/bases",
+      "/experimental/v2/items/bases/<item_base_id>",
+      "/experimental/v2/items/implicits",
+      "/experimental/v2/items/debug"
+    ],
+    "modifiers": [
+      "/experimental/v2/modifiers",
+      "/experimental/v2/modifiers/<modifier_id>",
+      "/experimental/v2/modifiers/debug"
+    ],
+    "passives": [
+      "/experimental/v2/passives",
+      "/experimental/v2/passives/<tree_id>",
+      "/experimental/v2/passives/<tree_id>/nodes/<node_id>",
+      "/experimental/v2/passives/debug"
+    ],
+    "skills": [
+      "/experimental/v2/skills",
+      "/experimental/v2/skills/<skill_id>",
+      "/experimental/v2/skills/<skill_id>/tree",
+      "/experimental/v2/skills/trees/<tree_id>",
+      "/experimental/v2/skills/trees/<tree_id>/nodes/<node_id>",
+      "/experimental/v2/skills/debug"
+    ],
+    "stats": [
+      "/experimental/v2/stats",
+      "/experimental/v2/stats/<stat_id>"
+    ],
+    "unique_sets": [
+      "/experimental/v2/uniques",
+      "/experimental/v2/uniques/<unique_id>",
+      "/experimental/v2/sets",
+      "/experimental/v2/sets/<set_id>",
+      "/experimental/v2/uniques/debug",
+      "/experimental/v2/sets/debug"
+    ],
+    "value_policy": []
+  },
+  "metadata": {
+    "experimental": true,
+    "planner_consumed": false,
+    "production_consumed": false,
+    "production_safe": false,
+    "read_only": true,
+    "source": "generated_v2_backend_repositories",
+    "unresolved_skill_identity_bridged": false
+  },
+  "method_coverage": {
+    "affixes": {
+      "debug_summary": true,
+      "filter_affixes": true,
+      "get_affix": true,
+      "list_affixes": true,
+      "load": true
+    },
+    "classes_masteries": {
+      "debug_summary": true,
+      "filter_classes": true,
+      "get_class": true,
+      "get_mastery": true,
+      "list_classes": true,
+      "list_masteries": true,
+      "load": true
+    },
+    "idols": {
+      "debug_summary": true,
+      "filter_idols": true,
+      "get_affix": true,
+      "get_idol": true,
+      "list_affixes": true,
+      "list_idols": true,
+      "load": true
+    },
+    "items": {
+      "debug_summary": true,
+      "filter_bases": true,
+      "get_base": true,
+      "get_implicit": true,
+      "list_bases": true,
+      "list_implicits": true,
+      "load": true
+    },
+    "modifiers": {
+      "debug_summary": true,
+      "get_modifier": true,
+      "list_modifiers": true,
+      "load": true
+    },
+    "passives": {
+      "debug_summary": true,
+      "filter_trees": true,
+      "get_node": true,
+      "get_nodes_by_tree": true,
+      "get_tree": true,
+      "list_trees": true,
+      "load": true
+    },
+    "skills": {
+      "debug_summary": true,
+      "filter_skills": true,
+      "get_node": true,
+      "get_nodes_by_tree": true,
+      "get_skill": true,
+      "get_tree": true,
+      "get_tree_by_skill": true,
+      "list_skills": true,
+      "load": true
+    },
+    "stats": {
+      "debug_summary": true,
+      "get_stat": true,
+      "list_stats": true,
+      "load": true
+    },
+    "unique_sets": {
+      "debug_summary": true,
+      "filter_uniques": true,
+      "get_set": true,
+      "get_unique": true,
+      "list_sets": true,
+      "list_uniques": true,
+      "load": true
+    },
+    "value_policy": {}
+  },
+  "missing_artifacts": [],
+  "repositories": [
+    {
+      "artifacts": [
+        {
+          "artifact_key": "affix_bundle",
+          "exists": true,
+          "path": "D:\\Forge\\le-the-forge\\docs\\generated\\v2_affix_bundle.json"
+        }
+      ],
+      "debug_summary": {
+        "affix_count": 1098,
+        "affix_domain_counts": {
+          "equipment": 615,
+          "idol": 483
+        },
+        "modifier_reference_count_distribution": {
+          "1": 572,
+          "2": 526
+        },
+        "production_consumer": false,
+        "production_safe": false,
+        "source_path": "D:\\Forge\\le-the-forge\\docs\\generated\\v2_affix_bundle.json",
+        "summary": {
+          "affix_count": 1098,
+          "affix_domain_counts": {
+            "equipment": 615,
+            "idol": 483
+          },
+          "modifier_reference_count_distribution": {
+            "1": 572,
+            "2": 526
+          },
+          "prefix_suffix_counts": {
+            "prefix": 832,
+            "suffix": 266
+          },
+          "production_consumed": false,
+          "records_with_warnings_count": 1098,
+          "source_affix_count": 1098,
+          "source_modifier_count": 1624,
+          "stable_calculable_count": 0,
+          "support_status_counts": {
+            "partial": 1098
+          },
+          "trust_level_counts": {
+            "generated_from_game_data": 1098
+          },
+          "validation_error_count": 0,
+          "validation_warning_count": 0
+        },
+        "support_status_counts": {
+          "partial": 1098
+        }
+      },
+      "domain": "affixes",
+      "experimental_routes": [
+        "/experimental/v2/affixes",
+        "/experimental/v2/affixes/<affix_id>",
+        "/experimental/v2/affixes/debug"
+      ],
+      "label": "Affixes",
+      "method_coverage": {
+        "debug_summary": true,
+        "filter_affixes": true,
+        "get_affix": true,
+        "list_affixes": true,
+        "load": true
+      },
+      "missing_artifact_count": 0,
+      "missing_methods": [],
+      "production_consumed": false,
+      "status": "ok"
+    },
+    {
+      "artifacts": [
+        {
+          "artifact_key": "class_mastery_bundle",
+          "exists": true,
+          "path": "D:\\Forge\\le-the-forge\\docs\\generated\\v2_class_mastery_bundle.json"
+        }
+      ],
+      "debug_summary": {
+        "bundle_path": "D:\\Forge\\le-the-forge\\docs\\generated\\v2_class_mastery_bundle.json",
+        "class_count": 5,
+        "cross_reference": {
+          "labels": [
+            {
+              "count": 46,
+              "label": "Acolyte",
+              "mapped_class_id": "class:acolyte",
+              "mapped_mastery_id": null,
+              "source_breakdown": {
+                "v2_idol_bundle.json:idols": 12,
+                "v2_item_base_bundle.json:item_bases": 34
+              }
+            },
+            {
+              "count": 46,
+              "label": "Mage",
+              "mapped_class_id": "class:mage",
+              "mapped_mastery_id": null,
+              "source_breakdown": {
+                "v2_idol_bundle.json:idols": 12,
+                "v2_item_base_bundle.json:item_bases": 34
+              }
+            },
+            {
+              "count": 48,
+              "label": "Primalist",
+              "mapped_class_id": "class:primalist",
+              "mapped_mastery_id": null,
+              "source_breakdown": {
+                "v2_idol_bundle.json:idols": 12,
+                "v2_item_base_bundle.json:item_bases": 36
+              }
+            }
+          ],
+          "mapped_label_count": 3,
+          "mapped_labels": [
+            {
+              "count": 46,
+              "label": "Acolyte",
+              "mapped_class_id": "class:acolyte",
+              "mapped_mastery_id": null,
+              "source_breakdown": {
+                "v2_idol_bundle.json:idols": 12,
+                "v2_item_base_bundle.json:item_bases": 34
+              }
+            },
+            {
+              "count": 46,
+              "label": "Mage",
+              "mapped_class_id": "class:mage",
+              "mapped_mastery_id": null,
+              "source_breakdown": {
+                "v2_idol_bundle.json:idols": 12,
+                "v2_item_base_bundle.json:item_bases": 34
+              }
+            },
+            {
+              "count": 48,
+              "label": "Primalist",
+              "mapped_class_id": "class:primalist",
+              "mapped_mastery_id": null,
+              "source_breakdown": {
+                "v2_idol_bundle.json:idols": 12,
+                "v2_item_base_bundle.json:item_bases": 36
+              }
+            }
+          ],
+          "restriction_label_count": 140,
+          "unique_restriction_label_count": 3,
+          "unmapped_label_count": 0,
+          "unmapped_labels": []
+        },
+        "mastery_count": 15,
+        "production_consumer": false,
+        "production_safe": false,
+        "summary": {
+          "class_count": 5,
+          "manual_bridge_count": 0,
+          "mapped_restriction_label_count": 3,
+          "mastery_count": 15,
+          "production_consumed": false,
+          "stable_calculable_count": 0,
+          "support_status_counts": {
+            "partial": 20
+          },
+          "trust_level_counts": {
+            "generated_from_game_data": 20
+          },
+          "unique_restriction_label_count": 3,
+          "unmapped_restriction_label_count": 0,
+          "validation_error_count": 0,
+          "validation_warning_count": 0
+        }
+      },
+      "domain": "classes_masteries",
+      "experimental_routes": [
+        "/experimental/v2/classes",
+        "/experimental/v2/classes/<class_id>",
+        "/experimental/v2/masteries",
+        "/experimental/v2/masteries/<mastery_id>",
+        "/experimental/v2/classes/debug"
+      ],
+      "label": "Classes and masteries",
+      "method_coverage": {
+        "debug_summary": true,
+        "filter_classes": true,
+        "get_class": true,
+        "get_mastery": true,
+        "list_classes": true,
+        "list_masteries": true,
+        "load": true
+      },
+      "missing_artifact_count": 0,
+      "missing_methods": [],
+      "production_consumed": false,
+      "status": "ok"
+    },
+    {
+      "artifacts": [
+        {
+          "artifact_key": "idol_bundle",
+          "exists": true,
+          "path": "D:\\Forge\\le-the-forge\\docs\\generated\\v2_idol_bundle.json"
+        },
+        {
+          "artifact_key": "idol_affix_bundle",
+          "exists": true,
+          "path": "D:\\Forge\\le-the-forge\\docs\\generated\\v2_idol_affix_bundle.json"
+        }
+      ],
+      "debug_summary": {
+        "idol_affix_bundle_path": "D:\\Forge\\le-the-forge\\docs\\generated\\v2_idol_affix_bundle.json",
+        "idol_affix_count": 483,
+        "idol_affix_summary": {
+          "idol_affix_count": 483,
+          "idol_type_restriction_counts": {
+            "IDOL_1x1_ETERRA": 39,
+            "IDOL_1x1_LAGON": 39,
+            "IDOL_1x2": 41,
+            "IDOL_1x3": 125,
+            "IDOL_1x4": 132,
+            "IDOL_2x1": 40,
+            "IDOL_2x2": 119,
+            "IDOL_3x1": 120,
+            "IDOL_4x1": 128,
+            "IDOL_ALTAR": 20
+          },
+          "modifier_row_count": 647,
+          "prefix_suffix_counts": {
+            "prefix": 290,
+            "suffix": 193
+          },
+          "production_consumed": false,
+          "stable_calculable_count": 0,
+          "support_status_counts": {
+            "partial": 483
+          },
+          "trust_level_counts": {
+            "generated_from_game_data": 483
+          },
+          "validation_error_count": 0
+        },
+        "idol_bundle_path": "D:\\Forge\\le-the-forge\\docs\\generated\\v2_idol_bundle.json",
+        "idol_count": 71,
+        "idol_summary": {
+          "class_restriction_counts": {
+            "Acolyte": 12,
+            "Any": 35,
+            "Mage": 12,
+            "Primalist": 12
+          },
+          "idol_count": 71,
+          "idol_shape_counts": {
+            "idol_1x1_eterra": 3,
+            "idol_1x1_lagon": 2,
+            "idol_1x2": 2,
+            "idol_1x3": 15,
+            "idol_1x4": 10,
+            "idol_2x1": 2,
+            "idol_2x2": 12,
+            "idol_3x1": 15,
+            "idol_4x1": 10
+          },
+          "production_consumed": false,
+          "records_with_implicits_count": 0,
+          "stable_calculable_count": 0,
+          "support_status_counts": {
+            "partial": 71
+          },
+          "trust_level_counts": {
+            "generated_from_game_data": 71
+          },
+          "validation_error_count": 0
+        },
+        "production_consumer": false,
+        "production_safe": false
+      },
+      "domain": "idols",
+      "experimental_routes": [
+        "/experimental/v2/idols",
+        "/experimental/v2/idols/<idol_id>",
+        "/experimental/v2/idols/affixes",
+        "/experimental/v2/idols/affixes/<affix_id>",
+        "/experimental/v2/idols/debug"
+      ],
+      "label": "Idols and idol affixes",
+      "method_coverage": {
+        "debug_summary": true,
+        "filter_idols": true,
+        "get_affix": true,
+        "get_idol": true,
+        "list_affixes": true,
+        "list_idols": true,
+        "load": true
+      },
+      "missing_artifact_count": 0,
+      "missing_methods": [],
+      "production_consumed": false,
+      "status": "ok"
+    },
+    {
+      "artifacts": [
+        {
+          "artifact_key": "item_base_bundle",
+          "exists": true,
+          "path": "D:\\Forge\\le-the-forge\\docs\\generated\\v2_item_base_bundle.json"
+        },
+        {
+          "artifact_key": "item_implicit_bundle",
+          "exists": true,
+          "path": "D:\\Forge\\le-the-forge\\docs\\generated\\v2_item_implicit_bundle.json"
+        }
+      ],
+      "debug_summary": {
+        "base_bundle_path": "D:\\Forge\\le-the-forge\\docs\\generated\\v2_item_base_bundle.json",
+        "base_summary": {
+          "base_type_count": 25,
+          "classification_counts": {
+            "accessory": 154,
+            "armor": 194,
+            "weapon": 194
+          },
+          "excluded_non_phase4_base_type_count": 17,
+          "item_base_count": 542,
+          "item_type_counts": {
+            "amulet": 19,
+            "belt": 15,
+            "body_armor": 71,
+            "boots": 15,
+            "bow": 16,
+            "catalyst": 21,
+            "gloves": 15,
+            "helmet": 71,
+            "one_handed_axe": 17,
+            "one_handed_dagger": 15,
+            "one_handed_maces": 15,
+            "one_handed_sceptre": 14,
+            "one_handed_sword": 16,
+            "quiver": 11,
+            "relic": 72,
+            "ring": 16,
+            "shield": 22,
+            "two_handed_axe": 18,
+            "two_handed_mace": 14,
+            "two_handed_spear": 19,
+            "two_handed_staff": 19,
+            "two_handed_sword": 16,
+            "wand": 15
+          },
+          "production_consumed": false,
+          "records_with_class_restrictions_count": 104,
+          "records_with_implicits_count": 541,
+          "stable_calculable_count": 0,
+          "support_status_counts": {
+            "partial": 542
+          },
+          "trust_level_counts": {
+            "generated_from_game_data": 542
+          },
+          "validation_error_count": 0
+        },
+        "implicit_bundle_path": "D:\\Forge\\le-the-forge\\docs\\generated\\v2_item_implicit_bundle.json",
+        "implicit_count": 1182,
+        "implicit_summary": {
+          "implicit_count": 1182,
+          "modifier_row_count_distribution": {
+            "1": 1182
+          },
+          "production_consumed": false,
+          "property_counts": {
+            "AbilityProperty": 12,
+            "AilmentChance": 45,
+            "AllAttributes": 4,
+            "AllResistances": 4,
+            "Armour": 179,
+            "ArmourMitigationAppliesToDamageOverTime": 2,
+            "AttackSpeed": 9,
+            "Attunement": 3,
+            "BlockChance": 24,
+            "BlockEffectiveness": 21,
+            "CastSpeed": 8,
+            "ColdResistance": 13,
+            "CritAvoidance": 3,
+            "CriticalChance": 50,
+            "CriticalMultiplier": 21,
+            "Damage": 337,
+            "DamageTaken": 6,
+            "Dexterity": 3,
+            "DodgeRating": 5,
+            "EffectOfAilmentOnYou": 5,
+            "ElementalResistance": 2,
+            "Endurance": 12,
+            "EnduranceThreshold": 5,
+            "FireResistance": 13,
+            "FreezeRateMultiplier": 6,
+            "GlancingBlowChance": 1,
+            "GlobalConditionalDamage": 4,
+            "HasteOnHitChance": 2,
+            "Health": 17,
+            "HealthGain": 5,
+            "HealthLeech": 14,
+            "HealthRegen": 12,
+            "IncreasedAilmentDuration": 10,
+            "IncreasedAilmentEffect": 1,
+            "IncreasedAreaForAreaSkills": 2,
+            "IncreasedCooldownRecoverySpeed": 11,
+            "IncreasedHealing": 2,
+            "IncreasedLeechRate": 1,
+            "IncreasedStunChance": 18,
+            "IncreasedStunDuration": 2,
+            "Intelligence": 20,
+            "LevelOfSkills": 6,
+            "LightningResistance": 10,
+            "Mana": 26,
+            "ManaCost": 23,
+            "ManaRegen": 25,
+            "ManaSpentGainedAsWard": 7,
+            "MaximumHealthGainedAsEnduranceThreshold": 3,
+            "Movespeed": 27,
+            "NecroticResistance": 8,
+            "Penetration": 14,
+            "PhysicalResistance": 11,
+            "PlayerProperty": 30,
+            "PoisonResistance": 12,
+            "PotionHealth": 1,
+            "PotionSlots": 15,
+            "ReducedBonusDamageTakenFromCrits": 3,
+            "Strength": 4,
+            "StunAvoidance": 5,
+            "Thorns": 1,
+            "Vitality": 4,
+            "VoidResistance": 5,
+            "WardDecayThreshold": 10,
+            "WardGain": 5,
+            "WardOnPotionUse": 1,
+            "WardRegen": 7,
+            "WardRetention": 5
+          },
+          "stable_calculable_count": 0,
+          "support_status_counts": {
+            "partial": 1182
+          },
+          "trust_level_counts": {
+            "generated_from_game_data": 1182
+          },
+          "validation_error_count": 0
+        },
+        "item_base_count": 542,
+        "production_consumer": false,
+        "production_safe": false
+      },
+      "domain": "items",
+      "experimental_routes": [
+        "/experimental/v2/items/bases",
+        "/experimental/v2/items/bases/<item_base_id>",
+        "/experimental/v2/items/implicits",
+        "/experimental/v2/items/debug"
+      ],
+      "label": "Item bases and implicits",
+      "method_coverage": {
+        "debug_summary": true,
+        "filter_bases": true,
+        "get_base": true,
+        "get_implicit": true,
+        "list_bases": true,
+        "list_implicits": true,
+        "load": true
+      },
+      "missing_artifact_count": 0,
+      "missing_methods": [],
+      "production_consumed": false,
+      "status": "ok"
+    },
+    {
+      "artifacts": [
+        {
+          "artifact_key": "modifier_registry",
+          "exists": true,
+          "path": "D:\\Forge\\le-the-forge\\docs\\generated\\v2_modifier_registry.json"
+        }
+      ],
+      "debug_summary": {
+        "modifier_count": 19398,
+        "production_consumer": false,
+        "production_safe": false,
+        "source_path": "D:\\Forge\\le-the-forge\\docs\\generated\\v2_modifier_registry.json",
+        "summary": {
+          "ambiguous_skill_reference_count": 1,
+          "blocked_reason_counts": {
+            "operation_unknown": 11606,
+            "source_identity_not_resolved": 11924,
+            "special_behavior_not_calculable": 13036,
+            "stat_id_unknown": 4714,
+            "support_status_not_trusted": 19398,
+            "value_scale_not_planner_normalized": 19398
+          },
+          "modifier_count": 19398,
+          "operation_counts": {
+            "chance": 69,
+            "cooldown": 429,
+            "cost": 440,
+            "duration": 949,
+            "flat": 4627,
+            "increased": 1112,
+            "less": 1,
+            "more": 165,
+            "unknown": 11606
+          },
+          "production_consumed": false,
+          "source_type_counts": {
+            "affix": 1624,
+            "idol_affix_modifier": 647,
+            "item_implicit": 1182,
+            "passive_node_modifier": 1660,
+            "set_bonus_modifier": 27,
+            "set_item_modifier": 287,
+            "skill_node_modifier": 10843,
+            "skill_structured_value": 1081,
+            "unique_modifier": 2047
+          },
+          "stable_calculable_count": 0,
+          "stat_count": 2070,
+          "unresolved_skill_reference_count": 2,
+          "value_scale_status_counts": {
+            "source_units": 6248,
+            "unknown": 13150
+          }
+        }
+      },
+      "domain": "modifiers",
+      "experimental_routes": [
+        "/experimental/v2/modifiers",
+        "/experimental/v2/modifiers/<modifier_id>",
+        "/experimental/v2/modifiers/debug"
+      ],
+      "label": "Modifier registry",
+      "method_coverage": {
+        "debug_summary": true,
+        "get_modifier": true,
+        "list_modifiers": true,
+        "load": true
+      },
+      "missing_artifact_count": 0,
+      "missing_methods": [],
+      "production_consumed": false,
+      "status": "ok"
+    },
+    {
+      "artifacts": [
+        {
+          "artifact_key": "passive_tree_bundle",
+          "exists": true,
+          "path": "D:\\Forge\\le-the-forge\\docs\\generated\\v2_passive_tree_bundle.json"
+        }
+      ],
+      "debug_summary": {
+        "bundle_path": "D:\\Forge\\le-the-forge\\docs\\generated\\v2_passive_tree_bundle.json",
+        "cross_reference": {
+          "class_mastery_passive_tree_link_count": 5,
+          "class_mastery_passive_tree_links": [
+            {
+              "passive_tree_id": "passive_tree:ac_1",
+              "resolved_tree_id": "passive_tree:ac_1",
+              "status": "resolved"
+            },
+            {
+              "passive_tree_id": "passive_tree:kn_1",
+              "resolved_tree_id": "passive_tree:kn_1",
+              "status": "resolved"
+            },
+            {
+              "passive_tree_id": "passive_tree:mg_1",
+              "resolved_tree_id": "passive_tree:mg_1",
+              "status": "resolved"
+            },
+            {
+              "passive_tree_id": "passive_tree:pr_1",
+              "resolved_tree_id": "passive_tree:pr_1",
+              "status": "resolved"
+            },
+            {
+              "passive_tree_id": "passive_tree:rg_1",
+              "resolved_tree_id": "passive_tree:rg_1",
+              "status": "resolved"
+            }
+          ],
+          "manual_bridge_count": 0,
+          "resolved_passive_tree_link_count": 5,
+          "unresolved_passive_tree_ids": [],
+          "unresolved_passive_tree_link_count": 0
+        },
+        "passive_node_count": 535,
+        "passive_tree_count": 5,
+        "production_consumer": false,
+        "production_safe": false,
+        "summary": {
+          "class_mastery_resolved_passive_tree_link_count": 5,
+          "class_mastery_unresolved_passive_tree_link_count": 0,
+          "layout_matched_node_count": 535,
+          "manual_bridge_count": 0,
+          "passive_node_count": 535,
+          "passive_tree_count": 5,
+          "production_consumed": false,
+          "special_behavior_classification_counts": {
+            "partial_modifier": 72,
+            "scripted_runtime_behavior": 209,
+            "unsupported_special_behavior": 254
+          },
+          "stable_calculable_count": 0,
+          "support_status_counts": {
+            "partial": 540
+          },
+          "trust_level_counts": {
+            "generated_from_game_data": 540
+          },
+          "unsupported_or_text_only_count": 463,
+          "validation_error_count": 0,
+          "validation_warning_count": 0
+        }
+      },
+      "domain": "passives",
+      "experimental_routes": [
+        "/experimental/v2/passives",
+        "/experimental/v2/passives/<tree_id>",
+        "/experimental/v2/passives/<tree_id>/nodes/<node_id>",
+        "/experimental/v2/passives/debug"
+      ],
+      "label": "Passive trees",
+      "method_coverage": {
+        "debug_summary": true,
+        "filter_trees": true,
+        "get_node": true,
+        "get_nodes_by_tree": true,
+        "get_tree": true,
+        "list_trees": true,
+        "load": true
+      },
+      "missing_artifact_count": 0,
+      "missing_methods": [],
+      "production_consumed": false,
+      "status": "ok"
+    },
+    {
+      "artifacts": [
+        {
+          "artifact_key": "skill_bundle",
+          "exists": true,
+          "path": "D:\\Forge\\le-the-forge\\docs\\generated\\v2_skill_bundle.json"
+        },
+        {
+          "artifact_key": "skill_tree_bundle",
+          "exists": true,
+          "path": "D:\\Forge\\le-the-forge\\docs\\generated\\v2_skill_tree_bundle.json"
+        }
+      ],
+      "debug_summary": {
+        "cross_reference": {
+          "class_mastery_skill_link_count": 63,
+          "class_mastery_skill_links": [
+            {
+              "class_mastery_skill_source_id": "skill_path:260926",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:261142",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:261173",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:261591",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:262309",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:262328",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:262431",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:262458",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:262473",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:262497",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:262531",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:262552",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:262625",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:262645",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:262677",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:262850",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:262912",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:262951",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:262952",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:262953",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:263025",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:263035",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:263053",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:263498",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:263704",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:263788",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:263799",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:263800",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:263816",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:263834",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:263841",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:263852",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:263853",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:263871",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:263905",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:263955",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:263956",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:263991",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:264015",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:264164",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:264230",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:264237",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:264241",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:264309",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:264355",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:264437",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:264444",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:264451",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:264453",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:264458",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:264461",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:264462",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:264551",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:264554",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:264562",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:264675",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:264730",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:264735",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:264807",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:264863",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:264874",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:264881",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            },
+            {
+              "class_mastery_skill_source_id": "skill_path:264922",
+              "resolved_skill_id": null,
+              "status": "unresolved"
+            }
+          ],
+          "manual_bridge_count": 0,
+          "resolved_skill_link_count": 0,
+          "unresolved_skill_link_count": 63,
+          "unresolved_skill_source_ids": [
+            "skill_path:260926",
+            "skill_path:261142",
+            "skill_path:261173",
+            "skill_path:261591",
+            "skill_path:262309",
+            "skill_path:262328",
+            "skill_path:262431",
+            "skill_path:262458",
+            "skill_path:262473",
+            "skill_path:262497",
+            "skill_path:262531",
+            "skill_path:262552",
+            "skill_path:262625",
+            "skill_path:262645",
+            "skill_path:262677",
+            "skill_path:262850",
+            "skill_path:262912",
+            "skill_path:262951",
+            "skill_path:262952",
+            "skill_path:262953",
+            "skill_path:263025",
+            "skill_path:263035",
+            "skill_path:263053",
+            "skill_path:263498",
+            "skill_path:263704",
+            "skill_path:263788",
+            "skill_path:263799",
+            "skill_path:263800",
+            "skill_path:263816",
+            "skill_path:263834",
+            "skill_path:263841",
+            "skill_path:263852",
+            "skill_path:263853",
+            "skill_path:263871",
+            "skill_path:263905",
+            "skill_path:263955",
+            "skill_path:263956",
+            "skill_path:263991",
+            "skill_path:264015",
+            "skill_path:264164",
+            "skill_path:264230",
+            "skill_path:264237",
+            "skill_path:264241",
+            "skill_path:264309",
+            "skill_path:264355",
+            "skill_path:264437",
+            "skill_path:264444",
+            "skill_path:264451",
+            "skill_path:264453",
+            "skill_path:264458",
+            "skill_path:264461",
+            "skill_path:264462",
+            "skill_path:264551",
+            "skill_path:264554",
+            "skill_path:264562",
+            "skill_path:264675",
+            "skill_path:264730",
+            "skill_path:264735",
+            "skill_path:264807",
+            "skill_path:264863",
+            "skill_path:264874",
+            "skill_path:264881",
+            "skill_path:264922"
+          ]
+        },
+        "production_consumer": false,
+        "production_safe": false,
+        "skill_bundle_path": "D:\\Forge\\le-the-forge\\docs\\generated\\v2_skill_bundle.json",
+        "skill_count": 184,
+        "skill_node_count": 3919,
+        "skill_summary": {
+          "class_mastery_resolved_skill_link_count": 0,
+          "class_mastery_unresolved_skill_link_count": 63,
+          "manual_bridge_count": 0,
+          "production_consumed": false,
+          "skill_count": 184,
+          "skill_node_count": 3919,
+          "skill_special_behavior_classification_counts": {
+            "partial_modifier": 57,
+            "scripted_runtime_behavior": 83,
+            "text_only_effect": 44
+          },
+          "skill_tree_count": 136,
+          "skill_with_tree_count": 136,
+          "stable_calculable_count": 0,
+          "support_status_counts": {
+            "partial": 184
+          },
+          "trust_level_counts": {
+            "generated_from_game_data": 184
+          },
+          "unsupported_or_text_only_skill_count": 127,
+          "validation_error_count": 0,
+          "validation_warning_count": 64
+        },
+        "skill_tree_bundle_path": "D:\\Forge\\le-the-forge\\docs\\generated\\v2_skill_tree_bundle.json",
+        "skill_tree_count": 136,
+        "skill_tree_summary": {
+          "layout_matched_node_count": 3919,
+          "node_special_behavior_classification_counts": {
+            "partial_modifier": 31,
+            "scripted_runtime_behavior": 2342,
+            "text_only_effect": 105,
+            "unknown": 30,
+            "unsupported_special_behavior": 1411
+          },
+          "production_consumed": false,
+          "skill_count": 184,
+          "skill_node_count": 3919,
+          "skill_tree_count": 136,
+          "stable_calculable_count": 0,
+          "support_status_counts": {
+            "partial": 4055
+          },
+          "trust_level_counts": {
+            "generated_from_game_data": 4055
+          },
+          "unsupported_or_text_only_node_count": 3888,
+          "validation_error_count": 0,
+          "validation_warning_count": 64
+        }
+      },
+      "domain": "skills",
+      "experimental_routes": [
+        "/experimental/v2/skills",
+        "/experimental/v2/skills/<skill_id>",
+        "/experimental/v2/skills/<skill_id>/tree",
+        "/experimental/v2/skills/trees/<tree_id>",
+        "/experimental/v2/skills/trees/<tree_id>/nodes/<node_id>",
+        "/experimental/v2/skills/debug"
+      ],
+      "label": "Skills and skill trees",
+      "method_coverage": {
+        "debug_summary": true,
+        "filter_skills": true,
+        "get_node": true,
+        "get_nodes_by_tree": true,
+        "get_skill": true,
+        "get_tree": true,
+        "get_tree_by_skill": true,
+        "list_skills": true,
+        "load": true
+      },
+      "missing_artifact_count": 0,
+      "missing_methods": [],
+      "production_consumed": false,
+      "status": "ok"
+    },
+    {
+      "artifacts": [
+        {
+          "artifact_key": "stat_registry",
+          "exists": true,
+          "path": "D:\\Forge\\le-the-forge\\docs\\generated\\v2_stat_registry.json"
+        }
+      ],
+      "debug_summary": {
+        "production_consumer": false,
+        "production_safe": false,
+        "source_path": "D:\\Forge\\le-the-forge\\docs\\generated\\v2_stat_registry.json",
+        "stat_count": 2070,
+        "summary": {
+          "modifier_count": 19398,
+          "production_consumed": false,
+          "source_category_counts": {
+            "affix": 705,
+            "idol_affix_modifier": 380,
+            "item_implicit": 184,
+            "passive_node_modifier": 236,
+            "set_bonus_modifier": 27,
+            "set_item_modifier": 175,
+            "skill_node_modifier": 619,
+            "skill_structured_value": 14,
+            "unique_modifier": 846
+          },
+          "stat_count": 2070,
+          "support_status_counts": {
+            "partial": 2070
+          },
+          "trust_level_counts": {
+            "generated_from_game_data": 2070
+          }
+        }
+      },
+      "domain": "stats",
+      "experimental_routes": [
+        "/experimental/v2/stats",
+        "/experimental/v2/stats/<stat_id>"
+      ],
+      "label": "Stat registry",
+      "method_coverage": {
+        "debug_summary": true,
+        "get_stat": true,
+        "list_stats": true,
+        "load": true
+      },
+      "missing_artifact_count": 0,
+      "missing_methods": [],
+      "production_consumed": false,
+      "status": "ok"
+    },
+    {
+      "artifacts": [
+        {
+          "artifact_key": "unique_bundle",
+          "exists": true,
+          "path": "D:\\Forge\\le-the-forge\\docs\\generated\\v2_unique_bundle.json"
+        },
+        {
+          "artifact_key": "set_bundle",
+          "exists": true,
+          "path": "D:\\Forge\\le-the-forge\\docs\\generated\\v2_set_bundle.json"
+        }
+      ],
+      "debug_summary": {
+        "production_consumer": false,
+        "production_safe": false,
+        "set_bonus_count": 45,
+        "set_bundle_path": "D:\\Forge\\le-the-forge\\docs\\generated\\v2_set_bundle.json",
+        "set_group_count": 23,
+        "set_item_count": 59,
+        "set_summary": {
+          "item_type_counts": {
+            "amulet": 3,
+            "belt": 4,
+            "body_armor": 6,
+            "boots": 2,
+            "catalyst": 2,
+            "gloves": 4,
+            "helmet": 9,
+            "one_handed_axe": 2,
+            "one_handed_dagger": 1,
+            "one_handed_maces": 2,
+            "one_handed_sceptre": 2,
+            "one_handed_sword": 4,
+            "relic": 4,
+            "ring": 6,
+            "shield": 4,
+            "two_handed_mace": 1,
+            "two_handed_staff": 2,
+            "wand": 1
+          },
+          "modifier_row_count": 314,
+          "production_consumed": false,
+          "set_bonus_count": 45,
+          "set_bonuses_with_modifier_rows_count": 27,
+          "set_group_count": 23,
+          "set_item_count": 59,
+          "set_items_with_base_links_count": 59,
+          "special_mechanic_classification_counts": {
+            "partial_modifier": 103,
+            "text_only_effect": 24
+          },
+          "stable_calculable_count": 0,
+          "support_status_counts": {
+            "partial": 127
+          },
+          "trust_level_counts": {
+            "generated_from_game_data": 127
+          },
+          "validation_error_count": 0
+        },
+        "unique_bundle_path": "D:\\Forge\\le-the-forge\\docs\\generated\\v2_unique_bundle.json",
+        "unique_count": 409,
+        "unique_summary": {
+          "item_type_counts": {
+            "amulet": 32,
+            "belt": 20,
+            "body_armor": 28,
+            "boots": 27,
+            "bow": 13,
+            "catalyst": 16,
+            "gloves": 30,
+            "helmet": 25,
+            "idol_1x1_eterra": 2,
+            "idol_1x3": 2,
+            "idol_1x4": 1,
+            "idol_2x2": 4,
+            "one_handed_axe": 11,
+            "one_handed_dagger": 9,
+            "one_handed_maces": 6,
+            "one_handed_sceptre": 7,
+            "one_handed_sword": 14,
+            "quiver": 8,
+            "relic": 36,
+            "ring": 26,
+            "shield": 21,
+            "two_handed_axe": 11,
+            "two_handed_mace": 7,
+            "two_handed_spear": 14,
+            "two_handed_staff": 15,
+            "two_handed_sword": 14,
+            "wand": 10
+          },
+          "modifier_row_count": 2047,
+          "production_consumed": false,
+          "records_with_base_links_count": 400,
+          "records_with_tooltip_text_count": 290,
+          "special_mechanic_classification_counts": {
+            "partial_modifier": 385,
+            "text_only_effect": 24
+          },
+          "stable_calculable_count": 0,
+          "support_status_counts": {
+            "partial": 409
+          },
+          "trust_level_counts": {
+            "generated_from_game_data": 409
+          },
+          "unique_count": 409,
+          "validation_error_count": 0
+        }
+      },
+      "domain": "unique_sets",
+      "experimental_routes": [
+        "/experimental/v2/uniques",
+        "/experimental/v2/uniques/<unique_id>",
+        "/experimental/v2/sets",
+        "/experimental/v2/sets/<set_id>",
+        "/experimental/v2/uniques/debug",
+        "/experimental/v2/sets/debug"
+      ],
+      "label": "Uniques and sets",
+      "method_coverage": {
+        "debug_summary": true,
+        "filter_uniques": true,
+        "get_set": true,
+        "get_unique": true,
+        "list_sets": true,
+        "list_uniques": true,
+        "load": true
+      },
+      "missing_artifact_count": 0,
+      "missing_methods": [],
+      "production_consumed": false,
+      "status": "ok"
+    },
+    {
+      "artifacts": [
+        {
+          "artifact_key": "value_normalization_policy_report",
+          "exists": true,
+          "path": "D:\\Forge\\le-the-forge\\docs\\generated\\v2_value_normalization_policy_report.json"
+        }
+      ],
+      "debug_summary": {},
+      "domain": "value_policy",
+      "experimental_routes": [],
+      "label": "Value normalization policy",
+      "method_coverage": {},
+      "missing_artifact_count": 0,
+      "missing_methods": [],
+      "production_consumed": false,
+      "status": "ok"
+    }
+  ],
+  "summary": {
+    "debug_summary_domain_count": 10,
+    "experimental_route_count": 38,
+    "generated_at": "2026-05-13T02:11:15.580701+00:00",
+    "invalid_repository_count": 0,
+    "loaded_repository_count": 10,
+    "method_coverage_count": 57,
+    "missing_artifact_count": 0,
+    "missing_method_count": 0,
+    "production_consumed": false,
+    "repository_domain_count": 10
+  }
+}

--- a/docs/migration/V2_BACKEND_REPOSITORY_LAYER.md
+++ b/docs/migration/V2_BACKEND_REPOSITORY_LAYER.md
@@ -1,0 +1,60 @@
+# V2 Backend Repository Layer
+
+## Purpose
+
+This report consolidates the read-only v2 backend repository layer after Phases 3 through 10.5. It documents generated artifact dependencies, loader validation, method coverage, experimental route coverage, and production-consumption safety.
+
+This phase does not remap planner behavior and does not make partial, unsupported, unknown, or source-unit records stable-calculable.
+
+## Summary
+
+- Repository domains: `10`
+- Loaded repositories/artifacts: `10`
+- Missing artifacts: `0`
+- Invalid repositories: `0`
+- Missing required methods: `0`
+- Experimental routes documented: `38`
+- Production consumed: `false`
+
+## Repository Coverage
+
+| Domain | Status | Artifacts | Missing Methods | Experimental Routes |
+| --- | --- | ---: | ---: | ---: |
+| `affixes` | `ok` | `1` | `0` | `3` |
+| `classes_masteries` | `ok` | `1` | `0` | `5` |
+| `idols` | `ok` | `2` | `0` | `5` |
+| `items` | `ok` | `2` | `0` | `4` |
+| `modifiers` | `ok` | `1` | `0` | `3` |
+| `passives` | `ok` | `1` | `0` | `4` |
+| `skills` | `ok` | `2` | `0` | `6` |
+| `stats` | `ok` | `1` | `0` | `2` |
+| `unique_sets` | `ok` | `2` | `0` | `6` |
+| `value_policy` | `ok` | `1` | `0` | `0` |
+
+## Missing Artifacts
+
+No missing generated artifacts were found.
+
+## Route Coverage
+
+- `affixes`: `/experimental/v2/affixes`, `/experimental/v2/affixes/<affix_id>`, `/experimental/v2/affixes/debug`
+- `classes_masteries`: `/experimental/v2/classes`, `/experimental/v2/classes/<class_id>`, `/experimental/v2/masteries`, `/experimental/v2/masteries/<mastery_id>`, `/experimental/v2/classes/debug`
+- `idols`: `/experimental/v2/idols`, `/experimental/v2/idols/<idol_id>`, `/experimental/v2/idols/affixes`, `/experimental/v2/idols/affixes/<affix_id>`, `/experimental/v2/idols/debug`
+- `items`: `/experimental/v2/items/bases`, `/experimental/v2/items/bases/<item_base_id>`, `/experimental/v2/items/implicits`, `/experimental/v2/items/debug`
+- `modifiers`: `/experimental/v2/modifiers`, `/experimental/v2/modifiers/<modifier_id>`, `/experimental/v2/modifiers/debug`
+- `passives`: `/experimental/v2/passives`, `/experimental/v2/passives/<tree_id>`, `/experimental/v2/passives/<tree_id>/nodes/<node_id>`, `/experimental/v2/passives/debug`
+- `skills`: `/experimental/v2/skills`, `/experimental/v2/skills/<skill_id>`, `/experimental/v2/skills/<skill_id>/tree`, `/experimental/v2/skills/trees/<tree_id>`, `/experimental/v2/skills/trees/<tree_id>/nodes/<node_id>`, `/experimental/v2/skills/debug`
+- `stats`: `/experimental/v2/stats`, `/experimental/v2/stats/<stat_id>`
+- `unique_sets`: `/experimental/v2/uniques`, `/experimental/v2/uniques/<unique_id>`, `/experimental/v2/sets`, `/experimental/v2/sets/<set_id>`, `/experimental/v2/uniques/debug`, `/experimental/v2/sets/debug`
+- `value_policy`: no experimental route; audit/report-only domain.
+
+## Safety Notes
+
+- All v2 repositories remain read-only.
+- Production planner, crafting, stat aggregation, simulation, and production reference routes do not consume this registry.
+- The value normalization policy remains audit-only.
+- Remaining skill identity gaps remain unbridged and must not be treated as resolved.
+
+## Recommended Next Step
+
+Proceed to API contract finalization only after this repository layer is reviewed. Planner remapping should remain deferred until value-scale normalization and stable eligibility policy have stronger evidence.


### PR DESCRIPTION
## Summary

Adds Phase 11 of the v2 trusted data rebuild: backend repository layer consolidation.

This introduces shared v2 repository utilities, a central read-only repository registry, generated repository coverage reporting, and documentation for the backend v2 access layer.

## Added

- shared v2 generated artifact path map
- `V2RepositoryRegistry`
- `V2RepositoryDescriptor`
- aggregate validation/debug/reporting facade
- backend repository layer report generator
- backend repository coverage report
- migration documentation
- focused repository layer tests

## Findings

- Repository domains: `10`
- Loaded domains: `10`
- Missing artifacts: `0`
- Invalid repositories: `0`
- Missing required methods: `0`
- Experimental routes documented: `38`
- Production consumed: `false`

## Validation

- focused repository layer tests passed: `14 passed`
- explicit v2 backend suite passed: `101 passed`
- production non-consumption guard passed: `6 passed`
- existing experimental Forge-safe tests passed: `25 passed`
- py_compile passed
- JSON validation passed
- `git diff --check` passed

## Notes

- Existing experimental routes were preserved.
- The registry is read-only and backend-only.
- No planner adapter was added.
- Stable-calculable eligibility remains unchanged.
- Value scale and unresolved identity gaps still block future planner consumption.

## Runtime behavior

Production planner, crafting, stat aggregation, simulation, and production routes remain unchanged.