### PR TITLE
v3.1: add baseline fixture approval workflow infrastructure

### DIFF
--- a/backend/app/planner_adapters/v3_1/__init__.py
+++ b/backend/app/planner_adapters/v3_1/__init__.py
@@ -5,6 +5,11 @@ from .dual_run_comparison import (
     V31DualRunComparison,
     build_sample_dual_run_inputs,
 )
+from .baseline_fixture_workflows import (
+    FIXTURE_WORKFLOW_STATES,
+    V31BaselineFixtureWorkflows,
+    build_sample_baseline_fixture_workflow_inputs,
+)
 from .planner_snapshot_baselines import (
     BASELINE_READINESS_CLASSIFICATIONS,
     V31PlannerSnapshotBaselines,
@@ -20,10 +25,13 @@ from .trusted_shadow_consumption import (
 __all__ = [
     "DRIFT_CLASSIFICATIONS",
     "BASELINE_READINESS_CLASSIFICATIONS",
+    "FIXTURE_WORKFLOW_STATES",
     "SUPPORTED_TRUSTED_SHADOW_DOMAINS",
+    "V31BaselineFixtureWorkflows",
     "V31DualRunComparison",
     "V31PlannerSnapshotBaselines",
     "V31TrustedProductionShadowConsumption",
+    "build_sample_baseline_fixture_workflow_inputs",
     "build_sample_planner_snapshot_baseline_inputs",
     "build_sample_dual_run_inputs",
     "build_default_trusted_repository_probes",

--- a/backend/app/planner_adapters/v3_1/baseline_fixture_workflows.py
+++ b/backend/app/planner_adapters/v3_1/baseline_fixture_workflows.py
@@ -1,0 +1,201 @@
+"""Deterministic baseline fixture approval workflow infrastructure.
+
+Fixture workflows are governance records over planner snapshot baselines. They
+do not approve production routing and do not replace legacy planner ownership.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from copy import deepcopy
+from datetime import UTC, datetime
+from typing import Any
+
+from .planner_snapshot_baselines import (
+    V31PlannerSnapshotBaselines,
+    build_sample_planner_snapshot_baseline_inputs,
+)
+from .trusted_shadow_consumption import deterministic_hash
+
+
+FIXTURE_WORKFLOW_STATES = (
+    "pending_review",
+    "approved_candidate",
+    "approved_baseline",
+    "rejected",
+    "unsupported",
+    "blocked",
+    "insufficient_data",
+    "archived",
+)
+STABLE_WORKFLOW_GENERATION_TOKEN = "v3_1_phase_4_baseline_fixture_workflow_token"
+
+
+class V31BaselineFixtureWorkflows:
+    """Build deterministic approval workflow records from snapshot baselines."""
+
+    def build(
+        self,
+        *,
+        planner_snapshot_baselines: dict[str, Any],
+        approval_overrides: dict[str, dict[str, Any]] | None = None,
+        run_id: str = "v3_1_phase_4_baseline_fixture_workflows",
+    ) -> dict[str, Any]:
+        overrides = approval_overrides or {}
+        snapshots = list(planner_snapshot_baselines.get("snapshots") or [])
+        fixtures = [
+            _fixture_from_snapshot(snapshot=snapshot, approval_override=_override_for(snapshot, overrides))
+            for snapshot in sorted(snapshots, key=lambda item: str(item.get("snapshot_id") or item.get("stable_key") or ""))
+        ]
+        counts = Counter(fixture["approval_state"] for fixture in fixtures)
+        production_affected_count = sum(1 for fixture in fixtures if fixture["production_output_affected"])
+        envelope = {
+            "schema_version": "v3_1.baseline_fixture_workflows.1",
+            "generated_at": datetime.now(UTC).isoformat(),
+            "run": {
+                "run_id": run_id,
+                "source_snapshot_schema": planner_snapshot_baselines.get("schema_version"),
+                "source_snapshot_hash": planner_snapshot_baselines.get("deterministic_hash"),
+                "fixture_count": len(fixtures),
+                "approval_override_count": len(overrides),
+            },
+            "summary": {
+                "total_fixtures": len(fixtures),
+                "pending_review_count": counts["pending_review"],
+                "approved_candidate_count": counts["approved_candidate"],
+                "approved_baseline_count": counts["approved_baseline"],
+                "rejected_count": counts["rejected"],
+                "unsupported_count": counts["unsupported"],
+                "blocked_count": counts["blocked"],
+                "insufficient_data_count": counts["insufficient_data"],
+                "archived_count": counts["archived"],
+                "production_affected_count": production_affected_count,
+                "production_output_affected": False,
+                "production_behavior_changed": False,
+                "trusted_data_default_truth": False,
+                "deterministic": True,
+            },
+            "approval_state_counts": {
+                state: counts[state]
+                for state in FIXTURE_WORKFLOW_STATES
+            },
+            "fixtures": fixtures,
+            "safety_confirmations": {
+                "production_output_affected": False,
+                "production_behavior_changed": False,
+                "trusted_data_default_truth": False,
+                "legacy_planner_ownership_preserved": True,
+                "planner_output_replaced": False,
+                "runtime_state_mutated": False,
+                "approval_status_authorizes_production_routing": False,
+                "automatic_drift_acceptance": False,
+                "unsupported_states_hidden": False,
+                "blocked_states_hidden": False,
+            },
+            "metadata": {
+                "source": "v3_1_baseline_fixture_workflows",
+                "observational_only": True,
+                "production_consumer": False,
+                "production_behavior_changed": False,
+                "planner_remap_performed": False,
+                "production_default_routing_authorized": False,
+                "stable_workflow_generation_token": STABLE_WORKFLOW_GENERATION_TOKEN,
+                "deterministic_serializer": "json_sort_keys_sha256",
+            },
+        }
+        envelope["deterministic_hash"] = deterministic_hash(_stable_envelope(envelope))
+        return envelope
+
+
+def build_sample_baseline_fixture_workflow_inputs() -> dict[str, Any]:
+    dual_run = build_sample_planner_snapshot_baseline_inputs()
+    return V31PlannerSnapshotBaselines().build(
+        dual_run_comparison=dual_run,
+        run_id="v3_1_phase_4_snapshot_workflow_sample",
+    )
+
+
+def _fixture_from_snapshot(*, snapshot: dict[str, Any], approval_override: dict[str, Any] | None) -> dict[str, Any]:
+    state, reason_codes = _approval_state(snapshot=snapshot, approval_override=approval_override)
+    snapshot_id = str(snapshot.get("snapshot_id"))
+    fixture_seed = {
+        "snapshot_id": snapshot_id,
+        "generation_token": STABLE_WORKFLOW_GENERATION_TOKEN,
+    }
+    unsupported = state == "unsupported" or bool(snapshot.get("unsupported", False))
+    blocked = state == "blocked" or bool(snapshot.get("blocked", False))
+    review_notes = list((approval_override or {}).get("review_notes") or [])
+    return {
+        "fixture_id": f"v3_1_fixture_{deterministic_hash(fixture_seed)[:16]}",
+        "associated_snapshot_id": snapshot_id,
+        "snapshot_stable_key": snapshot.get("stable_key"),
+        "approval_state": state,
+        "baseline_classification": snapshot.get("baseline_readiness"),
+        "comparison_readiness": {
+            "comparison_eligible": bool(snapshot.get("comparison_eligible", False)),
+            "baseline_candidate": bool(snapshot.get("baseline_candidate", False)),
+            "dual_run_drift_classification": (snapshot.get("dual_run_comparison_state") or {}).get("drift_classification"),
+        },
+        "unsupported": unsupported,
+        "blocked": blocked,
+        "unsupported_or_blocked_reason": snapshot.get("unsupported_or_blocked_reason"),
+        "review_notes": review_notes,
+        "reason_codes": reason_codes,
+        "production_ownership_state": {
+            "owner": "legacy",
+            "legacy_controlled": True,
+            "trusted_default_routing": False,
+            "approval_authorizes_production_routing": False,
+        },
+        "production_output_affected": False,
+        "generation": {
+            "strategy": "stable_token_and_sorted_json_hash",
+            "token": STABLE_WORKFLOW_GENERATION_TOKEN,
+            "timestamp_strategy": "report_level_deterministic_token",
+        },
+        "metadata": {
+            "observational_only": True,
+            "production_consumer": False,
+            "production_behavior_changed": False,
+            "planner_remap_performed": False,
+        },
+    }
+
+
+def _approval_state(*, snapshot: dict[str, Any], approval_override: dict[str, Any] | None) -> tuple[str, list[str]]:
+    baseline_readiness = str(snapshot.get("baseline_readiness"))
+    if baseline_readiness == "unsupported":
+        return "unsupported", ["unsupported_state_visible"]
+    if baseline_readiness == "blocked":
+        return "blocked", ["blocked_state_visible"]
+    if baseline_readiness == "insufficient_data":
+        return "insufficient_data", ["insufficient_data_visible"]
+    if approval_override:
+        requested = str(approval_override.get("approval_state", ""))
+        if requested in FIXTURE_WORKFLOW_STATES and requested not in {"unsupported", "blocked", "insufficient_data"}:
+            return requested, [f"explicit_{requested}"]
+        return "pending_review", ["invalid_or_unsafe_approval_override"]
+    if baseline_readiness in {"baseline_candidate", "comparison_ready"}:
+        return "pending_review", [f"{baseline_readiness}_requires_review"]
+    if baseline_readiness == "legacy_only":
+        return "insufficient_data", ["legacy_only_missing_trusted_shadow"]
+    if baseline_readiness == "shadow_only":
+        return "insufficient_data", ["shadow_only_missing_legacy_summary"]
+    return "insufficient_data", ["unknown_baseline_readiness"]
+
+
+def _override_for(snapshot: dict[str, Any], overrides: dict[str, dict[str, Any]]) -> dict[str, Any] | None:
+    snapshot_id = str(snapshot.get("snapshot_id"))
+    stable_key = str(snapshot.get("stable_key"))
+    if snapshot_id in overrides:
+        return overrides[snapshot_id]
+    if stable_key in overrides:
+        return overrides[stable_key]
+    return None
+
+
+def _stable_envelope(envelope: dict[str, Any]) -> dict[str, Any]:
+    stable = deepcopy(envelope)
+    stable.pop("generated_at", None)
+    stable.pop("deterministic_hash", None)
+    return stable

--- a/backend/scripts/report_v3_1_baseline_fixture_workflows.py
+++ b/backend/scripts/report_v3_1_baseline_fixture_workflows.py
@@ -1,0 +1,150 @@
+"""Generate the v3.1 baseline fixture approval workflow report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.planner_adapters.v3_1.baseline_fixture_workflows import (  # noqa: E402
+    V31BaselineFixtureWorkflows,
+    build_sample_baseline_fixture_workflow_inputs,
+)
+
+
+DETERMINISTIC_GENERATED_AT = "2026-05-15T00:00:00+00:00"
+
+
+def build_v3_1_baseline_fixture_workflows_report() -> dict[str, Any]:
+    snapshots = build_sample_baseline_fixture_workflow_inputs()
+    workflows = V31BaselineFixtureWorkflows().build(planner_snapshot_baselines=snapshots)
+    repeated = V31BaselineFixtureWorkflows().build(planner_snapshot_baselines=snapshots)
+    deterministic = workflows["deterministic_hash"] == repeated["deterministic_hash"]
+    report = {
+        "schema_version": "v3_1.baseline_fixture_workflows_report.1",
+        "generated_at": DETERMINISTIC_GENERATED_AT,
+        "phase": "v3.1_phase_4_baseline_fixture_approval_workflows",
+        "recommendation": "OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING",
+        "production_default_routing_authorized": False,
+        "summary": {
+            **workflows["summary"],
+            "deterministic": deterministic,
+        },
+        "baseline_fixture_workflows": workflows,
+        "deterministic_guarantees": {
+            "passed": deterministic,
+            "sample_hash": workflows["deterministic_hash"],
+            "repeated_hash": repeated["deterministic_hash"],
+            "timestamp_excluded_from_hash": True,
+            "json_sort_keys": True,
+            "stable_workflow_generation_token": workflows["metadata"]["stable_workflow_generation_token"],
+        },
+        "phase_4_boundaries": [
+            "workflows are observational governance infrastructure only",
+            "trusted infrastructure is still not production default",
+            "production planner ownership remains legacy-controlled",
+            "approval workflows are migration-readiness tooling",
+            "unsupported and blocked states remain intentionally visible",
+            "approval status does not imply production routing approval",
+        ],
+        "metadata": {
+            "source": "v3_1_baseline_fixture_workflows_report",
+            "observational_only": True,
+            "production_behavior_changed": False,
+            "production_default_routing_authorized": False,
+            "planner_remap_performed": False,
+        },
+    }
+    return _normalize_generated_at(report)
+
+
+def write_report(report: dict[str, Any], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_markdown(report: dict[str, Any], output_path: Path) -> None:
+    summary = report["summary"]
+    lines = [
+        "# V3.1 Baseline Fixture Workflows",
+        "",
+        "Phase 4 introduces deterministic baseline fixture approval workflow infrastructure.",
+        "Approval status is migration-readiness governance only and does not authorize production routing.",
+        "",
+        "## Recommendation",
+        "",
+        f"- Recommendation: `{report['recommendation']}`",
+        f"- Production default routing authorized: `{str(report['production_default_routing_authorized']).lower()}`",
+        "",
+        "## Summary",
+        "",
+        f"- Total fixtures: `{summary['total_fixtures']}`",
+        f"- Pending review: `{summary['pending_review_count']}`",
+        f"- Approved candidate: `{summary['approved_candidate_count']}`",
+        f"- Approved baseline: `{summary['approved_baseline_count']}`",
+        f"- Rejected: `{summary['rejected_count']}`",
+        f"- Unsupported: `{summary['unsupported_count']}`",
+        f"- Blocked: `{summary['blocked_count']}`",
+        f"- Insufficient data: `{summary['insufficient_data_count']}`",
+        f"- Archived: `{summary['archived_count']}`",
+        f"- Production affected: `{summary['production_affected_count']}`",
+        f"- Deterministic: `{str(summary['deterministic']).lower()}`",
+        "",
+        "## Fixture Results",
+        "",
+        "| Fixture | Snapshot | Baseline | Approval State | Production Affected |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    for fixture in report["baseline_fixture_workflows"]["fixtures"]:
+        lines.append(
+            f"| `{fixture['fixture_id']}` | `{fixture['associated_snapshot_id']}` | `{fixture['baseline_classification']}` | `{fixture['approval_state']}` | `{str(fixture['production_output_affected']).lower()}` |"
+        )
+    lines.extend(["", "## Phase 4 Boundaries", ""])
+    lines.extend(f"- {item}" for item in report["phase_4_boundaries"])
+    lines.extend(
+        [
+            "",
+            "## Conclusion",
+            "",
+            "Baseline fixture workflows are available for migration governance, but production planner ownership and routing remain unchanged.",
+        ]
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _normalize_generated_at(value: Any) -> Any:
+    if isinstance(value, dict):
+        normalized = {}
+        for key, item in value.items():
+            normalized[key] = DETERMINISTIC_GENERATED_AT if key == "generated_at" else _normalize_generated_at(item)
+        return normalized
+    if isinstance(value, list):
+        return [_normalize_generated_at(item) for item in value]
+    return deepcopy(value)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", default="docs/generated/v3_1_baseline_fixture_workflows_report.json")
+    parser.add_argument("--markdown-output", default="docs/migration/V3_1_BASELINE_FIXTURE_WORKFLOWS.md")
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[2]
+    report = build_v3_1_baseline_fixture_workflows_report()
+    write_report(report, repo_root / args.output)
+    write_markdown(report, repo_root / args.markdown_output)
+    print(json.dumps(report["summary"], indent=2, sort_keys=True))
+    print(report["recommendation"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_v3_1_baseline_fixture_workflows.py
+++ b/backend/tests/test_v3_1_baseline_fixture_workflows.py
@@ -1,0 +1,214 @@
+import json
+
+from app.planner_adapters.v3_1.baseline_fixture_workflows import (
+    V31BaselineFixtureWorkflows,
+)
+from app.planner_adapters.v3_1.planner_snapshot_baselines import (
+    V31PlannerSnapshotBaselines,
+)
+from scripts.report_v3_1_baseline_fixture_workflows import (
+    build_v3_1_baseline_fixture_workflows_report,
+    write_report,
+)
+
+
+def test_fixture_workflow_generation_is_deterministic():
+    snapshots = _snapshot_baselines([_snapshot("affix", "baseline_candidate")])
+
+    first = V31BaselineFixtureWorkflows().build(planner_snapshot_baselines=snapshots)
+    second = V31BaselineFixtureWorkflows().build(planner_snapshot_baselines=snapshots)
+
+    assert first["deterministic_hash"] == second["deterministic_hash"]
+    assert first["summary"]["deterministic"] is True
+
+
+def test_stable_fixture_ids_remain_stable():
+    snapshots = _snapshot_baselines([_snapshot("affix", "baseline_candidate")])
+
+    first = V31BaselineFixtureWorkflows().build(planner_snapshot_baselines=snapshots)
+    second = V31BaselineFixtureWorkflows().build(planner_snapshot_baselines=snapshots)
+
+    assert first["fixtures"][0]["fixture_id"] == second["fixtures"][0]["fixture_id"]
+    assert first["fixtures"][0]["fixture_id"].startswith("v3_1_fixture_")
+
+
+def test_lifecycle_states_classify_correctly():
+    snapshots = _snapshot_baselines(
+        [
+            _snapshot("pending", "baseline_candidate"),
+            _snapshot("candidate", "baseline_candidate"),
+            _snapshot("baseline", "baseline_candidate"),
+            _snapshot("rejected", "comparison_ready"),
+            _snapshot("archived", "legacy_only"),
+        ]
+    )
+    workflows = V31BaselineFixtureWorkflows().build(
+        planner_snapshot_baselines=snapshots,
+        approval_overrides={
+            "candidate": {"approval_state": "approved_candidate"},
+            "baseline": {"approval_state": "approved_baseline"},
+            "rejected": {"approval_state": "rejected"},
+            "archived": {"approval_state": "archived"},
+        },
+    )
+    observed = {fixture["snapshot_stable_key"]: fixture["approval_state"] for fixture in workflows["fixtures"]}
+
+    assert observed["pending"] == "pending_review"
+    assert observed["candidate"] == "approved_candidate"
+    assert observed["baseline"] == "approved_baseline"
+    assert observed["rejected"] == "rejected"
+    assert observed["archived"] == "archived"
+
+
+def test_unsupported_states_remain_visible():
+    fixture = _single_fixture("passive_skill", "unsupported")
+
+    assert fixture["approval_state"] == "unsupported"
+    assert fixture["unsupported"] is True
+    assert "unsupported_state_visible" in fixture["reason_codes"]
+
+
+def test_blocked_states_remain_visible():
+    fixture = _single_fixture("affix", "blocked", reason="blocked_for_test")
+
+    assert fixture["approval_state"] == "blocked"
+    assert fixture["blocked"] is True
+    assert fixture["unsupported_or_blocked_reason"] == "blocked_for_test"
+
+
+def test_rejected_states_remain_visible():
+    snapshots = _snapshot_baselines([_snapshot("item_base", "comparison_ready")])
+    workflows = V31BaselineFixtureWorkflows().build(
+        planner_snapshot_baselines=snapshots,
+        approval_overrides={"item_base": {"approval_state": "rejected", "review_notes": ["drift requires review"]}},
+    )
+    fixture = workflows["fixtures"][0]
+
+    assert fixture["approval_state"] == "rejected"
+    assert fixture["review_notes"] == ["drift requires review"]
+    assert fixture["production_ownership_state"]["approval_authorizes_production_routing"] is False
+
+
+def test_aggregate_counts_are_correct():
+    snapshots = _snapshot_baselines(
+        [
+            _snapshot("pending", "baseline_candidate"),
+            _snapshot("candidate", "baseline_candidate"),
+            _snapshot("baseline", "baseline_candidate"),
+            _snapshot("rejected", "comparison_ready"),
+            _snapshot("unsupported", "unsupported"),
+            _snapshot("blocked", "blocked"),
+            _snapshot("insufficient", "insufficient_data"),
+            _snapshot("archived", "legacy_only"),
+        ]
+    )
+    workflows = V31BaselineFixtureWorkflows().build(
+        planner_snapshot_baselines=snapshots,
+        approval_overrides={
+            "candidate": {"approval_state": "approved_candidate"},
+            "baseline": {"approval_state": "approved_baseline"},
+            "rejected": {"approval_state": "rejected"},
+            "archived": {"approval_state": "archived"},
+        },
+    )
+
+    assert workflows["summary"]["total_fixtures"] == 8
+    assert workflows["summary"]["pending_review_count"] == 1
+    assert workflows["summary"]["approved_candidate_count"] == 1
+    assert workflows["summary"]["approved_baseline_count"] == 1
+    assert workflows["summary"]["rejected_count"] == 1
+    assert workflows["summary"]["unsupported_count"] == 1
+    assert workflows["summary"]["blocked_count"] == 1
+    assert workflows["summary"]["insufficient_data_count"] == 1
+    assert workflows["summary"]["archived_count"] == 1
+    assert workflows["summary"]["production_affected_count"] == 0
+
+
+def test_production_output_affected_remains_false():
+    workflows = V31BaselineFixtureWorkflows().build(
+        planner_snapshot_baselines=_snapshot_baselines([_snapshot("affix", "baseline_candidate")]),
+        approval_overrides={"affix": {"approval_state": "approved_baseline"}},
+    )
+
+    assert workflows["summary"]["production_output_affected"] is False
+    assert workflows["summary"]["production_affected_count"] == 0
+    assert workflows["safety_confirmations"]["approval_status_authorizes_production_routing"] is False
+    assert all(fixture["production_output_affected"] is False for fixture in workflows["fixtures"])
+
+
+def test_prior_phase_compatibility_is_preserved():
+    snapshots = V31PlannerSnapshotBaselines().build(
+        dual_run_comparison={
+            "schema_version": "v3_1.dual_run_comparison.1",
+            "deterministic_hash": "phase2-hash",
+            "trusted_shadow_gate": {"enabled": True, "mode": "shadow", "shadow_only": True},
+            "comparison_results": [
+                {
+                    "comparison_id": "affix",
+                    "stable_key": "affix",
+                    "legacy_status": "available",
+                    "trusted_shadow_status": "available",
+                    "drift_classification": "equivalent",
+                    "production_output_affected": False,
+                    "trusted_shadow_gate": {"enabled": True, "mode": "shadow", "shadow_only": True},
+                    "unsupported_or_blocked_reason": None,
+                    "reason_codes": ["comparable_value_hash_match"],
+                    "legacy_hash": "legacy",
+                    "trusted_hash": "trusted",
+                }
+            ],
+        }
+    )
+    workflows = V31BaselineFixtureWorkflows().build(planner_snapshot_baselines=snapshots)
+
+    assert workflows["run"]["source_snapshot_hash"] == snapshots["deterministic_hash"]
+    assert workflows["fixtures"][0]["baseline_classification"] == "baseline_candidate"
+    assert workflows["fixtures"][0]["approval_state"] == "pending_review"
+
+
+def test_report_generation_is_deterministic(tmp_path):
+    first = build_v3_1_baseline_fixture_workflows_report()
+    second = build_v3_1_baseline_fixture_workflows_report()
+
+    assert first["deterministic_guarantees"]["passed"] is True
+    assert first["baseline_fixture_workflows"]["deterministic_hash"] == second["baseline_fixture_workflows"]["deterministic_hash"]
+    assert first["summary"] == second["summary"]
+
+    output = tmp_path / "fixture_workflows.json"
+    write_report(first, output)
+    loaded = json.loads(output.read_text(encoding="utf-8"))
+    assert loaded["schema_version"] == "v3_1.baseline_fixture_workflows_report.1"
+    assert loaded["production_default_routing_authorized"] is False
+    assert loaded["metadata"]["observational_only"] is True
+
+
+def _single_fixture(stable_key, baseline_readiness, reason=None):
+    workflows = V31BaselineFixtureWorkflows().build(
+        planner_snapshot_baselines=_snapshot_baselines([_snapshot(stable_key, baseline_readiness, reason=reason)])
+    )
+    return workflows["fixtures"][0]
+
+
+def _snapshot_baselines(snapshots):
+    return {
+        "schema_version": "v3_1.planner_snapshot_baselines.1",
+        "deterministic_hash": "fixture-snapshot-hash",
+        "snapshots": snapshots,
+    }
+
+
+def _snapshot(stable_key, baseline_readiness, reason=None):
+    return {
+        "snapshot_id": f"snapshot_{stable_key}",
+        "stable_key": stable_key,
+        "baseline_readiness": baseline_readiness,
+        "comparison_eligible": baseline_readiness in {"baseline_candidate", "comparison_ready"},
+        "baseline_candidate": baseline_readiness == "baseline_candidate",
+        "unsupported": baseline_readiness == "unsupported",
+        "blocked": baseline_readiness == "blocked",
+        "unsupported_or_blocked_reason": reason,
+        "production_output_affected": False,
+        "dual_run_comparison_state": {
+            "drift_classification": baseline_readiness,
+        },
+    }

--- a/docs/generated/v3_1_baseline_fixture_workflows_report.json
+++ b/docs/generated/v3_1_baseline_fixture_workflows_report.json
@@ -1,0 +1,293 @@
+{
+  "baseline_fixture_workflows": {
+    "approval_state_counts": {
+      "approved_baseline": 0,
+      "approved_candidate": 0,
+      "archived": 0,
+      "blocked": 0,
+      "insufficient_data": 1,
+      "pending_review": 2,
+      "rejected": 0,
+      "unsupported": 2
+    },
+    "deterministic_hash": "505143cc38f7239909dd6c7d73ac357f2b2251576830718a33b0cd196778ed29",
+    "fixtures": [
+      {
+        "approval_state": "pending_review",
+        "associated_snapshot_id": "v3_1_snapshot_372c946743469ec5",
+        "baseline_classification": "comparison_ready",
+        "blocked": false,
+        "comparison_readiness": {
+          "baseline_candidate": false,
+          "comparison_eligible": true,
+          "dual_run_drift_classification": "divergent"
+        },
+        "fixture_id": "v3_1_fixture_6c378a420c0a4ced",
+        "generation": {
+          "strategy": "stable_token_and_sorted_json_hash",
+          "timestamp_strategy": "report_level_deterministic_token",
+          "token": "v3_1_phase_4_baseline_fixture_workflow_token"
+        },
+        "metadata": {
+          "observational_only": true,
+          "planner_remap_performed": false,
+          "production_behavior_changed": false,
+          "production_consumer": false
+        },
+        "production_output_affected": false,
+        "production_ownership_state": {
+          "approval_authorizes_production_routing": false,
+          "legacy_controlled": true,
+          "owner": "legacy",
+          "trusted_default_routing": false
+        },
+        "reason_codes": [
+          "comparison_ready_requires_review"
+        ],
+        "review_notes": [],
+        "snapshot_stable_key": "item_base",
+        "unsupported": false,
+        "unsupported_or_blocked_reason": null
+      },
+      {
+        "approval_state": "insufficient_data",
+        "associated_snapshot_id": "v3_1_snapshot_42674d7f460ed71c",
+        "baseline_classification": "legacy_only",
+        "blocked": false,
+        "comparison_readiness": {
+          "baseline_candidate": false,
+          "comparison_eligible": false,
+          "dual_run_drift_classification": "legacy_only"
+        },
+        "fixture_id": "v3_1_fixture_b82b601f9b088bb8",
+        "generation": {
+          "strategy": "stable_token_and_sorted_json_hash",
+          "timestamp_strategy": "report_level_deterministic_token",
+          "token": "v3_1_phase_4_baseline_fixture_workflow_token"
+        },
+        "metadata": {
+          "observational_only": true,
+          "planner_remap_performed": false,
+          "production_behavior_changed": false,
+          "production_consumer": false
+        },
+        "production_output_affected": false,
+        "production_ownership_state": {
+          "approval_authorizes_production_routing": false,
+          "legacy_controlled": true,
+          "owner": "legacy",
+          "trusted_default_routing": false
+        },
+        "reason_codes": [
+          "legacy_only_missing_trusted_shadow"
+        ],
+        "review_notes": [],
+        "snapshot_stable_key": "idol",
+        "unsupported": false,
+        "unsupported_or_blocked_reason": "trusted_shadow_summary_missing"
+      },
+      {
+        "approval_state": "pending_review",
+        "associated_snapshot_id": "v3_1_snapshot_472bcd4c1169053b",
+        "baseline_classification": "baseline_candidate",
+        "blocked": false,
+        "comparison_readiness": {
+          "baseline_candidate": true,
+          "comparison_eligible": true,
+          "dual_run_drift_classification": "equivalent"
+        },
+        "fixture_id": "v3_1_fixture_756415e2e7d3feb2",
+        "generation": {
+          "strategy": "stable_token_and_sorted_json_hash",
+          "timestamp_strategy": "report_level_deterministic_token",
+          "token": "v3_1_phase_4_baseline_fixture_workflow_token"
+        },
+        "metadata": {
+          "observational_only": true,
+          "planner_remap_performed": false,
+          "production_behavior_changed": false,
+          "production_consumer": false
+        },
+        "production_output_affected": false,
+        "production_ownership_state": {
+          "approval_authorizes_production_routing": false,
+          "legacy_controlled": true,
+          "owner": "legacy",
+          "trusted_default_routing": false
+        },
+        "reason_codes": [
+          "baseline_candidate_requires_review"
+        ],
+        "review_notes": [],
+        "snapshot_stable_key": "affix",
+        "unsupported": false,
+        "unsupported_or_blocked_reason": null
+      },
+      {
+        "approval_state": "unsupported",
+        "associated_snapshot_id": "v3_1_snapshot_4d312622ce8de408",
+        "baseline_classification": "unsupported",
+        "blocked": false,
+        "comparison_readiness": {
+          "baseline_candidate": false,
+          "comparison_eligible": false,
+          "dual_run_drift_classification": "unsupported"
+        },
+        "fixture_id": "v3_1_fixture_8118751ba1b46140",
+        "generation": {
+          "strategy": "stable_token_and_sorted_json_hash",
+          "timestamp_strategy": "report_level_deterministic_token",
+          "token": "v3_1_phase_4_baseline_fixture_workflow_token"
+        },
+        "metadata": {
+          "observational_only": true,
+          "planner_remap_performed": false,
+          "production_behavior_changed": false,
+          "production_consumer": false
+        },
+        "production_output_affected": false,
+        "production_ownership_state": {
+          "approval_authorizes_production_routing": false,
+          "legacy_controlled": true,
+          "owner": "legacy",
+          "trusted_default_routing": false
+        },
+        "reason_codes": [
+          "unsupported_state_visible"
+        ],
+        "review_notes": [],
+        "snapshot_stable_key": "passive_skill",
+        "unsupported": true,
+        "unsupported_or_blocked_reason": "unsupported_state_visible"
+      },
+      {
+        "approval_state": "unsupported",
+        "associated_snapshot_id": "v3_1_snapshot_7fed448d66ec5b1b",
+        "baseline_classification": "unsupported",
+        "blocked": false,
+        "comparison_readiness": {
+          "baseline_candidate": false,
+          "comparison_eligible": false,
+          "dual_run_drift_classification": "unsupported"
+        },
+        "fixture_id": "v3_1_fixture_9c3d260c0dda7b4f",
+        "generation": {
+          "strategy": "stable_token_and_sorted_json_hash",
+          "timestamp_strategy": "report_level_deterministic_token",
+          "token": "v3_1_phase_4_baseline_fixture_workflow_token"
+        },
+        "metadata": {
+          "observational_only": true,
+          "planner_remap_performed": false,
+          "production_behavior_changed": false,
+          "production_consumer": false
+        },
+        "production_output_affected": false,
+        "production_ownership_state": {
+          "approval_authorizes_production_routing": false,
+          "legacy_controlled": true,
+          "owner": "legacy",
+          "trusted_default_routing": false
+        },
+        "reason_codes": [
+          "unsupported_state_visible"
+        ],
+        "review_notes": [],
+        "snapshot_stable_key": "monolith_echo",
+        "unsupported": true,
+        "unsupported_or_blocked_reason": "unsupported_trusted_shadow_domain"
+      }
+    ],
+    "generated_at": "2026-05-15T00:00:00+00:00",
+    "metadata": {
+      "deterministic_serializer": "json_sort_keys_sha256",
+      "observational_only": true,
+      "planner_remap_performed": false,
+      "production_behavior_changed": false,
+      "production_consumer": false,
+      "production_default_routing_authorized": false,
+      "source": "v3_1_baseline_fixture_workflows",
+      "stable_workflow_generation_token": "v3_1_phase_4_baseline_fixture_workflow_token"
+    },
+    "run": {
+      "approval_override_count": 0,
+      "fixture_count": 5,
+      "run_id": "v3_1_phase_4_baseline_fixture_workflows",
+      "source_snapshot_hash": "afdc78cfd2cd4213f3fda68ef2b6b63296ee4c155d87cbefbdd590f0d9634b61",
+      "source_snapshot_schema": "v3_1.planner_snapshot_baselines.1"
+    },
+    "safety_confirmations": {
+      "approval_status_authorizes_production_routing": false,
+      "automatic_drift_acceptance": false,
+      "blocked_states_hidden": false,
+      "legacy_planner_ownership_preserved": true,
+      "planner_output_replaced": false,
+      "production_behavior_changed": false,
+      "production_output_affected": false,
+      "runtime_state_mutated": false,
+      "trusted_data_default_truth": false,
+      "unsupported_states_hidden": false
+    },
+    "schema_version": "v3_1.baseline_fixture_workflows.1",
+    "summary": {
+      "approved_baseline_count": 0,
+      "approved_candidate_count": 0,
+      "archived_count": 0,
+      "blocked_count": 0,
+      "deterministic": true,
+      "insufficient_data_count": 1,
+      "pending_review_count": 2,
+      "production_affected_count": 0,
+      "production_behavior_changed": false,
+      "production_output_affected": false,
+      "rejected_count": 0,
+      "total_fixtures": 5,
+      "trusted_data_default_truth": false,
+      "unsupported_count": 2
+    }
+  },
+  "deterministic_guarantees": {
+    "json_sort_keys": true,
+    "passed": true,
+    "repeated_hash": "505143cc38f7239909dd6c7d73ac357f2b2251576830718a33b0cd196778ed29",
+    "sample_hash": "505143cc38f7239909dd6c7d73ac357f2b2251576830718a33b0cd196778ed29",
+    "stable_workflow_generation_token": "v3_1_phase_4_baseline_fixture_workflow_token",
+    "timestamp_excluded_from_hash": true
+  },
+  "generated_at": "2026-05-15T00:00:00+00:00",
+  "metadata": {
+    "observational_only": true,
+    "planner_remap_performed": false,
+    "production_behavior_changed": false,
+    "production_default_routing_authorized": false,
+    "source": "v3_1_baseline_fixture_workflows_report"
+  },
+  "phase": "v3.1_phase_4_baseline_fixture_approval_workflows",
+  "phase_4_boundaries": [
+    "workflows are observational governance infrastructure only",
+    "trusted infrastructure is still not production default",
+    "production planner ownership remains legacy-controlled",
+    "approval workflows are migration-readiness tooling",
+    "unsupported and blocked states remain intentionally visible",
+    "approval status does not imply production routing approval"
+  ],
+  "production_default_routing_authorized": false,
+  "recommendation": "OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING",
+  "schema_version": "v3_1.baseline_fixture_workflows_report.1",
+  "summary": {
+    "approved_baseline_count": 0,
+    "approved_candidate_count": 0,
+    "archived_count": 0,
+    "blocked_count": 0,
+    "deterministic": true,
+    "insufficient_data_count": 1,
+    "pending_review_count": 2,
+    "production_affected_count": 0,
+    "production_behavior_changed": false,
+    "production_output_affected": false,
+    "rejected_count": 0,
+    "total_fixtures": 5,
+    "trusted_data_default_truth": false,
+    "unsupported_count": 2
+  }
+}

--- a/docs/migration/V3_1_BASELINE_FIXTURE_WORKFLOWS.md
+++ b/docs/migration/V3_1_BASELINE_FIXTURE_WORKFLOWS.md
@@ -1,0 +1,46 @@
+# V3.1 Baseline Fixture Workflows
+
+Phase 4 introduces deterministic baseline fixture approval workflow infrastructure.
+Approval status is migration-readiness governance only and does not authorize production routing.
+
+## Recommendation
+
+- Recommendation: `OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING`
+- Production default routing authorized: `false`
+
+## Summary
+
+- Total fixtures: `5`
+- Pending review: `2`
+- Approved candidate: `0`
+- Approved baseline: `0`
+- Rejected: `0`
+- Unsupported: `2`
+- Blocked: `0`
+- Insufficient data: `1`
+- Archived: `0`
+- Production affected: `0`
+- Deterministic: `true`
+
+## Fixture Results
+
+| Fixture | Snapshot | Baseline | Approval State | Production Affected |
+| --- | --- | --- | --- | --- |
+| `v3_1_fixture_6c378a420c0a4ced` | `v3_1_snapshot_372c946743469ec5` | `comparison_ready` | `pending_review` | `false` |
+| `v3_1_fixture_b82b601f9b088bb8` | `v3_1_snapshot_42674d7f460ed71c` | `legacy_only` | `insufficient_data` | `false` |
+| `v3_1_fixture_756415e2e7d3feb2` | `v3_1_snapshot_472bcd4c1169053b` | `baseline_candidate` | `pending_review` | `false` |
+| `v3_1_fixture_8118751ba1b46140` | `v3_1_snapshot_4d312622ce8de408` | `unsupported` | `unsupported` | `false` |
+| `v3_1_fixture_9c3d260c0dda7b4f` | `v3_1_snapshot_7fed448d66ec5b1b` | `unsupported` | `unsupported` | `false` |
+
+## Phase 4 Boundaries
+
+- workflows are observational governance infrastructure only
+- trusted infrastructure is still not production default
+- production planner ownership remains legacy-controlled
+- approval workflows are migration-readiness tooling
+- unsupported and blocked states remain intentionally visible
+- approval status does not imply production routing approval
+
+## Conclusion
+
+Baseline fixture workflows are available for migration governance, but production planner ownership and routing remain unchanged.


### PR DESCRIPTION
Adds deterministic baseline fixture approval workflow infrastructure for v3.1 migration readiness.

This phase introduces approval-state handling, lifecycle metadata, governance summaries, and deterministic reporting connected to planner snapshot baselines. Production behavior remains unchanged, legacy planner ownership is preserved, and approval metadata does not authorize trusted production routing.

Validation:
- test_v3_1_baseline_fixture_workflows.py -> 10 passed
- prior v3.1 Phase 1-3 tests -> 30 passed
- related v3 production gate / adapter / non-consumption tests -> 20 passed
- py_compile passed
- report script run twice with stable JSON and markdown hashes