### PR TITLE
v3.1: add fixture set approval readiness gate

### DIFF
--- a/backend/app/planner_adapters/v3_1/__init__.py
+++ b/backend/app/planner_adapters/v3_1/__init__.py
@@ -25,6 +25,10 @@ from .review_policy_evaluation import (
     V31ReviewPolicyEvaluation,
     build_sample_review_policy_inputs,
 )
+from .fixture_set_readiness_gate import (
+    FIXTURE_SET_READINESS_CLASSIFICATIONS,
+    build_fixture_set_readiness_gate,
+)
 from .reviewed_fixture_inputs import (
     REVIEWED_FIXTURE_INPUT_STATUSES,
     discover_default_reviewed_fixture_input_sources,
@@ -44,6 +48,7 @@ __all__ = [
     "FIXTURE_SET_LIFECYCLE_STATES",
     "REVIEW_POLICY_OUTCOMES",
     "REVIEWED_FIXTURE_INPUT_STATUSES",
+    "FIXTURE_SET_READINESS_CLASSIFICATIONS",
     "SUPPORTED_TRUSTED_SHADOW_DOMAINS",
     "V31BaselineFixtureWorkflows",
     "V31DualRunComparison",
@@ -57,6 +62,7 @@ __all__ = [
     "build_sample_review_policy_inputs",
     "build_sample_dual_run_inputs",
     "build_default_trusted_repository_probes",
+    "build_fixture_set_readiness_gate",
     "discover_default_reviewed_fixture_input_sources",
     "deterministic_hash",
     "normalize_reviewed_fixture_inputs",

--- a/backend/app/planner_adapters/v3_1/fixture_set_readiness_gate.py
+++ b/backend/app/planner_adapters/v3_1/fixture_set_readiness_gate.py
@@ -1,0 +1,201 @@
+"""Deterministic fixture-set approval readiness gate.
+
+The gate combines reviewed inputs, persisted fixture sets, and policy outcomes
+to determine future approval-review readiness. It never authorizes runtime
+routing or changes production planner ownership.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from copy import deepcopy
+from typing import Any
+
+from .trusted_shadow_consumption import deterministic_hash
+
+
+FIXTURE_SET_READINESS_CLASSIFICATIONS = (
+    "ready_for_approval_review",
+    "blocked_missing_inputs",
+    "blocked_policy_failure",
+    "blocked_malformed_inputs",
+    "blocked_duplicate_inputs",
+    "blocked_insufficient_review",
+)
+STABLE_READINESS_GATE_TOKEN = "v3_1_phase_7_fixture_set_readiness_gate_token"
+
+
+def build_fixture_set_readiness_gate(
+    *,
+    reviewed_fixture_inputs: dict[str, Any] | list[dict[str, Any]],
+    persisted_fixture_sets: dict[str, Any],
+    review_policy_evaluation: dict[str, Any],
+    baseline_fixture_workflows: dict[str, Any] | None = None,
+    run_id: str = "v3_1_phase_7_fixture_set_readiness_gate",
+) -> dict[str, Any]:
+    normalized_inputs = _normalized_inputs(reviewed_fixture_inputs)
+    input_by_id = {str(row.get("normalized_fixture_id")): row for row in normalized_inputs}
+    policy_by_set = {
+        str(row.get("fixture_set_id")): row
+        for row in review_policy_evaluation.get("evaluations", [])
+    }
+    workflow_by_fixture_id = {
+        str(row.get("fixture_id")): row
+        for row in (baseline_fixture_workflows or {}).get("fixtures", [])
+    }
+    records = [
+        _readiness_record(
+            fixture_set=fixture_set,
+            input_by_id=input_by_id,
+            policy=policy_by_set.get(str(fixture_set.get("fixture_set_id"))),
+            workflow_by_fixture_id=workflow_by_fixture_id,
+        )
+        for fixture_set in sorted(persisted_fixture_sets.get("fixture_sets", []), key=lambda row: str(row.get("fixture_set_id") or ""))
+    ]
+    counts = Counter(row["readiness_classification"] for row in records)
+    block_reasons = Counter(reason for row in records for reason in row["block_reason_codes"])
+    envelope = {
+        "schema_version": "v3_1.fixture_set_readiness_gate.1",
+        "run": {
+            "run_id": run_id,
+            "fixture_set_count": len(records),
+            "reviewed_input_count": len(normalized_inputs),
+            "policy_evaluation_count": len(policy_by_set),
+            "workflow_fixture_count": len(workflow_by_fixture_id),
+        },
+        "summary": {
+            "total_fixture_sets_evaluated": len(records),
+            "ready_count": counts["ready_for_approval_review"],
+            "blocked_count": len(records) - counts["ready_for_approval_review"],
+            "production_affected_count": sum(1 for row in records if row["production_output_affected"]),
+            "production_output_affected": False,
+            "production_behavior_changed": False,
+            "trusted_data_default_truth": False,
+            "deterministic": True,
+        },
+        "readiness_classification_counts": {
+            classification: counts[classification]
+            for classification in FIXTURE_SET_READINESS_CLASSIFICATIONS
+        },
+        "block_reason_counts": dict(sorted(block_reasons.items())),
+        "readiness_records": records,
+        "input_consumption": {
+            "reviewed_fixture_inputs_hash": _source_hash(reviewed_fixture_inputs),
+            "persisted_fixture_sets_hash": persisted_fixture_sets.get("deterministic_hash"),
+            "review_policy_evaluation_hash": review_policy_evaluation.get("deterministic_hash"),
+            "baseline_fixture_workflows_hash": (baseline_fixture_workflows or {}).get("deterministic_hash"),
+        },
+        "safety_confirmations": {
+            "production_output_affected": False,
+            "production_behavior_changed": False,
+            "trusted_data_default_truth": False,
+            "legacy_planner_ownership_preserved": True,
+            "runtime_state_mutated": False,
+            "readiness_authorizes_production_routing": False,
+        },
+        "metadata": {
+            "source": "v3_1_fixture_set_readiness_gate",
+            "observational_only": True,
+            "production_consumer": False,
+            "production_behavior_changed": False,
+            "planner_remap_performed": False,
+            "production_default_routing_authorized": False,
+            "stable_generation_token": STABLE_READINESS_GATE_TOKEN,
+            "deterministic_serializer": "json_sort_keys_sha256",
+        },
+    }
+    envelope["deterministic_hash"] = deterministic_hash(envelope)
+    return envelope
+
+
+def _readiness_record(
+    *,
+    fixture_set: dict[str, Any],
+    input_by_id: dict[str, dict[str, Any]],
+    policy: dict[str, Any] | None,
+    workflow_by_fixture_id: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    fixture_ids = [str(value) for value in fixture_set.get("associated_fixture_ids", [])]
+    input_statuses = {
+        fixture_id: (input_by_id.get(_normalize_id(fixture_id)) or {}).get("status", "missing_source")
+        for fixture_id in fixture_ids
+    }
+    workflow_states = {
+        fixture_id: (workflow_by_fixture_id.get(fixture_id) or {}).get("approval_state", "unknown")
+        for fixture_id in fixture_ids
+    }
+    classification, reasons = _classify(fixture_set=fixture_set, policy=policy, input_statuses=input_statuses, workflow_states=workflow_states)
+    return {
+        "fixture_set_id": fixture_set.get("fixture_set_id"),
+        "set_key": fixture_set.get("set_key"),
+        "readiness_classification": classification,
+        "associated_fixture_ids": fixture_ids,
+        "input_statuses": dict(sorted(input_statuses.items())),
+        "policy_outcome": (policy or {}).get("policy_outcome", "missing"),
+        "workflow_states": dict(sorted(workflow_states.items())),
+        "block_reason_codes": reasons,
+        "non_production_authorization": {
+            "readiness_authorizes_production_routing": False,
+            "legacy_planner_ownership_preserved": True,
+            "trusted_default_routing": False,
+        },
+        "production_output_affected": False,
+        "metadata": {
+            "observational_only": True,
+            "production_consumer": False,
+            "planner_remap_performed": False,
+        },
+    }
+
+
+def _classify(
+    *,
+    fixture_set: dict[str, Any],
+    policy: dict[str, Any] | None,
+    input_statuses: dict[str, str],
+    workflow_states: dict[str, str],
+) -> tuple[str, list[str]]:
+    statuses = Counter(input_statuses.values())
+    if not input_statuses or statuses["missing_source"]:
+        return "blocked_missing_inputs", ["missing_reviewed_fixture_input"]
+    if statuses["malformed"]:
+        return "blocked_malformed_inputs", ["malformed_reviewed_fixture_input"]
+    if statuses["duplicate"]:
+        return "blocked_duplicate_inputs", ["duplicate_reviewed_fixture_input"]
+    policy_outcome = str((policy or {}).get("policy_outcome") or "missing")
+    if policy_outcome != "passes_policy":
+        return "blocked_policy_failure", [f"policy_{policy_outcome}"]
+    if any(status != "reviewed" for status in input_statuses.values()):
+        return "blocked_insufficient_review", ["input_not_reviewed"]
+    if any(state in {"unsupported", "blocked", "insufficient_data", "unknown"} for state in workflow_states.values()):
+        return "blocked_insufficient_review", ["workflow_not_review_ready"]
+    if fixture_set.get("unsupported") or fixture_set.get("blocked"):
+        return "blocked_policy_failure", ["fixture_set_not_governance_ready"]
+    return "ready_for_approval_review", ["all_inputs_reviewed_policy_passed"]
+
+
+def _normalized_inputs(reviewed_fixture_inputs: dict[str, Any] | list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if isinstance(reviewed_fixture_inputs, dict):
+        return list(reviewed_fixture_inputs.get("normalized_fixture_inputs") or [])
+    return list(reviewed_fixture_inputs)
+
+
+def _source_hash(value: Any) -> str | None:
+    if isinstance(value, dict) and value.get("deterministic_hash"):
+        return str(value["deterministic_hash"])
+    return deterministic_hash({"source": _canonicalize(value)}) if value is not None else None
+
+
+def _normalize_id(value: str) -> str:
+    return "_".join(value.strip().lower().replace("\\", "/").replace(":", "_").split())
+
+
+def _canonicalize(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: _canonicalize(item) for key, item in sorted(value.items())}
+    if isinstance(value, list):
+        return sorted(
+            (_canonicalize(item) for item in value),
+            key=lambda item: deterministic_hash({"item": item}),
+        )
+    return value

--- a/backend/scripts/report_v3_1_fixture_set_readiness_gate.py
+++ b/backend/scripts/report_v3_1_fixture_set_readiness_gate.py
@@ -1,0 +1,154 @@
+"""Generate the v3.1 fixture-set approval readiness gate report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.planner_adapters.v3_1.fixture_set_readiness_gate import build_fixture_set_readiness_gate  # noqa: E402
+
+
+DETERMINISTIC_GENERATED_AT = "2026-05-15T00:00:00+00:00"
+
+
+def build_v3_1_fixture_set_readiness_gate_report() -> dict[str, Any]:
+    repo_root = Path(__file__).resolve().parents[2]
+    generated = repo_root / "docs" / "generated"
+    reviewed_inputs = _read_json(generated / "v3_1_reviewed_fixture_inputs_report.json")["reviewed_fixture_inputs"]
+    persisted_sets = _read_json(generated / "v3_1_persisted_fixture_sets_report.json")["persisted_fixture_sets"]
+    policy = _read_json(generated / "v3_1_review_policy_evaluation_report.json")["review_policy_evaluation"]
+    workflows = _read_json(generated / "v3_1_baseline_fixture_workflows_report.json")["baseline_fixture_workflows"]
+    gate = build_fixture_set_readiness_gate(
+        reviewed_fixture_inputs=reviewed_inputs,
+        persisted_fixture_sets=persisted_sets,
+        review_policy_evaluation=policy,
+        baseline_fixture_workflows=workflows,
+    )
+    repeated = build_fixture_set_readiness_gate(
+        reviewed_fixture_inputs=reviewed_inputs,
+        persisted_fixture_sets=persisted_sets,
+        review_policy_evaluation=policy,
+        baseline_fixture_workflows=workflows,
+    )
+    report = {
+        "schema_version": "v3_1.fixture_set_readiness_gate_report.1",
+        "generated_at": DETERMINISTIC_GENERATED_AT,
+        "phase": "v3.1_phase_7_fixture_set_approval_readiness_gate",
+        "recommendation": "OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING",
+        "production_default_routing_authorized": False,
+        "summary": {
+            **gate["summary"],
+            "deterministic": gate["deterministic_hash"] == repeated["deterministic_hash"],
+        },
+        "fixture_set_readiness_gate": gate,
+        "deterministic_guarantees": {
+            "passed": gate["deterministic_hash"] == repeated["deterministic_hash"],
+            "sample_hash": gate["deterministic_hash"],
+            "repeated_hash": repeated["deterministic_hash"],
+            "timestamp_excluded_from_hash": True,
+            "json_sort_keys": True,
+        },
+        "phase_7_boundaries": [
+            "readiness is observational governance only",
+            "readiness does not authorize production routing",
+            "trusted infrastructure is still not production default",
+            "legacy planner ownership remains intact",
+            "blocked and insufficient-review states remain visible",
+        ],
+        "metadata": {
+            "source": "v3_1_fixture_set_readiness_gate_report",
+            "observational_only": True,
+            "production_behavior_changed": False,
+            "production_default_routing_authorized": False,
+            "planner_remap_performed": False,
+        },
+    }
+    return _normalize_generated_at(report)
+
+
+def write_report(report: dict[str, Any], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_markdown(report: dict[str, Any], output_path: Path) -> None:
+    summary = report["summary"]
+    gate = report["fixture_set_readiness_gate"]
+    lines = [
+        "# V3.1 Fixture Set Readiness Gate",
+        "",
+        "Phase 7 introduces deterministic observational readiness gating for fixture-set approval review.",
+        "Readiness does not authorize production planner routing.",
+        "",
+        "## Recommendation",
+        "",
+        f"- Recommendation: `{report['recommendation']}`",
+        f"- Production default routing authorized: `{str(report['production_default_routing_authorized']).lower()}`",
+        "",
+        "## Summary",
+        "",
+        f"- Total fixture sets evaluated: `{summary['total_fixture_sets_evaluated']}`",
+        f"- Ready: `{summary['ready_count']}`",
+        f"- Blocked: `{summary['blocked_count']}`",
+        f"- Production affected: `{summary['production_affected_count']}`",
+        f"- Deterministic: `{str(summary['deterministic']).lower()}`",
+        "",
+        "## Block Reason Counts",
+        "",
+        "| Reason | Count |",
+        "| --- | ---: |",
+    ]
+    for reason, count in gate["block_reason_counts"].items():
+        lines.append(f"| `{reason}` | `{count}` |")
+    lines.extend(["", "## Inputs Consumed", ""])
+    for key, value in gate["input_consumption"].items():
+        lines.append(f"- {key}: `{value}`")
+    lines.extend(["", "## Readiness Records", "", "| Fixture Set | Classification | Policy | Production Affected |", "| --- | --- | --- | --- |"])
+    for row in gate["readiness_records"]:
+        lines.append(
+            f"| `{row['fixture_set_id']}` | `{row['readiness_classification']}` | `{row['policy_outcome']}` | `{str(row['production_output_affected']).lower()}` |"
+        )
+    lines.extend(["", "## Phase 7 Boundaries", ""])
+    lines.extend(f"- {item}" for item in report["phase_7_boundaries"])
+    lines.extend(["", "## Conclusion", "", "Fixture-set readiness is available for governance review, while production routing remains unchanged."])
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _normalize_generated_at(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: DETERMINISTIC_GENERATED_AT if key == "generated_at" else _normalize_generated_at(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_normalize_generated_at(item) for item in value]
+    return deepcopy(value)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", default="docs/generated/v3_1_fixture_set_readiness_gate_report.json")
+    parser.add_argument("--markdown-output", default="docs/migration/V3_1_FIXTURE_SET_READINESS_GATE.md")
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[2]
+    report = build_v3_1_fixture_set_readiness_gate_report()
+    write_report(report, repo_root / args.output)
+    write_markdown(report, repo_root / args.markdown_output)
+    print(json.dumps(report["summary"], indent=2, sort_keys=True))
+    print(report["recommendation"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_v3_1_fixture_set_readiness_gate.py
+++ b/backend/tests/test_v3_1_fixture_set_readiness_gate.py
@@ -1,0 +1,121 @@
+from app.planner_adapters.v3_1.fixture_set_readiness_gate import build_fixture_set_readiness_gate
+from scripts.report_v3_1_fixture_set_readiness_gate import build_v3_1_fixture_set_readiness_gate_report
+
+
+def test_ready_classification():
+    result = _gate(inputs=[_input("fixture_a")], sets=[_set("set_a", ["fixture_a"])], policies=[_policy("set_a", "passes_policy")], workflows=[_workflow("fixture_a")])
+
+    assert result["readiness_records"][0]["readiness_classification"] == "ready_for_approval_review"
+    assert result["summary"]["ready_count"] == 1
+
+
+def test_blocked_missing_inputs_classification():
+    result = _gate(inputs=[], sets=[_set("set_a", ["fixture_a"])], policies=[_policy("set_a", "passes_policy")])
+
+    assert result["readiness_records"][0]["readiness_classification"] == "blocked_missing_inputs"
+    assert result["block_reason_counts"]["missing_reviewed_fixture_input"] == 1
+
+
+def test_blocked_policy_failure_classification():
+    result = _gate(inputs=[_input("fixture_a")], sets=[_set("set_a", ["fixture_a"])], policies=[_policy("set_a", "unsupported")])
+
+    assert result["readiness_records"][0]["readiness_classification"] == "blocked_policy_failure"
+    assert result["block_reason_counts"]["policy_unsupported"] == 1
+
+
+def test_blocked_malformed_inputs_classification():
+    result = _gate(inputs=[_input("fixture_a", "malformed")], sets=[_set("set_a", ["fixture_a"])], policies=[_policy("set_a", "passes_policy")])
+
+    assert result["readiness_records"][0]["readiness_classification"] == "blocked_malformed_inputs"
+
+
+def test_blocked_duplicate_inputs_classification():
+    result = _gate(inputs=[_input("fixture_a", "duplicate")], sets=[_set("set_a", ["fixture_a"])], policies=[_policy("set_a", "passes_policy")])
+
+    assert result["readiness_records"][0]["readiness_classification"] == "blocked_duplicate_inputs"
+
+
+def test_blocked_insufficient_review_classification():
+    result = _gate(inputs=[_input("fixture_a", "unsupported")], sets=[_set("set_a", ["fixture_a"])], policies=[_policy("set_a", "passes_policy")])
+
+    assert result["readiness_records"][0]["readiness_classification"] == "blocked_insufficient_review"
+    assert result["block_reason_counts"]["input_not_reviewed"] == 1
+
+
+def test_deterministic_ordering():
+    inputs = [_input("fixture_b"), _input("fixture_a")]
+    sets = [_set("set_b", ["fixture_b"]), _set("set_a", ["fixture_a"])]
+    policies = [_policy("set_b", "passes_policy"), _policy("set_a", "passes_policy")]
+
+    first = _gate(inputs=inputs, sets=sets, policies=policies)
+    second = _gate(inputs=list(reversed(inputs)), sets=list(reversed(sets)), policies=list(reversed(policies)))
+
+    assert first["deterministic_hash"] == second["deterministic_hash"]
+    assert [row["fixture_set_id"] for row in first["readiness_records"]] == ["set_a", "set_b"]
+
+
+def test_stable_report_generation():
+    first = build_v3_1_fixture_set_readiness_gate_report()
+    second = build_v3_1_fixture_set_readiness_gate_report()
+
+    assert first["deterministic_guarantees"]["passed"] is True
+    assert first["fixture_set_readiness_gate"]["deterministic_hash"] == second["fixture_set_readiness_gate"]["deterministic_hash"]
+    assert first["summary"] == second["summary"]
+
+
+def test_no_production_routing_enablement():
+    result = _gate(inputs=[_input("fixture_a")], sets=[_set("set_a", ["fixture_a"])], policies=[_policy("set_a", "passes_policy")], workflows=[_workflow("fixture_a")])
+    record = result["readiness_records"][0]
+
+    assert result["safety_confirmations"]["readiness_authorizes_production_routing"] is False
+    assert record["non_production_authorization"]["readiness_authorizes_production_routing"] is False
+    assert record["production_output_affected"] is False
+
+
+def test_compatibility_with_reviewed_inputs_and_policy_layers():
+    reviewed_inputs = {"deterministic_hash": "inputs", "normalized_fixture_inputs": [_input("fixture_a")]}
+    persisted_sets = {"deterministic_hash": "sets", "fixture_sets": [_set("set_a", ["fixture_a"])]}
+    policy = {"deterministic_hash": "policy", "evaluations": [_policy("set_a", "passes_policy")]}
+
+    result = build_fixture_set_readiness_gate(
+        reviewed_fixture_inputs=reviewed_inputs,
+        persisted_fixture_sets=persisted_sets,
+        review_policy_evaluation=policy,
+        baseline_fixture_workflows={"deterministic_hash": "workflows", "fixtures": [_workflow("fixture_a")]},
+    )
+
+    assert result["input_consumption"]["reviewed_fixture_inputs_hash"] == "inputs"
+    assert result["input_consumption"]["persisted_fixture_sets_hash"] == "sets"
+    assert result["input_consumption"]["review_policy_evaluation_hash"] == "policy"
+
+
+def _gate(inputs, sets, policies, workflows=None):
+    return build_fixture_set_readiness_gate(
+        reviewed_fixture_inputs={"normalized_fixture_inputs": inputs},
+        persisted_fixture_sets={"fixture_sets": sets},
+        review_policy_evaluation={"evaluations": policies},
+        baseline_fixture_workflows={"fixtures": workflows or []},
+    )
+
+
+def _input(fixture_id, status="reviewed"):
+    return {"normalized_fixture_id": fixture_id, "status": status, "production_output_affected": False}
+
+
+def _set(set_id, fixture_ids):
+    return {
+        "fixture_set_id": set_id,
+        "set_key": set_id,
+        "associated_fixture_ids": fixture_ids,
+        "unsupported": False,
+        "blocked": False,
+        "production_output_affected": False,
+    }
+
+
+def _policy(set_id, outcome):
+    return {"fixture_set_id": set_id, "policy_outcome": outcome, "production_output_affected": False}
+
+
+def _workflow(fixture_id, state="pending_review"):
+    return {"fixture_id": fixture_id, "approval_state": state, "production_output_affected": False}

--- a/docs/generated/v3_1_fixture_set_readiness_gate_report.json
+++ b/docs/generated/v3_1_fixture_set_readiness_gate_report.json
@@ -1,0 +1,137 @@
+{
+  "deterministic_guarantees": {
+    "json_sort_keys": true,
+    "passed": true,
+    "repeated_hash": "85dbb478983263c00b093882c9a141e93b186dc688aedcfa6094b50a40040db2",
+    "sample_hash": "85dbb478983263c00b093882c9a141e93b186dc688aedcfa6094b50a40040db2",
+    "timestamp_excluded_from_hash": true
+  },
+  "fixture_set_readiness_gate": {
+    "block_reason_counts": {
+      "policy_unsupported": 1
+    },
+    "deterministic_hash": "85dbb478983263c00b093882c9a141e93b186dc688aedcfa6094b50a40040db2",
+    "input_consumption": {
+      "baseline_fixture_workflows_hash": "505143cc38f7239909dd6c7d73ac357f2b2251576830718a33b0cd196778ed29",
+      "persisted_fixture_sets_hash": "87bb0f1888fa99a2bb2bd99fa7806a365d1e4cceaefbd72118fae064d600116e",
+      "review_policy_evaluation_hash": "e4c4d8158ed053e7f882796308ae244780a41a203a6c44608789c091cddab766",
+      "reviewed_fixture_inputs_hash": "bcc71a0573a2de21ed29ab1a7cae6ac04323875d4abccc85e387f4f266f6e077"
+    },
+    "metadata": {
+      "deterministic_serializer": "json_sort_keys_sha256",
+      "observational_only": true,
+      "planner_remap_performed": false,
+      "production_behavior_changed": false,
+      "production_consumer": false,
+      "production_default_routing_authorized": false,
+      "source": "v3_1_fixture_set_readiness_gate",
+      "stable_generation_token": "v3_1_phase_7_fixture_set_readiness_gate_token"
+    },
+    "readiness_classification_counts": {
+      "blocked_duplicate_inputs": 0,
+      "blocked_insufficient_review": 0,
+      "blocked_malformed_inputs": 0,
+      "blocked_missing_inputs": 0,
+      "blocked_policy_failure": 1,
+      "ready_for_approval_review": 0
+    },
+    "readiness_records": [
+      {
+        "associated_fixture_ids": [
+          "v3_1_fixture_6c378a420c0a4ced",
+          "v3_1_fixture_756415e2e7d3feb2",
+          "v3_1_fixture_8118751ba1b46140",
+          "v3_1_fixture_9c3d260c0dda7b4f",
+          "v3_1_fixture_b82b601f9b088bb8"
+        ],
+        "block_reason_codes": [
+          "policy_unsupported"
+        ],
+        "fixture_set_id": "v3_1_fixture_set_6d3b668a84cfbb69",
+        "input_statuses": {
+          "v3_1_fixture_6c378a420c0a4ced": "reviewed",
+          "v3_1_fixture_756415e2e7d3feb2": "reviewed",
+          "v3_1_fixture_8118751ba1b46140": "unsupported",
+          "v3_1_fixture_9c3d260c0dda7b4f": "unsupported",
+          "v3_1_fixture_b82b601f9b088bb8": "unsupported"
+        },
+        "metadata": {
+          "observational_only": true,
+          "planner_remap_performed": false,
+          "production_consumer": false
+        },
+        "non_production_authorization": {
+          "legacy_planner_ownership_preserved": true,
+          "readiness_authorizes_production_routing": false,
+          "trusted_default_routing": false
+        },
+        "policy_outcome": "unsupported",
+        "production_output_affected": false,
+        "readiness_classification": "blocked_policy_failure",
+        "set_key": "sample_migration_readiness_set",
+        "workflow_states": {
+          "v3_1_fixture_6c378a420c0a4ced": "pending_review",
+          "v3_1_fixture_756415e2e7d3feb2": "pending_review",
+          "v3_1_fixture_8118751ba1b46140": "unsupported",
+          "v3_1_fixture_9c3d260c0dda7b4f": "unsupported",
+          "v3_1_fixture_b82b601f9b088bb8": "insufficient_data"
+        }
+      }
+    ],
+    "run": {
+      "fixture_set_count": 1,
+      "policy_evaluation_count": 1,
+      "reviewed_input_count": 6,
+      "run_id": "v3_1_phase_7_fixture_set_readiness_gate",
+      "workflow_fixture_count": 5
+    },
+    "safety_confirmations": {
+      "legacy_planner_ownership_preserved": true,
+      "production_behavior_changed": false,
+      "production_output_affected": false,
+      "readiness_authorizes_production_routing": false,
+      "runtime_state_mutated": false,
+      "trusted_data_default_truth": false
+    },
+    "schema_version": "v3_1.fixture_set_readiness_gate.1",
+    "summary": {
+      "blocked_count": 1,
+      "deterministic": true,
+      "production_affected_count": 0,
+      "production_behavior_changed": false,
+      "production_output_affected": false,
+      "ready_count": 0,
+      "total_fixture_sets_evaluated": 1,
+      "trusted_data_default_truth": false
+    }
+  },
+  "generated_at": "2026-05-15T00:00:00+00:00",
+  "metadata": {
+    "observational_only": true,
+    "planner_remap_performed": false,
+    "production_behavior_changed": false,
+    "production_default_routing_authorized": false,
+    "source": "v3_1_fixture_set_readiness_gate_report"
+  },
+  "phase": "v3.1_phase_7_fixture_set_approval_readiness_gate",
+  "phase_7_boundaries": [
+    "readiness is observational governance only",
+    "readiness does not authorize production routing",
+    "trusted infrastructure is still not production default",
+    "legacy planner ownership remains intact",
+    "blocked and insufficient-review states remain visible"
+  ],
+  "production_default_routing_authorized": false,
+  "recommendation": "OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING",
+  "schema_version": "v3_1.fixture_set_readiness_gate_report.1",
+  "summary": {
+    "blocked_count": 1,
+    "deterministic": true,
+    "production_affected_count": 0,
+    "production_behavior_changed": false,
+    "production_output_affected": false,
+    "ready_count": 0,
+    "total_fixture_sets_evaluated": 1,
+    "trusted_data_default_truth": false
+  }
+}

--- a/docs/migration/V3_1_FIXTURE_SET_READINESS_GATE.md
+++ b/docs/migration/V3_1_FIXTURE_SET_READINESS_GATE.md
@@ -1,0 +1,48 @@
+# V3.1 Fixture Set Readiness Gate
+
+Phase 7 introduces deterministic observational readiness gating for fixture-set approval review.
+Readiness does not authorize production planner routing.
+
+## Recommendation
+
+- Recommendation: `OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING`
+- Production default routing authorized: `false`
+
+## Summary
+
+- Total fixture sets evaluated: `1`
+- Ready: `0`
+- Blocked: `1`
+- Production affected: `0`
+- Deterministic: `true`
+
+## Block Reason Counts
+
+| Reason | Count |
+| --- | ---: |
+| `policy_unsupported` | `1` |
+
+## Inputs Consumed
+
+- reviewed_fixture_inputs_hash: `bcc71a0573a2de21ed29ab1a7cae6ac04323875d4abccc85e387f4f266f6e077`
+- persisted_fixture_sets_hash: `87bb0f1888fa99a2bb2bd99fa7806a365d1e4cceaefbd72118fae064d600116e`
+- review_policy_evaluation_hash: `e4c4d8158ed053e7f882796308ae244780a41a203a6c44608789c091cddab766`
+- baseline_fixture_workflows_hash: `505143cc38f7239909dd6c7d73ac357f2b2251576830718a33b0cd196778ed29`
+
+## Readiness Records
+
+| Fixture Set | Classification | Policy | Production Affected |
+| --- | --- | --- | --- |
+| `v3_1_fixture_set_6d3b668a84cfbb69` | `blocked_policy_failure` | `unsupported` | `false` |
+
+## Phase 7 Boundaries
+
+- readiness is observational governance only
+- readiness does not authorize production routing
+- trusted infrastructure is still not production default
+- legacy planner ownership remains intact
+- blocked and insufficient-review states remain visible
+
+## Conclusion
+
+Fixture-set readiness is available for governance review, while production routing remains unchanged.


### PR DESCRIPTION
Adds deterministic observational readiness gating for reviewed fixture sets, combining reviewed inputs, persisted fixture summaries, policy outcomes, and workflow status without enabling production planner routing.