### PR TITLE
v3.1: add persisted fixture set and review policy infrastructure

### DIFF
--- a/backend/app/planner_adapters/v3_1/__init__.py
+++ b/backend/app/planner_adapters/v3_1/__init__.py
@@ -10,10 +10,20 @@ from .baseline_fixture_workflows import (
     V31BaselineFixtureWorkflows,
     build_sample_baseline_fixture_workflow_inputs,
 )
+from .persisted_fixture_sets import (
+    FIXTURE_SET_LIFECYCLE_STATES,
+    V31PersistedFixtureSets,
+    build_sample_persisted_fixture_set_inputs,
+)
 from .planner_snapshot_baselines import (
     BASELINE_READINESS_CLASSIFICATIONS,
     V31PlannerSnapshotBaselines,
     build_sample_planner_snapshot_baseline_inputs,
+)
+from .review_policy_evaluation import (
+    REVIEW_POLICY_OUTCOMES,
+    V31ReviewPolicyEvaluation,
+    build_sample_review_policy_inputs,
 )
 from .trusted_shadow_consumption import (
     SUPPORTED_TRUSTED_SHADOW_DOMAINS,
@@ -26,13 +36,19 @@ __all__ = [
     "DRIFT_CLASSIFICATIONS",
     "BASELINE_READINESS_CLASSIFICATIONS",
     "FIXTURE_WORKFLOW_STATES",
+    "FIXTURE_SET_LIFECYCLE_STATES",
+    "REVIEW_POLICY_OUTCOMES",
     "SUPPORTED_TRUSTED_SHADOW_DOMAINS",
     "V31BaselineFixtureWorkflows",
     "V31DualRunComparison",
+    "V31PersistedFixtureSets",
     "V31PlannerSnapshotBaselines",
+    "V31ReviewPolicyEvaluation",
     "V31TrustedProductionShadowConsumption",
     "build_sample_baseline_fixture_workflow_inputs",
     "build_sample_planner_snapshot_baseline_inputs",
+    "build_sample_persisted_fixture_set_inputs",
+    "build_sample_review_policy_inputs",
     "build_sample_dual_run_inputs",
     "build_default_trusted_repository_probes",
     "deterministic_hash",

--- a/backend/app/planner_adapters/v3_1/persisted_fixture_sets.py
+++ b/backend/app/planner_adapters/v3_1/persisted_fixture_sets.py
@@ -1,0 +1,213 @@
+"""Deterministic persisted fixture-set infrastructure.
+
+Persisted fixture sets are migration-governance groupings over baseline fixture
+workflow records. They do not authorize runtime routing or production planner
+replacement.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from copy import deepcopy
+from datetime import UTC, datetime
+from typing import Any
+
+from .baseline_fixture_workflows import (
+    V31BaselineFixtureWorkflows,
+    build_sample_baseline_fixture_workflow_inputs,
+)
+from .trusted_shadow_consumption import deterministic_hash
+
+
+FIXTURE_SET_LIFECYCLE_STATES = (
+    "draft",
+    "review_ready",
+    "partially_approved",
+    "approved_candidate",
+    "archived",
+    "blocked",
+    "unsupported",
+    "insufficient_data",
+)
+STABLE_FIXTURE_SET_GENERATION_TOKEN = "v3_1_phase_5_persisted_fixture_set_token"
+
+
+class V31PersistedFixtureSets:
+    """Build deterministic persisted fixture-set records from workflow fixtures."""
+
+    def build(
+        self,
+        *,
+        baseline_fixture_workflows: dict[str, Any],
+        set_definitions: list[dict[str, Any]] | None = None,
+        run_id: str = "v3_1_phase_5_persisted_fixture_sets",
+    ) -> dict[str, Any]:
+        fixtures = list(baseline_fixture_workflows.get("fixtures") or [])
+        fixture_by_id = {str(fixture.get("fixture_id")): fixture for fixture in fixtures}
+        definitions = set_definitions or [_default_definition(fixtures)]
+        fixture_sets = [
+            _fixture_set_from_definition(definition=definition, fixture_by_id=fixture_by_id)
+            for definition in sorted(definitions, key=lambda row: str(row.get("set_key") or ""))
+        ]
+        counts = Counter(row["lifecycle_state"] for row in fixture_sets)
+        policy_counts = Counter(row["policy_evaluation_status"] for row in fixture_sets)
+        production_affected_count = sum(1 for row in fixture_sets if row["production_output_affected"])
+        envelope = {
+            "schema_version": "v3_1.persisted_fixture_sets.1",
+            "generated_at": datetime.now(UTC).isoformat(),
+            "run": {
+                "run_id": run_id,
+                "source_fixture_workflow_schema": baseline_fixture_workflows.get("schema_version"),
+                "source_fixture_workflow_hash": baseline_fixture_workflows.get("deterministic_hash"),
+                "fixture_set_count": len(fixture_sets),
+            },
+            "summary": {
+                "total_fixture_sets": len(fixture_sets),
+                "draft_count": counts["draft"],
+                "review_ready_count": counts["review_ready"],
+                "partially_approved_count": counts["partially_approved"],
+                "approved_candidate_count": counts["approved_candidate"],
+                "archived_count": counts["archived"],
+                "blocked_count": counts["blocked"],
+                "unsupported_count": counts["unsupported"],
+                "insufficient_data_count": counts["insufficient_data"],
+                "policy_pass_count": policy_counts["passes_policy"],
+                "requires_review_count": policy_counts["requires_review"],
+                "production_affected_count": production_affected_count,
+                "production_output_affected": False,
+                "production_behavior_changed": False,
+                "trusted_data_default_truth": False,
+                "deterministic": True,
+            },
+            "lifecycle_state_counts": {
+                state: counts[state]
+                for state in FIXTURE_SET_LIFECYCLE_STATES
+            },
+            "policy_evaluation_status_counts": dict(sorted(policy_counts.items())),
+            "fixture_sets": fixture_sets,
+            "safety_confirmations": {
+                "production_output_affected": False,
+                "production_behavior_changed": False,
+                "trusted_data_default_truth": False,
+                "legacy_planner_ownership_preserved": True,
+                "runtime_state_mutated": False,
+                "fixture_set_authorizes_production_routing": False,
+                "unsupported_states_hidden": False,
+                "blocked_states_hidden": False,
+            },
+            "metadata": {
+                "source": "v3_1_persisted_fixture_sets",
+                "observational_only": True,
+                "production_consumer": False,
+                "production_behavior_changed": False,
+                "planner_remap_performed": False,
+                "production_default_routing_authorized": False,
+                "stable_fixture_set_generation_token": STABLE_FIXTURE_SET_GENERATION_TOKEN,
+                "deterministic_serializer": "json_sort_keys_sha256",
+            },
+        }
+        envelope["deterministic_hash"] = deterministic_hash(_stable_envelope(envelope))
+        return envelope
+
+
+def build_sample_persisted_fixture_set_inputs() -> dict[str, Any]:
+    snapshots = build_sample_baseline_fixture_workflow_inputs()
+    return V31BaselineFixtureWorkflows().build(
+        planner_snapshot_baselines=snapshots,
+        run_id="v3_1_phase_5_fixture_set_workflow_sample",
+    )
+
+
+def _default_definition(fixtures: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "set_key": "sample_migration_readiness_set",
+        "fixture_ids": sorted(str(fixture.get("fixture_id")) for fixture in fixtures),
+    }
+
+
+def _fixture_set_from_definition(*, definition: dict[str, Any], fixture_by_id: dict[str, dict[str, Any]]) -> dict[str, Any]:
+    set_key = str(definition.get("set_key") or "fixture_set")
+    requested_ids = sorted(str(value) for value in definition.get("fixture_ids") or [])
+    fixtures = [fixture_by_id[fixture_id] for fixture_id in requested_ids if fixture_id in fixture_by_id]
+    missing_ids = [fixture_id for fixture_id in requested_ids if fixture_id not in fixture_by_id]
+    state, reason_codes = _lifecycle_state(definition=definition, fixtures=fixtures, missing_ids=missing_ids)
+    fixture_set_seed = {
+        "set_key": set_key,
+        "fixture_ids": requested_ids,
+        "generation_token": STABLE_FIXTURE_SET_GENERATION_TOKEN,
+    }
+    unsupported = state == "unsupported" or any(fixture.get("unsupported") for fixture in fixtures)
+    blocked = state == "blocked" or any(fixture.get("blocked") for fixture in fixtures)
+    return {
+        "fixture_set_id": f"v3_1_fixture_set_{deterministic_hash(fixture_set_seed)[:16]}",
+        "set_key": set_key,
+        "associated_fixture_ids": requested_ids,
+        "resolved_fixture_ids": sorted(str(fixture.get("fixture_id")) for fixture in fixtures),
+        "missing_fixture_ids": missing_ids,
+        "lifecycle_state": state,
+        "policy_evaluation_status": _policy_status_for_lifecycle(state),
+        "unsupported": unsupported,
+        "blocked": blocked,
+        "deterministic_reason_codes": reason_codes,
+        "fixture_state_counts": dict(sorted(Counter(str(fixture.get("approval_state")) for fixture in fixtures).items())),
+        "production_ownership_metadata": {
+            "owner": "legacy",
+            "legacy_controlled": True,
+            "trusted_default_routing": False,
+            "fixture_set_authorizes_production_routing": False,
+        },
+        "production_output_affected": False,
+        "generation": {
+            "strategy": "stable_token_fixture_membership_hash",
+            "token": STABLE_FIXTURE_SET_GENERATION_TOKEN,
+            "timestamp_strategy": "report_level_deterministic_token",
+        },
+        "metadata": {
+            "observational_only": True,
+            "production_consumer": False,
+            "production_behavior_changed": False,
+            "planner_remap_performed": False,
+        },
+    }
+
+
+def _lifecycle_state(*, definition: dict[str, Any], fixtures: list[dict[str, Any]], missing_ids: list[str]) -> tuple[str, list[str]]:
+    requested = str(definition.get("lifecycle_state") or "")
+    if requested in FIXTURE_SET_LIFECYCLE_STATES:
+        return requested, [f"explicit_{requested}"]
+    if missing_ids or not fixtures:
+        return "insufficient_data", ["missing_or_empty_fixture_membership"]
+    states = Counter(str(fixture.get("approval_state")) for fixture in fixtures)
+    if states["blocked"]:
+        return "blocked", ["blocked_fixture_present"]
+    if states["unsupported"]:
+        return "unsupported", ["unsupported_fixture_present"]
+    if states["insufficient_data"]:
+        return "insufficient_data", ["insufficient_data_fixture_present"]
+    if states["archived"] == len(fixtures):
+        return "archived", ["all_fixtures_archived"]
+    approved = states["approved_candidate"] + states["approved_baseline"]
+    if approved == len(fixtures):
+        return "approved_candidate", ["all_fixtures_approved_for_candidate_review"]
+    if approved:
+        return "partially_approved", ["mixed_approval_states"]
+    if states["pending_review"] == len(fixtures):
+        return "review_ready", ["all_fixtures_pending_review"]
+    return "draft", ["fixture_set_requires_review_setup"]
+
+
+def _policy_status_for_lifecycle(lifecycle_state: str) -> str:
+    if lifecycle_state == "approved_candidate":
+        return "passes_policy"
+    if lifecycle_state in {"review_ready", "partially_approved", "draft", "archived"}:
+        return "requires_review"
+    if lifecycle_state in {"blocked", "unsupported", "insufficient_data"}:
+        return lifecycle_state
+    return "not_evaluated"
+
+
+def _stable_envelope(envelope: dict[str, Any]) -> dict[str, Any]:
+    stable = deepcopy(envelope)
+    stable.pop("generated_at", None)
+    stable.pop("deterministic_hash", None)
+    return stable

--- a/backend/app/planner_adapters/v3_1/review_policy_evaluation.py
+++ b/backend/app/planner_adapters/v3_1/review_policy_evaluation.py
@@ -1,0 +1,165 @@
+"""Deterministic review policy evaluation infrastructure."""
+
+from __future__ import annotations
+
+from collections import Counter
+from copy import deepcopy
+from datetime import UTC, datetime
+from typing import Any
+
+from .persisted_fixture_sets import V31PersistedFixtureSets, build_sample_persisted_fixture_set_inputs
+from .trusted_shadow_consumption import deterministic_hash
+
+
+REVIEW_POLICY_OUTCOMES = (
+    "passes_policy",
+    "requires_review",
+    "blocked",
+    "unsupported",
+    "insufficient_data",
+    "not_evaluated",
+)
+STABLE_POLICY_GENERATION_TOKEN = "v3_1_phase_5_review_policy_evaluation_token"
+
+
+class V31ReviewPolicyEvaluation:
+    """Evaluate persisted fixture sets against explicit review policy metadata."""
+
+    def evaluate(
+        self,
+        *,
+        persisted_fixture_sets: dict[str, Any],
+        policy: dict[str, Any] | None = None,
+        run_id: str = "v3_1_phase_5_review_policy_evaluation",
+    ) -> dict[str, Any]:
+        policy_record = _normalize_policy(policy)
+        evaluations = [
+            _evaluate_fixture_set(fixture_set=row, policy=policy_record)
+            for row in sorted(persisted_fixture_sets.get("fixture_sets") or [], key=lambda item: str(item.get("fixture_set_id") or ""))
+        ]
+        counts = Counter(row["policy_outcome"] for row in evaluations)
+        production_affected_count = sum(1 for row in evaluations if row["production_output_affected"])
+        envelope = {
+            "schema_version": "v3_1.review_policy_evaluation.1",
+            "generated_at": datetime.now(UTC).isoformat(),
+            "run": {
+                "run_id": run_id,
+                "source_fixture_set_schema": persisted_fixture_sets.get("schema_version"),
+                "source_fixture_set_hash": persisted_fixture_sets.get("deterministic_hash"),
+                "evaluation_count": len(evaluations),
+            },
+            "policy": policy_record,
+            "summary": {
+                "total_evaluations": len(evaluations),
+                "policy_pass_count": counts["passes_policy"],
+                "requires_review_count": counts["requires_review"],
+                "blocked_count": counts["blocked"],
+                "unsupported_count": counts["unsupported"],
+                "insufficient_data_count": counts["insufficient_data"],
+                "not_evaluated_count": counts["not_evaluated"],
+                "production_affected_count": production_affected_count,
+                "production_output_affected": False,
+                "production_behavior_changed": False,
+                "trusted_data_default_truth": False,
+                "deterministic": True,
+            },
+            "policy_outcome_counts": {
+                outcome: counts[outcome]
+                for outcome in REVIEW_POLICY_OUTCOMES
+            },
+            "evaluations": evaluations,
+            "safety_confirmations": {
+                "production_output_affected": False,
+                "production_behavior_changed": False,
+                "trusted_data_default_truth": False,
+                "legacy_planner_ownership_preserved": True,
+                "runtime_state_mutated": False,
+                "policy_authorizes_production_routing": False,
+                "hidden_heuristics_used": False,
+                "unsupported_states_hidden": False,
+                "blocked_states_hidden": False,
+            },
+            "metadata": {
+                "source": "v3_1_review_policy_evaluation",
+                "observational_only": True,
+                "production_consumer": False,
+                "production_behavior_changed": False,
+                "planner_remap_performed": False,
+                "production_default_routing_authorized": False,
+                "stable_policy_generation_token": STABLE_POLICY_GENERATION_TOKEN,
+                "deterministic_serializer": "json_sort_keys_sha256",
+            },
+        }
+        envelope["deterministic_hash"] = deterministic_hash(_stable_envelope(envelope))
+        return envelope
+
+
+def build_sample_review_policy_inputs() -> dict[str, Any]:
+    workflows = build_sample_persisted_fixture_set_inputs()
+    return V31PersistedFixtureSets().build(
+        baseline_fixture_workflows=workflows,
+        run_id="v3_1_phase_5_review_policy_fixture_set_sample",
+    )
+
+
+def _normalize_policy(policy: dict[str, Any] | None) -> dict[str, Any]:
+    policy = policy or {}
+    return {
+        "policy_id": str(policy.get("policy_id") or "v3_1_default_review_policy"),
+        "policy_version": str(policy.get("policy_version") or "1"),
+        "requires_no_blocked": bool(policy.get("requires_no_blocked", True)),
+        "requires_no_unsupported": bool(policy.get("requires_no_unsupported", True)),
+        "requires_no_insufficient_data": bool(policy.get("requires_no_insufficient_data", True)),
+        "requires_approved_candidate_state": bool(policy.get("requires_approved_candidate_state", True)),
+        "production_routing_authorized": False,
+        "generation_token": STABLE_POLICY_GENERATION_TOKEN,
+    }
+
+
+def _evaluate_fixture_set(*, fixture_set: dict[str, Any], policy: dict[str, Any]) -> dict[str, Any]:
+    outcome, reason_codes = _policy_outcome(fixture_set=fixture_set, policy=policy)
+    return {
+        "fixture_set_id": fixture_set.get("fixture_set_id"),
+        "set_key": fixture_set.get("set_key"),
+        "lifecycle_state": fixture_set.get("lifecycle_state"),
+        "policy_outcome": outcome,
+        "review_readiness_classification": outcome,
+        "unsupported": bool(fixture_set.get("unsupported", False)),
+        "blocked": bool(fixture_set.get("blocked", False)),
+        "deterministic_reason_codes": reason_codes,
+        "production_ownership_metadata": {
+            "owner": "legacy",
+            "legacy_controlled": True,
+            "trusted_default_routing": False,
+            "policy_authorizes_production_routing": False,
+        },
+        "production_output_affected": False,
+        "metadata": {
+            "observational_only": True,
+            "production_consumer": False,
+            "production_behavior_changed": False,
+            "planner_remap_performed": False,
+        },
+    }
+
+
+def _policy_outcome(*, fixture_set: dict[str, Any], policy: dict[str, Any]) -> tuple[str, list[str]]:
+    state = str(fixture_set.get("lifecycle_state"))
+    if state == "blocked" or (policy["requires_no_blocked"] and fixture_set.get("blocked")):
+        return "blocked", ["blocked_fixture_set_visible"]
+    if state == "unsupported" or (policy["requires_no_unsupported"] and fixture_set.get("unsupported")):
+        return "unsupported", ["unsupported_fixture_set_visible"]
+    if state == "insufficient_data" or (policy["requires_no_insufficient_data"] and state == "insufficient_data"):
+        return "insufficient_data", ["insufficient_data_visible"]
+    if state == "approved_candidate" and policy["requires_approved_candidate_state"]:
+        return "passes_policy", ["approved_candidate_fixture_set"]
+    if state in {"review_ready", "partially_approved", "draft", "archived"}:
+        return "requires_review", [f"{state}_requires_review"]
+    return "not_evaluated", ["unrecognized_fixture_set_lifecycle"]
+
+
+def _stable_envelope(envelope: dict[str, Any]) -> dict[str, Any]:
+    stable = deepcopy(envelope)
+    stable.pop("generated_at", None)
+    stable.pop("deterministic_hash", None)
+    return stable

--- a/backend/scripts/report_v3_1_persisted_fixture_sets.py
+++ b/backend/scripts/report_v3_1_persisted_fixture_sets.py
@@ -1,0 +1,140 @@
+"""Generate the v3.1 persisted fixture set report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.planner_adapters.v3_1.persisted_fixture_sets import (  # noqa: E402
+    V31PersistedFixtureSets,
+    build_sample_persisted_fixture_set_inputs,
+)
+
+
+DETERMINISTIC_GENERATED_AT = "2026-05-15T00:00:00+00:00"
+
+
+def build_v3_1_persisted_fixture_sets_report() -> dict[str, Any]:
+    workflows = build_sample_persisted_fixture_set_inputs()
+    fixture_sets = V31PersistedFixtureSets().build(baseline_fixture_workflows=workflows)
+    repeated = V31PersistedFixtureSets().build(baseline_fixture_workflows=workflows)
+    deterministic = fixture_sets["deterministic_hash"] == repeated["deterministic_hash"]
+    report = {
+        "schema_version": "v3_1.persisted_fixture_sets_report.1",
+        "generated_at": DETERMINISTIC_GENERATED_AT,
+        "phase": "v3.1_phase_5_persisted_fixture_sets",
+        "recommendation": "OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING",
+        "production_default_routing_authorized": False,
+        "summary": {
+            **fixture_sets["summary"],
+            "deterministic": deterministic,
+        },
+        "persisted_fixture_sets": fixture_sets,
+        "deterministic_guarantees": {
+            "passed": deterministic,
+            "sample_hash": fixture_sets["deterministic_hash"],
+            "repeated_hash": repeated["deterministic_hash"],
+            "timestamp_excluded_from_hash": True,
+            "json_sort_keys": True,
+            "stable_fixture_set_generation_token": fixture_sets["metadata"]["stable_fixture_set_generation_token"],
+        },
+        "phase_5_boundaries": [
+            "workflows remain observational only",
+            "trusted infrastructure is still not production default",
+            "fixture-set membership does not authorize runtime routing",
+            "unsupported and blocked states remain intentionally visible",
+            "legacy planner ownership remains intact",
+        ],
+        "metadata": {
+            "source": "v3_1_persisted_fixture_sets_report",
+            "observational_only": True,
+            "production_behavior_changed": False,
+            "production_default_routing_authorized": False,
+            "planner_remap_performed": False,
+        },
+    }
+    return _normalize_generated_at(report)
+
+
+def write_report(report: dict[str, Any], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_markdown(report: dict[str, Any], output_path: Path) -> None:
+    summary = report["summary"]
+    lines = [
+        "# V3.1 Persisted Fixture Sets",
+        "",
+        "Phase 5 introduces deterministic persisted fixture-set infrastructure.",
+        "Fixture sets are migration-readiness groupings only and do not authorize production routing.",
+        "",
+        "## Recommendation",
+        "",
+        f"- Recommendation: `{report['recommendation']}`",
+        f"- Production default routing authorized: `{str(report['production_default_routing_authorized']).lower()}`",
+        "",
+        "## Summary",
+        "",
+        f"- Total fixture sets: `{summary['total_fixture_sets']}`",
+        f"- Draft: `{summary['draft_count']}`",
+        f"- Review ready: `{summary['review_ready_count']}`",
+        f"- Partially approved: `{summary['partially_approved_count']}`",
+        f"- Approved candidate: `{summary['approved_candidate_count']}`",
+        f"- Blocked: `{summary['blocked_count']}`",
+        f"- Unsupported: `{summary['unsupported_count']}`",
+        f"- Insufficient data: `{summary['insufficient_data_count']}`",
+        f"- Policy pass: `{summary['policy_pass_count']}`",
+        f"- Requires review: `{summary['requires_review_count']}`",
+        f"- Production affected: `{summary['production_affected_count']}`",
+        f"- Deterministic: `{str(summary['deterministic']).lower()}`",
+        "",
+        "## Fixture Sets",
+        "",
+        "| Fixture Set | State | Fixtures | Policy Status | Production Affected |",
+        "| --- | --- | ---: | --- | --- |",
+    ]
+    for row in report["persisted_fixture_sets"]["fixture_sets"]:
+        lines.append(
+            f"| `{row['fixture_set_id']}` | `{row['lifecycle_state']}` | `{len(row['associated_fixture_ids'])}` | `{row['policy_evaluation_status']}` | `{str(row['production_output_affected']).lower()}` |"
+        )
+    lines.extend(["", "## Phase 5 Boundaries", ""])
+    lines.extend(f"- {item}" for item in report["phase_5_boundaries"])
+    lines.extend(["", "## Conclusion", "", "Persisted fixture sets are available for migration governance, while production routing remains unchanged."])
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _normalize_generated_at(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: DETERMINISTIC_GENERATED_AT if key == "generated_at" else _normalize_generated_at(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_normalize_generated_at(item) for item in value]
+    return deepcopy(value)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", default="docs/generated/v3_1_persisted_fixture_sets_report.json")
+    parser.add_argument("--markdown-output", default="docs/migration/V3_1_PERSISTED_FIXTURE_SETS.md")
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[2]
+    report = build_v3_1_persisted_fixture_sets_report()
+    write_report(report, repo_root / args.output)
+    write_markdown(report, repo_root / args.markdown_output)
+    print(json.dumps(report["summary"], indent=2, sort_keys=True))
+    print(report["recommendation"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/scripts/report_v3_1_review_policy_evaluation.py
+++ b/backend/scripts/report_v3_1_review_policy_evaluation.py
@@ -1,0 +1,137 @@
+"""Generate the v3.1 review policy evaluation report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.planner_adapters.v3_1.review_policy_evaluation import (  # noqa: E402
+    V31ReviewPolicyEvaluation,
+    build_sample_review_policy_inputs,
+)
+
+
+DETERMINISTIC_GENERATED_AT = "2026-05-15T00:00:00+00:00"
+
+
+def build_v3_1_review_policy_evaluation_report() -> dict[str, Any]:
+    fixture_sets = build_sample_review_policy_inputs()
+    evaluation = V31ReviewPolicyEvaluation().evaluate(persisted_fixture_sets=fixture_sets)
+    repeated = V31ReviewPolicyEvaluation().evaluate(persisted_fixture_sets=fixture_sets)
+    deterministic = evaluation["deterministic_hash"] == repeated["deterministic_hash"]
+    report = {
+        "schema_version": "v3_1.review_policy_evaluation_report.1",
+        "generated_at": DETERMINISTIC_GENERATED_AT,
+        "phase": "v3.1_phase_5_review_policy_evaluation",
+        "recommendation": "OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING",
+        "production_default_routing_authorized": False,
+        "summary": {
+            **evaluation["summary"],
+            "deterministic": deterministic,
+        },
+        "review_policy_evaluation": evaluation,
+        "deterministic_guarantees": {
+            "passed": deterministic,
+            "sample_hash": evaluation["deterministic_hash"],
+            "repeated_hash": repeated["deterministic_hash"],
+            "timestamp_excluded_from_hash": True,
+            "json_sort_keys": True,
+            "stable_policy_generation_token": evaluation["metadata"]["stable_policy_generation_token"],
+        },
+        "phase_5_boundaries": [
+            "workflows remain observational only",
+            "trusted infrastructure is still not production default",
+            "policy evaluation does not authorize runtime routing",
+            "unsupported and blocked states remain intentionally visible",
+            "legacy planner ownership remains intact",
+        ],
+        "metadata": {
+            "source": "v3_1_review_policy_evaluation_report",
+            "observational_only": True,
+            "production_behavior_changed": False,
+            "production_default_routing_authorized": False,
+            "planner_remap_performed": False,
+        },
+    }
+    return _normalize_generated_at(report)
+
+
+def write_report(report: dict[str, Any], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_markdown(report: dict[str, Any], output_path: Path) -> None:
+    summary = report["summary"]
+    lines = [
+        "# V3.1 Review Policy Evaluation",
+        "",
+        "Phase 5 introduces deterministic review policy evaluation infrastructure.",
+        "Policy evaluation is governance metadata only and does not authorize production routing.",
+        "",
+        "## Recommendation",
+        "",
+        f"- Recommendation: `{report['recommendation']}`",
+        f"- Production default routing authorized: `{str(report['production_default_routing_authorized']).lower()}`",
+        "",
+        "## Summary",
+        "",
+        f"- Total evaluations: `{summary['total_evaluations']}`",
+        f"- Policy pass: `{summary['policy_pass_count']}`",
+        f"- Requires review: `{summary['requires_review_count']}`",
+        f"- Blocked: `{summary['blocked_count']}`",
+        f"- Unsupported: `{summary['unsupported_count']}`",
+        f"- Insufficient data: `{summary['insufficient_data_count']}`",
+        f"- Not evaluated: `{summary['not_evaluated_count']}`",
+        f"- Production affected: `{summary['production_affected_count']}`",
+        f"- Deterministic: `{str(summary['deterministic']).lower()}`",
+        "",
+        "## Policy Evaluations",
+        "",
+        "| Fixture Set | Lifecycle | Outcome | Production Affected |",
+        "| --- | --- | --- | --- |",
+    ]
+    for row in report["review_policy_evaluation"]["evaluations"]:
+        lines.append(
+            f"| `{row['fixture_set_id']}` | `{row['lifecycle_state']}` | `{row['policy_outcome']}` | `{str(row['production_output_affected']).lower()}` |"
+        )
+    lines.extend(["", "## Phase 5 Boundaries", ""])
+    lines.extend(f"- {item}" for item in report["phase_5_boundaries"])
+    lines.extend(["", "## Conclusion", "", "Review policy evaluation is available for migration governance, while production routing remains unchanged."])
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _normalize_generated_at(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: DETERMINISTIC_GENERATED_AT if key == "generated_at" else _normalize_generated_at(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_normalize_generated_at(item) for item in value]
+    return deepcopy(value)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", default="docs/generated/v3_1_review_policy_evaluation_report.json")
+    parser.add_argument("--markdown-output", default="docs/migration/V3_1_REVIEW_POLICY_EVALUATION.md")
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[2]
+    report = build_v3_1_review_policy_evaluation_report()
+    write_report(report, repo_root / args.output)
+    write_markdown(report, repo_root / args.markdown_output)
+    print(json.dumps(report["summary"], indent=2, sort_keys=True))
+    print(report["recommendation"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_v3_1_persisted_fixture_sets.py
+++ b/backend/tests/test_v3_1_persisted_fixture_sets.py
@@ -1,0 +1,188 @@
+import json
+
+from app.planner_adapters.v3_1.baseline_fixture_workflows import V31BaselineFixtureWorkflows
+from app.planner_adapters.v3_1.persisted_fixture_sets import V31PersistedFixtureSets
+from scripts.report_v3_1_persisted_fixture_sets import (
+    build_v3_1_persisted_fixture_sets_report,
+    write_report,
+)
+
+
+def test_fixture_set_generation_is_deterministic():
+    workflows = _workflow_envelope([_fixture("a", "pending_review")])
+    first = V31PersistedFixtureSets().build(baseline_fixture_workflows=workflows)
+    second = V31PersistedFixtureSets().build(baseline_fixture_workflows=workflows)
+
+    assert first["deterministic_hash"] == second["deterministic_hash"]
+    assert first["summary"]["deterministic"] is True
+
+
+def test_stable_ids_remain_stable():
+    workflows = _workflow_envelope([_fixture("a", "pending_review")])
+    first = V31PersistedFixtureSets().build(baseline_fixture_workflows=workflows)
+    second = V31PersistedFixtureSets().build(baseline_fixture_workflows=workflows)
+
+    assert first["fixture_sets"][0]["fixture_set_id"] == second["fixture_sets"][0]["fixture_set_id"]
+    assert first["fixture_sets"][0]["fixture_set_id"].startswith("v3_1_fixture_set_")
+
+
+def test_lifecycle_states_classify_correctly():
+    workflows = _workflow_envelope(
+        [
+            _fixture("pending", "pending_review"),
+            _fixture("candidate", "approved_candidate"),
+            _fixture("baseline", "approved_baseline"),
+            _fixture("unsupported", "unsupported"),
+            _fixture("blocked", "blocked"),
+            _fixture("insufficient", "insufficient_data"),
+        ]
+    )
+    result = V31PersistedFixtureSets().build(
+        baseline_fixture_workflows=workflows,
+        set_definitions=[
+            _set("draft", []),
+            _set("review", ["pending"]),
+            _set("partial", ["pending", "candidate"]),
+            _set("approved", ["candidate", "baseline"]),
+            _set("unsupported", ["unsupported"]),
+            _set("blocked", ["blocked"]),
+            _set("insufficient", ["insufficient"]),
+            _set("archived", ["pending"], lifecycle_state="archived"),
+        ],
+    )
+    observed = {row["set_key"]: row["lifecycle_state"] for row in result["fixture_sets"]}
+
+    assert observed["draft"] == "insufficient_data"
+    assert observed["review"] == "review_ready"
+    assert observed["partial"] == "partially_approved"
+    assert observed["approved"] == "approved_candidate"
+    assert observed["unsupported"] == "unsupported"
+    assert observed["blocked"] == "blocked"
+    assert observed["insufficient"] == "insufficient_data"
+    assert observed["archived"] == "archived"
+
+
+def test_unsupported_and_blocked_states_remain_visible():
+    workflows = _workflow_envelope([_fixture("unsupported", "unsupported"), _fixture("blocked", "blocked")])
+    result = V31PersistedFixtureSets().build(
+        baseline_fixture_workflows=workflows,
+        set_definitions=[_set("unsupported", ["unsupported"]), _set("blocked", ["blocked"])],
+    )
+    observed = {row["set_key"]: row for row in result["fixture_sets"]}
+
+    assert observed["unsupported"]["unsupported"] is True
+    assert observed["unsupported"]["lifecycle_state"] == "unsupported"
+    assert observed["blocked"]["blocked"] is True
+    assert observed["blocked"]["lifecycle_state"] == "blocked"
+
+
+def test_aggregate_counts_are_correct():
+    workflows = _workflow_envelope(
+        [
+            _fixture("pending", "pending_review"),
+            _fixture("candidate", "approved_candidate"),
+            _fixture("baseline", "approved_baseline"),
+            _fixture("unsupported", "unsupported"),
+            _fixture("blocked", "blocked"),
+            _fixture("insufficient", "insufficient_data"),
+        ]
+    )
+    result = V31PersistedFixtureSets().build(
+        baseline_fixture_workflows=workflows,
+        set_definitions=[
+            _set("draft", [], lifecycle_state="draft"),
+            _set("review", ["pending"]),
+            _set("partial", ["pending", "candidate"]),
+            _set("approved", ["candidate", "baseline"]),
+            _set("unsupported", ["unsupported"]),
+            _set("blocked", ["blocked"]),
+            _set("insufficient", ["insufficient"]),
+        ],
+    )
+
+    assert result["summary"]["total_fixture_sets"] == 7
+    assert result["summary"]["draft_count"] == 1
+    assert result["summary"]["review_ready_count"] == 1
+    assert result["summary"]["partially_approved_count"] == 1
+    assert result["summary"]["approved_candidate_count"] == 1
+    assert result["summary"]["unsupported_count"] == 1
+    assert result["summary"]["blocked_count"] == 1
+    assert result["summary"]["insufficient_data_count"] == 1
+    assert result["summary"]["policy_pass_count"] == 1
+    assert result["summary"]["requires_review_count"] == 3
+    assert result["summary"]["production_affected_count"] == 0
+
+
+def test_production_output_affected_remains_false():
+    result = V31PersistedFixtureSets().build(baseline_fixture_workflows=_workflow_envelope([_fixture("a", "approved_candidate")]))
+
+    assert result["summary"]["production_output_affected"] is False
+    assert result["summary"]["production_affected_count"] == 0
+    assert result["safety_confirmations"]["fixture_set_authorizes_production_routing"] is False
+    assert all(row["production_output_affected"] is False for row in result["fixture_sets"])
+
+
+def test_prior_phase_compatibility_remains_intact():
+    workflows = V31BaselineFixtureWorkflows().build(
+        planner_snapshot_baselines={
+            "schema_version": "v3_1.planner_snapshot_baselines.1",
+            "deterministic_hash": "snapshot-hash",
+            "snapshots": [
+                {
+                    "snapshot_id": "snapshot_a",
+                    "stable_key": "affix",
+                    "baseline_readiness": "baseline_candidate",
+                    "comparison_eligible": True,
+                    "baseline_candidate": True,
+                    "unsupported": False,
+                    "blocked": False,
+                    "production_output_affected": False,
+                    "dual_run_comparison_state": {"drift_classification": "equivalent"},
+                }
+            ],
+        }
+    )
+    result = V31PersistedFixtureSets().build(baseline_fixture_workflows=workflows)
+
+    assert result["run"]["source_fixture_workflow_hash"] == workflows["deterministic_hash"]
+    assert result["fixture_sets"][0]["associated_fixture_ids"] == [workflows["fixtures"][0]["fixture_id"]]
+
+
+def test_report_generation_is_deterministic(tmp_path):
+    first = build_v3_1_persisted_fixture_sets_report()
+    second = build_v3_1_persisted_fixture_sets_report()
+
+    assert first["deterministic_guarantees"]["passed"] is True
+    assert first["persisted_fixture_sets"]["deterministic_hash"] == second["persisted_fixture_sets"]["deterministic_hash"]
+    assert first["summary"] == second["summary"]
+
+    output = tmp_path / "fixture_sets.json"
+    write_report(first, output)
+    loaded = json.loads(output.read_text(encoding="utf-8"))
+    assert loaded["schema_version"] == "v3_1.persisted_fixture_sets_report.1"
+    assert loaded["production_default_routing_authorized"] is False
+
+
+def _workflow_envelope(fixtures):
+    return {
+        "schema_version": "v3_1.baseline_fixture_workflows.1",
+        "deterministic_hash": "workflow-hash",
+        "fixtures": fixtures,
+    }
+
+
+def _fixture(key, state):
+    return {
+        "fixture_id": key,
+        "approval_state": state,
+        "unsupported": state == "unsupported",
+        "blocked": state == "blocked",
+        "production_output_affected": False,
+    }
+
+
+def _set(key, fixture_ids, lifecycle_state=None):
+    row = {"set_key": key, "fixture_ids": fixture_ids}
+    if lifecycle_state:
+        row["lifecycle_state"] = lifecycle_state
+    return row

--- a/backend/tests/test_v3_1_review_policy_evaluation.py
+++ b/backend/tests/test_v3_1_review_policy_evaluation.py
@@ -1,0 +1,145 @@
+import json
+
+from app.planner_adapters.v3_1.persisted_fixture_sets import V31PersistedFixtureSets
+from app.planner_adapters.v3_1.review_policy_evaluation import V31ReviewPolicyEvaluation
+from scripts.report_v3_1_review_policy_evaluation import (
+    build_v3_1_review_policy_evaluation_report,
+    write_report,
+)
+
+
+def test_policy_evaluation_is_deterministic():
+    fixture_sets = _fixture_set_envelope([_fixture_set("approved", "approved_candidate")])
+    first = V31ReviewPolicyEvaluation().evaluate(persisted_fixture_sets=fixture_sets)
+    second = V31ReviewPolicyEvaluation().evaluate(persisted_fixture_sets=fixture_sets)
+
+    assert first["deterministic_hash"] == second["deterministic_hash"]
+    assert first["summary"]["deterministic"] is True
+
+
+def test_policy_outcomes_classify_correctly():
+    result = V31ReviewPolicyEvaluation().evaluate(
+        persisted_fixture_sets=_fixture_set_envelope(
+            [
+                _fixture_set("approved", "approved_candidate"),
+                _fixture_set("review", "review_ready"),
+                _fixture_set("blocked", "blocked"),
+                _fixture_set("unsupported", "unsupported"),
+                _fixture_set("insufficient", "insufficient_data"),
+                _fixture_set("unknown", "unexpected"),
+            ]
+        )
+    )
+    observed = {row["set_key"]: row["policy_outcome"] for row in result["evaluations"]}
+
+    assert observed["approved"] == "passes_policy"
+    assert observed["review"] == "requires_review"
+    assert observed["blocked"] == "blocked"
+    assert observed["unsupported"] == "unsupported"
+    assert observed["insufficient"] == "insufficient_data"
+    assert observed["unknown"] == "not_evaluated"
+
+
+def test_unsupported_and_blocked_states_remain_visible():
+    result = V31ReviewPolicyEvaluation().evaluate(
+        persisted_fixture_sets=_fixture_set_envelope(
+            [_fixture_set("blocked", "blocked"), _fixture_set("unsupported", "unsupported")]
+        )
+    )
+    observed = {row["set_key"]: row for row in result["evaluations"]}
+
+    assert observed["blocked"]["policy_outcome"] == "blocked"
+    assert observed["blocked"]["blocked"] is True
+    assert observed["unsupported"]["policy_outcome"] == "unsupported"
+    assert observed["unsupported"]["unsupported"] is True
+
+
+def test_aggregate_counts_are_correct():
+    result = V31ReviewPolicyEvaluation().evaluate(
+        persisted_fixture_sets=_fixture_set_envelope(
+            [
+                _fixture_set("approved", "approved_candidate"),
+                _fixture_set("review", "review_ready"),
+                _fixture_set("blocked", "blocked"),
+                _fixture_set("unsupported", "unsupported"),
+                _fixture_set("insufficient", "insufficient_data"),
+                _fixture_set("unknown", "unexpected"),
+            ]
+        )
+    )
+
+    assert result["summary"]["total_evaluations"] == 6
+    assert result["summary"]["policy_pass_count"] == 1
+    assert result["summary"]["requires_review_count"] == 1
+    assert result["summary"]["blocked_count"] == 1
+    assert result["summary"]["unsupported_count"] == 1
+    assert result["summary"]["insufficient_data_count"] == 1
+    assert result["summary"]["not_evaluated_count"] == 1
+    assert result["summary"]["production_affected_count"] == 0
+
+
+def test_production_output_affected_remains_false():
+    result = V31ReviewPolicyEvaluation().evaluate(
+        persisted_fixture_sets=_fixture_set_envelope([_fixture_set("approved", "approved_candidate")])
+    )
+
+    assert result["summary"]["production_output_affected"] is False
+    assert result["summary"]["production_affected_count"] == 0
+    assert result["safety_confirmations"]["policy_authorizes_production_routing"] is False
+    assert all(row["production_output_affected"] is False for row in result["evaluations"])
+
+
+def test_prior_phase_compatibility_remains_intact():
+    fixture_sets = V31PersistedFixtureSets().build(
+        baseline_fixture_workflows={
+            "schema_version": "v3_1.baseline_fixture_workflows.1",
+            "deterministic_hash": "workflow-hash",
+            "fixtures": [
+                {
+                    "fixture_id": "fixture_a",
+                    "approval_state": "approved_candidate",
+                    "unsupported": False,
+                    "blocked": False,
+                    "production_output_affected": False,
+                }
+            ],
+        }
+    )
+    result = V31ReviewPolicyEvaluation().evaluate(persisted_fixture_sets=fixture_sets)
+
+    assert result["run"]["source_fixture_set_hash"] == fixture_sets["deterministic_hash"]
+    assert result["evaluations"][0]["policy_outcome"] == "passes_policy"
+
+
+def test_report_generation_is_deterministic(tmp_path):
+    first = build_v3_1_review_policy_evaluation_report()
+    second = build_v3_1_review_policy_evaluation_report()
+
+    assert first["deterministic_guarantees"]["passed"] is True
+    assert first["review_policy_evaluation"]["deterministic_hash"] == second["review_policy_evaluation"]["deterministic_hash"]
+    assert first["summary"] == second["summary"]
+
+    output = tmp_path / "policy.json"
+    write_report(first, output)
+    loaded = json.loads(output.read_text(encoding="utf-8"))
+    assert loaded["schema_version"] == "v3_1.review_policy_evaluation_report.1"
+    assert loaded["production_default_routing_authorized"] is False
+
+
+def _fixture_set_envelope(fixture_sets):
+    return {
+        "schema_version": "v3_1.persisted_fixture_sets.1",
+        "deterministic_hash": "fixture-set-hash",
+        "fixture_sets": fixture_sets,
+    }
+
+
+def _fixture_set(key, lifecycle_state):
+    return {
+        "fixture_set_id": f"set_{key}",
+        "set_key": key,
+        "lifecycle_state": lifecycle_state,
+        "unsupported": lifecycle_state == "unsupported",
+        "blocked": lifecycle_state == "blocked",
+        "production_output_affected": False,
+    }

--- a/docs/generated/v3_1_persisted_fixture_sets_report.json
+++ b/docs/generated/v3_1_persisted_fixture_sets_report.json
@@ -1,0 +1,160 @@
+{
+  "deterministic_guarantees": {
+    "json_sort_keys": true,
+    "passed": true,
+    "repeated_hash": "87bb0f1888fa99a2bb2bd99fa7806a365d1e4cceaefbd72118fae064d600116e",
+    "sample_hash": "87bb0f1888fa99a2bb2bd99fa7806a365d1e4cceaefbd72118fae064d600116e",
+    "stable_fixture_set_generation_token": "v3_1_phase_5_persisted_fixture_set_token",
+    "timestamp_excluded_from_hash": true
+  },
+  "generated_at": "2026-05-15T00:00:00+00:00",
+  "metadata": {
+    "observational_only": true,
+    "planner_remap_performed": false,
+    "production_behavior_changed": false,
+    "production_default_routing_authorized": false,
+    "source": "v3_1_persisted_fixture_sets_report"
+  },
+  "persisted_fixture_sets": {
+    "deterministic_hash": "87bb0f1888fa99a2bb2bd99fa7806a365d1e4cceaefbd72118fae064d600116e",
+    "fixture_sets": [
+      {
+        "associated_fixture_ids": [
+          "v3_1_fixture_6c378a420c0a4ced",
+          "v3_1_fixture_756415e2e7d3feb2",
+          "v3_1_fixture_8118751ba1b46140",
+          "v3_1_fixture_9c3d260c0dda7b4f",
+          "v3_1_fixture_b82b601f9b088bb8"
+        ],
+        "blocked": false,
+        "deterministic_reason_codes": [
+          "unsupported_fixture_present"
+        ],
+        "fixture_set_id": "v3_1_fixture_set_6d3b668a84cfbb69",
+        "fixture_state_counts": {
+          "insufficient_data": 1,
+          "pending_review": 2,
+          "unsupported": 2
+        },
+        "generation": {
+          "strategy": "stable_token_fixture_membership_hash",
+          "timestamp_strategy": "report_level_deterministic_token",
+          "token": "v3_1_phase_5_persisted_fixture_set_token"
+        },
+        "lifecycle_state": "unsupported",
+        "metadata": {
+          "observational_only": true,
+          "planner_remap_performed": false,
+          "production_behavior_changed": false,
+          "production_consumer": false
+        },
+        "missing_fixture_ids": [],
+        "policy_evaluation_status": "unsupported",
+        "production_output_affected": false,
+        "production_ownership_metadata": {
+          "fixture_set_authorizes_production_routing": false,
+          "legacy_controlled": true,
+          "owner": "legacy",
+          "trusted_default_routing": false
+        },
+        "resolved_fixture_ids": [
+          "v3_1_fixture_6c378a420c0a4ced",
+          "v3_1_fixture_756415e2e7d3feb2",
+          "v3_1_fixture_8118751ba1b46140",
+          "v3_1_fixture_9c3d260c0dda7b4f",
+          "v3_1_fixture_b82b601f9b088bb8"
+        ],
+        "set_key": "sample_migration_readiness_set",
+        "unsupported": true
+      }
+    ],
+    "generated_at": "2026-05-15T00:00:00+00:00",
+    "lifecycle_state_counts": {
+      "approved_candidate": 0,
+      "archived": 0,
+      "blocked": 0,
+      "draft": 0,
+      "insufficient_data": 0,
+      "partially_approved": 0,
+      "review_ready": 0,
+      "unsupported": 1
+    },
+    "metadata": {
+      "deterministic_serializer": "json_sort_keys_sha256",
+      "observational_only": true,
+      "planner_remap_performed": false,
+      "production_behavior_changed": false,
+      "production_consumer": false,
+      "production_default_routing_authorized": false,
+      "source": "v3_1_persisted_fixture_sets",
+      "stable_fixture_set_generation_token": "v3_1_phase_5_persisted_fixture_set_token"
+    },
+    "policy_evaluation_status_counts": {
+      "unsupported": 1
+    },
+    "run": {
+      "fixture_set_count": 1,
+      "run_id": "v3_1_phase_5_persisted_fixture_sets",
+      "source_fixture_workflow_hash": "27a2b6dbe38f81224daa34d9674e92a056c0e5515b71019cfabe7e773c8d1735",
+      "source_fixture_workflow_schema": "v3_1.baseline_fixture_workflows.1"
+    },
+    "safety_confirmations": {
+      "blocked_states_hidden": false,
+      "fixture_set_authorizes_production_routing": false,
+      "legacy_planner_ownership_preserved": true,
+      "production_behavior_changed": false,
+      "production_output_affected": false,
+      "runtime_state_mutated": false,
+      "trusted_data_default_truth": false,
+      "unsupported_states_hidden": false
+    },
+    "schema_version": "v3_1.persisted_fixture_sets.1",
+    "summary": {
+      "approved_candidate_count": 0,
+      "archived_count": 0,
+      "blocked_count": 0,
+      "deterministic": true,
+      "draft_count": 0,
+      "insufficient_data_count": 0,
+      "partially_approved_count": 0,
+      "policy_pass_count": 0,
+      "production_affected_count": 0,
+      "production_behavior_changed": false,
+      "production_output_affected": false,
+      "requires_review_count": 0,
+      "review_ready_count": 0,
+      "total_fixture_sets": 1,
+      "trusted_data_default_truth": false,
+      "unsupported_count": 1
+    }
+  },
+  "phase": "v3.1_phase_5_persisted_fixture_sets",
+  "phase_5_boundaries": [
+    "workflows remain observational only",
+    "trusted infrastructure is still not production default",
+    "fixture-set membership does not authorize runtime routing",
+    "unsupported and blocked states remain intentionally visible",
+    "legacy planner ownership remains intact"
+  ],
+  "production_default_routing_authorized": false,
+  "recommendation": "OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING",
+  "schema_version": "v3_1.persisted_fixture_sets_report.1",
+  "summary": {
+    "approved_candidate_count": 0,
+    "archived_count": 0,
+    "blocked_count": 0,
+    "deterministic": true,
+    "draft_count": 0,
+    "insufficient_data_count": 0,
+    "partially_approved_count": 0,
+    "policy_pass_count": 0,
+    "production_affected_count": 0,
+    "production_behavior_changed": false,
+    "production_output_affected": false,
+    "requires_review_count": 0,
+    "review_ready_count": 0,
+    "total_fixture_sets": 1,
+    "trusted_data_default_truth": false,
+    "unsupported_count": 1
+  }
+}

--- a/docs/generated/v3_1_review_policy_evaluation_report.json
+++ b/docs/generated/v3_1_review_policy_evaluation_report.json
@@ -1,0 +1,134 @@
+{
+  "deterministic_guarantees": {
+    "json_sort_keys": true,
+    "passed": true,
+    "repeated_hash": "e4c4d8158ed053e7f882796308ae244780a41a203a6c44608789c091cddab766",
+    "sample_hash": "e4c4d8158ed053e7f882796308ae244780a41a203a6c44608789c091cddab766",
+    "stable_policy_generation_token": "v3_1_phase_5_review_policy_evaluation_token",
+    "timestamp_excluded_from_hash": true
+  },
+  "generated_at": "2026-05-15T00:00:00+00:00",
+  "metadata": {
+    "observational_only": true,
+    "planner_remap_performed": false,
+    "production_behavior_changed": false,
+    "production_default_routing_authorized": false,
+    "source": "v3_1_review_policy_evaluation_report"
+  },
+  "phase": "v3.1_phase_5_review_policy_evaluation",
+  "phase_5_boundaries": [
+    "workflows remain observational only",
+    "trusted infrastructure is still not production default",
+    "policy evaluation does not authorize runtime routing",
+    "unsupported and blocked states remain intentionally visible",
+    "legacy planner ownership remains intact"
+  ],
+  "production_default_routing_authorized": false,
+  "recommendation": "OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING",
+  "review_policy_evaluation": {
+    "deterministic_hash": "e4c4d8158ed053e7f882796308ae244780a41a203a6c44608789c091cddab766",
+    "evaluations": [
+      {
+        "blocked": false,
+        "deterministic_reason_codes": [
+          "unsupported_fixture_set_visible"
+        ],
+        "fixture_set_id": "v3_1_fixture_set_6d3b668a84cfbb69",
+        "lifecycle_state": "unsupported",
+        "metadata": {
+          "observational_only": true,
+          "planner_remap_performed": false,
+          "production_behavior_changed": false,
+          "production_consumer": false
+        },
+        "policy_outcome": "unsupported",
+        "production_output_affected": false,
+        "production_ownership_metadata": {
+          "legacy_controlled": true,
+          "owner": "legacy",
+          "policy_authorizes_production_routing": false,
+          "trusted_default_routing": false
+        },
+        "review_readiness_classification": "unsupported",
+        "set_key": "sample_migration_readiness_set",
+        "unsupported": true
+      }
+    ],
+    "generated_at": "2026-05-15T00:00:00+00:00",
+    "metadata": {
+      "deterministic_serializer": "json_sort_keys_sha256",
+      "observational_only": true,
+      "planner_remap_performed": false,
+      "production_behavior_changed": false,
+      "production_consumer": false,
+      "production_default_routing_authorized": false,
+      "source": "v3_1_review_policy_evaluation",
+      "stable_policy_generation_token": "v3_1_phase_5_review_policy_evaluation_token"
+    },
+    "policy": {
+      "generation_token": "v3_1_phase_5_review_policy_evaluation_token",
+      "policy_id": "v3_1_default_review_policy",
+      "policy_version": "1",
+      "production_routing_authorized": false,
+      "requires_approved_candidate_state": true,
+      "requires_no_blocked": true,
+      "requires_no_insufficient_data": true,
+      "requires_no_unsupported": true
+    },
+    "policy_outcome_counts": {
+      "blocked": 0,
+      "insufficient_data": 0,
+      "not_evaluated": 0,
+      "passes_policy": 0,
+      "requires_review": 0,
+      "unsupported": 1
+    },
+    "run": {
+      "evaluation_count": 1,
+      "run_id": "v3_1_phase_5_review_policy_evaluation",
+      "source_fixture_set_hash": "d79462e70382b91afc3c448bd8f2a8d865369c728ea77ba2bb9f24308dda23e7",
+      "source_fixture_set_schema": "v3_1.persisted_fixture_sets.1"
+    },
+    "safety_confirmations": {
+      "blocked_states_hidden": false,
+      "hidden_heuristics_used": false,
+      "legacy_planner_ownership_preserved": true,
+      "policy_authorizes_production_routing": false,
+      "production_behavior_changed": false,
+      "production_output_affected": false,
+      "runtime_state_mutated": false,
+      "trusted_data_default_truth": false,
+      "unsupported_states_hidden": false
+    },
+    "schema_version": "v3_1.review_policy_evaluation.1",
+    "summary": {
+      "blocked_count": 0,
+      "deterministic": true,
+      "insufficient_data_count": 0,
+      "not_evaluated_count": 0,
+      "policy_pass_count": 0,
+      "production_affected_count": 0,
+      "production_behavior_changed": false,
+      "production_output_affected": false,
+      "requires_review_count": 0,
+      "total_evaluations": 1,
+      "trusted_data_default_truth": false,
+      "unsupported_count": 1
+    }
+  },
+  "schema_version": "v3_1.review_policy_evaluation_report.1",
+  "summary": {
+    "blocked_count": 0,
+    "deterministic": true,
+    "insufficient_data_count": 0,
+    "not_evaluated_count": 0,
+    "policy_pass_count": 0,
+    "production_affected_count": 0,
+    "production_behavior_changed": false,
+    "production_output_affected": false,
+    "requires_review_count": 0,
+    "total_evaluations": 1,
+    "trusted_data_default_truth": false,
+    "unsupported_count": 1
+  }
+}

--- a/docs/migration/V3_1_PERSISTED_FIXTURE_SETS.md
+++ b/docs/migration/V3_1_PERSISTED_FIXTURE_SETS.md
@@ -1,0 +1,42 @@
+# V3.1 Persisted Fixture Sets
+
+Phase 5 introduces deterministic persisted fixture-set infrastructure.
+Fixture sets are migration-readiness groupings only and do not authorize production routing.
+
+## Recommendation
+
+- Recommendation: `OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING`
+- Production default routing authorized: `false`
+
+## Summary
+
+- Total fixture sets: `1`
+- Draft: `0`
+- Review ready: `0`
+- Partially approved: `0`
+- Approved candidate: `0`
+- Blocked: `0`
+- Unsupported: `1`
+- Insufficient data: `0`
+- Policy pass: `0`
+- Requires review: `0`
+- Production affected: `0`
+- Deterministic: `true`
+
+## Fixture Sets
+
+| Fixture Set | State | Fixtures | Policy Status | Production Affected |
+| --- | --- | ---: | --- | --- |
+| `v3_1_fixture_set_6d3b668a84cfbb69` | `unsupported` | `5` | `unsupported` | `false` |
+
+## Phase 5 Boundaries
+
+- workflows remain observational only
+- trusted infrastructure is still not production default
+- fixture-set membership does not authorize runtime routing
+- unsupported and blocked states remain intentionally visible
+- legacy planner ownership remains intact
+
+## Conclusion
+
+Persisted fixture sets are available for migration governance, while production routing remains unchanged.

--- a/docs/migration/V3_1_REVIEW_POLICY_EVALUATION.md
+++ b/docs/migration/V3_1_REVIEW_POLICY_EVALUATION.md
@@ -1,0 +1,39 @@
+# V3.1 Review Policy Evaluation
+
+Phase 5 introduces deterministic review policy evaluation infrastructure.
+Policy evaluation is governance metadata only and does not authorize production routing.
+
+## Recommendation
+
+- Recommendation: `OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING`
+- Production default routing authorized: `false`
+
+## Summary
+
+- Total evaluations: `1`
+- Policy pass: `0`
+- Requires review: `0`
+- Blocked: `0`
+- Unsupported: `1`
+- Insufficient data: `0`
+- Not evaluated: `0`
+- Production affected: `0`
+- Deterministic: `true`
+
+## Policy Evaluations
+
+| Fixture Set | Lifecycle | Outcome | Production Affected |
+| --- | --- | --- | --- |
+| `v3_1_fixture_set_6d3b668a84cfbb69` | `unsupported` | `unsupported` | `false` |
+
+## Phase 5 Boundaries
+
+- workflows remain observational only
+- trusted infrastructure is still not production default
+- policy evaluation does not authorize runtime routing
+- unsupported and blocked states remain intentionally visible
+- legacy planner ownership remains intact
+
+## Conclusion
+
+Review policy evaluation is available for migration governance, while production routing remains unchanged.


### PR DESCRIPTION
Adds deterministic persisted fixture set and review policy infrastructure for v3.1 migration readiness. This phase introduces stable persisted fixture collections, explicit review policy metadata, and deterministic policy evaluation summaries connected to baseline workflow governance without enabling trusted default routing or production planner replacement.