### PR TITLE
v3.1: add deterministic dual-run comparison infrastructure

### DIFF
--- a/backend/app/planner_adapters/v3_1/__init__.py
+++ b/backend/app/planner_adapters/v3_1/__init__.py
@@ -1,5 +1,10 @@
 """V3.1 trusted production shadow-consumption safety scaffolds."""
 
+from .dual_run_comparison import (
+    DRIFT_CLASSIFICATIONS,
+    V31DualRunComparison,
+    build_sample_dual_run_inputs,
+)
 from .trusted_shadow_consumption import (
     SUPPORTED_TRUSTED_SHADOW_DOMAINS,
     V31TrustedProductionShadowConsumption,
@@ -8,8 +13,11 @@ from .trusted_shadow_consumption import (
 )
 
 __all__ = [
+    "DRIFT_CLASSIFICATIONS",
     "SUPPORTED_TRUSTED_SHADOW_DOMAINS",
+    "V31DualRunComparison",
     "V31TrustedProductionShadowConsumption",
+    "build_sample_dual_run_inputs",
     "build_default_trusted_repository_probes",
     "deterministic_hash",
 ]

--- a/backend/app/planner_adapters/v3_1/dual_run_comparison.py
+++ b/backend/app/planner_adapters/v3_1/dual_run_comparison.py
@@ -1,0 +1,309 @@
+"""Deterministic v3.1 legacy/trusted-shadow dual-run comparison.
+
+The comparison layer accepts already-built legacy summaries and Phase 1 trusted
+shadow metadata. It does not call production planner/runtime code and cannot
+replace production output.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from copy import deepcopy
+from datetime import UTC, datetime
+from typing import Any
+
+from .trusted_shadow_consumption import V31TrustedProductionShadowConsumption, deterministic_hash
+
+
+DRIFT_CLASSIFICATIONS = (
+    "equivalent",
+    "legacy_only",
+    "trusted_only",
+    "divergent",
+    "unavailable",
+    "unsupported",
+    "blocked",
+    "not_evaluated",
+)
+
+
+class V31DualRunComparison:
+    """Compare legacy production summaries against trusted shadow metadata."""
+
+    def compare(
+        self,
+        *,
+        legacy_summaries: list[dict[str, Any]],
+        trusted_shadow_metadata: dict[str, Any],
+        run_id: str = "v3_1_phase_2_dual_run_comparison",
+    ) -> dict[str, Any]:
+        legacy_by_key = {
+            _comparison_key(row): deepcopy(row)
+            for row in legacy_summaries
+        }
+        trusted_by_key = _trusted_rows_by_key(trusted_shadow_metadata)
+        keys = sorted(set(legacy_by_key) | set(trusted_by_key))
+        gate = trusted_shadow_metadata.get("gate") or {}
+
+        results = [
+            _comparison_result(
+                comparison_id=key,
+                legacy=legacy_by_key.get(key),
+                trusted=trusted_by_key.get(key),
+                trusted_gate=gate,
+            )
+            for key in keys
+        ]
+        counts = Counter(row["drift_classification"] for row in results)
+        production_affected_count = sum(1 for row in results if row["production_output_affected"])
+        envelope = {
+            "schema_version": "v3_1.dual_run_comparison.1",
+            "generated_at": datetime.now(UTC).isoformat(),
+            "run": {
+                "run_id": run_id,
+                "legacy_summary_count": len(legacy_summaries),
+                "trusted_summary_count": len(trusted_by_key),
+                "comparison_count": len(results),
+            },
+            "summary": {
+                "total_comparisons": len(results),
+                "equivalent_count": counts["equivalent"],
+                "divergent_count": counts["divergent"],
+                "unsupported_count": counts["unsupported"],
+                "blocked_count": counts["blocked"],
+                "legacy_only_count": counts["legacy_only"],
+                "trusted_only_count": counts["trusted_only"],
+                "unavailable_count": counts["unavailable"],
+                "not_evaluated_count": counts["not_evaluated"],
+                "production_affected_count": production_affected_count,
+                "production_output_affected": False,
+                "production_behavior_changed": False,
+                "trusted_data_default_truth": False,
+                "deterministic": True,
+            },
+            "drift_classification_counts": {
+                category: counts[category]
+                for category in DRIFT_CLASSIFICATIONS
+            },
+            "comparison_results": results,
+            "trusted_shadow_gate": {
+                "enabled": bool(gate.get("enabled", False)),
+                "mode": str(gate.get("mode", "unknown")),
+                "shadow_only": bool(gate.get("shadow_only", True)),
+                "production_truth_source": gate.get("production_truth_source", "legacy"),
+                "production_output_affected": bool(gate.get("production_output_affected", False)),
+            },
+            "safety_confirmations": {
+                "production_output_affected": False,
+                "production_behavior_changed": False,
+                "trusted_data_default_truth": False,
+                "legacy_output_replaced": False,
+                "runtime_state_mutated": False,
+                "silent_missing_trusted_accepted": False,
+                "silent_missing_legacy_accepted": False,
+                "unsupported_states_hidden": False,
+            },
+            "metadata": {
+                "source": "v3_1_dual_run_comparison",
+                "observational_only": True,
+                "production_consumer": False,
+                "production_behavior_changed": False,
+                "planner_remap_performed": False,
+                "production_default_routing_authorized": False,
+                "deterministic_serializer": "json_sort_keys_sha256",
+            },
+        }
+        envelope["deterministic_hash"] = deterministic_hash(_stable_envelope(envelope))
+        return envelope
+
+
+def build_sample_dual_run_inputs() -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    trusted_shadow = V31TrustedProductionShadowConsumption().inspect(
+        enabled=True,
+        trusted_repository_probes=[
+            _sample_probe("affix", "v2_affix_bundle", 1098),
+            _sample_probe("item_base", "v2_item_base_bundle", 542),
+            _sample_probe("passive_skill", "v2_passive_tree_bundle", 5),
+        ],
+        legacy_output={"route": "legacy", "sample_total": 3},
+        run_id="v3_1_phase_2_trusted_shadow_sample",
+    )
+    legacy = [
+        _legacy_summary("affix", "available", 1098, "legacy_affix_catalog"),
+        _legacy_summary("item_base", "available", 540, "legacy_item_catalog"),
+        _legacy_summary("passive_skill", "unsupported", None, "legacy_passive_skill_runtime"),
+        _legacy_summary("idol", "available", 81, "legacy_idol_catalog"),
+    ]
+    trusted_shadow["trusted_repository_rows"].append(
+        {
+            "domain": "monolith_echo",
+            "repository_name": "unsupported_shadow_repository",
+            "routing_status": "blocked_unsupported_domain",
+            "trusted_repository_available": False,
+            "trusted_entity_count": 0,
+            "legacy_path_still_active": True,
+            "trusted_path_shadowed_only": True,
+            "production_output_affected": False,
+            "blocked_reasons": ["unsupported_trusted_shadow_domain"],
+            "fallback_behavior": "legacy_remains_active_reported",
+            "metadata": {},
+        }
+    )
+    return legacy, trusted_shadow
+
+
+def _sample_probe(domain: str, repository_name: str, count: int):
+    from .trusted_shadow_consumption import TrustedRepositoryProbe
+
+    return TrustedRepositoryProbe(
+        domain=domain,
+        repository_name=repository_name,
+        count_loader=lambda: count,
+        metadata_loader=lambda: {"entity_count": count, "schema_version": "sample", "source_path": f"sample:{repository_name}"},
+    )
+
+
+def _legacy_summary(comparison_id: str, status: str, comparable_value: Any, source: str) -> dict[str, Any]:
+    return {
+        "comparison_id": comparison_id,
+        "legacy_status": status,
+        "comparable_value": comparable_value,
+        "source": source,
+        "production_output": True,
+    }
+
+
+def _trusted_rows_by_key(trusted_shadow_metadata: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    rows: dict[str, dict[str, Any]] = {}
+    for row in trusted_shadow_metadata.get("trusted_repository_rows") or []:
+        key = str(row.get("comparison_id") or row.get("domain") or row.get("repository_name") or "")
+        if not key:
+            continue
+        rows[key] = {
+            "comparison_id": key,
+            "trusted_shadow_status": _trusted_status(row),
+            "comparable_value": row.get("trusted_entity_count"),
+            "routing_status": row.get("routing_status"),
+            "repository_name": row.get("repository_name"),
+            "blocked_reasons": list(row.get("blocked_reasons") or []),
+            "production_output_affected": bool(row.get("production_output_affected", False)),
+            "raw_shadow_row": deepcopy(row),
+        }
+    return rows
+
+
+def _trusted_status(row: dict[str, Any]) -> str:
+    routing_status = str(row.get("routing_status", ""))
+    if routing_status == "trusted_repository_shadowed":
+        return "available"
+    if routing_status == "trusted_repository_unavailable":
+        return "unavailable"
+    if routing_status == "blocked_unsupported_domain":
+        return "unsupported"
+    if routing_status.startswith("blocked"):
+        return "blocked"
+    return "not_evaluated"
+
+
+def _comparison_result(
+    *,
+    comparison_id: str,
+    legacy: dict[str, Any] | None,
+    trusted: dict[str, Any] | None,
+    trusted_gate: dict[str, Any],
+) -> dict[str, Any]:
+    legacy_status = str((legacy or {}).get("legacy_status") or (legacy or {}).get("status") or "missing")
+    trusted_status = str((trusted or {}).get("trusted_shadow_status") or "missing")
+    classification, reason_codes = _classify(
+        legacy=legacy,
+        trusted=trusted,
+        legacy_status=legacy_status,
+        trusted_status=trusted_status,
+        trusted_gate=trusted_gate,
+    )
+    return {
+        "comparison_id": comparison_id,
+        "stable_key": comparison_id,
+        "legacy_status": legacy_status,
+        "trusted_shadow_status": trusted_status,
+        "drift_classification": classification,
+        "production_output_affected": False,
+        "trusted_shadow_gate": {
+            "enabled": bool(trusted_gate.get("enabled", False)),
+            "mode": str(trusted_gate.get("mode", "unknown")),
+            "shadow_only": bool(trusted_gate.get("shadow_only", True)),
+        },
+        "unsupported_or_blocked_reason": _unsupported_or_blocked_reason(legacy=legacy, trusted=trusted, reason_codes=reason_codes),
+        "reason_codes": reason_codes,
+        "legacy_hash": _value_hash((legacy or {}).get("comparable_value")) if legacy is not None else None,
+        "trusted_hash": _value_hash((trusted or {}).get("comparable_value")) if trusted is not None else None,
+        "deterministic_notes": [
+            "comparison rows sorted by stable key",
+            "comparable values hashed through sorted JSON serialization",
+            "production output is not mutated or replaced",
+        ],
+    }
+
+
+def _classify(
+    *,
+    legacy: dict[str, Any] | None,
+    trusted: dict[str, Any] | None,
+    legacy_status: str,
+    trusted_status: str,
+    trusted_gate: dict[str, Any],
+) -> tuple[str, list[str]]:
+    if not bool(trusted_gate.get("enabled", False)):
+        return "not_evaluated", ["trusted_shadow_gate_disabled"]
+    if legacy is None and trusted is None:
+        return "not_evaluated", ["legacy_and_trusted_missing"]
+    if legacy_status == "unsupported" or trusted_status == "unsupported":
+        return "unsupported", ["unsupported_state_visible"]
+    if legacy_status == "blocked" or trusted_status == "blocked":
+        return "blocked", ["blocked_state_visible"]
+    if legacy_status == "unavailable" or trusted_status == "unavailable":
+        return "unavailable", ["unavailable_state_visible"]
+    if legacy_status == "not_evaluated" or trusted_status == "not_evaluated":
+        return "not_evaluated", ["not_evaluated_state_visible"]
+    if legacy is None and trusted is not None:
+        return "trusted_only", ["legacy_summary_missing"]
+    if trusted is None and legacy is not None:
+        return "legacy_only", ["trusted_shadow_summary_missing"]
+    legacy_hash = _value_hash(legacy.get("comparable_value"))
+    trusted_hash = _value_hash(trusted.get("comparable_value"))
+    if legacy_hash == trusted_hash:
+        return "equivalent", ["comparable_value_hash_match"]
+    return "divergent", ["comparable_value_hash_mismatch"]
+
+
+def _unsupported_or_blocked_reason(
+    *,
+    legacy: dict[str, Any] | None,
+    trusted: dict[str, Any] | None,
+    reason_codes: list[str],
+) -> str | None:
+    trusted_reasons = list((trusted or {}).get("blocked_reasons") or [])
+    legacy_reason = (legacy or {}).get("blocked_reason") or (legacy or {}).get("unsupported_reason")
+    reasons = [str(legacy_reason)] if legacy_reason else []
+    reasons.extend(str(reason) for reason in trusted_reasons)
+    if reasons:
+        return ";".join(sorted(set(reasons)))
+    if any("missing" in reason or "visible" in reason for reason in reason_codes):
+        return ";".join(reason_codes)
+    return None
+
+
+def _comparison_key(row: dict[str, Any]) -> str:
+    return str(row.get("comparison_id") or row.get("stable_key") or row.get("domain") or "")
+
+
+def _value_hash(value: Any) -> str:
+    return deterministic_hash({"value": value})
+
+
+def _stable_envelope(envelope: dict[str, Any]) -> dict[str, Any]:
+    stable = deepcopy(envelope)
+    stable.pop("generated_at", None)
+    stable.pop("deterministic_hash", None)
+    return stable

--- a/backend/scripts/report_v3_1_dual_run_comparison.py
+++ b/backend/scripts/report_v3_1_dual_run_comparison.py
@@ -1,0 +1,156 @@
+"""Generate the v3.1 deterministic dual-run comparison report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.planner_adapters.v3_1.dual_run_comparison import (  # noqa: E402
+    V31DualRunComparison,
+    build_sample_dual_run_inputs,
+)
+
+
+DETERMINISTIC_GENERATED_AT = "2026-05-15T00:00:00+00:00"
+
+
+def build_v3_1_dual_run_comparison_report() -> dict[str, Any]:
+    legacy, trusted_shadow = build_sample_dual_run_inputs()
+    comparator = V31DualRunComparison()
+    comparison = comparator.compare(
+        legacy_summaries=legacy,
+        trusted_shadow_metadata=trusted_shadow,
+    )
+    repeated = comparator.compare(
+        legacy_summaries=legacy,
+        trusted_shadow_metadata=trusted_shadow,
+    )
+    deterministic = comparison["deterministic_hash"] == repeated["deterministic_hash"]
+    report = {
+        "schema_version": "v3_1.dual_run_comparison_report.1",
+        "generated_at": DETERMINISTIC_GENERATED_AT,
+        "phase": "v3.1_phase_2_deterministic_dual_run_comparison",
+        "recommendation": "OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING",
+        "production_default_routing_authorized": False,
+        "summary": {
+            **comparison["summary"],
+            "deterministic": deterministic,
+        },
+        "comparison": comparison,
+        "deterministic_guarantees": {
+            "passed": deterministic,
+            "sample_hash": comparison["deterministic_hash"],
+            "repeated_hash": repeated["deterministic_hash"],
+            "timestamp_excluded_from_hash": True,
+            "json_sort_keys": True,
+        },
+        "phase_2_boundaries": [
+            "dual-run comparison accepts summaries and shadow metadata only",
+            "legacy production output remains the truth source",
+            "trusted data is not default production truth",
+            "drift visibility is established through explicit classifications",
+            "unsupported and blocked states are intentionally surfaced",
+        ],
+        "metadata": {
+            "source": "v3_1_dual_run_comparison_report",
+            "observational_only": True,
+            "production_behavior_changed": False,
+            "production_default_routing_authorized": False,
+            "planner_remap_performed": False,
+        },
+    }
+    return _normalize_generated_at(report)
+
+
+def write_report(report: dict[str, Any], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_markdown(report: dict[str, Any], output_path: Path) -> None:
+    summary = report["summary"]
+    lines = [
+        "# V3.1 Dual-Run Comparison",
+        "",
+        "Phase 2 introduces deterministic dual-run comparison infrastructure around the trusted shadow layer.",
+        "It is observational only; production output remains legacy-owned and trusted data is not default production truth.",
+        "",
+        "## Recommendation",
+        "",
+        f"- Recommendation: `{report['recommendation']}`",
+        f"- Production default routing authorized: `{str(report['production_default_routing_authorized']).lower()}`",
+        "",
+        "## Summary",
+        "",
+        f"- Total comparisons: `{summary['total_comparisons']}`",
+        f"- Equivalent: `{summary['equivalent_count']}`",
+        f"- Divergent: `{summary['divergent_count']}`",
+        f"- Unsupported: `{summary['unsupported_count']}`",
+        f"- Blocked: `{summary['blocked_count']}`",
+        f"- Legacy only: `{summary['legacy_only_count']}`",
+        f"- Trusted only: `{summary['trusted_only_count']}`",
+        f"- Unavailable: `{summary['unavailable_count']}`",
+        f"- Not evaluated: `{summary['not_evaluated_count']}`",
+        f"- Production affected: `{summary['production_affected_count']}`",
+        f"- Deterministic: `{str(summary['deterministic']).lower()}`",
+        "",
+        "## Drift Results",
+        "",
+        "| Comparison | Legacy | Trusted Shadow | Classification | Reason |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    for row in report["comparison"]["comparison_results"]:
+        reason = row["unsupported_or_blocked_reason"] or ",".join(row["reason_codes"])
+        lines.append(
+            f"| `{row['comparison_id']}` | `{row['legacy_status']}` | `{row['trusted_shadow_status']}` | `{row['drift_classification']}` | `{reason}` |"
+        )
+    lines.extend(["", "## Phase 2 Boundaries", ""])
+    lines.extend(f"- {item}" for item in report["phase_2_boundaries"])
+    lines.extend(
+        [
+            "",
+            "## Conclusion",
+            "",
+            "Dual-run drift visibility is now available, but production routing remains unchanged and legacy-owned.",
+        ]
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _normalize_generated_at(value: Any) -> Any:
+    if isinstance(value, dict):
+        normalized = {}
+        for key, item in value.items():
+            normalized[key] = DETERMINISTIC_GENERATED_AT if key == "generated_at" else _normalize_generated_at(item)
+        return normalized
+    if isinstance(value, list):
+        return [_normalize_generated_at(item) for item in value]
+    return deepcopy(value)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", default="docs/generated/v3_1_dual_run_comparison_report.json")
+    parser.add_argument("--markdown-output", default="docs/migration/V3_1_DUAL_RUN_COMPARISON.md")
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[2]
+    report = build_v3_1_dual_run_comparison_report()
+    write_report(report, repo_root / args.output)
+    write_markdown(report, repo_root / args.markdown_output)
+    print(json.dumps(report["summary"], indent=2, sort_keys=True))
+    print(report["recommendation"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_v3_1_dual_run_comparison.py
+++ b/backend/tests/test_v3_1_dual_run_comparison.py
@@ -1,0 +1,237 @@
+import json
+
+from app.planner_adapters.v3_1.dual_run_comparison import (
+    V31DualRunComparison,
+)
+from app.planner_adapters.v3_1.trusted_shadow_consumption import (
+    TrustedRepositoryProbe,
+    V31TrustedProductionShadowConsumption,
+)
+from scripts.report_v3_1_dual_run_comparison import (
+    build_v3_1_dual_run_comparison_report,
+    write_report,
+)
+
+
+def test_comparison_output_is_deterministic():
+    legacy = [_legacy("affix", "available", 3)]
+    trusted = _shadow([_probe("affix", "affixes", 3)])
+
+    first = V31DualRunComparison().compare(legacy_summaries=legacy, trusted_shadow_metadata=trusted)
+    second = V31DualRunComparison().compare(legacy_summaries=legacy, trusted_shadow_metadata=trusted)
+
+    assert first["deterministic_hash"] == second["deterministic_hash"]
+    assert first["summary"]["deterministic"] is True
+
+
+def test_equivalent_cases_classify_correctly():
+    result = _compare([_legacy("affix", "available", 3)], [_probe("affix", "affixes", 3)])
+
+    assert result["comparison_results"][0]["drift_classification"] == "equivalent"
+    assert result["summary"]["equivalent_count"] == 1
+    assert result["summary"]["production_affected_count"] == 0
+
+
+def test_divergent_cases_classify_correctly():
+    result = _compare([_legacy("affix", "available", 3)], [_probe("affix", "affixes", 4)])
+
+    row = result["comparison_results"][0]
+    assert row["drift_classification"] == "divergent"
+    assert row["reason_codes"] == ["comparable_value_hash_mismatch"]
+    assert result["summary"]["divergent_count"] == 1
+
+
+def test_missing_legacy_data_is_not_silently_accepted():
+    result = _compare([], [_probe("affix", "affixes", 3)])
+
+    row = result["comparison_results"][0]
+    assert row["drift_classification"] == "trusted_only"
+    assert row["unsupported_or_blocked_reason"] == "legacy_summary_missing"
+    assert result["summary"]["trusted_only_count"] == 1
+
+
+def test_missing_trusted_data_is_not_silently_accepted():
+    result = _compare([_legacy("affix", "available", 3)], [])
+
+    row = result["comparison_results"][0]
+    assert row["drift_classification"] == "legacy_only"
+    assert row["unsupported_or_blocked_reason"] == "trusted_shadow_summary_missing"
+    assert result["summary"]["legacy_only_count"] == 1
+
+
+def test_unavailable_trusted_data_remains_visible():
+    result = _compare([_legacy("affix", "available", 3)], [_unavailable_probe("affix", "missing_affixes")])
+
+    row = result["comparison_results"][0]
+    assert row["drift_classification"] == "unavailable"
+    assert row["trusted_shadow_status"] == "unavailable"
+    assert row["unsupported_or_blocked_reason"] == "trusted_repository_unavailable"
+    assert result["summary"]["unavailable_count"] == 1
+
+
+def test_unsupported_cases_remain_visible():
+    result = _compare([_legacy("affix", "unsupported", None)], [_probe("affix", "affixes", 3)])
+
+    row = result["comparison_results"][0]
+    assert row["drift_classification"] == "unsupported"
+    assert row["reason_codes"] == ["unsupported_state_visible"]
+    assert result["summary"]["unsupported_count"] == 1
+
+
+def test_blocked_cases_remain_visible():
+    trusted = _shadow([_probe("affix", "affixes", 3)], allowed_domains=[])
+    result = V31DualRunComparison().compare(
+        legacy_summaries=[_legacy("affix", "available", 3)],
+        trusted_shadow_metadata=trusted,
+    )
+
+    row = result["comparison_results"][0]
+    assert row["drift_classification"] == "blocked"
+    assert row["trusted_shadow_status"] == "blocked"
+    assert row["unsupported_or_blocked_reason"] == "domain_not_allowed_for_v3_1_shadow_consumption"
+    assert result["summary"]["blocked_count"] == 1
+
+
+def test_shadow_gate_disabled_marks_not_evaluated():
+    trusted = V31TrustedProductionShadowConsumption().inspect(
+        enabled=False,
+        trusted_repository_probes=[_probe("affix", "affixes", 3)],
+    )
+    result = V31DualRunComparison().compare(
+        legacy_summaries=[_legacy("affix", "available", 3)],
+        trusted_shadow_metadata=trusted,
+    )
+
+    assert result["comparison_results"][0]["drift_classification"] == "not_evaluated"
+    assert result["summary"]["not_evaluated_count"] == 1
+
+
+def test_production_output_affected_is_always_false():
+    result = _compare(
+        [_legacy("affix", "available", 3), _legacy("item_base", "available", 2)],
+        [_probe("affix", "affixes", 4), _probe("item_base", "items", 2)],
+    )
+
+    assert result["summary"]["production_output_affected"] is False
+    assert result["summary"]["production_affected_count"] == 0
+    assert all(row["production_output_affected"] is False for row in result["comparison_results"])
+    assert result["safety_confirmations"]["runtime_state_mutated"] is False
+
+
+def test_aggregate_counts_are_correct():
+    trusted = _trusted_metadata(
+        [
+            _trusted_row("equivalent", "trusted_repository_shadowed", 1),
+            _trusted_row("divergent", "trusted_repository_shadowed", 2),
+            _trusted_row("trusted_only", "trusted_repository_shadowed", 3),
+            _trusted_row("unavailable", "trusted_repository_unavailable", 0, ["trusted_repository_unavailable"]),
+            _trusted_row("unsupported_trusted", "blocked_unsupported_domain", 0, ["unsupported_trusted_shadow_domain"]),
+            _trusted_row("blocked", "blocked_domain_not_allowed", 0, ["blocked_for_test"]),
+        ]
+    )
+    legacy = [
+        _legacy("equivalent", "available", 1),
+        _legacy("divergent", "available", 99),
+        _legacy("legacy_only", "available", 1),
+        _legacy("unavailable", "available", 1),
+        _legacy("blocked", "available", 1),
+    ]
+    result = V31DualRunComparison().compare(legacy_summaries=legacy, trusted_shadow_metadata=trusted)
+
+    assert result["summary"]["total_comparisons"] == 7
+    assert result["summary"]["equivalent_count"] == 1
+    assert result["summary"]["divergent_count"] == 1
+    assert result["summary"]["unsupported_count"] == 1
+    assert result["summary"]["blocked_count"] == 1
+    assert result["summary"]["legacy_only_count"] == 1
+    assert result["summary"]["trusted_only_count"] == 1
+    assert result["summary"]["unavailable_count"] == 1
+    assert result["summary"]["not_evaluated_count"] == 0
+
+
+def test_report_generation_is_deterministic(tmp_path):
+    first = build_v3_1_dual_run_comparison_report()
+    second = build_v3_1_dual_run_comparison_report()
+
+    assert first["deterministic_guarantees"]["passed"] is True
+    assert first["comparison"]["deterministic_hash"] == second["comparison"]["deterministic_hash"]
+    assert first["summary"] == second["summary"]
+
+    output = tmp_path / "dual_run.json"
+    write_report(first, output)
+    loaded = json.loads(output.read_text(encoding="utf-8"))
+    assert loaded["schema_version"] == "v3_1.dual_run_comparison_report.1"
+    assert loaded["production_default_routing_authorized"] is False
+    assert loaded["metadata"]["observational_only"] is True
+
+
+def _compare(legacy_rows, probes):
+    return V31DualRunComparison().compare(
+        legacy_summaries=legacy_rows,
+        trusted_shadow_metadata=_shadow(probes),
+    )
+
+
+def _shadow(probes, allowed_domains=None):
+    if allowed_domains is None:
+        allowed_domains = {probe.domain for probe in probes}
+    return V31TrustedProductionShadowConsumption().inspect(
+        enabled=True,
+        trusted_repository_probes=probes,
+        allowed_domains=allowed_domains,
+    )
+
+
+def _legacy(comparison_id, status, value):
+    return {
+        "comparison_id": comparison_id,
+        "legacy_status": status,
+        "comparable_value": value,
+        "production_output": True,
+    }
+
+
+def _probe(domain, name, count):
+    return TrustedRepositoryProbe(
+        domain=domain,
+        repository_name=name,
+        count_loader=lambda: count,
+        metadata_loader=lambda: {"entity_count": count, "source_path": f"fixture:{name}"},
+    )
+
+
+def _unavailable_probe(domain, name):
+    def _raise():
+        raise FileNotFoundError(f"{name} unavailable")
+
+    return TrustedRepositoryProbe(
+        domain=domain,
+        repository_name=name,
+        count_loader=_raise,
+        metadata_loader=_raise,
+    )
+
+
+def _trusted_metadata(rows):
+    return {
+        "gate": {
+            "enabled": True,
+            "mode": "shadow",
+            "shadow_only": True,
+            "production_truth_source": "legacy",
+            "production_output_affected": False,
+        },
+        "trusted_repository_rows": rows,
+    }
+
+
+def _trusted_row(domain, routing_status, count, blocked_reasons=None):
+    return {
+        "domain": domain,
+        "repository_name": f"{domain}_repo",
+        "routing_status": routing_status,
+        "trusted_repository_available": routing_status == "trusted_repository_shadowed",
+        "trusted_entity_count": count,
+        "blocked_reasons": blocked_reasons or [],
+        "production_output_affected": False,
+    }

--- a/docs/generated/v3_1_dual_run_comparison_report.json
+++ b/docs/generated/v3_1_dual_run_comparison_report.json
@@ -1,0 +1,229 @@
+{
+  "comparison": {
+    "comparison_results": [
+      {
+        "comparison_id": "affix",
+        "deterministic_notes": [
+          "comparison rows sorted by stable key",
+          "comparable values hashed through sorted JSON serialization",
+          "production output is not mutated or replaced"
+        ],
+        "drift_classification": "equivalent",
+        "legacy_hash": "640cf0924ea88a86b5d8eeff3f7d3b68aa94b66f91cee4739d150acb7c35570a",
+        "legacy_status": "available",
+        "production_output_affected": false,
+        "reason_codes": [
+          "comparable_value_hash_match"
+        ],
+        "stable_key": "affix",
+        "trusted_hash": "640cf0924ea88a86b5d8eeff3f7d3b68aa94b66f91cee4739d150acb7c35570a",
+        "trusted_shadow_gate": {
+          "enabled": true,
+          "mode": "shadow",
+          "shadow_only": true
+        },
+        "trusted_shadow_status": "available",
+        "unsupported_or_blocked_reason": null
+      },
+      {
+        "comparison_id": "idol",
+        "deterministic_notes": [
+          "comparison rows sorted by stable key",
+          "comparable values hashed through sorted JSON serialization",
+          "production output is not mutated or replaced"
+        ],
+        "drift_classification": "legacy_only",
+        "legacy_hash": "dd6f78504144c7e111632e74d742da8c30376ed16c4b6dda8ccd29226bb2191b",
+        "legacy_status": "available",
+        "production_output_affected": false,
+        "reason_codes": [
+          "trusted_shadow_summary_missing"
+        ],
+        "stable_key": "idol",
+        "trusted_hash": null,
+        "trusted_shadow_gate": {
+          "enabled": true,
+          "mode": "shadow",
+          "shadow_only": true
+        },
+        "trusted_shadow_status": "missing",
+        "unsupported_or_blocked_reason": "trusted_shadow_summary_missing"
+      },
+      {
+        "comparison_id": "item_base",
+        "deterministic_notes": [
+          "comparison rows sorted by stable key",
+          "comparable values hashed through sorted JSON serialization",
+          "production output is not mutated or replaced"
+        ],
+        "drift_classification": "divergent",
+        "legacy_hash": "b032e547417db66eacea1c5124714787ab2c3c6319f550f55317408fd7950d5c",
+        "legacy_status": "available",
+        "production_output_affected": false,
+        "reason_codes": [
+          "comparable_value_hash_mismatch"
+        ],
+        "stable_key": "item_base",
+        "trusted_hash": "8750aa1eacbe174b9d0c257d37220cfdaaffcc8b2e32618541873851c3da6113",
+        "trusted_shadow_gate": {
+          "enabled": true,
+          "mode": "shadow",
+          "shadow_only": true
+        },
+        "trusted_shadow_status": "available",
+        "unsupported_or_blocked_reason": null
+      },
+      {
+        "comparison_id": "monolith_echo",
+        "deterministic_notes": [
+          "comparison rows sorted by stable key",
+          "comparable values hashed through sorted JSON serialization",
+          "production output is not mutated or replaced"
+        ],
+        "drift_classification": "unsupported",
+        "legacy_hash": null,
+        "legacy_status": "missing",
+        "production_output_affected": false,
+        "reason_codes": [
+          "unsupported_state_visible"
+        ],
+        "stable_key": "monolith_echo",
+        "trusted_hash": "23d7b286bd429460b92a2a1c21b6afc34110446c5034c17363fda363aa0a7c5d",
+        "trusted_shadow_gate": {
+          "enabled": true,
+          "mode": "shadow",
+          "shadow_only": true
+        },
+        "trusted_shadow_status": "unsupported",
+        "unsupported_or_blocked_reason": "unsupported_trusted_shadow_domain"
+      },
+      {
+        "comparison_id": "passive_skill",
+        "deterministic_notes": [
+          "comparison rows sorted by stable key",
+          "comparable values hashed through sorted JSON serialization",
+          "production output is not mutated or replaced"
+        ],
+        "drift_classification": "unsupported",
+        "legacy_hash": "1c197daef20de3f47eec5e2f735ec6669869d3180cc29f35be4788511e0af0f8",
+        "legacy_status": "unsupported",
+        "production_output_affected": false,
+        "reason_codes": [
+          "unsupported_state_visible"
+        ],
+        "stable_key": "passive_skill",
+        "trusted_hash": "36060134d807a85bd4de45d03754fc36d6f73b2349587345f0f71b5548caeaee",
+        "trusted_shadow_gate": {
+          "enabled": true,
+          "mode": "shadow",
+          "shadow_only": true
+        },
+        "trusted_shadow_status": "available",
+        "unsupported_or_blocked_reason": "unsupported_state_visible"
+      }
+    ],
+    "deterministic_hash": "7f2b7416d55dca68e92d5a5ecd519ddfd7654ae25c458b3dff4eb586ff5ba363",
+    "drift_classification_counts": {
+      "blocked": 0,
+      "divergent": 1,
+      "equivalent": 1,
+      "legacy_only": 1,
+      "not_evaluated": 0,
+      "trusted_only": 0,
+      "unavailable": 0,
+      "unsupported": 2
+    },
+    "generated_at": "2026-05-15T00:00:00+00:00",
+    "metadata": {
+      "deterministic_serializer": "json_sort_keys_sha256",
+      "observational_only": true,
+      "planner_remap_performed": false,
+      "production_behavior_changed": false,
+      "production_consumer": false,
+      "production_default_routing_authorized": false,
+      "source": "v3_1_dual_run_comparison"
+    },
+    "run": {
+      "comparison_count": 5,
+      "legacy_summary_count": 4,
+      "run_id": "v3_1_phase_2_dual_run_comparison",
+      "trusted_summary_count": 4
+    },
+    "safety_confirmations": {
+      "legacy_output_replaced": false,
+      "production_behavior_changed": false,
+      "production_output_affected": false,
+      "runtime_state_mutated": false,
+      "silent_missing_legacy_accepted": false,
+      "silent_missing_trusted_accepted": false,
+      "trusted_data_default_truth": false,
+      "unsupported_states_hidden": false
+    },
+    "schema_version": "v3_1.dual_run_comparison.1",
+    "summary": {
+      "blocked_count": 0,
+      "deterministic": true,
+      "divergent_count": 1,
+      "equivalent_count": 1,
+      "legacy_only_count": 1,
+      "not_evaluated_count": 0,
+      "production_affected_count": 0,
+      "production_behavior_changed": false,
+      "production_output_affected": false,
+      "total_comparisons": 5,
+      "trusted_data_default_truth": false,
+      "trusted_only_count": 0,
+      "unavailable_count": 0,
+      "unsupported_count": 2
+    },
+    "trusted_shadow_gate": {
+      "enabled": true,
+      "mode": "shadow",
+      "production_output_affected": false,
+      "production_truth_source": "legacy",
+      "shadow_only": true
+    }
+  },
+  "deterministic_guarantees": {
+    "json_sort_keys": true,
+    "passed": true,
+    "repeated_hash": "7f2b7416d55dca68e92d5a5ecd519ddfd7654ae25c458b3dff4eb586ff5ba363",
+    "sample_hash": "7f2b7416d55dca68e92d5a5ecd519ddfd7654ae25c458b3dff4eb586ff5ba363",
+    "timestamp_excluded_from_hash": true
+  },
+  "generated_at": "2026-05-15T00:00:00+00:00",
+  "metadata": {
+    "observational_only": true,
+    "planner_remap_performed": false,
+    "production_behavior_changed": false,
+    "production_default_routing_authorized": false,
+    "source": "v3_1_dual_run_comparison_report"
+  },
+  "phase": "v3.1_phase_2_deterministic_dual_run_comparison",
+  "phase_2_boundaries": [
+    "dual-run comparison accepts summaries and shadow metadata only",
+    "legacy production output remains the truth source",
+    "trusted data is not default production truth",
+    "drift visibility is established through explicit classifications",
+    "unsupported and blocked states are intentionally surfaced"
+  ],
+  "production_default_routing_authorized": false,
+  "recommendation": "OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING",
+  "schema_version": "v3_1.dual_run_comparison_report.1",
+  "summary": {
+    "blocked_count": 0,
+    "deterministic": true,
+    "divergent_count": 1,
+    "equivalent_count": 1,
+    "legacy_only_count": 1,
+    "not_evaluated_count": 0,
+    "production_affected_count": 0,
+    "production_behavior_changed": false,
+    "production_output_affected": false,
+    "total_comparisons": 5,
+    "trusted_data_default_truth": false,
+    "trusted_only_count": 0,
+    "unavailable_count": 0,
+    "unsupported_count": 2
+  }
+}

--- a/docs/migration/V3_1_DUAL_RUN_COMPARISON.md
+++ b/docs/migration/V3_1_DUAL_RUN_COMPARISON.md
@@ -1,0 +1,45 @@
+# V3.1 Dual-Run Comparison
+
+Phase 2 introduces deterministic dual-run comparison infrastructure around the trusted shadow layer.
+It is observational only; production output remains legacy-owned and trusted data is not default production truth.
+
+## Recommendation
+
+- Recommendation: `OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING`
+- Production default routing authorized: `false`
+
+## Summary
+
+- Total comparisons: `5`
+- Equivalent: `1`
+- Divergent: `1`
+- Unsupported: `2`
+- Blocked: `0`
+- Legacy only: `1`
+- Trusted only: `0`
+- Unavailable: `0`
+- Not evaluated: `0`
+- Production affected: `0`
+- Deterministic: `true`
+
+## Drift Results
+
+| Comparison | Legacy | Trusted Shadow | Classification | Reason |
+| --- | --- | --- | --- | --- |
+| `affix` | `available` | `available` | `equivalent` | `comparable_value_hash_match` |
+| `idol` | `available` | `missing` | `legacy_only` | `trusted_shadow_summary_missing` |
+| `item_base` | `available` | `available` | `divergent` | `comparable_value_hash_mismatch` |
+| `monolith_echo` | `missing` | `unsupported` | `unsupported` | `unsupported_trusted_shadow_domain` |
+| `passive_skill` | `unsupported` | `available` | `unsupported` | `unsupported_state_visible` |
+
+## Phase 2 Boundaries
+
+- dual-run comparison accepts summaries and shadow metadata only
+- legacy production output remains the truth source
+- trusted data is not default production truth
+- drift visibility is established through explicit classifications
+- unsupported and blocked states are intentionally surfaced
+
+## Conclusion
+
+Dual-run drift visibility is now available, but production routing remains unchanged and legacy-owned.


### PR DESCRIPTION
Adds deterministic v3.1 dual-run comparison infrastructure for observational drift visibility between legacy production behavior and trusted shadow metadata.

Production behavior remains unchanged. Legacy remains production truth, trusted data is not default-routed, and production_output_affected remains false.

Validation:
- test_v3_1_dual_run_comparison.py -> 12 passed
- test_v3_1_trusted_shadow_consumption.py -> 8 passed
- v3 production gate / adapter / non-consumption tests -> 20 passed
- py_compile passed
- report script run twice with stable JSON and markdown hashes