### PR TITLE
v3.1: add approval manifest candidates

### DIFF
--- a/backend/app/planner_adapters/v3_1/__init__.py
+++ b/backend/app/planner_adapters/v3_1/__init__.py
@@ -29,6 +29,10 @@ from .fixture_set_readiness_gate import (
     FIXTURE_SET_READINESS_CLASSIFICATIONS,
     build_fixture_set_readiness_gate,
 )
+from .approval_manifest_candidates import (
+    APPROVAL_MANIFEST_CANDIDATE_STATUSES,
+    build_approval_manifest_candidates,
+)
 from .reviewed_fixture_inputs import (
     REVIEWED_FIXTURE_INPUT_STATUSES,
     discover_default_reviewed_fixture_input_sources,
@@ -49,6 +53,7 @@ __all__ = [
     "REVIEW_POLICY_OUTCOMES",
     "REVIEWED_FIXTURE_INPUT_STATUSES",
     "FIXTURE_SET_READINESS_CLASSIFICATIONS",
+    "APPROVAL_MANIFEST_CANDIDATE_STATUSES",
     "SUPPORTED_TRUSTED_SHADOW_DOMAINS",
     "V31BaselineFixtureWorkflows",
     "V31DualRunComparison",
@@ -63,6 +68,7 @@ __all__ = [
     "build_sample_dual_run_inputs",
     "build_default_trusted_repository_probes",
     "build_fixture_set_readiness_gate",
+    "build_approval_manifest_candidates",
     "discover_default_reviewed_fixture_input_sources",
     "deterministic_hash",
     "normalize_reviewed_fixture_inputs",

--- a/backend/app/planner_adapters/v3_1/approval_manifest_candidates.py
+++ b/backend/app/planner_adapters/v3_1/approval_manifest_candidates.py
@@ -1,0 +1,138 @@
+"""Deterministic approval manifest candidate generation.
+
+Manifest candidates are governance artifacts derived from fixture-set readiness
+records. They never approve production routing or replace legacy planner
+ownership.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from copy import deepcopy
+from typing import Any
+
+from .trusted_shadow_consumption import deterministic_hash
+
+
+APPROVAL_MANIFEST_CANDIDATE_STATUSES = (
+    "candidate_ready",
+    "excluded_not_ready",
+    "excluded_missing_readiness",
+    "excluded_invalid_policy_state",
+)
+STABLE_APPROVAL_MANIFEST_TOKEN = "v3_1_phase_8_approval_manifest_candidates_token"
+
+
+def build_approval_manifest_candidates(
+    *,
+    readiness_gate: dict[str, Any],
+    run_id: str = "v3_1_phase_8_approval_manifest_candidates",
+) -> dict[str, Any]:
+    records = [
+        _candidate_record(record)
+        for record in sorted(readiness_gate.get("readiness_records", []), key=lambda row: str(row.get("fixture_set_id") or ""))
+    ]
+    counts = Counter(row["candidate_status"] for row in records)
+    exclusion_reasons = Counter(reason for row in records if row["candidate_status"] != "candidate_ready" for reason in row["reason_codes"])
+    envelope = {
+        "schema_version": "v3_1.approval_manifest_candidates.1",
+        "run": {
+            "run_id": run_id,
+            "readiness_record_count": len(records),
+            "source_readiness_hash": readiness_gate.get("deterministic_hash"),
+        },
+        "summary": {
+            "total_readiness_records_evaluated": len(records),
+            "candidate_ready_count": counts["candidate_ready"],
+            "excluded_count": len(records) - counts["candidate_ready"],
+            "production_affected_count": sum(1 for row in records if row["production_output_affected"]),
+            "production_output_affected": False,
+            "production_behavior_changed": False,
+            "trusted_data_default_truth": False,
+            "deterministic": True,
+        },
+        "candidate_status_counts": {
+            status: counts[status]
+            for status in APPROVAL_MANIFEST_CANDIDATE_STATUSES
+        },
+        "exclusion_reason_counts": dict(sorted(exclusion_reasons.items())),
+        "manifest_candidates": records,
+        "candidate_ready_manifest": [record for record in records if record["candidate_status"] == "candidate_ready"],
+        "input_consumption": {
+            "readiness_gate_hash": readiness_gate.get("deterministic_hash"),
+            "readiness_gate_schema": readiness_gate.get("schema_version"),
+        },
+        "safety_confirmations": {
+            "production_output_affected": False,
+            "production_behavior_changed": False,
+            "trusted_data_default_truth": False,
+            "legacy_planner_ownership_preserved": True,
+            "runtime_state_mutated": False,
+            "approval_manifest_authorizes_production_routing": False,
+            "manifest_candidates_are_production_approved": False,
+        },
+        "metadata": {
+            "source": "v3_1_approval_manifest_candidates",
+            "observational_only": True,
+            "production_consumer": False,
+            "production_behavior_changed": False,
+            "planner_remap_performed": False,
+            "production_default_routing_authorized": False,
+            "stable_generation_token": STABLE_APPROVAL_MANIFEST_TOKEN,
+            "deterministic_serializer": "json_sort_keys_sha256",
+        },
+    }
+    envelope["deterministic_hash"] = deterministic_hash(envelope)
+    return envelope
+
+
+def _candidate_record(readiness_record: dict[str, Any]) -> dict[str, Any]:
+    status, reason_codes = _candidate_status(readiness_record)
+    fixture_set_id = str(readiness_record.get("fixture_set_id") or "")
+    seed = {
+        "fixture_set_id": fixture_set_id,
+        "generation_token": STABLE_APPROVAL_MANIFEST_TOKEN,
+    }
+    return {
+        "manifest_candidate_id": f"v3_1_manifest_candidate_{deterministic_hash(seed)[:16]}",
+        "fixture_set_id": readiness_record.get("fixture_set_id"),
+        "candidate_status": status,
+        "source_summary": {
+            "set_key": readiness_record.get("set_key"),
+            "associated_fixture_ids": list(readiness_record.get("associated_fixture_ids") or []),
+            "input_statuses": deepcopy(readiness_record.get("input_statuses") or {}),
+        },
+        "policy_summary": {
+            "policy_outcome": readiness_record.get("policy_outcome"),
+            "valid_policy_state": readiness_record.get("policy_outcome") == "passes_policy",
+        },
+        "readiness_summary": {
+            "readiness_classification": readiness_record.get("readiness_classification"),
+            "block_reason_codes": list(readiness_record.get("block_reason_codes") or []),
+        },
+        "authorization_status": {
+            "candidate_is_production_approved": False,
+            "candidate_authorizes_production_routing": False,
+            "legacy_planner_ownership_preserved": True,
+            "trusted_default_routing": False,
+        },
+        "reason_codes": reason_codes,
+        "production_output_affected": False,
+        "metadata": {
+            "observational_only": True,
+            "production_consumer": False,
+            "planner_remap_performed": False,
+        },
+    }
+
+
+def _candidate_status(readiness_record: dict[str, Any]) -> tuple[str, list[str]]:
+    readiness = readiness_record.get("readiness_classification")
+    policy = readiness_record.get("policy_outcome")
+    if not readiness:
+        return "excluded_missing_readiness", ["missing_readiness_classification"]
+    if readiness == "ready_for_approval_review" and policy != "passes_policy":
+        return "excluded_invalid_policy_state", [f"invalid_policy_state_{policy or 'missing'}"]
+    if readiness != "ready_for_approval_review":
+        return "excluded_not_ready", list(readiness_record.get("block_reason_codes") or [f"readiness_{readiness}"])
+    return "candidate_ready", ["ready_for_approval_review_policy_passed"]

--- a/backend/scripts/report_v3_1_approval_manifest_candidates.py
+++ b/backend/scripts/report_v3_1_approval_manifest_candidates.py
@@ -1,0 +1,137 @@
+"""Generate the v3.1 approval manifest candidate report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.planner_adapters.v3_1.approval_manifest_candidates import build_approval_manifest_candidates  # noqa: E402
+
+
+DETERMINISTIC_GENERATED_AT = "2026-05-15T00:00:00+00:00"
+
+
+def build_v3_1_approval_manifest_candidates_report() -> dict[str, Any]:
+    repo_root = Path(__file__).resolve().parents[2]
+    readiness = _read_json(repo_root / "docs" / "generated" / "v3_1_fixture_set_readiness_gate_report.json")["fixture_set_readiness_gate"]
+    candidates = build_approval_manifest_candidates(readiness_gate=readiness)
+    repeated = build_approval_manifest_candidates(readiness_gate=readiness)
+    report = {
+        "schema_version": "v3_1.approval_manifest_candidates_report.1",
+        "generated_at": DETERMINISTIC_GENERATED_AT,
+        "phase": "v3.1_phase_8_approval_manifest_candidates",
+        "recommendation": "OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING",
+        "production_default_routing_authorized": False,
+        "summary": {
+            **candidates["summary"],
+            "deterministic": candidates["deterministic_hash"] == repeated["deterministic_hash"],
+        },
+        "approval_manifest_candidates": candidates,
+        "deterministic_guarantees": {
+            "passed": candidates["deterministic_hash"] == repeated["deterministic_hash"],
+            "sample_hash": candidates["deterministic_hash"],
+            "repeated_hash": repeated["deterministic_hash"],
+            "timestamp_excluded_from_hash": True,
+            "json_sort_keys": True,
+        },
+        "phase_8_boundaries": [
+            "manifest candidates are observational governance artifacts",
+            "manifest candidates do not authorize production routing",
+            "candidate_ready does not mean production-approved",
+            "trusted infrastructure is still not production default",
+            "legacy planner ownership remains intact",
+        ],
+        "metadata": {
+            "source": "v3_1_approval_manifest_candidates_report",
+            "observational_only": True,
+            "production_behavior_changed": False,
+            "production_default_routing_authorized": False,
+            "planner_remap_performed": False,
+        },
+    }
+    return _normalize_generated_at(report)
+
+
+def write_report(report: dict[str, Any], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_markdown(report: dict[str, Any], output_path: Path) -> None:
+    summary = report["summary"]
+    candidates = report["approval_manifest_candidates"]
+    lines = [
+        "# V3.1 Approval Manifest Candidates",
+        "",
+        "Phase 8 introduces deterministic approval manifest candidate generation from readiness-approved fixture sets.",
+        "Candidates do not authorize production planner routing.",
+        "",
+        "## Recommendation",
+        "",
+        f"- Recommendation: `{report['recommendation']}`",
+        f"- Production default routing authorized: `{str(report['production_default_routing_authorized']).lower()}`",
+        "",
+        "## Summary",
+        "",
+        f"- Total readiness records evaluated: `{summary['total_readiness_records_evaluated']}`",
+        f"- Candidate ready: `{summary['candidate_ready_count']}`",
+        f"- Excluded: `{summary['excluded_count']}`",
+        f"- Production affected: `{summary['production_affected_count']}`",
+        f"- Deterministic: `{str(summary['deterministic']).lower()}`",
+        "",
+        "## Exclusion Reasons",
+        "",
+        "| Reason | Count |",
+        "| --- | ---: |",
+    ]
+    for reason, count in candidates["exclusion_reason_counts"].items():
+        lines.append(f"| `{reason}` | `{count}` |")
+    lines.extend(["", "## Manifest Candidates", "", "| Candidate | Fixture Set | Status | Production Approved |", "| --- | --- | --- | --- |"])
+    for row in candidates["manifest_candidates"]:
+        lines.append(
+            f"| `{row['manifest_candidate_id']}` | `{row['fixture_set_id']}` | `{row['candidate_status']}` | `{str(row['authorization_status']['candidate_is_production_approved']).lower()}` |"
+        )
+    lines.extend(["", "## Phase 8 Boundaries", ""])
+    lines.extend(f"- {item}" for item in report["phase_8_boundaries"])
+    lines.extend(["", "## Conclusion", "", "Approval manifest candidates are available for governance review, while production routing remains unchanged."])
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _normalize_generated_at(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: DETERMINISTIC_GENERATED_AT if key == "generated_at" else _normalize_generated_at(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_normalize_generated_at(item) for item in value]
+    return deepcopy(value)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", default="docs/generated/v3_1_approval_manifest_candidates_report.json")
+    parser.add_argument("--markdown-output", default="docs/migration/V3_1_APPROVAL_MANIFEST_CANDIDATES.md")
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[2]
+    report = build_v3_1_approval_manifest_candidates_report()
+    write_report(report, repo_root / args.output)
+    write_markdown(report, repo_root / args.markdown_output)
+    print(json.dumps(report["summary"], indent=2, sort_keys=True))
+    print(report["recommendation"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_v3_1_approval_manifest_candidates.py
+++ b/backend/tests/test_v3_1_approval_manifest_candidates.py
@@ -1,0 +1,84 @@
+from app.planner_adapters.v3_1.approval_manifest_candidates import build_approval_manifest_candidates
+from scripts.report_v3_1_approval_manifest_candidates import build_v3_1_approval_manifest_candidates_report
+
+
+def test_ready_records_become_candidate_ready():
+    result = build_approval_manifest_candidates(readiness_gate=_gate([_record("set_a", "ready_for_approval_review", "passes_policy")]))
+
+    candidate = result["manifest_candidates"][0]
+    assert candidate["candidate_status"] == "candidate_ready"
+    assert result["summary"]["candidate_ready_count"] == 1
+
+
+def test_non_ready_records_are_excluded():
+    result = build_approval_manifest_candidates(readiness_gate=_gate([_record("set_a", "blocked_policy_failure", "unsupported", ["policy_unsupported"])]))
+
+    candidate = result["manifest_candidates"][0]
+    assert candidate["candidate_status"] == "excluded_not_ready"
+    assert result["summary"]["excluded_count"] == 1
+    assert result["exclusion_reason_counts"]["policy_unsupported"] == 1
+
+
+def test_missing_readiness_is_excluded():
+    row = _record("set_a", "ready_for_approval_review", "passes_policy")
+    row.pop("readiness_classification")
+    result = build_approval_manifest_candidates(readiness_gate=_gate([row]))
+
+    assert result["manifest_candidates"][0]["candidate_status"] == "excluded_missing_readiness"
+    assert result["exclusion_reason_counts"]["missing_readiness_classification"] == 1
+
+
+def test_invalid_policy_state_is_excluded():
+    result = build_approval_manifest_candidates(readiness_gate=_gate([_record("set_a", "ready_for_approval_review", "requires_review")]))
+
+    assert result["manifest_candidates"][0]["candidate_status"] == "excluded_invalid_policy_state"
+    assert result["exclusion_reason_counts"]["invalid_policy_state_requires_review"] == 1
+
+
+def test_deterministic_ordering():
+    first = build_approval_manifest_candidates(readiness_gate=_gate([_record("set_b", "ready_for_approval_review"), _record("set_a", "ready_for_approval_review")]))
+    second = build_approval_manifest_candidates(readiness_gate=_gate([_record("set_a", "ready_for_approval_review"), _record("set_b", "ready_for_approval_review")]))
+
+    assert first["deterministic_hash"] == second["deterministic_hash"]
+    assert [row["fixture_set_id"] for row in first["manifest_candidates"]] == ["set_a", "set_b"]
+
+
+def test_stable_report_generation():
+    first = build_v3_1_approval_manifest_candidates_report()
+    second = build_v3_1_approval_manifest_candidates_report()
+
+    assert first["deterministic_guarantees"]["passed"] is True
+    assert first["approval_manifest_candidates"]["deterministic_hash"] == second["approval_manifest_candidates"]["deterministic_hash"]
+    assert first["summary"] == second["summary"]
+
+
+def test_no_production_routing_enablement():
+    result = build_approval_manifest_candidates(readiness_gate=_gate([_record("set_a", "ready_for_approval_review")]))
+    candidate = result["manifest_candidates"][0]
+
+    assert result["safety_confirmations"]["approval_manifest_authorizes_production_routing"] is False
+    assert result["safety_confirmations"]["manifest_candidates_are_production_approved"] is False
+    assert candidate["authorization_status"]["candidate_is_production_approved"] is False
+    assert candidate["authorization_status"]["candidate_authorizes_production_routing"] is False
+
+
+def _gate(records):
+    return {
+        "schema_version": "v3_1.fixture_set_readiness_gate.1",
+        "deterministic_hash": "readiness-hash",
+        "readiness_records": records,
+    }
+
+
+def _record(set_id, readiness, policy="passes_policy", reasons=None):
+    return {
+        "fixture_set_id": set_id,
+        "set_key": set_id,
+        "readiness_classification": readiness,
+        "associated_fixture_ids": [f"fixture_{set_id}"],
+        "input_statuses": {f"fixture_{set_id}": "reviewed"},
+        "policy_outcome": policy,
+        "workflow_states": {f"fixture_{set_id}": "pending_review"},
+        "block_reason_codes": reasons or [],
+        "production_output_affected": False,
+    }

--- a/docs/generated/v3_1_approval_manifest_candidates_report.json
+++ b/docs/generated/v3_1_approval_manifest_candidates_report.json
@@ -1,0 +1,139 @@
+{
+  "approval_manifest_candidates": {
+    "candidate_ready_manifest": [],
+    "candidate_status_counts": {
+      "candidate_ready": 0,
+      "excluded_invalid_policy_state": 0,
+      "excluded_missing_readiness": 0,
+      "excluded_not_ready": 1
+    },
+    "deterministic_hash": "26e84f9a9f25f9ad94ddd70e449d328623079c6e651702eaef70285fa445db27",
+    "exclusion_reason_counts": {
+      "policy_unsupported": 1
+    },
+    "input_consumption": {
+      "readiness_gate_hash": "85dbb478983263c00b093882c9a141e93b186dc688aedcfa6094b50a40040db2",
+      "readiness_gate_schema": "v3_1.fixture_set_readiness_gate.1"
+    },
+    "manifest_candidates": [
+      {
+        "authorization_status": {
+          "candidate_authorizes_production_routing": false,
+          "candidate_is_production_approved": false,
+          "legacy_planner_ownership_preserved": true,
+          "trusted_default_routing": false
+        },
+        "candidate_status": "excluded_not_ready",
+        "fixture_set_id": "v3_1_fixture_set_6d3b668a84cfbb69",
+        "manifest_candidate_id": "v3_1_manifest_candidate_2db355128ef8ae54",
+        "metadata": {
+          "observational_only": true,
+          "planner_remap_performed": false,
+          "production_consumer": false
+        },
+        "policy_summary": {
+          "policy_outcome": "unsupported",
+          "valid_policy_state": false
+        },
+        "production_output_affected": false,
+        "readiness_summary": {
+          "block_reason_codes": [
+            "policy_unsupported"
+          ],
+          "readiness_classification": "blocked_policy_failure"
+        },
+        "reason_codes": [
+          "policy_unsupported"
+        ],
+        "source_summary": {
+          "associated_fixture_ids": [
+            "v3_1_fixture_6c378a420c0a4ced",
+            "v3_1_fixture_756415e2e7d3feb2",
+            "v3_1_fixture_8118751ba1b46140",
+            "v3_1_fixture_9c3d260c0dda7b4f",
+            "v3_1_fixture_b82b601f9b088bb8"
+          ],
+          "input_statuses": {
+            "v3_1_fixture_6c378a420c0a4ced": "reviewed",
+            "v3_1_fixture_756415e2e7d3feb2": "reviewed",
+            "v3_1_fixture_8118751ba1b46140": "unsupported",
+            "v3_1_fixture_9c3d260c0dda7b4f": "unsupported",
+            "v3_1_fixture_b82b601f9b088bb8": "unsupported"
+          },
+          "set_key": "sample_migration_readiness_set"
+        }
+      }
+    ],
+    "metadata": {
+      "deterministic_serializer": "json_sort_keys_sha256",
+      "observational_only": true,
+      "planner_remap_performed": false,
+      "production_behavior_changed": false,
+      "production_consumer": false,
+      "production_default_routing_authorized": false,
+      "source": "v3_1_approval_manifest_candidates",
+      "stable_generation_token": "v3_1_phase_8_approval_manifest_candidates_token"
+    },
+    "run": {
+      "readiness_record_count": 1,
+      "run_id": "v3_1_phase_8_approval_manifest_candidates",
+      "source_readiness_hash": "85dbb478983263c00b093882c9a141e93b186dc688aedcfa6094b50a40040db2"
+    },
+    "safety_confirmations": {
+      "approval_manifest_authorizes_production_routing": false,
+      "legacy_planner_ownership_preserved": true,
+      "manifest_candidates_are_production_approved": false,
+      "production_behavior_changed": false,
+      "production_output_affected": false,
+      "runtime_state_mutated": false,
+      "trusted_data_default_truth": false
+    },
+    "schema_version": "v3_1.approval_manifest_candidates.1",
+    "summary": {
+      "candidate_ready_count": 0,
+      "deterministic": true,
+      "excluded_count": 1,
+      "production_affected_count": 0,
+      "production_behavior_changed": false,
+      "production_output_affected": false,
+      "total_readiness_records_evaluated": 1,
+      "trusted_data_default_truth": false
+    }
+  },
+  "deterministic_guarantees": {
+    "json_sort_keys": true,
+    "passed": true,
+    "repeated_hash": "26e84f9a9f25f9ad94ddd70e449d328623079c6e651702eaef70285fa445db27",
+    "sample_hash": "26e84f9a9f25f9ad94ddd70e449d328623079c6e651702eaef70285fa445db27",
+    "timestamp_excluded_from_hash": true
+  },
+  "generated_at": "2026-05-15T00:00:00+00:00",
+  "metadata": {
+    "observational_only": true,
+    "planner_remap_performed": false,
+    "production_behavior_changed": false,
+    "production_default_routing_authorized": false,
+    "source": "v3_1_approval_manifest_candidates_report"
+  },
+  "phase": "v3.1_phase_8_approval_manifest_candidates",
+  "phase_8_boundaries": [
+    "manifest candidates are observational governance artifacts",
+    "manifest candidates do not authorize production routing",
+    "candidate_ready does not mean production-approved",
+    "trusted infrastructure is still not production default",
+    "legacy planner ownership remains intact"
+  ],
+  "production_default_routing_authorized": false,
+  "recommendation": "OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING",
+  "schema_version": "v3_1.approval_manifest_candidates_report.1",
+  "summary": {
+    "candidate_ready_count": 0,
+    "deterministic": true,
+    "excluded_count": 1,
+    "production_affected_count": 0,
+    "production_behavior_changed": false,
+    "production_output_affected": false,
+    "total_readiness_records_evaluated": 1,
+    "trusted_data_default_truth": false
+  }
+}

--- a/docs/migration/V3_1_APPROVAL_MANIFEST_CANDIDATES.md
+++ b/docs/migration/V3_1_APPROVAL_MANIFEST_CANDIDATES.md
@@ -1,0 +1,41 @@
+# V3.1 Approval Manifest Candidates
+
+Phase 8 introduces deterministic approval manifest candidate generation from readiness-approved fixture sets.
+Candidates do not authorize production planner routing.
+
+## Recommendation
+
+- Recommendation: `OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING`
+- Production default routing authorized: `false`
+
+## Summary
+
+- Total readiness records evaluated: `1`
+- Candidate ready: `0`
+- Excluded: `1`
+- Production affected: `0`
+- Deterministic: `true`
+
+## Exclusion Reasons
+
+| Reason | Count |
+| --- | ---: |
+| `policy_unsupported` | `1` |
+
+## Manifest Candidates
+
+| Candidate | Fixture Set | Status | Production Approved |
+| --- | --- | --- | --- |
+| `v3_1_manifest_candidate_2db355128ef8ae54` | `v3_1_fixture_set_6d3b668a84cfbb69` | `excluded_not_ready` | `false` |
+
+## Phase 8 Boundaries
+
+- manifest candidates are observational governance artifacts
+- manifest candidates do not authorize production routing
+- candidate_ready does not mean production-approved
+- trusted infrastructure is still not production default
+- legacy planner ownership remains intact
+
+## Conclusion
+
+Approval manifest candidates are available for governance review, while production routing remains unchanged.


### PR DESCRIPTION
Adds deterministic approval manifest candidate generation from readiness-approved fixture sets while preserving observational-only governance and preventing production planner routing enablement.