### PR TITLE
v3.1: add trusted production shadow consumption gate

### DIFF
--- a/backend/app/planner_adapters/v3_1/__init__.py
+++ b/backend/app/planner_adapters/v3_1/__init__.py
@@ -1,0 +1,15 @@
+"""V3.1 trusted production shadow-consumption safety scaffolds."""
+
+from .trusted_shadow_consumption import (
+    SUPPORTED_TRUSTED_SHADOW_DOMAINS,
+    V31TrustedProductionShadowConsumption,
+    build_default_trusted_repository_probes,
+    deterministic_hash,
+)
+
+__all__ = [
+    "SUPPORTED_TRUSTED_SHADOW_DOMAINS",
+    "V31TrustedProductionShadowConsumption",
+    "build_default_trusted_repository_probes",
+    "deterministic_hash",
+]

--- a/backend/app/planner_adapters/v3_1/trusted_shadow_consumption.py
+++ b/backend/app/planner_adapters/v3_1/trusted_shadow_consumption.py
@@ -1,0 +1,360 @@
+"""V3.1 trusted repository shadow-consumption gate.
+
+This module inspects trusted repository availability beside legacy production
+paths. It is intentionally read-only and never selects trusted data as the
+production truth source.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from copy import deepcopy
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Callable
+
+
+SUPPORTED_TRUSTED_SHADOW_DOMAINS = frozenset({"affix", "item_base", "passive_skill"})
+DEFAULT_ALLOWED_DOMAINS = SUPPORTED_TRUSTED_SHADOW_DOMAINS
+GATE_NAME = "V3_1_TRUSTED_PRODUCTION_SHADOW_CONSUMPTION_ENABLED"
+
+
+@dataclass(frozen=True)
+class TrustedRepositoryProbe:
+    domain: str
+    repository_name: str
+    count_loader: Callable[[], int]
+    metadata_loader: Callable[[], dict[str, Any]] | None = None
+
+
+class V31TrustedProductionShadowConsumption:
+    """Build routing/debug metadata for observational trusted consumption."""
+
+    def inspect(
+        self,
+        *,
+        enabled: bool = False,
+        trusted_repository_probes: list[TrustedRepositoryProbe] | None = None,
+        allowed_domains: set[str] | frozenset[str] | tuple[str, ...] | list[str] | None = None,
+        legacy_path_name: str = "legacy_production_runtime",
+        legacy_output: Any | None = None,
+        run_id: str = "v3_1_phase_1_trusted_shadow_consumption",
+    ) -> dict[str, Any]:
+        normalized_domains = _normalize_allowed_domains(allowed_domains)
+        if allowed_domains is None:
+            normalized_domains = DEFAULT_ALLOWED_DOMAINS
+        probes = list(trusted_repository_probes or [])
+
+        if not enabled:
+            envelope = _disabled_envelope(
+                run_id=run_id,
+                allowed_domains=normalized_domains,
+                legacy_path_name=legacy_path_name,
+                legacy_output=legacy_output,
+            )
+            envelope["deterministic_hash"] = deterministic_hash(_stable_envelope(envelope))
+            return envelope
+
+        probe_rows = [
+            _inspect_probe(probe=probe, allowed_domains=normalized_domains)
+            for probe in sorted(probes, key=lambda item: (item.domain, item.repository_name))
+        ]
+        unsupported_domains = sorted({row["domain"] for row in probe_rows if row["routing_status"] == "blocked_unsupported_domain"})
+        unavailable = [row for row in probe_rows if row["routing_status"] == "trusted_repository_unavailable"]
+        available = [row for row in probe_rows if row["trusted_repository_available"]]
+        category_counts: dict[str, int] = {}
+        for row in probe_rows:
+            category_counts[row["routing_status"]] = category_counts.get(row["routing_status"], 0) + 1
+
+        fallback_behavior = _fallback_behavior(enabled=True, unavailable=unavailable, unsupported_domains=unsupported_domains)
+        envelope = {
+            "schema_version": "v3_1.trusted_shadow_consumption.1",
+            "generated_at": datetime.now(UTC).isoformat(),
+            "run": {
+                "run_id": run_id,
+                "probe_count": len(probe_rows),
+                "allowed_domains": sorted(normalized_domains),
+            },
+            "gate": {
+                "name": GATE_NAME,
+                "enabled": True,
+                "default_enabled": False,
+                "mode": "shadow",
+                "shadow_only": True,
+                "production_truth_source": "legacy",
+                "trusted_path_shadowed_only": True,
+                "legacy_path_still_active": True,
+                "production_output_affected": False,
+            },
+            "summary": {
+                "trusted_repository_available": bool(available),
+                "trusted_repository_available_count": len(available),
+                "trusted_repository_unavailable_count": len(unavailable),
+                "trusted_entity_count": sum(row["trusted_entity_count"] for row in available),
+                "unsupported_domain_count": len(unsupported_domains),
+                "legacy_path_still_active": True,
+                "trusted_path_shadowed_only": True,
+                "production_output_affected": False,
+                "production_behavior_changed": False,
+                "production_default_routing_authorized": False,
+                "deterministic": True,
+            },
+            "routing_category_counts": dict(sorted(category_counts.items())),
+            "trusted_repository_rows": probe_rows,
+            "unsupported_or_blocked_domains": unsupported_domains,
+            "fallback_behavior": fallback_behavior,
+            "legacy_routing": _legacy_routing_metadata(
+                legacy_path_name=legacy_path_name,
+                legacy_output=legacy_output,
+            ),
+            "safety_confirmations": _safety_confirmations(),
+            "metadata": {
+                "source": "v3_1_trusted_shadow_consumption",
+                "observational_only": True,
+                "production_consumer": False,
+                "production_behavior_changed": False,
+                "planner_remap_performed": False,
+                "production_default_routing_authorized": False,
+                "deterministic_serializer": "json_sort_keys_sha256",
+            },
+        }
+        envelope["deterministic_hash"] = deterministic_hash(_stable_envelope(envelope))
+        return envelope
+
+
+def build_default_trusted_repository_probes(repo_root: Path | None = None) -> list[TrustedRepositoryProbe]:
+    root = repo_root or Path(__file__).resolve().parents[4]
+    generated = root / "docs" / "generated"
+    return [
+        _json_record_probe(
+            domain="affix",
+            repository_name="v2_affix_bundle",
+            path=generated / "v2_affix_bundle.json",
+            records_key="affixes",
+        ),
+        _json_record_probe(
+            domain="item_base",
+            repository_name="v2_item_base_bundle",
+            path=generated / "v2_item_base_bundle.json",
+            records_key="item_bases",
+        ),
+        _json_record_probe(
+            domain="passive_skill",
+            repository_name="v2_passive_tree_bundle",
+            path=generated / "v2_passive_tree_bundle.json",
+            records_key="passive_trees",
+        ),
+    ]
+
+
+def deterministic_hash(payload: dict[str, Any]) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _json_record_probe(*, domain: str, repository_name: str, path: Path, records_key: str) -> TrustedRepositoryProbe:
+    def _payload() -> dict[str, Any]:
+        if not path.exists():
+            raise FileNotFoundError(f"trusted repository not found: {path}")
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            raise ValueError(f"{repository_name} payload must be a JSON object")
+        records = data.get("records")
+        if not isinstance(records, dict):
+            raise ValueError(f"{repository_name} records must be an object")
+        values = records.get(records_key)
+        if not isinstance(values, list):
+            raise ValueError(f"{repository_name} records.{records_key} must be a list")
+        return {
+            "entity_count": len(values),
+            "schema_version": data.get("schema_version"),
+            "source_path": str(path),
+        }
+
+    def _count_loader() -> int:
+        return int(_payload()["entity_count"])
+
+    return TrustedRepositoryProbe(
+        domain=domain,
+        repository_name=repository_name,
+        count_loader=_count_loader,
+        metadata_loader=_payload,
+    )
+
+
+def _inspect_probe(*, probe: TrustedRepositoryProbe, allowed_domains: frozenset[str]) -> dict[str, Any]:
+    if probe.domain not in SUPPORTED_TRUSTED_SHADOW_DOMAINS:
+        return {
+            "domain": probe.domain,
+            "repository_name": probe.repository_name,
+            "routing_status": "blocked_unsupported_domain",
+            "trusted_repository_available": False,
+            "trusted_entity_count": 0,
+            "legacy_path_still_active": True,
+            "trusted_path_shadowed_only": True,
+            "production_output_affected": False,
+            "blocked_reasons": ["unsupported_trusted_shadow_domain"],
+            "fallback_behavior": "legacy_remains_active_reported",
+            "metadata": {},
+        }
+    if probe.domain not in allowed_domains:
+        return {
+            "domain": probe.domain,
+            "repository_name": probe.repository_name,
+            "routing_status": "blocked_domain_not_allowed",
+            "trusted_repository_available": False,
+            "trusted_entity_count": 0,
+            "legacy_path_still_active": True,
+            "trusted_path_shadowed_only": True,
+            "production_output_affected": False,
+            "blocked_reasons": ["domain_not_allowed_for_v3_1_shadow_consumption"],
+            "fallback_behavior": "legacy_remains_active_reported",
+            "metadata": {},
+        }
+    try:
+        metadata = probe.metadata_loader() if probe.metadata_loader is not None else {}
+        count = int(metadata.get("entity_count", probe.count_loader()))
+    except Exception as exc:  # noqa: BLE001 - report visibility is the point.
+        return {
+            "domain": probe.domain,
+            "repository_name": probe.repository_name,
+            "routing_status": "trusted_repository_unavailable",
+            "trusted_repository_available": False,
+            "trusted_entity_count": 0,
+            "legacy_path_still_active": True,
+            "trusted_path_shadowed_only": True,
+            "production_output_affected": False,
+            "blocked_reasons": ["trusted_repository_unavailable"],
+            "error": str(exc),
+            "fallback_behavior": "legacy_remains_active_reported",
+            "metadata": {},
+        }
+    return {
+        "domain": probe.domain,
+        "repository_name": probe.repository_name,
+        "routing_status": "trusted_repository_shadowed",
+        "trusted_repository_available": True,
+        "trusted_entity_count": count,
+        "legacy_path_still_active": True,
+        "trusted_path_shadowed_only": True,
+        "production_output_affected": False,
+        "blocked_reasons": [],
+        "fallback_behavior": "none_required_shadow_only",
+        "metadata": _stable_metadata(metadata),
+    }
+
+
+def _normalize_allowed_domains(allowed_domains: set[str] | frozenset[str] | tuple[str, ...] | list[str] | None) -> frozenset[str]:
+    if allowed_domains is None:
+        return frozenset()
+    return frozenset(str(domain) for domain in allowed_domains if str(domain) in SUPPORTED_TRUSTED_SHADOW_DOMAINS)
+
+
+def _fallback_behavior(*, enabled: bool, unavailable: list[dict[str, Any]], unsupported_domains: list[str]) -> dict[str, Any]:
+    return {
+        "fallback_possible": True,
+        "fallback_silent": False,
+        "fallback_occurred": enabled and bool(unavailable or unsupported_domains),
+        "fallback_target": "legacy_production_runtime",
+        "reported_unavailable_repositories": [row["repository_name"] for row in unavailable],
+        "reported_unsupported_domains": unsupported_domains,
+    }
+
+
+def _legacy_routing_metadata(*, legacy_path_name: str, legacy_output: Any | None) -> dict[str, Any]:
+    return {
+        "path_name": legacy_path_name,
+        "active": True,
+        "production_truth_source": True,
+        "trusted_shadow_can_replace_output": False,
+        "output_hash": deterministic_hash({"legacy_output": legacy_output}) if legacy_output is not None else None,
+    }
+
+
+def _safety_confirmations() -> dict[str, bool]:
+    return {
+        "production_output_affected": False,
+        "production_behavior_changed": False,
+        "production_default_routing_authorized": False,
+        "trusted_repository_used_as_truth_source": False,
+        "legacy_path_removed": False,
+        "silent_fallback_allowed": False,
+        "unsupported_domains_production_safe": False,
+        "planner_remap_performed": False,
+    }
+
+
+def _disabled_envelope(
+    *,
+    run_id: str,
+    allowed_domains: frozenset[str],
+    legacy_path_name: str,
+    legacy_output: Any | None,
+) -> dict[str, Any]:
+    return {
+        "schema_version": "v3_1.trusted_shadow_consumption.1",
+        "generated_at": datetime.now(UTC).isoformat(),
+        "run": {
+            "run_id": run_id,
+            "probe_count": 0,
+            "allowed_domains": sorted(allowed_domains),
+        },
+        "gate": {
+            "name": GATE_NAME,
+            "enabled": False,
+            "default_enabled": False,
+            "mode": "disabled",
+            "shadow_only": True,
+            "production_truth_source": "legacy",
+            "trusted_path_shadowed_only": False,
+            "legacy_path_still_active": True,
+            "production_output_affected": False,
+        },
+        "summary": {
+            "trusted_repository_available": False,
+            "trusted_repository_available_count": 0,
+            "trusted_repository_unavailable_count": 0,
+            "trusted_entity_count": 0,
+            "unsupported_domain_count": 0,
+            "legacy_path_still_active": True,
+            "trusted_path_shadowed_only": False,
+            "production_output_affected": False,
+            "production_behavior_changed": False,
+            "production_default_routing_authorized": False,
+            "deterministic": True,
+        },
+        "routing_category_counts": {},
+        "trusted_repository_rows": [],
+        "unsupported_or_blocked_domains": [],
+        "fallback_behavior": _fallback_behavior(enabled=False, unavailable=[], unsupported_domains=[]),
+        "legacy_routing": _legacy_routing_metadata(
+            legacy_path_name=legacy_path_name,
+            legacy_output=legacy_output,
+        ),
+        "safety_confirmations": _safety_confirmations(),
+        "metadata": {
+            "source": "v3_1_trusted_shadow_consumption",
+            "observational_only": True,
+            "production_consumer": False,
+            "production_behavior_changed": False,
+            "planner_remap_performed": False,
+            "production_default_routing_authorized": False,
+            "deterministic_serializer": "json_sort_keys_sha256",
+        },
+    }
+
+
+def _stable_metadata(metadata: dict[str, Any]) -> dict[str, Any]:
+    stable = deepcopy(metadata)
+    if "source_path" in stable:
+        stable["source_path"] = str(stable["source_path"])
+    return stable
+
+
+def _stable_envelope(envelope: dict[str, Any]) -> dict[str, Any]:
+    stable = deepcopy(envelope)
+    stable.pop("generated_at", None)
+    stable.pop("deterministic_hash", None)
+    return stable

--- a/backend/config.py
+++ b/backend/config.py
@@ -69,6 +69,18 @@ class Config:
     )
     FORGE_SAFE_AFFIX_BUNDLE_PATH = os.environ.get("FORGE_SAFE_AFFIX_BUNDLE_PATH", "")
 
+    # v3.1 trusted repository production shadow consumption. Disabled by
+    # default; when enabled it is observational only and cannot become the
+    # production planner/runtime truth source.
+    V3_1_TRUSTED_PRODUCTION_SHADOW_CONSUMPTION_ENABLED = (
+        os.environ.get("V3_1_TRUSTED_PRODUCTION_SHADOW_CONSUMPTION_ENABLED", "").lower()
+        in {"1", "true", "yes", "on"}
+    )
+    V3_1_TRUSTED_PRODUCTION_SHADOW_ALLOWED_DOMAINS = os.environ.get(
+        "V3_1_TRUSTED_PRODUCTION_SHADOW_ALLOWED_DOMAINS",
+        "affix,item_base,passive_skill",
+    )
+
 
 class DevelopmentConfig(Config):
     DEBUG = True

--- a/backend/scripts/report_v3_1_trusted_shadow_consumption.py
+++ b/backend/scripts/report_v3_1_trusted_shadow_consumption.py
@@ -1,0 +1,171 @@
+"""Generate the v3.1 trusted production shadow consumption report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.planner_adapters.v3_1.trusted_shadow_consumption import (  # noqa: E402
+    V31TrustedProductionShadowConsumption,
+    build_default_trusted_repository_probes,
+)
+
+DETERMINISTIC_GENERATED_AT = "2026-05-15T00:00:00+00:00"
+
+
+def build_v3_1_trusted_shadow_consumption_report() -> dict[str, Any]:
+    repo_root = Path(__file__).resolve().parents[2]
+    adapter = V31TrustedProductionShadowConsumption()
+    probes = build_default_trusted_repository_probes(repo_root)
+    disabled = adapter.inspect(
+        enabled=False,
+        trusted_repository_probes=probes,
+        legacy_output={"route": "legacy", "sample_total": 3},
+    )
+    enabled = adapter.inspect(
+        enabled=True,
+        trusted_repository_probes=probes,
+        legacy_output={"route": "legacy", "sample_total": 3},
+    )
+    repeated = adapter.inspect(
+        enabled=True,
+        trusted_repository_probes=probes,
+        legacy_output={"route": "legacy", "sample_total": 3},
+    )
+
+    deterministic = enabled["deterministic_hash"] == repeated["deterministic_hash"]
+    report = {
+        "schema_version": "v3_1.trusted_shadow_consumption_report.1",
+        "generated_at": DETERMINISTIC_GENERATED_AT,
+        "phase": "v3.1_phase_1_trusted_production_shadow_consumption_gate",
+        "recommendation": "OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING",
+        "production_default_routing_authorized": False,
+        "summary": {
+            "gate_default_enabled": disabled["gate"]["default_enabled"],
+            "disabled_production_output_affected": disabled["summary"]["production_output_affected"],
+            "enabled_production_output_affected": enabled["summary"]["production_output_affected"],
+            "trusted_repository_available_count": enabled["summary"]["trusted_repository_available_count"],
+            "trusted_repository_unavailable_count": enabled["summary"]["trusted_repository_unavailable_count"],
+            "trusted_entity_count": enabled["summary"]["trusted_entity_count"],
+            "unsupported_domain_count": enabled["summary"]["unsupported_domain_count"],
+            "legacy_path_still_active": enabled["summary"]["legacy_path_still_active"],
+            "trusted_path_shadowed_only": enabled["summary"]["trusted_path_shadowed_only"],
+            "deterministic": deterministic,
+        },
+        "disabled_gate_sample": disabled,
+        "enabled_shadow_sample": enabled,
+        "deterministic_guarantees": {
+            "passed": deterministic,
+            "sample_hash": enabled["deterministic_hash"],
+            "repeated_hash": repeated["deterministic_hash"],
+            "timestamp_excluded_from_hash": True,
+            "json_sort_keys": True,
+        },
+        "phase_1_boundaries": [
+            "trusted repositories may be inspected only in shadow mode",
+            "legacy production routing remains the truth source",
+            "trusted repository availability failures are reported explicitly",
+            "unsupported trusted domains remain blocked",
+            "production default routing is not authorized",
+        ],
+        "metadata": {
+            "source": "v3_1_trusted_shadow_consumption_report",
+            "observational_only": True,
+            "production_behavior_changed": False,
+            "production_default_routing_authorized": False,
+            "planner_remap_performed": False,
+        },
+    }
+    return _normalize_generated_at(report)
+
+
+def write_report(report: dict[str, Any], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _normalize_generated_at(value: Any) -> Any:
+    if isinstance(value, dict):
+        normalized = {}
+        for key, item in value.items():
+            normalized[key] = DETERMINISTIC_GENERATED_AT if key == "generated_at" else _normalize_generated_at(item)
+        return normalized
+    if isinstance(value, list):
+        return [_normalize_generated_at(item) for item in value]
+    return deepcopy(value)
+
+
+def write_markdown(report: dict[str, Any], output_path: Path) -> None:
+    summary = report["summary"]
+    lines = [
+        "# V3.1 Trusted Shadow Consumption",
+        "",
+        "Phase 1 introduces a disabled-by-default trusted production shadow-consumption gate.",
+        "It is observational only and does not authorize trusted repositories as production default routing.",
+        "",
+        "## Recommendation",
+        "",
+        f"- Recommendation: `{report['recommendation']}`",
+        f"- Production default routing authorized: `{str(report['production_default_routing_authorized']).lower()}`",
+        "",
+        "## Summary",
+        "",
+        f"- Gate default enabled: `{str(summary['gate_default_enabled']).lower()}`",
+        f"- Disabled production output affected: `{str(summary['disabled_production_output_affected']).lower()}`",
+        f"- Enabled production output affected: `{str(summary['enabled_production_output_affected']).lower()}`",
+        f"- Trusted repositories available: `{summary['trusted_repository_available_count']}`",
+        f"- Trusted repositories unavailable: `{summary['trusted_repository_unavailable_count']}`",
+        f"- Trusted entity count: `{summary['trusted_entity_count']}`",
+        f"- Unsupported domains: `{summary['unsupported_domain_count']}`",
+        f"- Legacy path still active: `{str(summary['legacy_path_still_active']).lower()}`",
+        f"- Trusted path shadowed only: `{str(summary['trusted_path_shadowed_only']).lower()}`",
+        f"- Deterministic: `{str(summary['deterministic']).lower()}`",
+        "",
+        "## Shadow Rows",
+        "",
+        "| Domain | Repository | Status | Entities | Production Output Affected |",
+        "| --- | --- | --- | ---: | --- |",
+    ]
+    for row in report["enabled_shadow_sample"]["trusted_repository_rows"]:
+        lines.append(
+            f"| `{row['domain']}` | `{row['repository_name']}` | `{row['routing_status']}` | `{row['trusted_entity_count']}` | `{str(row['production_output_affected']).lower()}` |"
+        )
+    lines.extend(["", "## Phase 1 Boundaries", ""])
+    lines.extend(f"- {item}" for item in report["phase_1_boundaries"])
+    lines.extend(
+        [
+            "",
+            "## Conclusion",
+            "",
+            "Trusted repository consumption remains shadow-only. Production planner/runtime outputs continue to come from legacy paths.",
+        ]
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", default="docs/generated/v3_1_trusted_shadow_consumption_report.json")
+    parser.add_argument("--markdown-output", default="docs/migration/V3_1_TRUSTED_SHADOW_CONSUMPTION.md")
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[2]
+    report = build_v3_1_trusted_shadow_consumption_report()
+    write_report(report, repo_root / args.output)
+    write_markdown(report, repo_root / args.markdown_output)
+    print(json.dumps(report["summary"], indent=2, sort_keys=True))
+    print(report["recommendation"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_v3_1_trusted_shadow_consumption.py
+++ b/backend/tests/test_v3_1_trusted_shadow_consumption.py
@@ -1,0 +1,144 @@
+import json
+from pathlib import Path
+
+from app.planner_adapters.v3_1.trusted_shadow_consumption import (
+    TrustedRepositoryProbe,
+    V31TrustedProductionShadowConsumption,
+)
+from scripts.report_v3_1_trusted_shadow_consumption import (
+    build_v3_1_trusted_shadow_consumption_report,
+    write_report,
+)
+
+
+def test_shadow_gate_defaults_disabled(app):
+    assert app.config["V3_1_TRUSTED_PRODUCTION_SHADOW_CONSUMPTION_ENABLED"] is False
+
+    report = V31TrustedProductionShadowConsumption().inspect(
+        trusted_repository_probes=[_probe("affix", "available_affixes", 2)],
+        legacy_output={"value": 10},
+    )
+
+    assert report["gate"]["enabled"] is False
+    assert report["gate"]["default_enabled"] is False
+    assert report["trusted_repository_rows"] == []
+    assert report["summary"]["production_output_affected"] is False
+
+
+def test_production_behavior_is_unchanged_when_disabled():
+    legacy_output = {"route": "legacy", "score": 42}
+    report = V31TrustedProductionShadowConsumption().inspect(
+        enabled=False,
+        trusted_repository_probes=[_probe("affix", "available_affixes", 99)],
+        legacy_output=legacy_output,
+    )
+
+    assert report["legacy_routing"]["active"] is True
+    assert report["legacy_routing"]["production_truth_source"] is True
+    assert report["legacy_routing"]["trusted_shadow_can_replace_output"] is False
+    assert report["summary"]["trusted_entity_count"] == 0
+    assert report["summary"]["production_behavior_changed"] is False
+
+
+def test_enabled_shadow_mode_does_not_replace_production_output():
+    legacy_output = {"route": "legacy", "score": 42}
+    report = V31TrustedProductionShadowConsumption().inspect(
+        enabled=True,
+        trusted_repository_probes=[_probe("affix", "available_affixes", 3)],
+        legacy_output=legacy_output,
+    )
+
+    assert report["gate"]["mode"] == "shadow"
+    assert report["gate"]["production_truth_source"] == "legacy"
+    assert report["summary"]["trusted_entity_count"] == 3
+    assert report["summary"]["production_output_affected"] is False
+    assert report["safety_confirmations"]["trusted_repository_used_as_truth_source"] is False
+
+
+def test_routing_debug_metadata_is_produced():
+    report = V31TrustedProductionShadowConsumption().inspect(
+        enabled=True,
+        trusted_repository_probes=[_probe("affix", "available_affixes", 3)],
+    )
+    row = report["trusted_repository_rows"][0]
+
+    assert row["routing_status"] == "trusted_repository_shadowed"
+    assert row["trusted_repository_available"] is True
+    assert row["trusted_entity_count"] == 3
+    assert row["legacy_path_still_active"] is True
+    assert row["trusted_path_shadowed_only"] is True
+    assert row["production_output_affected"] is False
+
+
+def test_unavailable_trusted_data_fails_visibly_in_metadata():
+    report = V31TrustedProductionShadowConsumption().inspect(
+        enabled=True,
+        trusted_repository_probes=[_unavailable_probe("affix", "missing_affixes")],
+    )
+    row = report["trusted_repository_rows"][0]
+
+    assert row["routing_status"] == "trusted_repository_unavailable"
+    assert row["trusted_repository_available"] is False
+    assert row["blocked_reasons"] == ["trusted_repository_unavailable"]
+    assert "missing_affixes unavailable" in row["error"]
+    assert report["fallback_behavior"]["fallback_silent"] is False
+    assert report["fallback_behavior"]["fallback_occurred"] is True
+
+
+def test_unsupported_trusted_domain_is_not_production_safe():
+    report = V31TrustedProductionShadowConsumption().inspect(
+        enabled=True,
+        trusted_repository_probes=[_probe("monolith_echo", "unsupported_repo", 10)],
+    )
+    row = report["trusted_repository_rows"][0]
+
+    assert row["routing_status"] == "blocked_unsupported_domain"
+    assert row["blocked_reasons"] == ["unsupported_trusted_shadow_domain"]
+    assert row["production_output_affected"] is False
+    assert report["unsupported_or_blocked_domains"] == ["monolith_echo"]
+    assert report["safety_confirmations"]["unsupported_domains_production_safe"] is False
+
+
+def test_report_generation_is_deterministic(tmp_path):
+    first = build_v3_1_trusted_shadow_consumption_report()
+    second = build_v3_1_trusted_shadow_consumption_report()
+
+    assert first["deterministic_guarantees"]["passed"] is True
+    assert first["enabled_shadow_sample"]["deterministic_hash"] == second["enabled_shadow_sample"]["deterministic_hash"]
+
+    output = tmp_path / "report.json"
+    write_report(first, output)
+    loaded = json.loads(output.read_text(encoding="utf-8"))
+    assert loaded["schema_version"] == "v3_1.trusted_shadow_consumption_report.1"
+    assert loaded["production_default_routing_authorized"] is False
+
+
+def test_report_marks_phase_1_observational_only():
+    report = build_v3_1_trusted_shadow_consumption_report()
+
+    assert report["recommendation"] == "OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING"
+    assert report["metadata"]["observational_only"] is True
+    assert report["metadata"]["production_behavior_changed"] is False
+    assert report["metadata"]["planner_remap_performed"] is False
+    assert "trusted repositories may be inspected only in shadow mode" in report["phase_1_boundaries"]
+
+
+def _probe(domain: str, name: str, count: int) -> TrustedRepositoryProbe:
+    return TrustedRepositoryProbe(
+        domain=domain,
+        repository_name=name,
+        count_loader=lambda: count,
+        metadata_loader=lambda: {"entity_count": count, "source_path": Path("fixture.json")},
+    )
+
+
+def _unavailable_probe(domain: str, name: str) -> TrustedRepositoryProbe:
+    def _raise():
+        raise FileNotFoundError(f"{name} unavailable")
+
+    return TrustedRepositoryProbe(
+        domain=domain,
+        repository_name=name,
+        count_loader=_raise,
+        metadata_loader=_raise,
+    )

--- a/docs/generated/v3_1_trusted_shadow_consumption_report.json
+++ b/docs/generated/v3_1_trusted_shadow_consumption_report.json
@@ -1,0 +1,244 @@
+{
+  "deterministic_guarantees": {
+    "json_sort_keys": true,
+    "passed": true,
+    "repeated_hash": "0381c24254add958e4905bcdd250b90c059ab8e65e487a0f517e345e4ac0ff5e",
+    "sample_hash": "0381c24254add958e4905bcdd250b90c059ab8e65e487a0f517e345e4ac0ff5e",
+    "timestamp_excluded_from_hash": true
+  },
+  "disabled_gate_sample": {
+    "deterministic_hash": "410a361efcfedb9298e5d3e036581f5a0405fbd1ed9473ce29ce9314450044f7",
+    "fallback_behavior": {
+      "fallback_occurred": false,
+      "fallback_possible": true,
+      "fallback_silent": false,
+      "fallback_target": "legacy_production_runtime",
+      "reported_unavailable_repositories": [],
+      "reported_unsupported_domains": []
+    },
+    "gate": {
+      "default_enabled": false,
+      "enabled": false,
+      "legacy_path_still_active": true,
+      "mode": "disabled",
+      "name": "V3_1_TRUSTED_PRODUCTION_SHADOW_CONSUMPTION_ENABLED",
+      "production_output_affected": false,
+      "production_truth_source": "legacy",
+      "shadow_only": true,
+      "trusted_path_shadowed_only": false
+    },
+    "generated_at": "2026-05-15T00:00:00+00:00",
+    "legacy_routing": {
+      "active": true,
+      "output_hash": "fb55fe26bac749857408949a969da4d2b77d23ac0d26a7c2f9e0516cd2b3dcee",
+      "path_name": "legacy_production_runtime",
+      "production_truth_source": true,
+      "trusted_shadow_can_replace_output": false
+    },
+    "metadata": {
+      "deterministic_serializer": "json_sort_keys_sha256",
+      "observational_only": true,
+      "planner_remap_performed": false,
+      "production_behavior_changed": false,
+      "production_consumer": false,
+      "production_default_routing_authorized": false,
+      "source": "v3_1_trusted_shadow_consumption"
+    },
+    "routing_category_counts": {},
+    "run": {
+      "allowed_domains": [
+        "affix",
+        "item_base",
+        "passive_skill"
+      ],
+      "probe_count": 0,
+      "run_id": "v3_1_phase_1_trusted_shadow_consumption"
+    },
+    "safety_confirmations": {
+      "legacy_path_removed": false,
+      "planner_remap_performed": false,
+      "production_behavior_changed": false,
+      "production_default_routing_authorized": false,
+      "production_output_affected": false,
+      "silent_fallback_allowed": false,
+      "trusted_repository_used_as_truth_source": false,
+      "unsupported_domains_production_safe": false
+    },
+    "schema_version": "v3_1.trusted_shadow_consumption.1",
+    "summary": {
+      "deterministic": true,
+      "legacy_path_still_active": true,
+      "production_behavior_changed": false,
+      "production_default_routing_authorized": false,
+      "production_output_affected": false,
+      "trusted_entity_count": 0,
+      "trusted_path_shadowed_only": false,
+      "trusted_repository_available": false,
+      "trusted_repository_available_count": 0,
+      "trusted_repository_unavailable_count": 0,
+      "unsupported_domain_count": 0
+    },
+    "trusted_repository_rows": [],
+    "unsupported_or_blocked_domains": []
+  },
+  "enabled_shadow_sample": {
+    "deterministic_hash": "0381c24254add958e4905bcdd250b90c059ab8e65e487a0f517e345e4ac0ff5e",
+    "fallback_behavior": {
+      "fallback_occurred": false,
+      "fallback_possible": true,
+      "fallback_silent": false,
+      "fallback_target": "legacy_production_runtime",
+      "reported_unavailable_repositories": [],
+      "reported_unsupported_domains": []
+    },
+    "gate": {
+      "default_enabled": false,
+      "enabled": true,
+      "legacy_path_still_active": true,
+      "mode": "shadow",
+      "name": "V3_1_TRUSTED_PRODUCTION_SHADOW_CONSUMPTION_ENABLED",
+      "production_output_affected": false,
+      "production_truth_source": "legacy",
+      "shadow_only": true,
+      "trusted_path_shadowed_only": true
+    },
+    "generated_at": "2026-05-15T00:00:00+00:00",
+    "legacy_routing": {
+      "active": true,
+      "output_hash": "fb55fe26bac749857408949a969da4d2b77d23ac0d26a7c2f9e0516cd2b3dcee",
+      "path_name": "legacy_production_runtime",
+      "production_truth_source": true,
+      "trusted_shadow_can_replace_output": false
+    },
+    "metadata": {
+      "deterministic_serializer": "json_sort_keys_sha256",
+      "observational_only": true,
+      "planner_remap_performed": false,
+      "production_behavior_changed": false,
+      "production_consumer": false,
+      "production_default_routing_authorized": false,
+      "source": "v3_1_trusted_shadow_consumption"
+    },
+    "routing_category_counts": {
+      "trusted_repository_shadowed": 3
+    },
+    "run": {
+      "allowed_domains": [
+        "affix",
+        "item_base",
+        "passive_skill"
+      ],
+      "probe_count": 3,
+      "run_id": "v3_1_phase_1_trusted_shadow_consumption"
+    },
+    "safety_confirmations": {
+      "legacy_path_removed": false,
+      "planner_remap_performed": false,
+      "production_behavior_changed": false,
+      "production_default_routing_authorized": false,
+      "production_output_affected": false,
+      "silent_fallback_allowed": false,
+      "trusted_repository_used_as_truth_source": false,
+      "unsupported_domains_production_safe": false
+    },
+    "schema_version": "v3_1.trusted_shadow_consumption.1",
+    "summary": {
+      "deterministic": true,
+      "legacy_path_still_active": true,
+      "production_behavior_changed": false,
+      "production_default_routing_authorized": false,
+      "production_output_affected": false,
+      "trusted_entity_count": 1645,
+      "trusted_path_shadowed_only": true,
+      "trusted_repository_available": true,
+      "trusted_repository_available_count": 3,
+      "trusted_repository_unavailable_count": 0,
+      "unsupported_domain_count": 0
+    },
+    "trusted_repository_rows": [
+      {
+        "blocked_reasons": [],
+        "domain": "affix",
+        "fallback_behavior": "none_required_shadow_only",
+        "legacy_path_still_active": true,
+        "metadata": {
+          "entity_count": 1098,
+          "schema_version": "v2.affix_bundle.1",
+          "source_path": "D:\\Forge\\le-the-forge\\docs\\generated\\v2_affix_bundle.json"
+        },
+        "production_output_affected": false,
+        "repository_name": "v2_affix_bundle",
+        "routing_status": "trusted_repository_shadowed",
+        "trusted_entity_count": 1098,
+        "trusted_path_shadowed_only": true,
+        "trusted_repository_available": true
+      },
+      {
+        "blocked_reasons": [],
+        "domain": "item_base",
+        "fallback_behavior": "none_required_shadow_only",
+        "legacy_path_still_active": true,
+        "metadata": {
+          "entity_count": 542,
+          "schema_version": "v2.item_base_bundle.1",
+          "source_path": "D:\\Forge\\le-the-forge\\docs\\generated\\v2_item_base_bundle.json"
+        },
+        "production_output_affected": false,
+        "repository_name": "v2_item_base_bundle",
+        "routing_status": "trusted_repository_shadowed",
+        "trusted_entity_count": 542,
+        "trusted_path_shadowed_only": true,
+        "trusted_repository_available": true
+      },
+      {
+        "blocked_reasons": [],
+        "domain": "passive_skill",
+        "fallback_behavior": "none_required_shadow_only",
+        "legacy_path_still_active": true,
+        "metadata": {
+          "entity_count": 5,
+          "schema_version": "v2.passive_tree_bundle.1",
+          "source_path": "D:\\Forge\\le-the-forge\\docs\\generated\\v2_passive_tree_bundle.json"
+        },
+        "production_output_affected": false,
+        "repository_name": "v2_passive_tree_bundle",
+        "routing_status": "trusted_repository_shadowed",
+        "trusted_entity_count": 5,
+        "trusted_path_shadowed_only": true,
+        "trusted_repository_available": true
+      }
+    ],
+    "unsupported_or_blocked_domains": []
+  },
+  "generated_at": "2026-05-15T00:00:00+00:00",
+  "metadata": {
+    "observational_only": true,
+    "planner_remap_performed": false,
+    "production_behavior_changed": false,
+    "production_default_routing_authorized": false,
+    "source": "v3_1_trusted_shadow_consumption_report"
+  },
+  "phase": "v3.1_phase_1_trusted_production_shadow_consumption_gate",
+  "phase_1_boundaries": [
+    "trusted repositories may be inspected only in shadow mode",
+    "legacy production routing remains the truth source",
+    "trusted repository availability failures are reported explicitly",
+    "unsupported trusted domains remain blocked",
+    "production default routing is not authorized"
+  ],
+  "production_default_routing_authorized": false,
+  "recommendation": "OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING",
+  "schema_version": "v3_1.trusted_shadow_consumption_report.1",
+  "summary": {
+    "deterministic": true,
+    "disabled_production_output_affected": false,
+    "enabled_production_output_affected": false,
+    "gate_default_enabled": false,
+    "legacy_path_still_active": true,
+    "trusted_entity_count": 1645,
+    "trusted_path_shadowed_only": true,
+    "trusted_repository_available_count": 3,
+    "trusted_repository_unavailable_count": 0,
+    "unsupported_domain_count": 0
+  }
+}

--- a/docs/migration/V3_1_TRUSTED_SHADOW_CONSUMPTION.md
+++ b/docs/migration/V3_1_TRUSTED_SHADOW_CONSUMPTION.md
@@ -1,0 +1,42 @@
+# V3.1 Trusted Shadow Consumption
+
+Phase 1 introduces a disabled-by-default trusted production shadow-consumption gate.
+It is observational only and does not authorize trusted repositories as production default routing.
+
+## Recommendation
+
+- Recommendation: `OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING`
+- Production default routing authorized: `false`
+
+## Summary
+
+- Gate default enabled: `false`
+- Disabled production output affected: `false`
+- Enabled production output affected: `false`
+- Trusted repositories available: `3`
+- Trusted repositories unavailable: `0`
+- Trusted entity count: `1645`
+- Unsupported domains: `0`
+- Legacy path still active: `true`
+- Trusted path shadowed only: `true`
+- Deterministic: `true`
+
+## Shadow Rows
+
+| Domain | Repository | Status | Entities | Production Output Affected |
+| --- | --- | --- | ---: | --- |
+| `affix` | `v2_affix_bundle` | `trusted_repository_shadowed` | `1098` | `false` |
+| `item_base` | `v2_item_base_bundle` | `trusted_repository_shadowed` | `542` | `false` |
+| `passive_skill` | `v2_passive_tree_bundle` | `trusted_repository_shadowed` | `5` | `false` |
+
+## Phase 1 Boundaries
+
+- trusted repositories may be inspected only in shadow mode
+- legacy production routing remains the truth source
+- trusted repository availability failures are reported explicitly
+- unsupported trusted domains remain blocked
+- production default routing is not authorized
+
+## Conclusion
+
+Trusted repository consumption remains shadow-only. Production planner/runtime outputs continue to come from legacy paths.


### PR DESCRIPTION
Adds the first v3.1 production-consumption safety layer by introducing a controlled shadow-routing gate for trusted repository consumption. This phase must not replace production planner behavior yet. It should allow trusted infrastructure to run beside legacy paths, capture routing/debug state, and generate deterministic reports proving whether trusted consumption is safe to expand.