### PR TITLE
v3.1: serialize approval manifests and audit diffs

### DIFF
--- a/backend/app/planner_adapters/v3_1/__init__.py
+++ b/backend/app/planner_adapters/v3_1/__init__.py
@@ -33,6 +33,14 @@ from .approval_manifest_candidates import (
     APPROVAL_MANIFEST_CANDIDATE_STATUSES,
     build_approval_manifest_candidates,
 )
+from .approval_manifest_diff_audit import (
+    APPROVAL_MANIFEST_DIFF_CLASSIFICATIONS,
+    audit_approval_manifest_diffs,
+)
+from .approval_manifest_serialization import (
+    SERIALIZED_APPROVAL_MANIFEST_STATUSES,
+    serialize_approval_manifest_candidates,
+)
 from .reviewed_fixture_inputs import (
     REVIEWED_FIXTURE_INPUT_STATUSES,
     discover_default_reviewed_fixture_input_sources,
@@ -54,6 +62,8 @@ __all__ = [
     "REVIEWED_FIXTURE_INPUT_STATUSES",
     "FIXTURE_SET_READINESS_CLASSIFICATIONS",
     "APPROVAL_MANIFEST_CANDIDATE_STATUSES",
+    "APPROVAL_MANIFEST_DIFF_CLASSIFICATIONS",
+    "SERIALIZED_APPROVAL_MANIFEST_STATUSES",
     "SUPPORTED_TRUSTED_SHADOW_DOMAINS",
     "V31BaselineFixtureWorkflows",
     "V31DualRunComparison",
@@ -69,7 +79,9 @@ __all__ = [
     "build_default_trusted_repository_probes",
     "build_fixture_set_readiness_gate",
     "build_approval_manifest_candidates",
+    "audit_approval_manifest_diffs",
     "discover_default_reviewed_fixture_input_sources",
     "deterministic_hash",
     "normalize_reviewed_fixture_inputs",
+    "serialize_approval_manifest_candidates",
 ]

--- a/backend/app/planner_adapters/v3_1/approval_manifest_diff_audit.py
+++ b/backend/app/planner_adapters/v3_1/approval_manifest_diff_audit.py
@@ -1,0 +1,160 @@
+"""Deterministic diff audit for serialized approval manifests."""
+
+from __future__ import annotations
+
+from collections import Counter
+from copy import deepcopy
+from typing import Any
+
+from .approval_manifest_serialization import NON_PRODUCTION_AUTHORIZATION_STATE
+from .trusted_shadow_consumption import deterministic_hash
+
+
+APPROVAL_MANIFEST_DIFF_CLASSIFICATIONS = (
+    "unchanged",
+    "added",
+    "removed",
+    "changed_hash",
+    "changed_metadata",
+    "changed_authorization_state",
+)
+STABLE_APPROVAL_MANIFEST_DIFF_AUDIT_TOKEN = "v3_1_phase_9_approval_manifest_diff_audit_token"
+
+
+def audit_approval_manifest_diffs(
+    *,
+    before: dict[str, Any] | list[dict[str, Any]],
+    after: dict[str, Any] | list[dict[str, Any]],
+    run_id: str = "v3_1_phase_9_approval_manifest_diff_audit",
+) -> dict[str, Any]:
+    """Compare two manifest snapshots and return deterministic diff metadata."""
+
+    before_by_id = _records_by_manifest_id(before)
+    after_by_id = _records_by_manifest_id(after)
+    manifest_ids = sorted(set(before_by_id) | set(after_by_id))
+    records = [
+        _diff_record(manifest_id, before_by_id.get(manifest_id), after_by_id.get(manifest_id))
+        for manifest_id in manifest_ids
+    ]
+    counts = Counter(row["diff_classification"] for row in records)
+    blocked_high_risk_count = sum(1 for row in records if row["blocked"] and row["high_risk"])
+    envelope = {
+        "schema_version": "v3_1.approval_manifest_diff_audit.1",
+        "run": {
+            "run_id": run_id,
+            "before_manifest_count": len(before_by_id),
+            "after_manifest_count": len(after_by_id),
+        },
+        "diff_summary": {
+            "total_diffs_evaluated": len(records),
+            "unchanged_count": counts["unchanged"],
+            "added_count": counts["added"],
+            "removed_count": counts["removed"],
+            "changed_hash_count": counts["changed_hash"],
+            "changed_metadata_count": counts["changed_metadata"],
+            "changed_authorization_state_count": counts["changed_authorization_state"],
+            "blocked_high_risk_count": blocked_high_risk_count,
+            "production_affected_count": 0,
+            "production_output_affected": False,
+            "production_behavior_changed": False,
+            "deterministic": True,
+        },
+        "classification_counts": {
+            status: counts[status]
+            for status in APPROVAL_MANIFEST_DIFF_CLASSIFICATIONS
+        },
+        "diff_records": records,
+        "safety_confirmations": {
+            "production_output_affected": False,
+            "production_behavior_changed": False,
+            "trusted_data_default_truth": False,
+            "legacy_planner_ownership_preserved": True,
+            "runtime_state_mutated": False,
+            "authorization_state_changes_are_blocked_high_risk": True,
+        },
+        "metadata": {
+            "source": "v3_1_approval_manifest_diff_audit",
+            "observational_only": True,
+            "production_consumer": False,
+            "production_behavior_changed": False,
+            "planner_remap_performed": False,
+            "production_default_routing_authorized": False,
+            "stable_generation_token": STABLE_APPROVAL_MANIFEST_DIFF_AUDIT_TOKEN,
+            "deterministic_serializer": "json_sort_keys_sha256",
+        },
+    }
+    envelope["deterministic_hash"] = deterministic_hash(envelope)
+    return envelope
+
+
+def _records_by_manifest_id(value: dict[str, Any] | list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    records = value.get("serialized_manifests", []) if isinstance(value, dict) else value
+    result: dict[str, dict[str, Any]] = {}
+    for record in records:
+        manifest_id = record.get("manifest_id")
+        if manifest_id:
+            result[str(manifest_id)] = deepcopy(record)
+    return result
+
+
+def _diff_record(manifest_id: str, before: dict[str, Any] | None, after: dict[str, Any] | None) -> dict[str, Any]:
+    if before is None:
+        return _base_record(manifest_id, "added", before, after, ["manifest_added"])
+    if after is None:
+        return _base_record(manifest_id, "removed", before, after, ["manifest_removed"])
+    if _authorization_state(before) != _authorization_state(after):
+        return _base_record(
+            manifest_id,
+            "changed_authorization_state",
+            before,
+            after,
+            ["authorization_state_changed_blocked_high_risk"],
+            high_risk=True,
+            blocked=True,
+        )
+    if before.get("generated_hash") != after.get("generated_hash"):
+        return _base_record(manifest_id, "changed_hash", before, after, ["manifest_generated_hash_changed"])
+    if _payload_hash(before) != _payload_hash(after):
+        return _base_record(manifest_id, "changed_metadata", before, after, ["manifest_metadata_changed"])
+    return _base_record(manifest_id, "unchanged", before, after, ["manifest_unchanged"])
+
+
+def _base_record(
+    manifest_id: str,
+    classification: str,
+    before: dict[str, Any] | None,
+    after: dict[str, Any] | None,
+    reason_codes: list[str],
+    *,
+    high_risk: bool = False,
+    blocked: bool = False,
+) -> dict[str, Any]:
+    return {
+        "manifest_id": manifest_id,
+        "diff_classification": classification,
+        "before_hash": before.get("generated_hash") if before else None,
+        "after_hash": after.get("generated_hash") if after else None,
+        "before_authorization_state": _authorization_state(before) if before else None,
+        "after_authorization_state": _authorization_state(after) if after else None,
+        "high_risk": high_risk,
+        "blocked": blocked,
+        "reason_codes": reason_codes,
+        "production_output_affected": False,
+        "metadata": {
+            "observational_only": True,
+            "production_consumer": False,
+            "authorization_state_change_blocked": classification == "changed_authorization_state",
+        },
+    }
+
+
+def _authorization_state(record: dict[str, Any] | None) -> str | None:
+    if not record:
+        return None
+    return (record.get("authorization_status") or {}).get("authorization_state", NON_PRODUCTION_AUTHORIZATION_STATE)
+
+
+def _payload_hash(record: dict[str, Any]) -> str:
+    payload = deepcopy(record)
+    payload.pop("generated_hash", None)
+    return deterministic_hash({"manifest_payload": payload})

--- a/backend/app/planner_adapters/v3_1/approval_manifest_serialization.py
+++ b/backend/app/planner_adapters/v3_1/approval_manifest_serialization.py
@@ -1,0 +1,185 @@
+"""Deterministic approval manifest serialization.
+
+Serialized approval manifests are governance artifacts derived from Phase 8
+manifest candidates. They are explicitly non-authoritative for production
+routing and do not replace legacy planner ownership.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from copy import deepcopy
+from typing import Any
+
+from .trusted_shadow_consumption import deterministic_hash
+
+
+SERIALIZED_APPROVAL_MANIFEST_STATUSES = (
+    "serialized_manifest",
+    "excluded_not_ready",
+    "excluded_missing_readiness",
+    "excluded_invalid_policy_state",
+)
+STABLE_APPROVAL_MANIFEST_SERIALIZATION_TOKEN = "v3_1_phase_9_approval_manifest_serialization_token"
+NON_PRODUCTION_AUTHORIZATION_STATE = "non_production_authoritative"
+
+
+def serialize_approval_manifest_candidates(
+    *,
+    approval_manifest_candidates: dict[str, Any] | list[dict[str, Any]],
+    run_id: str = "v3_1_phase_9_approval_manifest_serialization",
+) -> dict[str, Any]:
+    """Serialize candidate-ready approval manifests in a deterministic envelope."""
+
+    candidates = _candidate_records(approval_manifest_candidates)
+    records = [_serialization_record(candidate) for candidate in sorted(candidates, key=_candidate_sort_key)]
+    counts = Counter(row["serialization_status"] for row in records)
+    exclusion_reasons = Counter(
+        reason
+        for row in records
+        if row["serialization_status"] != "serialized_manifest"
+        for reason in row["reason_codes"]
+    )
+    serialized = [row for row in records if row["serialization_status"] == "serialized_manifest"]
+    excluded = [row for row in records if row["serialization_status"] != "serialized_manifest"]
+    source_hash = approval_manifest_candidates.get("deterministic_hash") if isinstance(approval_manifest_candidates, dict) else None
+    source_schema = approval_manifest_candidates.get("schema_version") if isinstance(approval_manifest_candidates, dict) else None
+
+    envelope = {
+        "schema_version": "v3_1.approval_manifest_serialization.1",
+        "run": {
+            "run_id": run_id,
+            "candidate_record_count": len(records),
+            "source_candidate_hash": source_hash,
+        },
+        "summary": {
+            "total_candidates_evaluated": len(records),
+            "serialized_manifest_count": len(serialized),
+            "excluded_count": len(excluded),
+            "production_affected_count": sum(1 for row in records if row["production_output_affected"]),
+            "production_output_affected": False,
+            "production_behavior_changed": False,
+            "trusted_data_default_truth": False,
+            "production_default_routing_authorized": False,
+            "deterministic": True,
+        },
+        "serialization_status_counts": {
+            status: counts[status]
+            for status in SERIALIZED_APPROVAL_MANIFEST_STATUSES
+        },
+        "exclusion_reason_counts": dict(sorted(exclusion_reasons.items())),
+        "serialized_manifests": serialized,
+        "excluded_candidates": excluded,
+        "input_consumption": {
+            "approval_manifest_candidate_hash": source_hash,
+            "approval_manifest_candidate_schema": source_schema,
+        },
+        "safety_confirmations": {
+            "production_output_affected": False,
+            "production_behavior_changed": False,
+            "trusted_data_default_truth": False,
+            "legacy_planner_ownership_preserved": True,
+            "runtime_state_mutated": False,
+            "serialized_manifests_authorize_production_routing": False,
+            "serialized_manifests_are_production_approved": False,
+            "all_manifests_non_production_authoritative": all(
+                row.get("authorization_status", {}).get("authorization_state") == NON_PRODUCTION_AUTHORIZATION_STATE
+                for row in serialized
+            ),
+        },
+        "metadata": {
+            "source": "v3_1_approval_manifest_serialization",
+            "observational_only": True,
+            "production_consumer": False,
+            "production_behavior_changed": False,
+            "planner_remap_performed": False,
+            "production_default_routing_authorized": False,
+            "stable_generation_token": STABLE_APPROVAL_MANIFEST_SERIALIZATION_TOKEN,
+            "deterministic_serializer": "json_sort_keys_sha256",
+        },
+    }
+    envelope["deterministic_hash"] = deterministic_hash(envelope)
+    return envelope
+
+
+def _candidate_records(value: dict[str, Any] | list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if isinstance(value, list):
+        return [deepcopy(row) for row in value]
+    return [deepcopy(row) for row in value.get("manifest_candidates", [])]
+
+
+def _candidate_sort_key(candidate: dict[str, Any]) -> tuple[str, str]:
+    return (
+        str(candidate.get("fixture_set_id") or ""),
+        str(candidate.get("manifest_candidate_id") or ""),
+    )
+
+
+def _serialization_record(candidate: dict[str, Any]) -> dict[str, Any]:
+    status, reason_codes = _serialization_status(candidate)
+    fixture_set_id = str(candidate.get("fixture_set_id") or "")
+    candidate_id = str(candidate.get("manifest_candidate_id") or "")
+    manifest_id = f"v3_1_approval_manifest_{deterministic_hash({'fixture_set_id': fixture_set_id, 'candidate_id': candidate_id, 'token': STABLE_APPROVAL_MANIFEST_SERIALIZATION_TOKEN})[:16]}"
+
+    if status != "serialized_manifest":
+        return {
+            "manifest_candidate_id": candidate.get("manifest_candidate_id"),
+            "fixture_set_id": candidate.get("fixture_set_id"),
+            "serialization_status": status,
+            "reason_codes": reason_codes,
+            "authorization_status": _authorization_status(),
+            "production_output_affected": False,
+            "metadata": {
+                "observational_only": True,
+                "production_consumer": False,
+                "planner_remap_performed": False,
+            },
+        }
+
+    manifest = {
+        "manifest_id": manifest_id,
+        "manifest_candidate_id": candidate.get("manifest_candidate_id"),
+        "fixture_set_id": candidate.get("fixture_set_id"),
+        "serialization_status": status,
+        "source_summary": deepcopy(candidate.get("source_summary") or {}),
+        "policy_summary": deepcopy(candidate.get("policy_summary") or {}),
+        "readiness_summary": deepcopy(candidate.get("readiness_summary") or {}),
+        "authorization_status": _authorization_status(),
+        "non_production_authoritative": True,
+        "reason_codes": reason_codes,
+        "production_output_affected": False,
+        "metadata": {
+            "observational_only": True,
+            "production_consumer": False,
+            "planner_remap_performed": False,
+            "stable_generation_token": STABLE_APPROVAL_MANIFEST_SERIALIZATION_TOKEN,
+        },
+    }
+    manifest["generated_hash"] = deterministic_hash({"serialized_manifest": manifest})
+    return manifest
+
+
+def _serialization_status(candidate: dict[str, Any]) -> tuple[str, list[str]]:
+    status = candidate.get("candidate_status")
+    if not status:
+        return "excluded_missing_readiness", ["missing_candidate_status"]
+    if status == "excluded_missing_readiness":
+        return "excluded_missing_readiness", list(candidate.get("reason_codes") or ["missing_readiness_classification"])
+    if status == "excluded_invalid_policy_state":
+        return "excluded_invalid_policy_state", list(candidate.get("reason_codes") or ["invalid_policy_state"])
+    if status != "candidate_ready":
+        return "excluded_not_ready", list(candidate.get("reason_codes") or [f"candidate_status_{status}"])
+    policy = (candidate.get("policy_summary") or {}).get("policy_outcome")
+    if policy != "passes_policy":
+        return "excluded_invalid_policy_state", [f"invalid_policy_state_{policy or 'missing'}"]
+    return "serialized_manifest", ["candidate_ready_serialized_non_authoritative_manifest"]
+
+
+def _authorization_status() -> dict[str, Any]:
+    return {
+        "authorization_state": NON_PRODUCTION_AUTHORIZATION_STATE,
+        "manifest_authorizes_production_routing": False,
+        "manifest_is_production_approved": False,
+        "legacy_planner_ownership_preserved": True,
+        "trusted_default_routing": False,
+    }

--- a/backend/scripts/report_v3_1_approval_manifest_serialization.py
+++ b/backend/scripts/report_v3_1_approval_manifest_serialization.py
@@ -1,0 +1,153 @@
+"""Generate the v3.1 approval manifest serialization and diff audit report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.planner_adapters.v3_1.approval_manifest_diff_audit import audit_approval_manifest_diffs  # noqa: E402
+from app.planner_adapters.v3_1.approval_manifest_serialization import serialize_approval_manifest_candidates  # noqa: E402
+
+
+DETERMINISTIC_GENERATED_AT = "2026-05-15T00:00:00+00:00"
+
+
+def build_v3_1_approval_manifest_serialization_report() -> dict[str, Any]:
+    repo_root = Path(__file__).resolve().parents[2]
+    candidates = _read_json(repo_root / "docs" / "generated" / "v3_1_approval_manifest_candidates_report.json")[
+        "approval_manifest_candidates"
+    ]
+    serialization = serialize_approval_manifest_candidates(approval_manifest_candidates=candidates)
+    repeated = serialize_approval_manifest_candidates(approval_manifest_candidates=candidates)
+    diff_audit = audit_approval_manifest_diffs(before=serialization, after=repeated)
+    report = {
+        "schema_version": "v3_1.approval_manifest_serialization_report.1",
+        "generated_at": DETERMINISTIC_GENERATED_AT,
+        "phase": "v3.1_phase_9_approval_manifest_serialization_diff_audit",
+        "recommendation": "OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING",
+        "production_default_routing_authorized": False,
+        "summary": {
+            **serialization["summary"],
+            "diff_record_count": diff_audit["diff_summary"]["total_diffs_evaluated"],
+            "blocked_high_risk_count": diff_audit["diff_summary"]["blocked_high_risk_count"],
+            "deterministic": serialization["deterministic_hash"] == repeated["deterministic_hash"]
+            and diff_audit["diff_summary"]["blocked_high_risk_count"] == 0,
+        },
+        "approval_manifest_serialization": serialization,
+        "approval_manifest_diff_audit": diff_audit,
+        "deterministic_guarantees": {
+            "passed": serialization["deterministic_hash"] == repeated["deterministic_hash"],
+            "sample_hash": serialization["deterministic_hash"],
+            "repeated_hash": repeated["deterministic_hash"],
+            "diff_audit_hash": diff_audit["deterministic_hash"],
+            "timestamp_excluded_from_hash": True,
+            "json_sort_keys": True,
+        },
+        "phase_9_boundaries": [
+            "serialized manifests are observational governance artifacts",
+            "serialized manifests do not authorize production routing",
+            "every serialized manifest is non-production authoritative",
+            "authorization-state changes are surfaced as blocked high-risk diffs",
+            "trusted infrastructure is still not production default",
+            "legacy planner ownership remains intact",
+        ],
+        "metadata": {
+            "source": "v3_1_approval_manifest_serialization_report",
+            "observational_only": True,
+            "production_behavior_changed": False,
+            "production_default_routing_authorized": False,
+            "planner_remap_performed": False,
+        },
+    }
+    return _normalize_generated_at(report)
+
+
+def write_report(report: dict[str, Any], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_markdown(report: dict[str, Any], output_path: Path) -> None:
+    summary = report["summary"]
+    serialization = report["approval_manifest_serialization"]
+    diff_audit = report["approval_manifest_diff_audit"]
+    lines = [
+        "# V3.1 Approval Manifest Serialization",
+        "",
+        "Phase 9 serializes approval manifest candidates into deterministic, inspectable governance artifacts.",
+        "Serialized manifests remain non-authoritative and do not authorize production planner routing.",
+        "",
+        "## Recommendation",
+        "",
+        f"- Recommendation: `{report['recommendation']}`",
+        f"- Production default routing authorized: `{str(report['production_default_routing_authorized']).lower()}`",
+        "",
+        "## Summary",
+        "",
+        f"- Total candidates evaluated: `{summary['total_candidates_evaluated']}`",
+        f"- Serialized manifests: `{summary['serialized_manifest_count']}`",
+        f"- Excluded candidates: `{summary['excluded_count']}`",
+        f"- Diff records: `{summary['diff_record_count']}`",
+        f"- Blocked high-risk diffs: `{summary['blocked_high_risk_count']}`",
+        f"- Production affected: `{summary['production_affected_count']}`",
+        f"- Deterministic: `{str(summary['deterministic']).lower()}`",
+        "",
+        "## Exclusion Reasons",
+        "",
+        "| Reason | Count |",
+        "| --- | ---: |",
+    ]
+    for reason, count in serialization["exclusion_reason_counts"].items():
+        lines.append(f"| `{reason}` | `{count}` |")
+    lines.extend(["", "## Serialized Manifests", "", "| Manifest | Fixture Set | Authorization State | Production Approved |", "| --- | --- | --- | --- |"])
+    for row in serialization["serialized_manifests"]:
+        lines.append(
+            f"| `{row['manifest_id']}` | `{row['fixture_set_id']}` | `{row['authorization_status']['authorization_state']}` | `{str(row['authorization_status']['manifest_is_production_approved']).lower()}` |"
+        )
+    lines.extend(["", "## Diff Audit Summary", "", "| Classification | Count |", "| --- | ---: |"])
+    for classification, count in diff_audit["classification_counts"].items():
+        lines.append(f"| `{classification}` | `{count}` |")
+    lines.extend(["", "## Phase 9 Boundaries", ""])
+    lines.extend(f"- {item}" for item in report["phase_9_boundaries"])
+    lines.extend(["", "## Conclusion", "", "Approval manifest serialization is available for governance review, while production routing remains unchanged."])
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _normalize_generated_at(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: DETERMINISTIC_GENERATED_AT if key == "generated_at" else _normalize_generated_at(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_normalize_generated_at(item) for item in value]
+    return deepcopy(value)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", default="docs/generated/v3_1_approval_manifest_serialization_report.json")
+    parser.add_argument("--markdown-output", default="docs/migration/V3_1_APPROVAL_MANIFEST_SERIALIZATION.md")
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[2]
+    report = build_v3_1_approval_manifest_serialization_report()
+    write_report(report, repo_root / args.output)
+    write_markdown(report, repo_root / args.markdown_output)
+    print(json.dumps(report["summary"], indent=2, sort_keys=True))
+    print(report["recommendation"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_v3_1_approval_manifest_serialization.py
+++ b/backend/tests/test_v3_1_approval_manifest_serialization.py
@@ -1,0 +1,130 @@
+from copy import deepcopy
+
+from app.planner_adapters.v3_1.approval_manifest_diff_audit import audit_approval_manifest_diffs
+from app.planner_adapters.v3_1.approval_manifest_serialization import (
+    NON_PRODUCTION_AUTHORIZATION_STATE,
+    serialize_approval_manifest_candidates,
+)
+from scripts.report_v3_1_approval_manifest_serialization import build_v3_1_approval_manifest_serialization_report
+
+
+def test_deterministic_manifest_serialization():
+    first = serialize_approval_manifest_candidates(approval_manifest_candidates=_candidate_envelope([_candidate("set_b"), _candidate("set_a")]))
+    second = serialize_approval_manifest_candidates(approval_manifest_candidates=_candidate_envelope([_candidate("set_a"), _candidate("set_b")]))
+
+    assert first["deterministic_hash"] == second["deterministic_hash"]
+    assert [row["fixture_set_id"] for row in first["serialized_manifests"]] == ["set_a", "set_b"]
+    assert first["summary"]["serialized_manifest_count"] == 2
+
+
+def test_non_ready_candidates_are_excluded():
+    result = serialize_approval_manifest_candidates(
+        approval_manifest_candidates=_candidate_envelope([_candidate("set_a", candidate_status="excluded_not_ready", reasons=["policy_unsupported"])])
+    )
+
+    assert result["summary"]["serialized_manifest_count"] == 0
+    assert result["summary"]["excluded_count"] == 1
+    assert result["excluded_candidates"][0]["serialization_status"] == "excluded_not_ready"
+    assert result["exclusion_reason_counts"]["policy_unsupported"] == 1
+
+
+def test_manifest_hashes_remain_stable():
+    first = serialize_approval_manifest_candidates(approval_manifest_candidates=_candidate_envelope([_candidate("set_a")]))
+    second = serialize_approval_manifest_candidates(approval_manifest_candidates=_candidate_envelope([_candidate("set_a")]))
+
+    assert first["serialized_manifests"][0]["generated_hash"] == second["serialized_manifests"][0]["generated_hash"]
+    assert first["serialized_manifests"][0]["authorization_status"]["authorization_state"] == NON_PRODUCTION_AUTHORIZATION_STATE
+
+
+def test_diff_audit_detects_added_removed_and_changed_records():
+    before = serialize_approval_manifest_candidates(approval_manifest_candidates=_candidate_envelope([_candidate("set_a"), _candidate("set_b")]))
+    after = serialize_approval_manifest_candidates(approval_manifest_candidates=_candidate_envelope([_candidate("set_b"), _candidate("set_c")]))
+    changed_hash_after = deepcopy(before)
+    changed_hash_after["serialized_manifests"][0]["generated_hash"] = "changed"
+    changed_metadata_after = deepcopy(before)
+    changed_metadata_after["serialized_manifests"][0]["metadata"]["review_note"] = "changed"
+
+    added_removed = audit_approval_manifest_diffs(before=before, after=after)
+    changed_hash = audit_approval_manifest_diffs(before=before, after=changed_hash_after)
+    changed_metadata = audit_approval_manifest_diffs(before=before, after=changed_metadata_after)
+
+    assert added_removed["classification_counts"]["added"] == 1
+    assert added_removed["classification_counts"]["removed"] == 1
+    assert changed_hash["classification_counts"]["changed_hash"] == 1
+    assert changed_metadata["classification_counts"]["changed_metadata"] == 1
+
+
+def test_authorization_state_changes_are_high_risk_blocked():
+    before = serialize_approval_manifest_candidates(approval_manifest_candidates=_candidate_envelope([_candidate("set_a")]))
+    after = deepcopy(before)
+    after["serialized_manifests"][0]["authorization_status"]["authorization_state"] = "production_authoritative"
+    result = audit_approval_manifest_diffs(before=before, after=after)
+
+    record = result["diff_records"][0]
+    assert record["diff_classification"] == "changed_authorization_state"
+    assert record["high_risk"] is True
+    assert record["blocked"] is True
+    assert result["diff_summary"]["blocked_high_risk_count"] == 1
+
+
+def test_report_generation_is_stable_and_non_authoritative():
+    first = build_v3_1_approval_manifest_serialization_report()
+    second = build_v3_1_approval_manifest_serialization_report()
+
+    assert first["deterministic_guarantees"]["passed"] is True
+    assert first["approval_manifest_serialization"]["deterministic_hash"] == second["approval_manifest_serialization"]["deterministic_hash"]
+    assert first["summary"] == second["summary"]
+    assert first["production_default_routing_authorized"] is False
+
+
+def test_no_production_routing_enablement():
+    result = serialize_approval_manifest_candidates(approval_manifest_candidates=_candidate_envelope([_candidate("set_a")]))
+    manifest = result["serialized_manifests"][0]
+
+    assert result["safety_confirmations"]["serialized_manifests_authorize_production_routing"] is False
+    assert result["safety_confirmations"]["serialized_manifests_are_production_approved"] is False
+    assert manifest["authorization_status"]["manifest_authorizes_production_routing"] is False
+    assert manifest["authorization_status"]["manifest_is_production_approved"] is False
+    assert manifest["non_production_authoritative"] is True
+
+
+def _candidate_envelope(candidates):
+    return {
+        "schema_version": "v3_1.approval_manifest_candidates.1",
+        "deterministic_hash": "candidate-hash",
+        "manifest_candidates": candidates,
+    }
+
+
+def _candidate(set_id, candidate_status="candidate_ready", policy="passes_policy", reasons=None):
+    return {
+        "manifest_candidate_id": f"candidate_{set_id}",
+        "fixture_set_id": set_id,
+        "candidate_status": candidate_status,
+        "source_summary": {
+            "set_key": set_id,
+            "associated_fixture_ids": [f"fixture_{set_id}"],
+            "input_statuses": {f"fixture_{set_id}": "reviewed"},
+        },
+        "policy_summary": {
+            "policy_outcome": policy,
+            "valid_policy_state": policy == "passes_policy",
+        },
+        "readiness_summary": {
+            "readiness_classification": "ready_for_approval_review",
+            "block_reason_codes": [],
+        },
+        "authorization_status": {
+            "candidate_is_production_approved": False,
+            "candidate_authorizes_production_routing": False,
+            "legacy_planner_ownership_preserved": True,
+            "trusted_default_routing": False,
+        },
+        "reason_codes": reasons or ["ready_for_approval_review_policy_passed"],
+        "production_output_affected": False,
+        "metadata": {
+            "observational_only": True,
+            "production_consumer": False,
+            "planner_remap_performed": False,
+        },
+    }

--- a/docs/generated/v3_1_approval_manifest_serialization_report.json
+++ b/docs/generated/v3_1_approval_manifest_serialization_report.json
@@ -1,0 +1,170 @@
+{
+  "approval_manifest_diff_audit": {
+    "classification_counts": {
+      "added": 0,
+      "changed_authorization_state": 0,
+      "changed_hash": 0,
+      "changed_metadata": 0,
+      "removed": 0,
+      "unchanged": 0
+    },
+    "deterministic_hash": "c0d263f3c5c6fbcae45ea1ba8b52ee0a89f2a5ad00e2ea61662ecf19dabcff3f",
+    "diff_records": [],
+    "diff_summary": {
+      "added_count": 0,
+      "blocked_high_risk_count": 0,
+      "changed_authorization_state_count": 0,
+      "changed_hash_count": 0,
+      "changed_metadata_count": 0,
+      "deterministic": true,
+      "production_affected_count": 0,
+      "production_behavior_changed": false,
+      "production_output_affected": false,
+      "removed_count": 0,
+      "total_diffs_evaluated": 0,
+      "unchanged_count": 0
+    },
+    "metadata": {
+      "deterministic_serializer": "json_sort_keys_sha256",
+      "observational_only": true,
+      "planner_remap_performed": false,
+      "production_behavior_changed": false,
+      "production_consumer": false,
+      "production_default_routing_authorized": false,
+      "source": "v3_1_approval_manifest_diff_audit",
+      "stable_generation_token": "v3_1_phase_9_approval_manifest_diff_audit_token"
+    },
+    "run": {
+      "after_manifest_count": 0,
+      "before_manifest_count": 0,
+      "run_id": "v3_1_phase_9_approval_manifest_diff_audit"
+    },
+    "safety_confirmations": {
+      "authorization_state_changes_are_blocked_high_risk": true,
+      "legacy_planner_ownership_preserved": true,
+      "production_behavior_changed": false,
+      "production_output_affected": false,
+      "runtime_state_mutated": false,
+      "trusted_data_default_truth": false
+    },
+    "schema_version": "v3_1.approval_manifest_diff_audit.1"
+  },
+  "approval_manifest_serialization": {
+    "deterministic_hash": "dea874b9d2a9ea3f2464e7aa51c64cdfa78a7639525aba8aa20a5d697cc992f5",
+    "excluded_candidates": [
+      {
+        "authorization_status": {
+          "authorization_state": "non_production_authoritative",
+          "legacy_planner_ownership_preserved": true,
+          "manifest_authorizes_production_routing": false,
+          "manifest_is_production_approved": false,
+          "trusted_default_routing": false
+        },
+        "fixture_set_id": "v3_1_fixture_set_6d3b668a84cfbb69",
+        "manifest_candidate_id": "v3_1_manifest_candidate_2db355128ef8ae54",
+        "metadata": {
+          "observational_only": true,
+          "planner_remap_performed": false,
+          "production_consumer": false
+        },
+        "production_output_affected": false,
+        "reason_codes": [
+          "policy_unsupported"
+        ],
+        "serialization_status": "excluded_not_ready"
+      }
+    ],
+    "exclusion_reason_counts": {
+      "policy_unsupported": 1
+    },
+    "input_consumption": {
+      "approval_manifest_candidate_hash": "26e84f9a9f25f9ad94ddd70e449d328623079c6e651702eaef70285fa445db27",
+      "approval_manifest_candidate_schema": "v3_1.approval_manifest_candidates.1"
+    },
+    "metadata": {
+      "deterministic_serializer": "json_sort_keys_sha256",
+      "observational_only": true,
+      "planner_remap_performed": false,
+      "production_behavior_changed": false,
+      "production_consumer": false,
+      "production_default_routing_authorized": false,
+      "source": "v3_1_approval_manifest_serialization",
+      "stable_generation_token": "v3_1_phase_9_approval_manifest_serialization_token"
+    },
+    "run": {
+      "candidate_record_count": 1,
+      "run_id": "v3_1_phase_9_approval_manifest_serialization",
+      "source_candidate_hash": "26e84f9a9f25f9ad94ddd70e449d328623079c6e651702eaef70285fa445db27"
+    },
+    "safety_confirmations": {
+      "all_manifests_non_production_authoritative": true,
+      "legacy_planner_ownership_preserved": true,
+      "production_behavior_changed": false,
+      "production_output_affected": false,
+      "runtime_state_mutated": false,
+      "serialized_manifests_are_production_approved": false,
+      "serialized_manifests_authorize_production_routing": false,
+      "trusted_data_default_truth": false
+    },
+    "schema_version": "v3_1.approval_manifest_serialization.1",
+    "serialization_status_counts": {
+      "excluded_invalid_policy_state": 0,
+      "excluded_missing_readiness": 0,
+      "excluded_not_ready": 1,
+      "serialized_manifest": 0
+    },
+    "serialized_manifests": [],
+    "summary": {
+      "deterministic": true,
+      "excluded_count": 1,
+      "production_affected_count": 0,
+      "production_behavior_changed": false,
+      "production_default_routing_authorized": false,
+      "production_output_affected": false,
+      "serialized_manifest_count": 0,
+      "total_candidates_evaluated": 1,
+      "trusted_data_default_truth": false
+    }
+  },
+  "deterministic_guarantees": {
+    "diff_audit_hash": "c0d263f3c5c6fbcae45ea1ba8b52ee0a89f2a5ad00e2ea61662ecf19dabcff3f",
+    "json_sort_keys": true,
+    "passed": true,
+    "repeated_hash": "dea874b9d2a9ea3f2464e7aa51c64cdfa78a7639525aba8aa20a5d697cc992f5",
+    "sample_hash": "dea874b9d2a9ea3f2464e7aa51c64cdfa78a7639525aba8aa20a5d697cc992f5",
+    "timestamp_excluded_from_hash": true
+  },
+  "generated_at": "2026-05-15T00:00:00+00:00",
+  "metadata": {
+    "observational_only": true,
+    "planner_remap_performed": false,
+    "production_behavior_changed": false,
+    "production_default_routing_authorized": false,
+    "source": "v3_1_approval_manifest_serialization_report"
+  },
+  "phase": "v3.1_phase_9_approval_manifest_serialization_diff_audit",
+  "phase_9_boundaries": [
+    "serialized manifests are observational governance artifacts",
+    "serialized manifests do not authorize production routing",
+    "every serialized manifest is non-production authoritative",
+    "authorization-state changes are surfaced as blocked high-risk diffs",
+    "trusted infrastructure is still not production default",
+    "legacy planner ownership remains intact"
+  ],
+  "production_default_routing_authorized": false,
+  "recommendation": "OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING",
+  "schema_version": "v3_1.approval_manifest_serialization_report.1",
+  "summary": {
+    "blocked_high_risk_count": 0,
+    "deterministic": true,
+    "diff_record_count": 0,
+    "excluded_count": 1,
+    "production_affected_count": 0,
+    "production_behavior_changed": false,
+    "production_default_routing_authorized": false,
+    "production_output_affected": false,
+    "serialized_manifest_count": 0,
+    "total_candidates_evaluated": 1,
+    "trusted_data_default_truth": false
+  }
+}

--- a/docs/migration/V3_1_APPROVAL_MANIFEST_SERIALIZATION.md
+++ b/docs/migration/V3_1_APPROVAL_MANIFEST_SERIALIZATION.md
@@ -1,0 +1,54 @@
+# V3.1 Approval Manifest Serialization
+
+Phase 9 serializes approval manifest candidates into deterministic, inspectable governance artifacts.
+Serialized manifests remain non-authoritative and do not authorize production planner routing.
+
+## Recommendation
+
+- Recommendation: `OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING`
+- Production default routing authorized: `false`
+
+## Summary
+
+- Total candidates evaluated: `1`
+- Serialized manifests: `0`
+- Excluded candidates: `1`
+- Diff records: `0`
+- Blocked high-risk diffs: `0`
+- Production affected: `0`
+- Deterministic: `true`
+
+## Exclusion Reasons
+
+| Reason | Count |
+| --- | ---: |
+| `policy_unsupported` | `1` |
+
+## Serialized Manifests
+
+| Manifest | Fixture Set | Authorization State | Production Approved |
+| --- | --- | --- | --- |
+
+## Diff Audit Summary
+
+| Classification | Count |
+| --- | ---: |
+| `unchanged` | `0` |
+| `added` | `0` |
+| `removed` | `0` |
+| `changed_hash` | `0` |
+| `changed_metadata` | `0` |
+| `changed_authorization_state` | `0` |
+
+## Phase 9 Boundaries
+
+- serialized manifests are observational governance artifacts
+- serialized manifests do not authorize production routing
+- every serialized manifest is non-production authoritative
+- authorization-state changes are surfaced as blocked high-risk diffs
+- trusted infrastructure is still not production default
+- legacy planner ownership remains intact
+
+## Conclusion
+
+Approval manifest serialization is available for governance review, while production routing remains unchanged.


### PR DESCRIPTION
Adds deterministic approval manifest serialization and diff auditing for v3.1 governance while keeping manifests non-authoritative and preventing production planner routing enablement.