### PR TITLE
v3.1: add reviewed fixture input discovery

### DIFF
--- a/backend/app/planner_adapters/v3_1/__init__.py
+++ b/backend/app/planner_adapters/v3_1/__init__.py
@@ -25,6 +25,11 @@ from .review_policy_evaluation import (
     V31ReviewPolicyEvaluation,
     build_sample_review_policy_inputs,
 )
+from .reviewed_fixture_inputs import (
+    REVIEWED_FIXTURE_INPUT_STATUSES,
+    discover_default_reviewed_fixture_input_sources,
+    normalize_reviewed_fixture_inputs,
+)
 from .trusted_shadow_consumption import (
     SUPPORTED_TRUSTED_SHADOW_DOMAINS,
     V31TrustedProductionShadowConsumption,
@@ -38,6 +43,7 @@ __all__ = [
     "FIXTURE_WORKFLOW_STATES",
     "FIXTURE_SET_LIFECYCLE_STATES",
     "REVIEW_POLICY_OUTCOMES",
+    "REVIEWED_FIXTURE_INPUT_STATUSES",
     "SUPPORTED_TRUSTED_SHADOW_DOMAINS",
     "V31BaselineFixtureWorkflows",
     "V31DualRunComparison",
@@ -51,5 +57,7 @@ __all__ = [
     "build_sample_review_policy_inputs",
     "build_sample_dual_run_inputs",
     "build_default_trusted_repository_probes",
+    "discover_default_reviewed_fixture_input_sources",
     "deterministic_hash",
+    "normalize_reviewed_fixture_inputs",
 ]

--- a/backend/app/planner_adapters/v3_1/reviewed_fixture_inputs.py
+++ b/backend/app/planner_adapters/v3_1/reviewed_fixture_inputs.py
@@ -1,0 +1,290 @@
+"""Reviewed fixture input discovery and normalization.
+
+This module is pure governance infrastructure. It reads candidate payloads
+provided by callers, normalizes deterministic fixture input records, and never
+integrates with production planner/runtime behavior.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+from .trusted_shadow_consumption import deterministic_hash
+
+
+REVIEWED_FIXTURE_INPUT_STATUSES = (
+    "reviewed",
+    "missing_source",
+    "malformed",
+    "duplicate",
+    "unsupported",
+)
+STABLE_REVIEWED_INPUT_GENERATION_TOKEN = "v3_1_phase_6_reviewed_fixture_inputs_token"
+SUPPORTED_SOURCE_TYPES = frozenset({"baseline_fixture_workflows", "persisted_fixture_sets"})
+
+
+def discover_default_reviewed_fixture_input_sources(repo_root: Path | None = None) -> list[dict[str, Any]]:
+    root = repo_root or Path(__file__).resolve().parents[4]
+    generated = root / "docs" / "generated"
+    return [
+        {
+            "source_id": "v3_1_baseline_fixture_workflows_report",
+            "source_type": "baseline_fixture_workflows",
+            "path": str(generated / "v3_1_baseline_fixture_workflows_report.json"),
+        },
+        {
+            "source_id": "v3_1_persisted_fixture_sets_report",
+            "source_type": "persisted_fixture_sets",
+            "path": str(generated / "v3_1_persisted_fixture_sets_report.json"),
+        },
+    ]
+
+
+def load_reviewed_fixture_input_sources(source_specs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    loaded: list[dict[str, Any]] = []
+    for spec in sorted(source_specs, key=lambda row: str(row.get("source_id") or row.get("path") or "")):
+        path = Path(str(spec.get("path") or ""))
+        if not path.exists():
+            loaded.append(_missing_source_record(spec, f"source path not found: {path}"))
+            continue
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            loaded.append(_missing_source_record(spec, f"invalid source JSON: {exc}"))
+            continue
+        loaded.append(
+            {
+                "source_id": str(spec.get("source_id") or path.name),
+                "source_type": str(spec.get("source_type") or "unknown"),
+                "source_path": str(path),
+                "payload": payload,
+                "source_available": True,
+            }
+        )
+    return loaded
+
+
+def build_reviewed_fixture_input_report(source_payloads: list[dict[str, Any]]) -> dict[str, Any]:
+    normalized = normalize_reviewed_fixture_inputs(source_payloads)
+    counts = Counter(record["status"] for record in normalized)
+    report = {
+        "schema_version": "v3_1.reviewed_fixture_inputs.1",
+        "source_count": len(source_payloads),
+        "discovered_input_source_count": len(source_payloads),
+        "normalized_fixture_count": len(normalized),
+        "duplicate_count": counts["duplicate"],
+        "malformed_count": counts["malformed"],
+        "unsupported_count": counts["unsupported"],
+        "missing_source_count": counts["missing_source"],
+        "reviewed_candidate_count": counts["reviewed"],
+        "status_counts": {
+            status: counts[status]
+            for status in REVIEWED_FIXTURE_INPUT_STATUSES
+        },
+        "normalized_fixture_inputs": normalized,
+        "safety_confirmations": {
+            "production_output_affected": False,
+            "production_behavior_changed": False,
+            "trusted_data_default_truth": False,
+            "legacy_planner_ownership_preserved": True,
+            "runtime_state_mutated": False,
+            "reviewed_inputs_authorize_production_routing": False,
+        },
+        "metadata": {
+            "source": "v3_1_reviewed_fixture_inputs",
+            "observational_only": True,
+            "production_consumer": False,
+            "production_behavior_changed": False,
+            "planner_remap_performed": False,
+            "production_default_routing_authorized": False,
+            "stable_generation_token": STABLE_REVIEWED_INPUT_GENERATION_TOKEN,
+            "deterministic_serializer": "json_sort_keys_sha256",
+        },
+    }
+    report["deterministic_hash"] = deterministic_hash(report)
+    return report
+
+
+def normalize_reviewed_fixture_inputs(source_payloads: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    raw_records: list[dict[str, Any]] = []
+    for source in sorted(source_payloads, key=lambda row: str(row.get("source_id") or "")):
+        raw_records.extend(_records_from_source(source))
+
+    seen: set[str] = set()
+    normalized: list[dict[str, Any]] = []
+    for record in sorted(raw_records, key=lambda row: (str(row.get("input_id") or ""), str(row.get("source_id") or ""))):
+        item = _normalize_record(record)
+        if item["status"] == "reviewed" and item["normalized_fixture_id"] in seen:
+            item["status"] = "duplicate"
+            item["reason_codes"] = ["duplicate_fixture_identifier"]
+        elif item["status"] == "reviewed":
+            seen.add(item["normalized_fixture_id"])
+        normalized.append(item)
+    return normalized
+
+
+def _records_from_source(source: dict[str, Any]) -> list[dict[str, Any]]:
+    if not source.get("source_available", True):
+        return [
+            {
+                "source_id": source.get("source_id"),
+                "source_type": source.get("source_type"),
+                "source_path": source.get("source_path"),
+                "input_id": source.get("source_id"),
+                "status_hint": "missing_source",
+                "reason_codes": [source.get("error") or "source_unavailable"],
+            }
+        ]
+    source_type = str(source.get("source_type") or "")
+    if source_type not in SUPPORTED_SOURCE_TYPES:
+        return [
+            {
+                "source_id": source.get("source_id"),
+                "source_type": source_type,
+                "source_path": source.get("source_path"),
+                "input_id": source.get("source_id"),
+                "status_hint": "unsupported",
+                "reason_codes": ["unsupported_source_type"],
+            }
+        ]
+    payload = source.get("payload") or {}
+    if source_type == "baseline_fixture_workflows":
+        fixtures = (((payload.get("baseline_fixture_workflows") or {}).get("fixtures")) or [])
+        if not isinstance(fixtures, list):
+            return [_malformed_source(source, "baseline_fixture_workflows.fixtures_not_list")]
+        return [
+            {
+                "source_id": source.get("source_id"),
+                "source_type": source_type,
+                "source_path": source.get("source_path"),
+                "input_id": fixture.get("fixture_id") if isinstance(fixture, dict) else None,
+                "status_hint": _status_from_fixture(fixture),
+                "reason_codes": _reasons_from_fixture(fixture),
+                "payload_digest": deterministic_hash({"fixture": fixture}),
+            }
+            for fixture in fixtures
+        ]
+    fixture_sets = (((payload.get("persisted_fixture_sets") or {}).get("fixture_sets")) or [])
+    if not isinstance(fixture_sets, list):
+        return [_malformed_source(source, "persisted_fixture_sets.fixture_sets_not_list")]
+    return [
+        {
+            "source_id": source.get("source_id"),
+            "source_type": source_type,
+            "source_path": source.get("source_path"),
+            "input_id": fixture_set.get("fixture_set_id") if isinstance(fixture_set, dict) else None,
+            "status_hint": _status_from_fixture_set(fixture_set),
+            "reason_codes": _reasons_from_fixture_set(fixture_set),
+            "payload_digest": deterministic_hash({"fixture_set": fixture_set}),
+        }
+        for fixture_set in fixture_sets
+    ]
+
+
+def _normalize_record(record: dict[str, Any]) -> dict[str, Any]:
+    input_id = record.get("input_id")
+    status = str(record.get("status_hint") or "reviewed")
+    reason_codes = [str(reason) for reason in record.get("reason_codes") or []]
+    if not input_id:
+        status = "malformed"
+        reason_codes = reason_codes or ["missing_fixture_identifier"]
+        normalized_id = f"malformed:{record.get('source_id')}"
+    else:
+        normalized_id = _normalize_identifier(str(input_id))
+    if status not in REVIEWED_FIXTURE_INPUT_STATUSES:
+        status = "malformed"
+        reason_codes = reason_codes or ["unknown_input_status"]
+    return {
+        "normalized_fixture_id": normalized_id,
+        "source_fixture_id": str(input_id) if input_id is not None else None,
+        "source_id": str(record.get("source_id") or ""),
+        "source_type": str(record.get("source_type") or ""),
+        "source_path": str(record.get("source_path") or ""),
+        "status": status,
+        "reason_codes": sorted(set(reason_codes or [f"{status}_fixture_input"])),
+        "payload_digest": record.get("payload_digest"),
+        "production_output_affected": False,
+        "production_routing_authorized": False,
+        "metadata": {
+            "observational_only": True,
+            "production_consumer": False,
+            "planner_remap_performed": False,
+        },
+    }
+
+
+def _normalize_identifier(value: str) -> str:
+    return "_".join(value.strip().lower().replace("\\", "/").replace(":", "_").split())
+
+
+def _status_from_fixture(fixture: Any) -> str:
+    if not isinstance(fixture, dict):
+        return "malformed"
+    state = str(fixture.get("approval_state") or "")
+    if fixture.get("unsupported") or state in {"unsupported", "blocked", "insufficient_data"}:
+        return "unsupported"
+    return "reviewed"
+
+
+def _reasons_from_fixture(fixture: Any) -> list[str]:
+    if not isinstance(fixture, dict):
+        return ["fixture_record_not_object"]
+    if not fixture.get("fixture_id"):
+        return ["missing_fixture_identifier"]
+    state = str(fixture.get("approval_state") or "")
+    if fixture.get("unsupported"):
+        return ["unsupported_fixture_visible"]
+    if fixture.get("blocked") or state == "blocked":
+        return ["blocked_fixture_visible"]
+    if state == "insufficient_data":
+        return ["insufficient_data_fixture_visible"]
+    return [f"approval_state_{state or 'unknown'}"]
+
+
+def _status_from_fixture_set(fixture_set: Any) -> str:
+    if not isinstance(fixture_set, dict):
+        return "malformed"
+    state = str(fixture_set.get("lifecycle_state") or "")
+    if fixture_set.get("unsupported") or fixture_set.get("blocked") or state in {"unsupported", "blocked", "insufficient_data"}:
+        return "unsupported"
+    return "reviewed"
+
+
+def _reasons_from_fixture_set(fixture_set: Any) -> list[str]:
+    if not isinstance(fixture_set, dict):
+        return ["fixture_set_record_not_object"]
+    if not fixture_set.get("fixture_set_id"):
+        return ["missing_fixture_set_identifier"]
+    state = str(fixture_set.get("lifecycle_state") or "")
+    if fixture_set.get("unsupported") or state == "unsupported":
+        return ["unsupported_fixture_set_visible"]
+    if fixture_set.get("blocked") or state == "blocked":
+        return ["blocked_fixture_set_visible"]
+    if state == "insufficient_data":
+        return ["insufficient_data_fixture_set_visible"]
+    return [f"lifecycle_state_{state or 'unknown'}"]
+
+
+def _missing_source_record(spec: dict[str, Any], error: str) -> dict[str, Any]:
+    return {
+        "source_id": str(spec.get("source_id") or spec.get("path") or "missing_source"),
+        "source_type": str(spec.get("source_type") or "unknown"),
+        "source_path": str(spec.get("path") or ""),
+        "source_available": False,
+        "error": error,
+    }
+
+
+def _malformed_source(source: dict[str, Any], reason: str) -> dict[str, Any]:
+    return {
+        "source_id": source.get("source_id"),
+        "source_type": source.get("source_type"),
+        "source_path": source.get("source_path"),
+        "input_id": source.get("source_id"),
+        "status_hint": "malformed",
+        "reason_codes": [reason],
+    }

--- a/backend/scripts/report_v3_1_reviewed_fixture_inputs.py
+++ b/backend/scripts/report_v3_1_reviewed_fixture_inputs.py
@@ -1,0 +1,151 @@
+"""Generate the v3.1 reviewed fixture input discovery report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.planner_adapters.v3_1.reviewed_fixture_inputs import (  # noqa: E402
+    build_reviewed_fixture_input_report,
+    discover_default_reviewed_fixture_input_sources,
+    load_reviewed_fixture_input_sources,
+)
+
+
+DETERMINISTIC_GENERATED_AT = "2026-05-15T00:00:00+00:00"
+
+
+def build_v3_1_reviewed_fixture_inputs_report() -> dict[str, Any]:
+    repo_root = Path(__file__).resolve().parents[2]
+    sources = discover_default_reviewed_fixture_input_sources(repo_root)
+    loaded = load_reviewed_fixture_input_sources(sources)
+    reviewed_inputs = build_reviewed_fixture_input_report(loaded)
+    report = {
+        "schema_version": "v3_1.reviewed_fixture_inputs_report.1",
+        "generated_at": DETERMINISTIC_GENERATED_AT,
+        "phase": "v3.1_phase_6_reviewed_fixture_input_discovery",
+        "recommendation": "OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING",
+        "production_default_routing_authorized": False,
+        "summary": {
+            "discovered_input_source_count": reviewed_inputs["discovered_input_source_count"],
+            "normalized_fixture_count": reviewed_inputs["normalized_fixture_count"],
+            "duplicate_count": reviewed_inputs["duplicate_count"],
+            "malformed_count": reviewed_inputs["malformed_count"],
+            "unsupported_count": reviewed_inputs["unsupported_count"],
+            "missing_source_count": reviewed_inputs["missing_source_count"],
+            "approved_reviewed_candidate_count": reviewed_inputs["reviewed_candidate_count"],
+            "production_output_affected": False,
+            "production_behavior_changed": False,
+            "deterministic": True,
+        },
+        "reviewed_fixture_inputs": reviewed_inputs,
+        "input_source_hashes": [
+            {
+                "source_id": source["source_id"],
+                "source_type": source["source_type"],
+                "source_available": bool(source.get("source_available", True)),
+                "source_hash": _source_hash(source),
+            }
+            for source in loaded
+        ],
+        "phase_6_boundaries": [
+            "reviewed fixture inputs are observational governance metadata only",
+            "trusted infrastructure is still not production default",
+            "reviewed inputs do not authorize production routing",
+            "unsupported and malformed inputs remain intentionally visible",
+            "legacy planner ownership remains intact",
+        ],
+        "metadata": {
+            "source": "v3_1_reviewed_fixture_inputs_report",
+            "observational_only": True,
+            "production_behavior_changed": False,
+            "production_default_routing_authorized": False,
+            "planner_remap_performed": False,
+        },
+    }
+    return _normalize_generated_at(report)
+
+
+def write_report(report: dict[str, Any], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_markdown(report: dict[str, Any], output_path: Path) -> None:
+    summary = report["summary"]
+    lines = [
+        "# V3.1 Reviewed Fixture Inputs",
+        "",
+        "Phase 6 introduces deterministic reviewed fixture input discovery and normalization.",
+        "Reviewed fixture inputs are governance metadata only and do not authorize production routing.",
+        "",
+        "## Recommendation",
+        "",
+        f"- Recommendation: `{report['recommendation']}`",
+        f"- Production default routing authorized: `{str(report['production_default_routing_authorized']).lower()}`",
+        "",
+        "## Summary",
+        "",
+        f"- Discovered input sources: `{summary['discovered_input_source_count']}`",
+        f"- Normalized fixtures: `{summary['normalized_fixture_count']}`",
+        f"- Duplicate inputs: `{summary['duplicate_count']}`",
+        f"- Malformed inputs: `{summary['malformed_count']}`",
+        f"- Unsupported inputs: `{summary['unsupported_count']}`",
+        f"- Missing sources: `{summary['missing_source_count']}`",
+        f"- Approved/reviewed candidates: `{summary['approved_reviewed_candidate_count']}`",
+        f"- Production affected: `{str(summary['production_output_affected']).lower()}`",
+        f"- Deterministic: `{str(summary['deterministic']).lower()}`",
+        "",
+        "## Input Status Counts",
+        "",
+        "| Status | Count |",
+        "| --- | ---: |",
+    ]
+    for status, count in report["reviewed_fixture_inputs"]["status_counts"].items():
+        lines.append(f"| `{status}` | `{count}` |")
+    lines.extend(["", "## Phase 6 Boundaries", ""])
+    lines.extend(f"- {item}" for item in report["phase_6_boundaries"])
+    lines.extend(["", "## Conclusion", "", "Reviewed fixture input discovery is available for governance, while production routing remains unchanged."])
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _source_hash(source: dict[str, Any]) -> str:
+    payload = deepcopy(source)
+    payload.pop("source_path", None)
+    return build_reviewed_fixture_input_report([payload])["deterministic_hash"]
+
+
+def _normalize_generated_at(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: DETERMINISTIC_GENERATED_AT if key == "generated_at" else _normalize_generated_at(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_normalize_generated_at(item) for item in value]
+    return deepcopy(value)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", default="docs/generated/v3_1_reviewed_fixture_inputs_report.json")
+    parser.add_argument("--markdown-output", default="docs/migration/V3_1_REVIEWED_FIXTURE_INPUTS.md")
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[2]
+    report = build_v3_1_reviewed_fixture_inputs_report()
+    write_report(report, repo_root / args.output)
+    write_markdown(report, repo_root / args.markdown_output)
+    print(json.dumps(report["summary"], indent=2, sort_keys=True))
+    print(report["recommendation"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_v3_1_reviewed_fixture_inputs.py
+++ b/backend/tests/test_v3_1_reviewed_fixture_inputs.py
@@ -1,0 +1,127 @@
+import json
+
+from app.planner_adapters.v3_1.reviewed_fixture_inputs import (
+    build_reviewed_fixture_input_report,
+    load_reviewed_fixture_input_sources,
+    normalize_reviewed_fixture_inputs,
+)
+from scripts.report_v3_1_reviewed_fixture_inputs import (
+    build_v3_1_reviewed_fixture_inputs_report,
+    write_report,
+)
+
+
+def test_deterministic_normalization():
+    sources = [_source("workflows", "baseline_fixture_workflows", [_fixture("fixture_b"), _fixture("fixture_a")])]
+
+    first = normalize_reviewed_fixture_inputs(sources)
+    second = normalize_reviewed_fixture_inputs(list(reversed(sources)))
+
+    assert first == second
+    assert [row["normalized_fixture_id"] for row in first] == ["fixture_a", "fixture_b"]
+
+
+def test_duplicate_handling():
+    sources = [
+        _source("a", "baseline_fixture_workflows", [_fixture("fixture_a")]),
+        _source("b", "baseline_fixture_workflows", [_fixture("fixture_a")]),
+    ]
+    report = build_reviewed_fixture_input_report(sources)
+
+    assert report["duplicate_count"] == 1
+    assert [row["status"] for row in report["normalized_fixture_inputs"]] == ["reviewed", "duplicate"]
+
+
+def test_malformed_input_handling():
+    sources = [_source("workflows", "baseline_fixture_workflows", [{"approval_state": "pending_review"}])]
+    report = build_reviewed_fixture_input_report(sources)
+
+    assert report["malformed_count"] == 1
+    row = report["normalized_fixture_inputs"][0]
+    assert row["status"] == "malformed"
+    assert "missing_fixture_identifier" in row["reason_codes"]
+
+
+def test_unsupported_input_handling():
+    sources = [_source("workflows", "baseline_fixture_workflows", [_fixture("fixture_u", unsupported=True)])]
+    report = build_reviewed_fixture_input_report(sources)
+
+    assert report["unsupported_count"] == 1
+    row = report["normalized_fixture_inputs"][0]
+    assert row["status"] == "unsupported"
+    assert "unsupported_fixture_visible" in row["reason_codes"]
+
+
+def test_missing_source_is_visible(tmp_path):
+    missing = tmp_path / "missing.json"
+    loaded = load_reviewed_fixture_input_sources(
+        [{"source_id": "missing", "source_type": "baseline_fixture_workflows", "path": str(missing)}]
+    )
+    report = build_reviewed_fixture_input_report(loaded)
+
+    assert report["missing_source_count"] == 1
+    assert report["normalized_fixture_inputs"][0]["status"] == "missing_source"
+
+
+def test_no_production_routing_enablement():
+    report = build_reviewed_fixture_input_report([_source("workflows", "baseline_fixture_workflows", [_fixture("fixture_a")])])
+
+    assert report["safety_confirmations"]["production_output_affected"] is False
+    assert report["safety_confirmations"]["reviewed_inputs_authorize_production_routing"] is False
+    assert report["metadata"]["production_default_routing_authorized"] is False
+    assert all(row["production_routing_authorized"] is False for row in report["normalized_fixture_inputs"])
+
+
+def test_no_live_runtime_planner_dependency():
+    report = build_reviewed_fixture_input_report([_source("sets", "persisted_fixture_sets", [_fixture_set("set_a")])])
+
+    assert report["normalized_fixture_count"] == 1
+    assert report["metadata"]["planner_remap_performed"] is False
+
+
+def test_report_generation_stability(tmp_path):
+    first = build_v3_1_reviewed_fixture_inputs_report()
+    second = build_v3_1_reviewed_fixture_inputs_report()
+
+    assert first["reviewed_fixture_inputs"]["deterministic_hash"] == second["reviewed_fixture_inputs"]["deterministic_hash"]
+    assert first["summary"] == second["summary"]
+
+    output = tmp_path / "reviewed_inputs.json"
+    write_report(first, output)
+    loaded = json.loads(output.read_text(encoding="utf-8"))
+    assert loaded["schema_version"] == "v3_1.reviewed_fixture_inputs_report.1"
+    assert loaded["production_default_routing_authorized"] is False
+
+
+def _source(source_id, source_type, records):
+    if source_type == "baseline_fixture_workflows":
+        payload = {"baseline_fixture_workflows": {"fixtures": records}}
+    else:
+        payload = {"persisted_fixture_sets": {"fixture_sets": records}}
+    return {
+        "source_id": source_id,
+        "source_type": source_type,
+        "source_path": f"fixture:{source_id}",
+        "source_available": True,
+        "payload": payload,
+    }
+
+
+def _fixture(fixture_id, unsupported=False):
+    return {
+        "fixture_id": fixture_id,
+        "approval_state": "unsupported" if unsupported else "pending_review",
+        "unsupported": unsupported,
+        "blocked": False,
+        "production_output_affected": False,
+    }
+
+
+def _fixture_set(fixture_set_id):
+    return {
+        "fixture_set_id": fixture_set_id,
+        "lifecycle_state": "review_ready",
+        "unsupported": False,
+        "blocked": False,
+        "production_output_affected": False,
+    }

--- a/docs/generated/v3_1_reviewed_fixture_inputs_report.json
+++ b/docs/generated/v3_1_reviewed_fixture_inputs_report.json
@@ -1,0 +1,200 @@
+{
+  "generated_at": "2026-05-15T00:00:00+00:00",
+  "input_source_hashes": [
+    {
+      "source_available": true,
+      "source_hash": "f41d44cdaadf629b1180f33bc8f71515224d49fc8a5c7a38dad5bc8b89ea143a",
+      "source_id": "v3_1_baseline_fixture_workflows_report",
+      "source_type": "baseline_fixture_workflows"
+    },
+    {
+      "source_available": true,
+      "source_hash": "5f0115ac09e2b1bbac76100e8af2a9cce866ca787bfe0359f1b2991b66ba59f0",
+      "source_id": "v3_1_persisted_fixture_sets_report",
+      "source_type": "persisted_fixture_sets"
+    }
+  ],
+  "metadata": {
+    "observational_only": true,
+    "planner_remap_performed": false,
+    "production_behavior_changed": false,
+    "production_default_routing_authorized": false,
+    "source": "v3_1_reviewed_fixture_inputs_report"
+  },
+  "phase": "v3.1_phase_6_reviewed_fixture_input_discovery",
+  "phase_6_boundaries": [
+    "reviewed fixture inputs are observational governance metadata only",
+    "trusted infrastructure is still not production default",
+    "reviewed inputs do not authorize production routing",
+    "unsupported and malformed inputs remain intentionally visible",
+    "legacy planner ownership remains intact"
+  ],
+  "production_default_routing_authorized": false,
+  "recommendation": "OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING",
+  "reviewed_fixture_inputs": {
+    "deterministic_hash": "bcc71a0573a2de21ed29ab1a7cae6ac04323875d4abccc85e387f4f266f6e077",
+    "discovered_input_source_count": 2,
+    "duplicate_count": 0,
+    "malformed_count": 0,
+    "metadata": {
+      "deterministic_serializer": "json_sort_keys_sha256",
+      "observational_only": true,
+      "planner_remap_performed": false,
+      "production_behavior_changed": false,
+      "production_consumer": false,
+      "production_default_routing_authorized": false,
+      "source": "v3_1_reviewed_fixture_inputs",
+      "stable_generation_token": "v3_1_phase_6_reviewed_fixture_inputs_token"
+    },
+    "missing_source_count": 0,
+    "normalized_fixture_count": 6,
+    "normalized_fixture_inputs": [
+      {
+        "metadata": {
+          "observational_only": true,
+          "planner_remap_performed": false,
+          "production_consumer": false
+        },
+        "normalized_fixture_id": "v3_1_fixture_6c378a420c0a4ced",
+        "payload_digest": "5eb23053f20162f83aaf36e823f005b8d2b2097a5a27c06cf425113fa093d1ad",
+        "production_output_affected": false,
+        "production_routing_authorized": false,
+        "reason_codes": [
+          "approval_state_pending_review"
+        ],
+        "source_fixture_id": "v3_1_fixture_6c378a420c0a4ced",
+        "source_id": "v3_1_baseline_fixture_workflows_report",
+        "source_path": "D:\\Forge\\le-the-forge\\docs\\generated\\v3_1_baseline_fixture_workflows_report.json",
+        "source_type": "baseline_fixture_workflows",
+        "status": "reviewed"
+      },
+      {
+        "metadata": {
+          "observational_only": true,
+          "planner_remap_performed": false,
+          "production_consumer": false
+        },
+        "normalized_fixture_id": "v3_1_fixture_756415e2e7d3feb2",
+        "payload_digest": "4c88e227955a5f8e9e70157a6b4b581455b0ee64d6dc0a6868da4d2a5e6ab92a",
+        "production_output_affected": false,
+        "production_routing_authorized": false,
+        "reason_codes": [
+          "approval_state_pending_review"
+        ],
+        "source_fixture_id": "v3_1_fixture_756415e2e7d3feb2",
+        "source_id": "v3_1_baseline_fixture_workflows_report",
+        "source_path": "D:\\Forge\\le-the-forge\\docs\\generated\\v3_1_baseline_fixture_workflows_report.json",
+        "source_type": "baseline_fixture_workflows",
+        "status": "reviewed"
+      },
+      {
+        "metadata": {
+          "observational_only": true,
+          "planner_remap_performed": false,
+          "production_consumer": false
+        },
+        "normalized_fixture_id": "v3_1_fixture_8118751ba1b46140",
+        "payload_digest": "e4e7ab70def53e0eef0a8affd2e88581f2c8e3db8e15060d9f964fb6b7482bed",
+        "production_output_affected": false,
+        "production_routing_authorized": false,
+        "reason_codes": [
+          "unsupported_fixture_visible"
+        ],
+        "source_fixture_id": "v3_1_fixture_8118751ba1b46140",
+        "source_id": "v3_1_baseline_fixture_workflows_report",
+        "source_path": "D:\\Forge\\le-the-forge\\docs\\generated\\v3_1_baseline_fixture_workflows_report.json",
+        "source_type": "baseline_fixture_workflows",
+        "status": "unsupported"
+      },
+      {
+        "metadata": {
+          "observational_only": true,
+          "planner_remap_performed": false,
+          "production_consumer": false
+        },
+        "normalized_fixture_id": "v3_1_fixture_9c3d260c0dda7b4f",
+        "payload_digest": "b5b96175959ee5ad48dffeaba818383c116cdb565f3ba810a7b732cfe04c2b4b",
+        "production_output_affected": false,
+        "production_routing_authorized": false,
+        "reason_codes": [
+          "unsupported_fixture_visible"
+        ],
+        "source_fixture_id": "v3_1_fixture_9c3d260c0dda7b4f",
+        "source_id": "v3_1_baseline_fixture_workflows_report",
+        "source_path": "D:\\Forge\\le-the-forge\\docs\\generated\\v3_1_baseline_fixture_workflows_report.json",
+        "source_type": "baseline_fixture_workflows",
+        "status": "unsupported"
+      },
+      {
+        "metadata": {
+          "observational_only": true,
+          "planner_remap_performed": false,
+          "production_consumer": false
+        },
+        "normalized_fixture_id": "v3_1_fixture_b82b601f9b088bb8",
+        "payload_digest": "4122371361202270eeee12264f25f01534bd0ef76025c49cc84f4e086b78e306",
+        "production_output_affected": false,
+        "production_routing_authorized": false,
+        "reason_codes": [
+          "insufficient_data_fixture_visible"
+        ],
+        "source_fixture_id": "v3_1_fixture_b82b601f9b088bb8",
+        "source_id": "v3_1_baseline_fixture_workflows_report",
+        "source_path": "D:\\Forge\\le-the-forge\\docs\\generated\\v3_1_baseline_fixture_workflows_report.json",
+        "source_type": "baseline_fixture_workflows",
+        "status": "unsupported"
+      },
+      {
+        "metadata": {
+          "observational_only": true,
+          "planner_remap_performed": false,
+          "production_consumer": false
+        },
+        "normalized_fixture_id": "v3_1_fixture_set_6d3b668a84cfbb69",
+        "payload_digest": "24e25541354d993caefc8a2d035491c6447cfb830f821cacbe2669d777025fd6",
+        "production_output_affected": false,
+        "production_routing_authorized": false,
+        "reason_codes": [
+          "unsupported_fixture_set_visible"
+        ],
+        "source_fixture_id": "v3_1_fixture_set_6d3b668a84cfbb69",
+        "source_id": "v3_1_persisted_fixture_sets_report",
+        "source_path": "D:\\Forge\\le-the-forge\\docs\\generated\\v3_1_persisted_fixture_sets_report.json",
+        "source_type": "persisted_fixture_sets",
+        "status": "unsupported"
+      }
+    ],
+    "reviewed_candidate_count": 2,
+    "safety_confirmations": {
+      "legacy_planner_ownership_preserved": true,
+      "production_behavior_changed": false,
+      "production_output_affected": false,
+      "reviewed_inputs_authorize_production_routing": false,
+      "runtime_state_mutated": false,
+      "trusted_data_default_truth": false
+    },
+    "schema_version": "v3_1.reviewed_fixture_inputs.1",
+    "source_count": 2,
+    "status_counts": {
+      "duplicate": 0,
+      "malformed": 0,
+      "missing_source": 0,
+      "reviewed": 2,
+      "unsupported": 4
+    },
+    "unsupported_count": 4
+  },
+  "schema_version": "v3_1.reviewed_fixture_inputs_report.1",
+  "summary": {
+    "approved_reviewed_candidate_count": 2,
+    "deterministic": true,
+    "discovered_input_source_count": 2,
+    "duplicate_count": 0,
+    "malformed_count": 0,
+    "missing_source_count": 0,
+    "normalized_fixture_count": 6,
+    "production_behavior_changed": false,
+    "production_output_affected": false,
+    "unsupported_count": 4
+  }
+}

--- a/docs/migration/V3_1_REVIEWED_FIXTURE_INPUTS.md
+++ b/docs/migration/V3_1_REVIEWED_FIXTURE_INPUTS.md
@@ -1,0 +1,43 @@
+# V3.1 Reviewed Fixture Inputs
+
+Phase 6 introduces deterministic reviewed fixture input discovery and normalization.
+Reviewed fixture inputs are governance metadata only and do not authorize production routing.
+
+## Recommendation
+
+- Recommendation: `OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING`
+- Production default routing authorized: `false`
+
+## Summary
+
+- Discovered input sources: `2`
+- Normalized fixtures: `6`
+- Duplicate inputs: `0`
+- Malformed inputs: `0`
+- Unsupported inputs: `4`
+- Missing sources: `0`
+- Approved/reviewed candidates: `2`
+- Production affected: `false`
+- Deterministic: `true`
+
+## Input Status Counts
+
+| Status | Count |
+| --- | ---: |
+| `reviewed` | `2` |
+| `missing_source` | `0` |
+| `malformed` | `0` |
+| `duplicate` | `0` |
+| `unsupported` | `4` |
+
+## Phase 6 Boundaries
+
+- reviewed fixture inputs are observational governance metadata only
+- trusted infrastructure is still not production default
+- reviewed inputs do not authorize production routing
+- unsupported and malformed inputs remain intentionally visible
+- legacy planner ownership remains intact
+
+## Conclusion
+
+Reviewed fixture input discovery is available for governance, while production routing remains unchanged.


### PR DESCRIPTION
Adds deterministic reviewed fixture input discovery, normalization, reporting, and tests for v3.1 governance. Keeps reviewed fixture inputs observational only and does not authorize production planner routing.