### PR TITLE
v3.1: add planner snapshot baseline comparison infrastructure

### DIFF
--- a/backend/app/planner_adapters/v3_1/__init__.py
+++ b/backend/app/planner_adapters/v3_1/__init__.py
@@ -5,6 +5,11 @@ from .dual_run_comparison import (
     V31DualRunComparison,
     build_sample_dual_run_inputs,
 )
+from .planner_snapshot_baselines import (
+    BASELINE_READINESS_CLASSIFICATIONS,
+    V31PlannerSnapshotBaselines,
+    build_sample_planner_snapshot_baseline_inputs,
+)
 from .trusted_shadow_consumption import (
     SUPPORTED_TRUSTED_SHADOW_DOMAINS,
     V31TrustedProductionShadowConsumption,
@@ -14,9 +19,12 @@ from .trusted_shadow_consumption import (
 
 __all__ = [
     "DRIFT_CLASSIFICATIONS",
+    "BASELINE_READINESS_CLASSIFICATIONS",
     "SUPPORTED_TRUSTED_SHADOW_DOMAINS",
     "V31DualRunComparison",
+    "V31PlannerSnapshotBaselines",
     "V31TrustedProductionShadowConsumption",
+    "build_sample_planner_snapshot_baseline_inputs",
     "build_sample_dual_run_inputs",
     "build_default_trusted_repository_probes",
     "deterministic_hash",

--- a/backend/app/planner_adapters/v3_1/planner_snapshot_baselines.py
+++ b/backend/app/planner_adapters/v3_1/planner_snapshot_baselines.py
@@ -1,0 +1,202 @@
+"""Deterministic planner-adjacent snapshot baseline infrastructure.
+
+Snapshots are migration-readiness artifacts derived from dual-run comparison
+metadata. They do not call planner/runtime code and cannot change production
+ownership.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from copy import deepcopy
+from datetime import UTC, datetime
+from typing import Any
+
+from .dual_run_comparison import V31DualRunComparison, build_sample_dual_run_inputs
+from .trusted_shadow_consumption import deterministic_hash
+
+
+BASELINE_READINESS_CLASSIFICATIONS = (
+    "baseline_candidate",
+    "comparison_ready",
+    "unsupported",
+    "blocked",
+    "insufficient_data",
+    "legacy_only",
+    "shadow_only",
+)
+STABLE_GENERATION_TOKEN = "v3_1_phase_3_planner_snapshot_baseline_token"
+
+
+class V31PlannerSnapshotBaselines:
+    """Build deterministic baseline candidate snapshots from dual-run output."""
+
+    def build(
+        self,
+        *,
+        dual_run_comparison: dict[str, Any],
+        snapshot_category: str = "planner_adjacent_summary",
+        run_id: str = "v3_1_phase_3_planner_snapshot_baselines",
+    ) -> dict[str, Any]:
+        comparison_rows = list(dual_run_comparison.get("comparison_results") or [])
+        snapshots = [
+            _snapshot_from_comparison(
+                row=row,
+                snapshot_category=snapshot_category,
+                dual_run_gate=dual_run_comparison.get("trusted_shadow_gate") or {},
+            )
+            for row in sorted(comparison_rows, key=lambda item: str(item.get("stable_key") or item.get("comparison_id") or ""))
+        ]
+        counts = Counter(snapshot["baseline_readiness"] for snapshot in snapshots)
+        production_affected_count = sum(1 for snapshot in snapshots if snapshot["production_output_affected"])
+        envelope = {
+            "schema_version": "v3_1.planner_snapshot_baselines.1",
+            "generated_at": datetime.now(UTC).isoformat(),
+            "run": {
+                "run_id": run_id,
+                "snapshot_category": snapshot_category,
+                "source_dual_run_schema": dual_run_comparison.get("schema_version"),
+                "source_dual_run_hash": dual_run_comparison.get("deterministic_hash"),
+                "snapshot_count": len(snapshots),
+            },
+            "summary": {
+                "total_snapshots": len(snapshots),
+                "baseline_candidate_count": counts["baseline_candidate"],
+                "comparison_ready_count": counts["comparison_ready"],
+                "unsupported_count": counts["unsupported"],
+                "blocked_count": counts["blocked"],
+                "insufficient_data_count": counts["insufficient_data"],
+                "legacy_only_count": counts["legacy_only"],
+                "shadow_only_count": counts["shadow_only"],
+                "production_affected_count": production_affected_count,
+                "production_output_affected": False,
+                "production_behavior_changed": False,
+                "trusted_data_default_truth": False,
+                "deterministic": True,
+            },
+            "baseline_readiness_counts": {
+                category: counts[category]
+                for category in BASELINE_READINESS_CLASSIFICATIONS
+            },
+            "snapshots": snapshots,
+            "safety_confirmations": {
+                "production_output_affected": False,
+                "production_behavior_changed": False,
+                "trusted_data_default_truth": False,
+                "legacy_planner_ownership_preserved": True,
+                "planner_output_replaced": False,
+                "runtime_state_mutated": False,
+                "unsupported_states_hidden": False,
+                "blocked_states_hidden": False,
+                "automatic_drift_acceptance": False,
+            },
+            "metadata": {
+                "source": "v3_1_planner_snapshot_baselines",
+                "observational_only": True,
+                "production_consumer": False,
+                "production_behavior_changed": False,
+                "planner_remap_performed": False,
+                "production_default_routing_authorized": False,
+                "stable_generation_token": STABLE_GENERATION_TOKEN,
+                "deterministic_serializer": "json_sort_keys_sha256",
+            },
+        }
+        envelope["deterministic_hash"] = deterministic_hash(_stable_envelope(envelope))
+        return envelope
+
+
+def build_sample_planner_snapshot_baseline_inputs() -> dict[str, Any]:
+    legacy, trusted_shadow = build_sample_dual_run_inputs()
+    return V31DualRunComparison().compare(
+        legacy_summaries=legacy,
+        trusted_shadow_metadata=trusted_shadow,
+        run_id="v3_1_phase_3_dual_run_snapshot_sample",
+    )
+
+
+def _snapshot_from_comparison(
+    *,
+    row: dict[str, Any],
+    snapshot_category: str,
+    dual_run_gate: dict[str, Any],
+) -> dict[str, Any]:
+    comparison_id = str(row.get("stable_key") or row.get("comparison_id"))
+    baseline_readiness, reason_codes = _baseline_readiness(row)
+    unsupported = baseline_readiness == "unsupported"
+    blocked = baseline_readiness == "blocked"
+    eligible = baseline_readiness in {"baseline_candidate", "comparison_ready"}
+    snapshot_seed = {
+        "comparison_id": comparison_id,
+        "snapshot_category": snapshot_category,
+        "generation_token": STABLE_GENERATION_TOKEN,
+    }
+    return {
+        "snapshot_id": f"v3_1_snapshot_{deterministic_hash(snapshot_seed)[:16]}",
+        "stable_key": comparison_id,
+        "snapshot_category": snapshot_category,
+        "planner_source_ownership": {
+            "owner": "legacy",
+            "legacy_controlled": True,
+            "trusted_default_routing": False,
+        },
+        "trusted_shadow_participation": {
+            "gate_enabled": bool((row.get("trusted_shadow_gate") or dual_run_gate).get("enabled", False)),
+            "gate_mode": str((row.get("trusted_shadow_gate") or dual_run_gate).get("mode", "unknown")),
+            "shadow_only": bool((row.get("trusted_shadow_gate") or dual_run_gate).get("shadow_only", True)),
+            "trusted_shadow_status": row.get("trusted_shadow_status"),
+        },
+        "dual_run_comparison_state": {
+            "comparison_id": row.get("comparison_id"),
+            "legacy_status": row.get("legacy_status"),
+            "trusted_shadow_status": row.get("trusted_shadow_status"),
+            "drift_classification": row.get("drift_classification"),
+            "reason_codes": list(row.get("reason_codes") or []),
+            "legacy_hash": row.get("legacy_hash"),
+            "trusted_hash": row.get("trusted_hash"),
+        },
+        "generation": {
+            "strategy": "stable_token_and_sorted_json_hash",
+            "token": STABLE_GENERATION_TOKEN,
+            "timestamp_strategy": "report_level_deterministic_token",
+        },
+        "unsupported": unsupported,
+        "blocked": blocked,
+        "unsupported_or_blocked_reason": row.get("unsupported_or_blocked_reason"),
+        "production_output_affected": False,
+        "comparison_eligible": eligible,
+        "baseline_candidate": baseline_readiness == "baseline_candidate",
+        "baseline_readiness": baseline_readiness,
+        "reason_codes": reason_codes,
+        "metadata": {
+            "observational_only": True,
+            "production_consumer": False,
+            "production_behavior_changed": False,
+            "planner_remap_performed": False,
+        },
+    }
+
+
+def _baseline_readiness(row: dict[str, Any]) -> tuple[str, list[str]]:
+    drift = str(row.get("drift_classification"))
+    if drift == "equivalent":
+        return "baseline_candidate", ["dual_run_equivalent"]
+    if drift == "divergent":
+        return "comparison_ready", ["dual_run_divergent_requires_review"]
+    if drift == "unsupported":
+        return "unsupported", ["unsupported_state_visible"]
+    if drift == "blocked":
+        return "blocked", ["blocked_state_visible"]
+    if drift in {"unavailable", "not_evaluated"}:
+        return "insufficient_data", [f"dual_run_{drift}"]
+    if drift == "legacy_only":
+        return "legacy_only", ["trusted_shadow_missing"]
+    if drift == "trusted_only":
+        return "shadow_only", ["legacy_summary_missing"]
+    return "insufficient_data", ["unknown_dual_run_classification"]
+
+
+def _stable_envelope(envelope: dict[str, Any]) -> dict[str, Any]:
+    stable = deepcopy(envelope)
+    stable.pop("generated_at", None)
+    stable.pop("deterministic_hash", None)
+    return stable

--- a/backend/scripts/report_v3_1_planner_snapshot_baselines.py
+++ b/backend/scripts/report_v3_1_planner_snapshot_baselines.py
@@ -1,0 +1,149 @@
+"""Generate the v3.1 planner snapshot baseline report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.planner_adapters.v3_1.planner_snapshot_baselines import (  # noqa: E402
+    V31PlannerSnapshotBaselines,
+    build_sample_planner_snapshot_baseline_inputs,
+)
+
+
+DETERMINISTIC_GENERATED_AT = "2026-05-15T00:00:00+00:00"
+
+
+def build_v3_1_planner_snapshot_baselines_report() -> dict[str, Any]:
+    dual_run = build_sample_planner_snapshot_baseline_inputs()
+    baselines = V31PlannerSnapshotBaselines().build(dual_run_comparison=dual_run)
+    repeated = V31PlannerSnapshotBaselines().build(dual_run_comparison=dual_run)
+    deterministic = baselines["deterministic_hash"] == repeated["deterministic_hash"]
+    report = {
+        "schema_version": "v3_1.planner_snapshot_baselines_report.1",
+        "generated_at": DETERMINISTIC_GENERATED_AT,
+        "phase": "v3.1_phase_3_planner_snapshot_baseline_infrastructure",
+        "recommendation": "OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING",
+        "production_default_routing_authorized": False,
+        "summary": {
+            **baselines["summary"],
+            "deterministic": deterministic,
+        },
+        "planner_snapshot_baselines": baselines,
+        "deterministic_guarantees": {
+            "passed": deterministic,
+            "sample_hash": baselines["deterministic_hash"],
+            "repeated_hash": repeated["deterministic_hash"],
+            "timestamp_excluded_from_hash": True,
+            "json_sort_keys": True,
+            "stable_generation_token": baselines["metadata"]["stable_generation_token"],
+        },
+        "phase_3_boundaries": [
+            "snapshots are observational migration-readiness artifacts",
+            "trusted infrastructure is still not production default",
+            "baselines support parity, drift, and regression evaluation only",
+            "unsupported and blocked states remain intentionally visible",
+            "planner ownership remains legacy-controlled",
+        ],
+        "metadata": {
+            "source": "v3_1_planner_snapshot_baselines_report",
+            "observational_only": True,
+            "production_behavior_changed": False,
+            "production_default_routing_authorized": False,
+            "planner_remap_performed": False,
+        },
+    }
+    return _normalize_generated_at(report)
+
+
+def write_report(report: dict[str, Any], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_markdown(report: dict[str, Any], output_path: Path) -> None:
+    summary = report["summary"]
+    lines = [
+        "# V3.1 Planner Snapshot Baselines",
+        "",
+        "Phase 3 introduces deterministic planner-adjacent snapshot baseline infrastructure.",
+        "Snapshots are observational migration-readiness artifacts; production output remains legacy-owned.",
+        "",
+        "## Recommendation",
+        "",
+        f"- Recommendation: `{report['recommendation']}`",
+        f"- Production default routing authorized: `{str(report['production_default_routing_authorized']).lower()}`",
+        "",
+        "## Summary",
+        "",
+        f"- Total snapshots: `{summary['total_snapshots']}`",
+        f"- Baseline candidates: `{summary['baseline_candidate_count']}`",
+        f"- Comparison ready: `{summary['comparison_ready_count']}`",
+        f"- Unsupported: `{summary['unsupported_count']}`",
+        f"- Blocked: `{summary['blocked_count']}`",
+        f"- Insufficient data: `{summary['insufficient_data_count']}`",
+        f"- Legacy only: `{summary['legacy_only_count']}`",
+        f"- Shadow only: `{summary['shadow_only_count']}`",
+        f"- Production affected: `{summary['production_affected_count']}`",
+        f"- Deterministic: `{str(summary['deterministic']).lower()}`",
+        "",
+        "## Snapshot Results",
+        "",
+        "| Snapshot | Key | Drift | Baseline Readiness | Eligible |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    for snapshot in report["planner_snapshot_baselines"]["snapshots"]:
+        drift = snapshot["dual_run_comparison_state"]["drift_classification"]
+        lines.append(
+            f"| `{snapshot['snapshot_id']}` | `{snapshot['stable_key']}` | `{drift}` | `{snapshot['baseline_readiness']}` | `{str(snapshot['comparison_eligible']).lower()}` |"
+        )
+    lines.extend(["", "## Phase 3 Boundaries", ""])
+    lines.extend(f"- {item}" for item in report["phase_3_boundaries"])
+    lines.extend(
+        [
+            "",
+            "## Conclusion",
+            "",
+            "Planner snapshot baselines are available for migration readiness review, but planner ownership and production routing remain unchanged.",
+        ]
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _normalize_generated_at(value: Any) -> Any:
+    if isinstance(value, dict):
+        normalized = {}
+        for key, item in value.items():
+            normalized[key] = DETERMINISTIC_GENERATED_AT if key == "generated_at" else _normalize_generated_at(item)
+        return normalized
+    if isinstance(value, list):
+        return [_normalize_generated_at(item) for item in value]
+    return deepcopy(value)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", default="docs/generated/v3_1_planner_snapshot_baselines_report.json")
+    parser.add_argument("--markdown-output", default="docs/migration/V3_1_PLANNER_SNAPSHOT_BASELINES.md")
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[2]
+    report = build_v3_1_planner_snapshot_baselines_report()
+    write_report(report, repo_root / args.output)
+    write_markdown(report, repo_root / args.markdown_output)
+    print(json.dumps(report["summary"], indent=2, sort_keys=True))
+    print(report["recommendation"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_v3_1_planner_snapshot_baselines.py
+++ b/backend/tests/test_v3_1_planner_snapshot_baselines.py
@@ -1,0 +1,194 @@
+import json
+
+from app.planner_adapters.v3_1.dual_run_comparison import V31DualRunComparison
+from app.planner_adapters.v3_1.planner_snapshot_baselines import (
+    V31PlannerSnapshotBaselines,
+)
+from scripts.report_v3_1_planner_snapshot_baselines import (
+    build_v3_1_planner_snapshot_baselines_report,
+    write_report,
+)
+
+
+def test_snapshot_generation_is_deterministic():
+    dual_run = _dual_run([_comparison("affix", "equivalent")])
+
+    first = V31PlannerSnapshotBaselines().build(dual_run_comparison=dual_run)
+    second = V31PlannerSnapshotBaselines().build(dual_run_comparison=dual_run)
+
+    assert first["deterministic_hash"] == second["deterministic_hash"]
+    assert first["summary"]["deterministic"] is True
+
+
+def test_stable_snapshot_ids_remain_stable():
+    dual_run = _dual_run([_comparison("affix", "equivalent")])
+
+    first = V31PlannerSnapshotBaselines().build(dual_run_comparison=dual_run)
+    second = V31PlannerSnapshotBaselines().build(dual_run_comparison=dual_run)
+
+    assert first["snapshots"][0]["snapshot_id"] == second["snapshots"][0]["snapshot_id"]
+    assert first["snapshots"][0]["snapshot_id"].startswith("v3_1_snapshot_")
+
+
+def test_baseline_classifications_are_deterministic():
+    baselines = V31PlannerSnapshotBaselines().build(
+        dual_run_comparison=_dual_run(
+            [
+                _comparison("affix", "equivalent"),
+                _comparison("item_base", "divergent"),
+                _comparison("legacy_only", "legacy_only"),
+                _comparison("shadow_only", "trusted_only"),
+            ]
+        )
+    )
+    observed = {snapshot["stable_key"]: snapshot["baseline_readiness"] for snapshot in baselines["snapshots"]}
+
+    assert observed["affix"] == "baseline_candidate"
+    assert observed["item_base"] == "comparison_ready"
+    assert observed["legacy_only"] == "legacy_only"
+    assert observed["shadow_only"] == "shadow_only"
+
+
+def test_unsupported_states_remain_visible():
+    snapshot = _single_snapshot("passive_skill", "unsupported")
+
+    assert snapshot["baseline_readiness"] == "unsupported"
+    assert snapshot["unsupported"] is True
+    assert snapshot["comparison_eligible"] is False
+    assert "unsupported_state_visible" in snapshot["reason_codes"]
+
+
+def test_blocked_states_remain_visible():
+    snapshot = _single_snapshot("affix", "blocked", reason="blocked_for_test")
+
+    assert snapshot["baseline_readiness"] == "blocked"
+    assert snapshot["blocked"] is True
+    assert snapshot["unsupported_or_blocked_reason"] == "blocked_for_test"
+    assert snapshot["comparison_eligible"] is False
+
+
+def test_insufficient_data_states_remain_visible():
+    unavailable = _single_snapshot("affix", "unavailable")
+    not_evaluated = _single_snapshot("item_base", "not_evaluated")
+
+    assert unavailable["baseline_readiness"] == "insufficient_data"
+    assert not_evaluated["baseline_readiness"] == "insufficient_data"
+    assert unavailable["comparison_eligible"] is False
+    assert not_evaluated["comparison_eligible"] is False
+
+
+def test_aggregate_counts_are_correct():
+    baselines = V31PlannerSnapshotBaselines().build(
+        dual_run_comparison=_dual_run(
+            [
+                _comparison("baseline", "equivalent"),
+                _comparison("comparison", "divergent"),
+                _comparison("unsupported", "unsupported"),
+                _comparison("blocked", "blocked"),
+                _comparison("unavailable", "unavailable"),
+                _comparison("legacy_only", "legacy_only"),
+                _comparison("shadow_only", "trusted_only"),
+            ]
+        )
+    )
+
+    assert baselines["summary"]["total_snapshots"] == 7
+    assert baselines["summary"]["baseline_candidate_count"] == 1
+    assert baselines["summary"]["comparison_ready_count"] == 1
+    assert baselines["summary"]["unsupported_count"] == 1
+    assert baselines["summary"]["blocked_count"] == 1
+    assert baselines["summary"]["insufficient_data_count"] == 1
+    assert baselines["summary"]["legacy_only_count"] == 1
+    assert baselines["summary"]["shadow_only_count"] == 1
+    assert baselines["summary"]["production_affected_count"] == 0
+
+
+def test_production_output_affected_remains_false():
+    baselines = V31PlannerSnapshotBaselines().build(
+        dual_run_comparison=_dual_run([_comparison("affix", "equivalent")])
+    )
+
+    assert baselines["summary"]["production_output_affected"] is False
+    assert baselines["summary"]["production_affected_count"] == 0
+    assert baselines["safety_confirmations"]["legacy_planner_ownership_preserved"] is True
+    assert all(snapshot["production_output_affected"] is False for snapshot in baselines["snapshots"])
+
+
+def test_phase_2_compatibility_is_preserved():
+    dual_run = V31DualRunComparison().compare(
+        legacy_summaries=[
+            {"comparison_id": "affix", "legacy_status": "available", "comparable_value": 2},
+        ],
+        trusted_shadow_metadata={
+            "gate": {"enabled": True, "mode": "shadow", "shadow_only": True},
+            "trusted_repository_rows": [
+                {
+                    "domain": "affix",
+                    "repository_name": "trusted_affix",
+                    "routing_status": "trusted_repository_shadowed",
+                    "trusted_entity_count": 2,
+                    "blocked_reasons": [],
+                    "production_output_affected": False,
+                }
+            ],
+        },
+    )
+    baselines = V31PlannerSnapshotBaselines().build(dual_run_comparison=dual_run)
+
+    assert baselines["run"]["source_dual_run_hash"] == dual_run["deterministic_hash"]
+    assert baselines["snapshots"][0]["dual_run_comparison_state"]["drift_classification"] == "equivalent"
+    assert baselines["snapshots"][0]["baseline_readiness"] == "baseline_candidate"
+
+
+def test_report_generation_is_deterministic(tmp_path):
+    first = build_v3_1_planner_snapshot_baselines_report()
+    second = build_v3_1_planner_snapshot_baselines_report()
+
+    assert first["deterministic_guarantees"]["passed"] is True
+    assert first["planner_snapshot_baselines"]["deterministic_hash"] == second["planner_snapshot_baselines"]["deterministic_hash"]
+    assert first["summary"] == second["summary"]
+
+    output = tmp_path / "snapshot_baselines.json"
+    write_report(first, output)
+    loaded = json.loads(output.read_text(encoding="utf-8"))
+    assert loaded["schema_version"] == "v3_1.planner_snapshot_baselines_report.1"
+    assert loaded["production_default_routing_authorized"] is False
+    assert loaded["metadata"]["observational_only"] is True
+
+
+def _single_snapshot(stable_key, drift, reason=None):
+    baselines = V31PlannerSnapshotBaselines().build(
+        dual_run_comparison=_dual_run([_comparison(stable_key, drift, reason=reason)])
+    )
+    return baselines["snapshots"][0]
+
+
+def _dual_run(rows):
+    return {
+        "schema_version": "v3_1.dual_run_comparison.1",
+        "deterministic_hash": "fixture-dual-run-hash",
+        "trusted_shadow_gate": {
+            "enabled": True,
+            "mode": "shadow",
+            "shadow_only": True,
+            "production_truth_source": "legacy",
+            "production_output_affected": False,
+        },
+        "comparison_results": rows,
+    }
+
+
+def _comparison(stable_key, drift, reason=None):
+    return {
+        "comparison_id": stable_key,
+        "stable_key": stable_key,
+        "legacy_status": "available",
+        "trusted_shadow_status": "available",
+        "drift_classification": drift,
+        "production_output_affected": False,
+        "trusted_shadow_gate": {"enabled": True, "mode": "shadow", "shadow_only": True},
+        "unsupported_or_blocked_reason": reason,
+        "reason_codes": [f"{drift}_fixture"],
+        "legacy_hash": f"legacy:{stable_key}",
+        "trusted_hash": f"trusted:{stable_key}",
+    }

--- a/docs/generated/v3_1_planner_snapshot_baselines_report.json
+++ b/docs/generated/v3_1_planner_snapshot_baselines_report.json
@@ -1,0 +1,343 @@
+{
+  "deterministic_guarantees": {
+    "json_sort_keys": true,
+    "passed": true,
+    "repeated_hash": "5b7a5ff8a33eb491d345ecf660fdd933e422e4aab475f835b6ab82d9c9097398",
+    "sample_hash": "5b7a5ff8a33eb491d345ecf660fdd933e422e4aab475f835b6ab82d9c9097398",
+    "stable_generation_token": "v3_1_phase_3_planner_snapshot_baseline_token",
+    "timestamp_excluded_from_hash": true
+  },
+  "generated_at": "2026-05-15T00:00:00+00:00",
+  "metadata": {
+    "observational_only": true,
+    "planner_remap_performed": false,
+    "production_behavior_changed": false,
+    "production_default_routing_authorized": false,
+    "source": "v3_1_planner_snapshot_baselines_report"
+  },
+  "phase": "v3.1_phase_3_planner_snapshot_baseline_infrastructure",
+  "phase_3_boundaries": [
+    "snapshots are observational migration-readiness artifacts",
+    "trusted infrastructure is still not production default",
+    "baselines support parity, drift, and regression evaluation only",
+    "unsupported and blocked states remain intentionally visible",
+    "planner ownership remains legacy-controlled"
+  ],
+  "planner_snapshot_baselines": {
+    "baseline_readiness_counts": {
+      "baseline_candidate": 1,
+      "blocked": 0,
+      "comparison_ready": 1,
+      "insufficient_data": 0,
+      "legacy_only": 1,
+      "shadow_only": 0,
+      "unsupported": 2
+    },
+    "deterministic_hash": "5b7a5ff8a33eb491d345ecf660fdd933e422e4aab475f835b6ab82d9c9097398",
+    "generated_at": "2026-05-15T00:00:00+00:00",
+    "metadata": {
+      "deterministic_serializer": "json_sort_keys_sha256",
+      "observational_only": true,
+      "planner_remap_performed": false,
+      "production_behavior_changed": false,
+      "production_consumer": false,
+      "production_default_routing_authorized": false,
+      "source": "v3_1_planner_snapshot_baselines",
+      "stable_generation_token": "v3_1_phase_3_planner_snapshot_baseline_token"
+    },
+    "run": {
+      "run_id": "v3_1_phase_3_planner_snapshot_baselines",
+      "snapshot_category": "planner_adjacent_summary",
+      "snapshot_count": 5,
+      "source_dual_run_hash": "8f2034315b7090f7b3354b393e65ed6e3ebeb03b6c0919a9fd3ca18f9ee536b1",
+      "source_dual_run_schema": "v3_1.dual_run_comparison.1"
+    },
+    "safety_confirmations": {
+      "automatic_drift_acceptance": false,
+      "blocked_states_hidden": false,
+      "legacy_planner_ownership_preserved": true,
+      "planner_output_replaced": false,
+      "production_behavior_changed": false,
+      "production_output_affected": false,
+      "runtime_state_mutated": false,
+      "trusted_data_default_truth": false,
+      "unsupported_states_hidden": false
+    },
+    "schema_version": "v3_1.planner_snapshot_baselines.1",
+    "snapshots": [
+      {
+        "baseline_candidate": true,
+        "baseline_readiness": "baseline_candidate",
+        "blocked": false,
+        "comparison_eligible": true,
+        "dual_run_comparison_state": {
+          "comparison_id": "affix",
+          "drift_classification": "equivalent",
+          "legacy_hash": "640cf0924ea88a86b5d8eeff3f7d3b68aa94b66f91cee4739d150acb7c35570a",
+          "legacy_status": "available",
+          "reason_codes": [
+            "comparable_value_hash_match"
+          ],
+          "trusted_hash": "640cf0924ea88a86b5d8eeff3f7d3b68aa94b66f91cee4739d150acb7c35570a",
+          "trusted_shadow_status": "available"
+        },
+        "generation": {
+          "strategy": "stable_token_and_sorted_json_hash",
+          "timestamp_strategy": "report_level_deterministic_token",
+          "token": "v3_1_phase_3_planner_snapshot_baseline_token"
+        },
+        "metadata": {
+          "observational_only": true,
+          "planner_remap_performed": false,
+          "production_behavior_changed": false,
+          "production_consumer": false
+        },
+        "planner_source_ownership": {
+          "legacy_controlled": true,
+          "owner": "legacy",
+          "trusted_default_routing": false
+        },
+        "production_output_affected": false,
+        "reason_codes": [
+          "dual_run_equivalent"
+        ],
+        "snapshot_category": "planner_adjacent_summary",
+        "snapshot_id": "v3_1_snapshot_472bcd4c1169053b",
+        "stable_key": "affix",
+        "trusted_shadow_participation": {
+          "gate_enabled": true,
+          "gate_mode": "shadow",
+          "shadow_only": true,
+          "trusted_shadow_status": "available"
+        },
+        "unsupported": false,
+        "unsupported_or_blocked_reason": null
+      },
+      {
+        "baseline_candidate": false,
+        "baseline_readiness": "legacy_only",
+        "blocked": false,
+        "comparison_eligible": false,
+        "dual_run_comparison_state": {
+          "comparison_id": "idol",
+          "drift_classification": "legacy_only",
+          "legacy_hash": "dd6f78504144c7e111632e74d742da8c30376ed16c4b6dda8ccd29226bb2191b",
+          "legacy_status": "available",
+          "reason_codes": [
+            "trusted_shadow_summary_missing"
+          ],
+          "trusted_hash": null,
+          "trusted_shadow_status": "missing"
+        },
+        "generation": {
+          "strategy": "stable_token_and_sorted_json_hash",
+          "timestamp_strategy": "report_level_deterministic_token",
+          "token": "v3_1_phase_3_planner_snapshot_baseline_token"
+        },
+        "metadata": {
+          "observational_only": true,
+          "planner_remap_performed": false,
+          "production_behavior_changed": false,
+          "production_consumer": false
+        },
+        "planner_source_ownership": {
+          "legacy_controlled": true,
+          "owner": "legacy",
+          "trusted_default_routing": false
+        },
+        "production_output_affected": false,
+        "reason_codes": [
+          "trusted_shadow_missing"
+        ],
+        "snapshot_category": "planner_adjacent_summary",
+        "snapshot_id": "v3_1_snapshot_42674d7f460ed71c",
+        "stable_key": "idol",
+        "trusted_shadow_participation": {
+          "gate_enabled": true,
+          "gate_mode": "shadow",
+          "shadow_only": true,
+          "trusted_shadow_status": "missing"
+        },
+        "unsupported": false,
+        "unsupported_or_blocked_reason": "trusted_shadow_summary_missing"
+      },
+      {
+        "baseline_candidate": false,
+        "baseline_readiness": "comparison_ready",
+        "blocked": false,
+        "comparison_eligible": true,
+        "dual_run_comparison_state": {
+          "comparison_id": "item_base",
+          "drift_classification": "divergent",
+          "legacy_hash": "b032e547417db66eacea1c5124714787ab2c3c6319f550f55317408fd7950d5c",
+          "legacy_status": "available",
+          "reason_codes": [
+            "comparable_value_hash_mismatch"
+          ],
+          "trusted_hash": "8750aa1eacbe174b9d0c257d37220cfdaaffcc8b2e32618541873851c3da6113",
+          "trusted_shadow_status": "available"
+        },
+        "generation": {
+          "strategy": "stable_token_and_sorted_json_hash",
+          "timestamp_strategy": "report_level_deterministic_token",
+          "token": "v3_1_phase_3_planner_snapshot_baseline_token"
+        },
+        "metadata": {
+          "observational_only": true,
+          "planner_remap_performed": false,
+          "production_behavior_changed": false,
+          "production_consumer": false
+        },
+        "planner_source_ownership": {
+          "legacy_controlled": true,
+          "owner": "legacy",
+          "trusted_default_routing": false
+        },
+        "production_output_affected": false,
+        "reason_codes": [
+          "dual_run_divergent_requires_review"
+        ],
+        "snapshot_category": "planner_adjacent_summary",
+        "snapshot_id": "v3_1_snapshot_372c946743469ec5",
+        "stable_key": "item_base",
+        "trusted_shadow_participation": {
+          "gate_enabled": true,
+          "gate_mode": "shadow",
+          "shadow_only": true,
+          "trusted_shadow_status": "available"
+        },
+        "unsupported": false,
+        "unsupported_or_blocked_reason": null
+      },
+      {
+        "baseline_candidate": false,
+        "baseline_readiness": "unsupported",
+        "blocked": false,
+        "comparison_eligible": false,
+        "dual_run_comparison_state": {
+          "comparison_id": "monolith_echo",
+          "drift_classification": "unsupported",
+          "legacy_hash": null,
+          "legacy_status": "missing",
+          "reason_codes": [
+            "unsupported_state_visible"
+          ],
+          "trusted_hash": "23d7b286bd429460b92a2a1c21b6afc34110446c5034c17363fda363aa0a7c5d",
+          "trusted_shadow_status": "unsupported"
+        },
+        "generation": {
+          "strategy": "stable_token_and_sorted_json_hash",
+          "timestamp_strategy": "report_level_deterministic_token",
+          "token": "v3_1_phase_3_planner_snapshot_baseline_token"
+        },
+        "metadata": {
+          "observational_only": true,
+          "planner_remap_performed": false,
+          "production_behavior_changed": false,
+          "production_consumer": false
+        },
+        "planner_source_ownership": {
+          "legacy_controlled": true,
+          "owner": "legacy",
+          "trusted_default_routing": false
+        },
+        "production_output_affected": false,
+        "reason_codes": [
+          "unsupported_state_visible"
+        ],
+        "snapshot_category": "planner_adjacent_summary",
+        "snapshot_id": "v3_1_snapshot_7fed448d66ec5b1b",
+        "stable_key": "monolith_echo",
+        "trusted_shadow_participation": {
+          "gate_enabled": true,
+          "gate_mode": "shadow",
+          "shadow_only": true,
+          "trusted_shadow_status": "unsupported"
+        },
+        "unsupported": true,
+        "unsupported_or_blocked_reason": "unsupported_trusted_shadow_domain"
+      },
+      {
+        "baseline_candidate": false,
+        "baseline_readiness": "unsupported",
+        "blocked": false,
+        "comparison_eligible": false,
+        "dual_run_comparison_state": {
+          "comparison_id": "passive_skill",
+          "drift_classification": "unsupported",
+          "legacy_hash": "1c197daef20de3f47eec5e2f735ec6669869d3180cc29f35be4788511e0af0f8",
+          "legacy_status": "unsupported",
+          "reason_codes": [
+            "unsupported_state_visible"
+          ],
+          "trusted_hash": "36060134d807a85bd4de45d03754fc36d6f73b2349587345f0f71b5548caeaee",
+          "trusted_shadow_status": "available"
+        },
+        "generation": {
+          "strategy": "stable_token_and_sorted_json_hash",
+          "timestamp_strategy": "report_level_deterministic_token",
+          "token": "v3_1_phase_3_planner_snapshot_baseline_token"
+        },
+        "metadata": {
+          "observational_only": true,
+          "planner_remap_performed": false,
+          "production_behavior_changed": false,
+          "production_consumer": false
+        },
+        "planner_source_ownership": {
+          "legacy_controlled": true,
+          "owner": "legacy",
+          "trusted_default_routing": false
+        },
+        "production_output_affected": false,
+        "reason_codes": [
+          "unsupported_state_visible"
+        ],
+        "snapshot_category": "planner_adjacent_summary",
+        "snapshot_id": "v3_1_snapshot_4d312622ce8de408",
+        "stable_key": "passive_skill",
+        "trusted_shadow_participation": {
+          "gate_enabled": true,
+          "gate_mode": "shadow",
+          "shadow_only": true,
+          "trusted_shadow_status": "available"
+        },
+        "unsupported": true,
+        "unsupported_or_blocked_reason": "unsupported_state_visible"
+      }
+    ],
+    "summary": {
+      "baseline_candidate_count": 1,
+      "blocked_count": 0,
+      "comparison_ready_count": 1,
+      "deterministic": true,
+      "insufficient_data_count": 0,
+      "legacy_only_count": 1,
+      "production_affected_count": 0,
+      "production_behavior_changed": false,
+      "production_output_affected": false,
+      "shadow_only_count": 0,
+      "total_snapshots": 5,
+      "trusted_data_default_truth": false,
+      "unsupported_count": 2
+    }
+  },
+  "production_default_routing_authorized": false,
+  "recommendation": "OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING",
+  "schema_version": "v3_1.planner_snapshot_baselines_report.1",
+  "summary": {
+    "baseline_candidate_count": 1,
+    "blocked_count": 0,
+    "comparison_ready_count": 1,
+    "deterministic": true,
+    "insufficient_data_count": 0,
+    "legacy_only_count": 1,
+    "production_affected_count": 0,
+    "production_behavior_changed": false,
+    "production_output_affected": false,
+    "shadow_only_count": 0,
+    "total_snapshots": 5,
+    "trusted_data_default_truth": false,
+    "unsupported_count": 2
+  }
+}

--- a/docs/migration/V3_1_PLANNER_SNAPSHOT_BASELINES.md
+++ b/docs/migration/V3_1_PLANNER_SNAPSHOT_BASELINES.md
@@ -1,0 +1,44 @@
+# V3.1 Planner Snapshot Baselines
+
+Phase 3 introduces deterministic planner-adjacent snapshot baseline infrastructure.
+Snapshots are observational migration-readiness artifacts; production output remains legacy-owned.
+
+## Recommendation
+
+- Recommendation: `OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING`
+- Production default routing authorized: `false`
+
+## Summary
+
+- Total snapshots: `5`
+- Baseline candidates: `1`
+- Comparison ready: `1`
+- Unsupported: `2`
+- Blocked: `0`
+- Insufficient data: `0`
+- Legacy only: `1`
+- Shadow only: `0`
+- Production affected: `0`
+- Deterministic: `true`
+
+## Snapshot Results
+
+| Snapshot | Key | Drift | Baseline Readiness | Eligible |
+| --- | --- | --- | --- | --- |
+| `v3_1_snapshot_472bcd4c1169053b` | `affix` | `equivalent` | `baseline_candidate` | `true` |
+| `v3_1_snapshot_42674d7f460ed71c` | `idol` | `legacy_only` | `legacy_only` | `false` |
+| `v3_1_snapshot_372c946743469ec5` | `item_base` | `divergent` | `comparison_ready` | `true` |
+| `v3_1_snapshot_7fed448d66ec5b1b` | `monolith_echo` | `unsupported` | `unsupported` | `false` |
+| `v3_1_snapshot_4d312622ce8de408` | `passive_skill` | `unsupported` | `unsupported` | `false` |
+
+## Phase 3 Boundaries
+
+- snapshots are observational migration-readiness artifacts
+- trusted infrastructure is still not production default
+- baselines support parity, drift, and regression evaluation only
+- unsupported and blocked states remain intentionally visible
+- planner ownership remains legacy-controlled
+
+## Conclusion
+
+Planner snapshot baselines are available for migration readiness review, but planner ownership and production routing remain unchanged.


### PR DESCRIPTION
Adds deterministic planner-adjacent snapshot baseline infrastructure for v3.1 migration readiness.

This phase derives snapshot baseline records from dual-run metadata only, preserves legacy planner ownership, and does not enable trusted default routing.

Validation:
- test_v3_1_planner_snapshot_baselines.py -> 10 passed
- v3.1 Phase 1 + Phase 2 tests -> 20 passed
- related v3 production gate / adapter / non-consumption tests -> 20 passed
- py_compile passed
- report script run twice with stable JSON and markdown hashes