### PR TITLE
v3.1: add approval blocker diagnosis

### DIFF
--- a/backend/app/planner_adapters/v3_1/__init__.py
+++ b/backend/app/planner_adapters/v3_1/__init__.py
@@ -33,6 +33,10 @@ from .approval_manifest_candidates import (
     APPROVAL_MANIFEST_CANDIDATE_STATUSES,
     build_approval_manifest_candidates,
 )
+from .approval_blocker_diagnosis import (
+    APPROVAL_BLOCKER_CLASSIFICATIONS,
+    build_approval_blocker_diagnosis,
+)
 from .approval_manifest_diff_audit import (
     APPROVAL_MANIFEST_DIFF_CLASSIFICATIONS,
     audit_approval_manifest_diffs,
@@ -62,6 +66,7 @@ __all__ = [
     "REVIEWED_FIXTURE_INPUT_STATUSES",
     "FIXTURE_SET_READINESS_CLASSIFICATIONS",
     "APPROVAL_MANIFEST_CANDIDATE_STATUSES",
+    "APPROVAL_BLOCKER_CLASSIFICATIONS",
     "APPROVAL_MANIFEST_DIFF_CLASSIFICATIONS",
     "SERIALIZED_APPROVAL_MANIFEST_STATUSES",
     "SUPPORTED_TRUSTED_SHADOW_DOMAINS",
@@ -79,6 +84,7 @@ __all__ = [
     "build_default_trusted_repository_probes",
     "build_fixture_set_readiness_gate",
     "build_approval_manifest_candidates",
+    "build_approval_blocker_diagnosis",
     "audit_approval_manifest_diffs",
     "discover_default_reviewed_fixture_input_sources",
     "deterministic_hash",

--- a/backend/app/planner_adapters/v3_1/approval_blocker_diagnosis.py
+++ b/backend/app/planner_adapters/v3_1/approval_blocker_diagnosis.py
@@ -1,0 +1,357 @@
+"""Deterministic approval blocker diagnosis across v3.1 governance layers.
+
+This module explains why fixture sets have not reached approval-manifest
+serialization. It is observational only and never authorizes production routing.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any
+
+from .trusted_shadow_consumption import deterministic_hash
+
+
+APPROVAL_BLOCKER_CLASSIFICATIONS = (
+    "missing_reviewed_inputs",
+    "insufficient_fixture_set_coverage",
+    "policy_not_satisfied",
+    "readiness_gate_blocked",
+    "no_candidate_ready_records",
+    "no_serialized_manifests",
+    "malformed_or_duplicate_inputs",
+    "unsupported_fixture_source",
+    "unknown_blocker",
+)
+APPROVAL_BLOCKER_SEVERITIES = ("info", "warning", "blocking")
+STABLE_APPROVAL_BLOCKER_DIAGNOSIS_TOKEN = "v3_1_phase_10_approval_blocker_diagnosis_token"
+
+
+def build_approval_blocker_diagnosis(
+    *,
+    reviewed_fixture_inputs: dict[str, Any] | None = None,
+    persisted_fixture_sets: dict[str, Any] | None = None,
+    review_policy_evaluation: dict[str, Any] | None = None,
+    fixture_set_readiness_gate: dict[str, Any] | None = None,
+    approval_manifest_candidates: dict[str, Any] | None = None,
+    approval_manifest_serialization: dict[str, Any] | None = None,
+    run_id: str = "v3_1_phase_10_approval_blocker_diagnosis",
+) -> dict[str, Any]:
+    """Build deterministic blocker diagnosis records from v3.1 governance outputs."""
+
+    records: list[dict[str, Any]] = []
+    records.extend(_reviewed_input_blockers(reviewed_fixture_inputs or {}))
+    records.extend(_fixture_set_blockers(persisted_fixture_sets or {}))
+    records.extend(_policy_blockers(review_policy_evaluation or {}))
+    records.extend(_readiness_blockers(fixture_set_readiness_gate or {}))
+    records.extend(_candidate_blockers(approval_manifest_candidates or {}))
+    records.extend(_serialization_blockers(approval_manifest_serialization or {}))
+
+    if not records:
+        records.append(
+            _blocker_record(
+                classification="unknown_blocker",
+                severity="info",
+                layer="diagnosis",
+                fixture_set_id=None,
+                reason="no explicit governance blocker was detected",
+                recommended_action="review upstream governance artifacts for missing diagnostic coverage",
+            )
+        )
+
+    records = sorted(records, key=lambda row: (row["severity_rank"], row["affected_layer"], row["blocker_type"], row["blocker_id"]))
+    severity_counts = Counter(row["severity"] for row in records)
+    layer_counts = Counter(row["affected_layer"] for row in records)
+    type_counts = Counter(row["blocker_type"] for row in records)
+    blocking_reason_counts = Counter(row["reason"] for row in records if row["severity"] == "blocking")
+
+    envelope = {
+        "schema_version": "v3_1.approval_blocker_diagnosis.1",
+        "run": {
+            "run_id": run_id,
+            "reviewed_fixture_input_hash": (reviewed_fixture_inputs or {}).get("deterministic_hash"),
+            "persisted_fixture_set_hash": (persisted_fixture_sets or {}).get("deterministic_hash"),
+            "review_policy_evaluation_hash": (review_policy_evaluation or {}).get("deterministic_hash"),
+            "readiness_gate_hash": (fixture_set_readiness_gate or {}).get("deterministic_hash"),
+            "approval_manifest_candidate_hash": (approval_manifest_candidates or {}).get("deterministic_hash"),
+            "approval_manifest_serialization_hash": (approval_manifest_serialization or {}).get("deterministic_hash"),
+        },
+        "summary": {
+            "total_blockers": len(records),
+            "info_count": severity_counts["info"],
+            "warning_count": severity_counts["warning"],
+            "blocking_count": severity_counts["blocking"],
+            "production_affected_count": 0,
+            "production_output_affected": False,
+            "production_behavior_changed": False,
+            "production_default_routing_authorized": False,
+            "trusted_data_default_truth": False,
+            "deterministic": True,
+        },
+        "blocker_type_counts": {
+            blocker_type: type_counts[blocker_type]
+            for blocker_type in APPROVAL_BLOCKER_CLASSIFICATIONS
+        },
+        "severity_counts": {
+            severity: severity_counts[severity]
+            for severity in APPROVAL_BLOCKER_SEVERITIES
+        },
+        "layer_counts": dict(sorted(layer_counts.items())),
+        "top_blocking_reasons": [
+            {"reason": reason, "count": count}
+            for reason, count in sorted(blocking_reason_counts.items(), key=lambda item: (-item[1], item[0]))
+        ],
+        "recommended_next_action_summary": _recommended_next_action_summary(records),
+        "blocker_records": [_public_record(row) for row in records],
+        "safety_confirmations": {
+            "diagnosis_authorizes_production_routing": False,
+            "diagnosis_promotes_fixture_sets": False,
+            "legacy_planner_ownership_preserved": True,
+            "production_output_affected": False,
+            "production_behavior_changed": False,
+            "runtime_state_mutated": False,
+            "trusted_data_default_truth": False,
+        },
+        "metadata": {
+            "source": "v3_1_approval_blocker_diagnosis",
+            "observational_only": True,
+            "production_consumer": False,
+            "production_behavior_changed": False,
+            "planner_remap_performed": False,
+            "production_default_routing_authorized": False,
+            "stable_generation_token": STABLE_APPROVAL_BLOCKER_DIAGNOSIS_TOKEN,
+            "deterministic_serializer": "json_sort_keys_sha256",
+        },
+    }
+    envelope["deterministic_hash"] = deterministic_hash(envelope)
+    return envelope
+
+
+def _reviewed_input_blockers(report: dict[str, Any]) -> list[dict[str, Any]]:
+    if not report:
+        return []
+    records: list[dict[str, Any]] = []
+    summary = report.get("summary") or report
+    if summary.get("missing_source_count", 0) > 0:
+        records.append(
+            _blocker_record(
+                classification="missing_reviewed_inputs",
+                severity="blocking",
+                layer="reviewed_fixture_inputs",
+                fixture_set_id=None,
+                reason="reviewed fixture input source is missing",
+                recommended_action="restore or generate the missing reviewed fixture input source before approval review",
+            )
+        )
+    if summary.get("malformed_count", 0) > 0 or summary.get("duplicate_count", 0) > 0:
+        records.append(
+            _blocker_record(
+                classification="malformed_or_duplicate_inputs",
+                severity="blocking",
+                layer="reviewed_fixture_inputs",
+                fixture_set_id=None,
+                reason="reviewed fixture inputs contain malformed or duplicate records",
+                recommended_action="repair malformed fixture identifiers and deduplicate reviewed fixture inputs",
+            )
+        )
+    normalized = _nested(report, "reviewed_fixture_inputs", "normalized_fixture_inputs", default=[])
+    for row in normalized:
+        if row.get("status") == "unsupported":
+            records.append(
+                _blocker_record(
+                    classification="unsupported_fixture_source",
+                    severity="warning",
+                    layer="reviewed_fixture_inputs",
+                    fixture_set_id=row.get("normalized_fixture_id"),
+                    reason="reviewed fixture input source is unsupported",
+                    recommended_action="replace unsupported fixture source data with supported reviewed fixture inputs",
+                )
+            )
+    return records
+
+
+def _fixture_set_blockers(report: dict[str, Any]) -> list[dict[str, Any]]:
+    if not report:
+        return []
+    records: list[dict[str, Any]] = []
+    summary = report.get("summary") or {}
+    fixture_sets = _nested(report, "persisted_fixture_sets", "fixture_sets", default=[])
+    if summary.get("total_fixture_sets", len(fixture_sets)) == 0:
+        records.append(
+            _blocker_record(
+                classification="insufficient_fixture_set_coverage",
+                severity="blocking",
+                layer="persisted_fixture_sets",
+                fixture_set_id=None,
+                reason="no persisted fixture sets are available for approval diagnosis",
+                recommended_action="create persisted fixture sets from reviewed fixture workflows before policy evaluation",
+            )
+        )
+    for row in fixture_sets:
+        state = str(row.get("lifecycle_state") or "")
+        if state in {"draft", "insufficient_data", "partially_approved"} or row.get("missing_fixture_ids"):
+            records.append(
+                _blocker_record(
+                    classification="insufficient_fixture_set_coverage",
+                    severity="blocking",
+                    layer="persisted_fixture_sets",
+                    fixture_set_id=row.get("fixture_set_id"),
+                    reason=f"fixture set coverage is insufficient ({state or 'unknown'})",
+                    recommended_action="complete fixture-set membership and lifecycle evidence before approval review",
+                )
+            )
+        if state == "unsupported" or row.get("unsupported"):
+            records.append(
+                _blocker_record(
+                    classification="unsupported_fixture_source",
+                    severity="blocking",
+                    layer="persisted_fixture_sets",
+                    fixture_set_id=row.get("fixture_set_id"),
+                    reason="persisted fixture set contains unsupported fixture source state",
+                    recommended_action="resolve unsupported fixture sources before policy review can pass",
+                )
+            )
+    return records
+
+
+def _policy_blockers(report: dict[str, Any]) -> list[dict[str, Any]]:
+    if not report:
+        return []
+    records: list[dict[str, Any]] = []
+    evaluations = _nested(report, "review_policy_evaluation", "evaluations", default=[])
+    for row in evaluations:
+        outcome = row.get("policy_outcome")
+        if outcome != "passes_policy":
+            records.append(
+                _blocker_record(
+                    classification="policy_not_satisfied",
+                    severity="blocking",
+                    layer="review_policy_evaluation",
+                    fixture_set_id=row.get("fixture_set_id"),
+                    reason=f"review policy outcome is {outcome or 'missing'}",
+                    recommended_action="resolve policy blockers until the fixture set reaches passes_policy",
+                )
+            )
+    return records
+
+
+def _readiness_blockers(report: dict[str, Any]) -> list[dict[str, Any]]:
+    if not report:
+        return []
+    records: list[dict[str, Any]] = []
+    readiness_records = _nested(report, "fixture_set_readiness_gate", "readiness_records", default=[])
+    for row in readiness_records:
+        classification = row.get("readiness_classification")
+        if classification != "ready_for_approval_review":
+            reasons = ", ".join(row.get("block_reason_codes") or [classification or "missing_readiness_classification"])
+            records.append(
+                _blocker_record(
+                    classification="readiness_gate_blocked",
+                    severity="blocking",
+                    layer="fixture_set_readiness_gate",
+                    fixture_set_id=row.get("fixture_set_id"),
+                    reason=f"readiness gate blocked approval review: {reasons}",
+                    recommended_action="clear readiness gate block reasons before manifest candidate generation",
+                )
+            )
+    return records
+
+
+def _candidate_blockers(report: dict[str, Any]) -> list[dict[str, Any]]:
+    summary = report.get("summary") or {}
+    candidates = _nested(report, "approval_manifest_candidates", "manifest_candidates", default=[])
+    ready_count = summary.get("candidate_ready_count")
+    if ready_count is None:
+        ready_count = sum(1 for row in candidates if row.get("candidate_status") == "candidate_ready")
+    if ready_count:
+        return []
+    return [
+        _blocker_record(
+            classification="no_candidate_ready_records",
+            severity="blocking",
+            layer="approval_manifest_candidates",
+            fixture_set_id=None,
+            reason="no manifest candidate records reached candidate_ready",
+            recommended_action="resolve upstream readiness and policy blockers before manifest candidate review",
+        )
+    ]
+
+
+def _serialization_blockers(report: dict[str, Any]) -> list[dict[str, Any]]:
+    summary = report.get("summary") or {}
+    manifests = _nested(report, "approval_manifest_serialization", "serialized_manifests", default=[])
+    manifest_count = summary.get("serialized_manifest_count")
+    if manifest_count is None:
+        manifest_count = len(manifests)
+    if manifest_count:
+        return []
+    return [
+        _blocker_record(
+            classification="no_serialized_manifests",
+            severity="blocking",
+            layer="approval_manifest_serialization",
+            fixture_set_id=None,
+            reason="no serialized approval manifests were produced",
+            recommended_action="produce candidate_ready records before serialization can emit non-authoritative manifests",
+        )
+    ]
+
+
+def _blocker_record(
+    *,
+    classification: str,
+    severity: str,
+    layer: str,
+    fixture_set_id: Any,
+    reason: str,
+    recommended_action: str,
+) -> dict[str, Any]:
+    seed = {
+        "classification": classification,
+        "severity": severity,
+        "layer": layer,
+        "fixture_set_id": fixture_set_id,
+        "reason": reason,
+        "token": STABLE_APPROVAL_BLOCKER_DIAGNOSIS_TOKEN,
+    }
+    return {
+        "blocker_id": f"v3_1_blocker_{deterministic_hash(seed)[:16]}",
+        "blocker_type": classification if classification in APPROVAL_BLOCKER_CLASSIFICATIONS else "unknown_blocker",
+        "severity": severity if severity in APPROVAL_BLOCKER_SEVERITIES else "warning",
+        "severity_rank": {"blocking": 0, "warning": 1, "info": 2}.get(severity, 2),
+        "affected_layer": layer,
+        "affected_fixture_set_id": fixture_set_id,
+        "reason": reason,
+        "recommended_next_governance_action": recommended_action,
+        "diagnosis_authorizes_production_routing": False,
+        "production_output_affected": False,
+        "metadata": {
+            "observational_only": True,
+            "production_consumer": False,
+            "planner_remap_performed": False,
+        },
+    }
+
+
+def _public_record(record: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in record.items() if key != "severity_rank"}
+
+
+def _recommended_next_action_summary(records: list[dict[str, Any]]) -> list[str]:
+    actions = {
+        row["recommended_next_governance_action"]
+        for row in records
+        if row["severity"] == "blocking"
+    }
+    return sorted(actions)
+
+
+def _nested(value: dict[str, Any], *keys: str, default: Any) -> Any:
+    current: Any = value
+    for key in keys:
+        if not isinstance(current, dict) or key not in current:
+            if isinstance(value, dict) and keys and keys[-1] in value:
+                return value[keys[-1]]
+            return default
+        current = current[key]
+    return current

--- a/backend/scripts/report_v3_1_approval_blocker_diagnosis.py
+++ b/backend/scripts/report_v3_1_approval_blocker_diagnosis.py
@@ -1,0 +1,156 @@
+"""Generate the v3.1 approval blocker diagnosis report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.planner_adapters.v3_1.approval_blocker_diagnosis import build_approval_blocker_diagnosis  # noqa: E402
+
+
+DETERMINISTIC_GENERATED_AT = "2026-05-15T00:00:00+00:00"
+
+
+def build_v3_1_approval_blocker_diagnosis_report() -> dict[str, Any]:
+    repo_root = Path(__file__).resolve().parents[2]
+    generated = repo_root / "docs" / "generated"
+    inputs = {
+        "reviewed_fixture_inputs": _read_json(generated / "v3_1_reviewed_fixture_inputs_report.json")["reviewed_fixture_inputs"],
+        "persisted_fixture_sets": _read_json(generated / "v3_1_persisted_fixture_sets_report.json")["persisted_fixture_sets"],
+        "review_policy_evaluation": _read_json(generated / "v3_1_review_policy_evaluation_report.json")["review_policy_evaluation"],
+        "fixture_set_readiness_gate": _read_json(generated / "v3_1_fixture_set_readiness_gate_report.json")["fixture_set_readiness_gate"],
+        "approval_manifest_candidates": _read_json(generated / "v3_1_approval_manifest_candidates_report.json")["approval_manifest_candidates"],
+        "approval_manifest_serialization": _read_json(generated / "v3_1_approval_manifest_serialization_report.json")[
+            "approval_manifest_serialization"
+        ],
+    }
+    diagnosis = build_approval_blocker_diagnosis(**inputs)
+    repeated = build_approval_blocker_diagnosis(**inputs)
+    report = {
+        "schema_version": "v3_1.approval_blocker_diagnosis_report.1",
+        "generated_at": DETERMINISTIC_GENERATED_AT,
+        "phase": "v3.1_phase_10_approval_blocker_diagnosis",
+        "recommendation": "OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING",
+        "production_default_routing_authorized": False,
+        "summary": {
+            **diagnosis["summary"],
+            "deterministic": diagnosis["deterministic_hash"] == repeated["deterministic_hash"],
+        },
+        "approval_blocker_diagnosis": diagnosis,
+        "deterministic_guarantees": {
+            "passed": diagnosis["deterministic_hash"] == repeated["deterministic_hash"],
+            "sample_hash": diagnosis["deterministic_hash"],
+            "repeated_hash": repeated["deterministic_hash"],
+            "timestamp_excluded_from_hash": True,
+            "json_sort_keys": True,
+        },
+        "phase_10_boundaries": [
+            "blocker diagnosis is observational governance metadata only",
+            "diagnosis explains absent approval readiness without approving fixture sets",
+            "diagnosis does not authorize production routing",
+            "trusted infrastructure is still not production default",
+            "legacy planner ownership remains intact",
+        ],
+        "metadata": {
+            "source": "v3_1_approval_blocker_diagnosis_report",
+            "observational_only": True,
+            "production_behavior_changed": False,
+            "production_default_routing_authorized": False,
+            "planner_remap_performed": False,
+        },
+    }
+    return _normalize_generated_at(report)
+
+
+def write_report(report: dict[str, Any], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_markdown(report: dict[str, Any], output_path: Path) -> None:
+    diagnosis = report["approval_blocker_diagnosis"]
+    summary = report["summary"]
+    lines = [
+        "# V3.1 Approval Blocker Diagnosis",
+        "",
+        "Phase 10 explains why approval manifest serialization has no production-ready output.",
+        "The diagnosis is observational only and does not authorize production planner routing.",
+        "",
+        "## Recommendation",
+        "",
+        f"- Recommendation: `{report['recommendation']}`",
+        f"- Production default routing authorized: `{str(report['production_default_routing_authorized']).lower()}`",
+        "",
+        "## Summary",
+        "",
+        f"- Total blockers: `{summary['total_blockers']}`",
+        f"- Blocking: `{summary['blocking_count']}`",
+        f"- Warning: `{summary['warning_count']}`",
+        f"- Info: `{summary['info_count']}`",
+        f"- Production affected: `{summary['production_affected_count']}`",
+        f"- Deterministic: `{str(summary['deterministic']).lower()}`",
+        "",
+        "## Blockers By Severity",
+        "",
+        "| Severity | Count |",
+        "| --- | ---: |",
+    ]
+    for severity, count in diagnosis["severity_counts"].items():
+        lines.append(f"| `{severity}` | `{count}` |")
+    lines.extend(["", "## Blockers By Layer", "", "| Layer | Count |", "| --- | ---: |"])
+    for layer, count in diagnosis["layer_counts"].items():
+        lines.append(f"| `{layer}` | `{count}` |")
+    lines.extend(["", "## Top Blocking Reasons", "", "| Reason | Count |", "| --- | ---: |"])
+    for item in diagnosis["top_blocking_reasons"]:
+        lines.append(f"| {item['reason']} | `{item['count']}` |")
+    lines.extend(["", "## Recommended Next Actions", ""])
+    lines.extend(f"- {action}" for action in diagnosis["recommended_next_action_summary"])
+    lines.extend(["", "## Blocker Records", "", "| Blocker | Severity | Layer | Type | Fixture Set |", "| --- | --- | --- | --- | --- |"])
+    for row in diagnosis["blocker_records"]:
+        lines.append(
+            f"| `{row['blocker_id']}` | `{row['severity']}` | `{row['affected_layer']}` | `{row['blocker_type']}` | `{row['affected_fixture_set_id'] or ''}` |"
+        )
+    lines.extend(["", "## Phase 10 Boundaries", ""])
+    lines.extend(f"- {item}" for item in report["phase_10_boundaries"])
+    lines.extend(["", "## Conclusion", "", "Approval blockers are visible for governance review, while production routing remains unchanged."])
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _normalize_generated_at(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: DETERMINISTIC_GENERATED_AT if key == "generated_at" else _normalize_generated_at(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_normalize_generated_at(item) for item in value]
+    return deepcopy(value)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", default="docs/generated/v3_1_approval_blocker_diagnosis_report.json")
+    parser.add_argument("--markdown-output", default="docs/migration/V3_1_APPROVAL_BLOCKER_DIAGNOSIS.md")
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[2]
+    report = build_v3_1_approval_blocker_diagnosis_report()
+    write_report(report, repo_root / args.output)
+    write_markdown(report, repo_root / args.markdown_output)
+    print(json.dumps(report["summary"], indent=2, sort_keys=True))
+    print(report["recommendation"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_v3_1_approval_blocker_diagnosis.py
+++ b/backend/tests/test_v3_1_approval_blocker_diagnosis.py
@@ -1,0 +1,176 @@
+from app.planner_adapters.v3_1.approval_blocker_diagnosis import build_approval_blocker_diagnosis
+from scripts.report_v3_1_approval_blocker_diagnosis import build_v3_1_approval_blocker_diagnosis_report
+
+
+def test_each_blocker_classification_is_visible():
+    result = build_approval_blocker_diagnosis(
+        reviewed_fixture_inputs=_reviewed_inputs(),
+        persisted_fixture_sets=_fixture_sets(),
+        review_policy_evaluation=_policy(),
+        fixture_set_readiness_gate=_readiness(),
+        approval_manifest_candidates=_candidates(),
+        approval_manifest_serialization=_serialization(),
+    )
+
+    counts = result["blocker_type_counts"]
+    assert counts["missing_reviewed_inputs"] == 1
+    assert counts["malformed_or_duplicate_inputs"] == 1
+    assert counts["unsupported_fixture_source"] >= 1
+    assert counts["insufficient_fixture_set_coverage"] >= 1
+    assert counts["policy_not_satisfied"] == 1
+    assert counts["readiness_gate_blocked"] == 1
+    assert counts["no_candidate_ready_records"] == 1
+    assert counts["no_serialized_manifests"] == 1
+
+
+def test_unknown_blocker_when_no_inputs_produce_explicit_record():
+    result = build_approval_blocker_diagnosis(
+        approval_manifest_candidates={"summary": {"candidate_ready_count": 1}},
+        approval_manifest_serialization={"summary": {"serialized_manifest_count": 1}},
+    )
+
+    assert result["blocker_type_counts"]["unknown_blocker"] == 1
+    assert result["blocker_records"][0]["severity"] == "info"
+
+
+def test_deterministic_ordering():
+    first = build_approval_blocker_diagnosis(
+        reviewed_fixture_inputs=_reviewed_inputs(),
+        persisted_fixture_sets=_fixture_sets(),
+        review_policy_evaluation=_policy(),
+        fixture_set_readiness_gate=_readiness(),
+        approval_manifest_candidates=_candidates(),
+        approval_manifest_serialization=_serialization(),
+    )
+    second = build_approval_blocker_diagnosis(
+        approval_manifest_serialization=_serialization(),
+        approval_manifest_candidates=_candidates(),
+        fixture_set_readiness_gate=_readiness(),
+        review_policy_evaluation=_policy(),
+        persisted_fixture_sets=_fixture_sets(),
+        reviewed_fixture_inputs=_reviewed_inputs(),
+    )
+
+    assert first["deterministic_hash"] == second["deterministic_hash"]
+    assert [row["blocker_id"] for row in first["blocker_records"]] == [row["blocker_id"] for row in second["blocker_records"]]
+
+
+def test_zero_serialized_manifests_are_diagnosed():
+    result = build_approval_blocker_diagnosis(
+        approval_manifest_candidates={"summary": {"candidate_ready_count": 0}},
+        approval_manifest_serialization={"summary": {"serialized_manifest_count": 0}},
+    )
+
+    assert result["blocker_type_counts"]["no_candidate_ready_records"] == 1
+    assert result["blocker_type_counts"]["no_serialized_manifests"] == 1
+    assert result["summary"]["blocking_count"] == 2
+
+
+def test_stable_report_generation():
+    first = build_v3_1_approval_blocker_diagnosis_report()
+    second = build_v3_1_approval_blocker_diagnosis_report()
+
+    assert first["deterministic_guarantees"]["passed"] is True
+    assert first["approval_blocker_diagnosis"]["deterministic_hash"] == second["approval_blocker_diagnosis"]["deterministic_hash"]
+    assert first["summary"] == second["summary"]
+
+
+def test_no_production_routing_enablement():
+    result = build_approval_blocker_diagnosis(
+        approval_manifest_candidates={"summary": {"candidate_ready_count": 0}},
+        approval_manifest_serialization={"summary": {"serialized_manifest_count": 0}},
+    )
+
+    assert result["safety_confirmations"]["diagnosis_authorizes_production_routing"] is False
+    assert result["safety_confirmations"]["diagnosis_promotes_fixture_sets"] is False
+    assert result["summary"]["production_output_affected"] is False
+    assert all(row["diagnosis_authorizes_production_routing"] is False for row in result["blocker_records"])
+
+
+def test_compatibility_with_phase_5_through_9_governance_outputs():
+    report = build_v3_1_approval_blocker_diagnosis_report()
+    diagnosis = report["approval_blocker_diagnosis"]
+
+    assert diagnosis["run"]["reviewed_fixture_input_hash"]
+    assert diagnosis["run"]["persisted_fixture_set_hash"]
+    assert diagnosis["run"]["review_policy_evaluation_hash"]
+    assert diagnosis["run"]["readiness_gate_hash"]
+    assert diagnosis["run"]["approval_manifest_candidate_hash"]
+    assert diagnosis["run"]["approval_manifest_serialization_hash"]
+    assert diagnosis["blocker_type_counts"]["no_serialized_manifests"] == 1
+
+
+def _reviewed_inputs():
+    return {
+        "deterministic_hash": "reviewed-hash",
+        "summary": {
+            "missing_source_count": 1,
+            "malformed_count": 1,
+            "duplicate_count": 1,
+        },
+        "normalized_fixture_inputs": [
+            {"normalized_fixture_id": "fixture_unsupported", "status": "unsupported"},
+        ],
+    }
+
+
+def _fixture_sets():
+    return {
+        "deterministic_hash": "sets-hash",
+        "summary": {"total_fixture_sets": 2},
+        "fixture_sets": [
+            {
+                "fixture_set_id": "set_insufficient",
+                "lifecycle_state": "insufficient_data",
+                "missing_fixture_ids": ["fixture_missing"],
+            },
+            {
+                "fixture_set_id": "set_unsupported",
+                "lifecycle_state": "unsupported",
+                "unsupported": True,
+            },
+        ],
+    }
+
+
+def _policy():
+    return {
+        "deterministic_hash": "policy-hash",
+        "evaluations": [
+            {
+                "fixture_set_id": "set_unsupported",
+                "policy_outcome": "unsupported",
+            }
+        ],
+    }
+
+
+def _readiness():
+    return {
+        "deterministic_hash": "readiness-hash",
+        "readiness_records": [
+            {
+                "fixture_set_id": "set_unsupported",
+                "readiness_classification": "blocked_policy_failure",
+                "block_reason_codes": ["policy_unsupported"],
+            }
+        ],
+    }
+
+
+def _candidates():
+    return {
+        "deterministic_hash": "candidate-hash",
+        "summary": {"candidate_ready_count": 0},
+        "manifest_candidates": [
+            {"fixture_set_id": "set_unsupported", "candidate_status": "excluded_not_ready"},
+        ],
+    }
+
+
+def _serialization():
+    return {
+        "deterministic_hash": "serialization-hash",
+        "summary": {"serialized_manifest_count": 0},
+        "serialized_manifests": [],
+    }

--- a/docs/generated/v3_1_approval_blocker_diagnosis_report.json
+++ b/docs/generated/v3_1_approval_blocker_diagnosis_report.json
@@ -1,0 +1,283 @@
+{
+  "approval_blocker_diagnosis": {
+    "blocker_records": [
+      {
+        "affected_fixture_set_id": null,
+        "affected_layer": "approval_manifest_candidates",
+        "blocker_id": "v3_1_blocker_6c5315b54f79b5ac",
+        "blocker_type": "no_candidate_ready_records",
+        "diagnosis_authorizes_production_routing": false,
+        "metadata": {
+          "observational_only": true,
+          "planner_remap_performed": false,
+          "production_consumer": false
+        },
+        "production_output_affected": false,
+        "reason": "no manifest candidate records reached candidate_ready",
+        "recommended_next_governance_action": "resolve upstream readiness and policy blockers before manifest candidate review",
+        "severity": "blocking"
+      },
+      {
+        "affected_fixture_set_id": null,
+        "affected_layer": "approval_manifest_serialization",
+        "blocker_id": "v3_1_blocker_68df46839c0426f2",
+        "blocker_type": "no_serialized_manifests",
+        "diagnosis_authorizes_production_routing": false,
+        "metadata": {
+          "observational_only": true,
+          "planner_remap_performed": false,
+          "production_consumer": false
+        },
+        "production_output_affected": false,
+        "reason": "no serialized approval manifests were produced",
+        "recommended_next_governance_action": "produce candidate_ready records before serialization can emit non-authoritative manifests",
+        "severity": "blocking"
+      },
+      {
+        "affected_fixture_set_id": "v3_1_fixture_set_6d3b668a84cfbb69",
+        "affected_layer": "fixture_set_readiness_gate",
+        "blocker_id": "v3_1_blocker_ca9c6664857bcb94",
+        "blocker_type": "readiness_gate_blocked",
+        "diagnosis_authorizes_production_routing": false,
+        "metadata": {
+          "observational_only": true,
+          "planner_remap_performed": false,
+          "production_consumer": false
+        },
+        "production_output_affected": false,
+        "reason": "readiness gate blocked approval review: policy_unsupported",
+        "recommended_next_governance_action": "clear readiness gate block reasons before manifest candidate generation",
+        "severity": "blocking"
+      },
+      {
+        "affected_fixture_set_id": "v3_1_fixture_set_6d3b668a84cfbb69",
+        "affected_layer": "persisted_fixture_sets",
+        "blocker_id": "v3_1_blocker_6a3b2d230142b7eb",
+        "blocker_type": "unsupported_fixture_source",
+        "diagnosis_authorizes_production_routing": false,
+        "metadata": {
+          "observational_only": true,
+          "planner_remap_performed": false,
+          "production_consumer": false
+        },
+        "production_output_affected": false,
+        "reason": "persisted fixture set contains unsupported fixture source state",
+        "recommended_next_governance_action": "resolve unsupported fixture sources before policy review can pass",
+        "severity": "blocking"
+      },
+      {
+        "affected_fixture_set_id": "v3_1_fixture_set_6d3b668a84cfbb69",
+        "affected_layer": "review_policy_evaluation",
+        "blocker_id": "v3_1_blocker_6167586158b62a0f",
+        "blocker_type": "policy_not_satisfied",
+        "diagnosis_authorizes_production_routing": false,
+        "metadata": {
+          "observational_only": true,
+          "planner_remap_performed": false,
+          "production_consumer": false
+        },
+        "production_output_affected": false,
+        "reason": "review policy outcome is unsupported",
+        "recommended_next_governance_action": "resolve policy blockers until the fixture set reaches passes_policy",
+        "severity": "blocking"
+      },
+      {
+        "affected_fixture_set_id": "v3_1_fixture_8118751ba1b46140",
+        "affected_layer": "reviewed_fixture_inputs",
+        "blocker_id": "v3_1_blocker_2dd249be5bcc9a8a",
+        "blocker_type": "unsupported_fixture_source",
+        "diagnosis_authorizes_production_routing": false,
+        "metadata": {
+          "observational_only": true,
+          "planner_remap_performed": false,
+          "production_consumer": false
+        },
+        "production_output_affected": false,
+        "reason": "reviewed fixture input source is unsupported",
+        "recommended_next_governance_action": "replace unsupported fixture source data with supported reviewed fixture inputs",
+        "severity": "warning"
+      },
+      {
+        "affected_fixture_set_id": "v3_1_fixture_9c3d260c0dda7b4f",
+        "affected_layer": "reviewed_fixture_inputs",
+        "blocker_id": "v3_1_blocker_34705c6931d5d538",
+        "blocker_type": "unsupported_fixture_source",
+        "diagnosis_authorizes_production_routing": false,
+        "metadata": {
+          "observational_only": true,
+          "planner_remap_performed": false,
+          "production_consumer": false
+        },
+        "production_output_affected": false,
+        "reason": "reviewed fixture input source is unsupported",
+        "recommended_next_governance_action": "replace unsupported fixture source data with supported reviewed fixture inputs",
+        "severity": "warning"
+      },
+      {
+        "affected_fixture_set_id": "v3_1_fixture_set_6d3b668a84cfbb69",
+        "affected_layer": "reviewed_fixture_inputs",
+        "blocker_id": "v3_1_blocker_942791ba1532e44b",
+        "blocker_type": "unsupported_fixture_source",
+        "diagnosis_authorizes_production_routing": false,
+        "metadata": {
+          "observational_only": true,
+          "planner_remap_performed": false,
+          "production_consumer": false
+        },
+        "production_output_affected": false,
+        "reason": "reviewed fixture input source is unsupported",
+        "recommended_next_governance_action": "replace unsupported fixture source data with supported reviewed fixture inputs",
+        "severity": "warning"
+      },
+      {
+        "affected_fixture_set_id": "v3_1_fixture_b82b601f9b088bb8",
+        "affected_layer": "reviewed_fixture_inputs",
+        "blocker_id": "v3_1_blocker_c877d3753e7d7968",
+        "blocker_type": "unsupported_fixture_source",
+        "diagnosis_authorizes_production_routing": false,
+        "metadata": {
+          "observational_only": true,
+          "planner_remap_performed": false,
+          "production_consumer": false
+        },
+        "production_output_affected": false,
+        "reason": "reviewed fixture input source is unsupported",
+        "recommended_next_governance_action": "replace unsupported fixture source data with supported reviewed fixture inputs",
+        "severity": "warning"
+      }
+    ],
+    "blocker_type_counts": {
+      "insufficient_fixture_set_coverage": 0,
+      "malformed_or_duplicate_inputs": 0,
+      "missing_reviewed_inputs": 0,
+      "no_candidate_ready_records": 1,
+      "no_serialized_manifests": 1,
+      "policy_not_satisfied": 1,
+      "readiness_gate_blocked": 1,
+      "unknown_blocker": 0,
+      "unsupported_fixture_source": 5
+    },
+    "deterministic_hash": "970004033cb45da0bae1e9e278650c637b008f941010ff52f2685b23346e2030",
+    "layer_counts": {
+      "approval_manifest_candidates": 1,
+      "approval_manifest_serialization": 1,
+      "fixture_set_readiness_gate": 1,
+      "persisted_fixture_sets": 1,
+      "review_policy_evaluation": 1,
+      "reviewed_fixture_inputs": 4
+    },
+    "metadata": {
+      "deterministic_serializer": "json_sort_keys_sha256",
+      "observational_only": true,
+      "planner_remap_performed": false,
+      "production_behavior_changed": false,
+      "production_consumer": false,
+      "production_default_routing_authorized": false,
+      "source": "v3_1_approval_blocker_diagnosis",
+      "stable_generation_token": "v3_1_phase_10_approval_blocker_diagnosis_token"
+    },
+    "recommended_next_action_summary": [
+      "clear readiness gate block reasons before manifest candidate generation",
+      "produce candidate_ready records before serialization can emit non-authoritative manifests",
+      "resolve policy blockers until the fixture set reaches passes_policy",
+      "resolve unsupported fixture sources before policy review can pass",
+      "resolve upstream readiness and policy blockers before manifest candidate review"
+    ],
+    "run": {
+      "approval_manifest_candidate_hash": "26e84f9a9f25f9ad94ddd70e449d328623079c6e651702eaef70285fa445db27",
+      "approval_manifest_serialization_hash": "dea874b9d2a9ea3f2464e7aa51c64cdfa78a7639525aba8aa20a5d697cc992f5",
+      "persisted_fixture_set_hash": "87bb0f1888fa99a2bb2bd99fa7806a365d1e4cceaefbd72118fae064d600116e",
+      "readiness_gate_hash": "85dbb478983263c00b093882c9a141e93b186dc688aedcfa6094b50a40040db2",
+      "review_policy_evaluation_hash": "e4c4d8158ed053e7f882796308ae244780a41a203a6c44608789c091cddab766",
+      "reviewed_fixture_input_hash": "bcc71a0573a2de21ed29ab1a7cae6ac04323875d4abccc85e387f4f266f6e077",
+      "run_id": "v3_1_phase_10_approval_blocker_diagnosis"
+    },
+    "safety_confirmations": {
+      "diagnosis_authorizes_production_routing": false,
+      "diagnosis_promotes_fixture_sets": false,
+      "legacy_planner_ownership_preserved": true,
+      "production_behavior_changed": false,
+      "production_output_affected": false,
+      "runtime_state_mutated": false,
+      "trusted_data_default_truth": false
+    },
+    "schema_version": "v3_1.approval_blocker_diagnosis.1",
+    "severity_counts": {
+      "blocking": 5,
+      "info": 0,
+      "warning": 4
+    },
+    "summary": {
+      "blocking_count": 5,
+      "deterministic": true,
+      "info_count": 0,
+      "production_affected_count": 0,
+      "production_behavior_changed": false,
+      "production_default_routing_authorized": false,
+      "production_output_affected": false,
+      "total_blockers": 9,
+      "trusted_data_default_truth": false,
+      "warning_count": 4
+    },
+    "top_blocking_reasons": [
+      {
+        "count": 1,
+        "reason": "no manifest candidate records reached candidate_ready"
+      },
+      {
+        "count": 1,
+        "reason": "no serialized approval manifests were produced"
+      },
+      {
+        "count": 1,
+        "reason": "persisted fixture set contains unsupported fixture source state"
+      },
+      {
+        "count": 1,
+        "reason": "readiness gate blocked approval review: policy_unsupported"
+      },
+      {
+        "count": 1,
+        "reason": "review policy outcome is unsupported"
+      }
+    ]
+  },
+  "deterministic_guarantees": {
+    "json_sort_keys": true,
+    "passed": true,
+    "repeated_hash": "970004033cb45da0bae1e9e278650c637b008f941010ff52f2685b23346e2030",
+    "sample_hash": "970004033cb45da0bae1e9e278650c637b008f941010ff52f2685b23346e2030",
+    "timestamp_excluded_from_hash": true
+  },
+  "generated_at": "2026-05-15T00:00:00+00:00",
+  "metadata": {
+    "observational_only": true,
+    "planner_remap_performed": false,
+    "production_behavior_changed": false,
+    "production_default_routing_authorized": false,
+    "source": "v3_1_approval_blocker_diagnosis_report"
+  },
+  "phase": "v3.1_phase_10_approval_blocker_diagnosis",
+  "phase_10_boundaries": [
+    "blocker diagnosis is observational governance metadata only",
+    "diagnosis explains absent approval readiness without approving fixture sets",
+    "diagnosis does not authorize production routing",
+    "trusted infrastructure is still not production default",
+    "legacy planner ownership remains intact"
+  ],
+  "production_default_routing_authorized": false,
+  "recommendation": "OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING",
+  "schema_version": "v3_1.approval_blocker_diagnosis_report.1",
+  "summary": {
+    "blocking_count": 5,
+    "deterministic": true,
+    "info_count": 0,
+    "production_affected_count": 0,
+    "production_behavior_changed": false,
+    "production_default_routing_authorized": false,
+    "production_output_affected": false,
+    "total_blockers": 9,
+    "trusted_data_default_truth": false,
+    "warning_count": 4
+  }
+}

--- a/docs/migration/V3_1_APPROVAL_BLOCKER_DIAGNOSIS.md
+++ b/docs/migration/V3_1_APPROVAL_BLOCKER_DIAGNOSIS.md
@@ -1,0 +1,81 @@
+# V3.1 Approval Blocker Diagnosis
+
+Phase 10 explains why approval manifest serialization has no production-ready output.
+The diagnosis is observational only and does not authorize production planner routing.
+
+## Recommendation
+
+- Recommendation: `OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING`
+- Production default routing authorized: `false`
+
+## Summary
+
+- Total blockers: `9`
+- Blocking: `5`
+- Warning: `4`
+- Info: `0`
+- Production affected: `0`
+- Deterministic: `true`
+
+## Blockers By Severity
+
+| Severity | Count |
+| --- | ---: |
+| `info` | `0` |
+| `warning` | `4` |
+| `blocking` | `5` |
+
+## Blockers By Layer
+
+| Layer | Count |
+| --- | ---: |
+| `approval_manifest_candidates` | `1` |
+| `approval_manifest_serialization` | `1` |
+| `fixture_set_readiness_gate` | `1` |
+| `persisted_fixture_sets` | `1` |
+| `review_policy_evaluation` | `1` |
+| `reviewed_fixture_inputs` | `4` |
+
+## Top Blocking Reasons
+
+| Reason | Count |
+| --- | ---: |
+| no manifest candidate records reached candidate_ready | `1` |
+| no serialized approval manifests were produced | `1` |
+| persisted fixture set contains unsupported fixture source state | `1` |
+| readiness gate blocked approval review: policy_unsupported | `1` |
+| review policy outcome is unsupported | `1` |
+
+## Recommended Next Actions
+
+- clear readiness gate block reasons before manifest candidate generation
+- produce candidate_ready records before serialization can emit non-authoritative manifests
+- resolve policy blockers until the fixture set reaches passes_policy
+- resolve unsupported fixture sources before policy review can pass
+- resolve upstream readiness and policy blockers before manifest candidate review
+
+## Blocker Records
+
+| Blocker | Severity | Layer | Type | Fixture Set |
+| --- | --- | --- | --- | --- |
+| `v3_1_blocker_6c5315b54f79b5ac` | `blocking` | `approval_manifest_candidates` | `no_candidate_ready_records` | `` |
+| `v3_1_blocker_68df46839c0426f2` | `blocking` | `approval_manifest_serialization` | `no_serialized_manifests` | `` |
+| `v3_1_blocker_ca9c6664857bcb94` | `blocking` | `fixture_set_readiness_gate` | `readiness_gate_blocked` | `v3_1_fixture_set_6d3b668a84cfbb69` |
+| `v3_1_blocker_6a3b2d230142b7eb` | `blocking` | `persisted_fixture_sets` | `unsupported_fixture_source` | `v3_1_fixture_set_6d3b668a84cfbb69` |
+| `v3_1_blocker_6167586158b62a0f` | `blocking` | `review_policy_evaluation` | `policy_not_satisfied` | `v3_1_fixture_set_6d3b668a84cfbb69` |
+| `v3_1_blocker_2dd249be5bcc9a8a` | `warning` | `reviewed_fixture_inputs` | `unsupported_fixture_source` | `v3_1_fixture_8118751ba1b46140` |
+| `v3_1_blocker_34705c6931d5d538` | `warning` | `reviewed_fixture_inputs` | `unsupported_fixture_source` | `v3_1_fixture_9c3d260c0dda7b4f` |
+| `v3_1_blocker_942791ba1532e44b` | `warning` | `reviewed_fixture_inputs` | `unsupported_fixture_source` | `v3_1_fixture_set_6d3b668a84cfbb69` |
+| `v3_1_blocker_c877d3753e7d7968` | `warning` | `reviewed_fixture_inputs` | `unsupported_fixture_source` | `v3_1_fixture_b82b601f9b088bb8` |
+
+## Phase 10 Boundaries
+
+- blocker diagnosis is observational governance metadata only
+- diagnosis explains absent approval readiness without approving fixture sets
+- diagnosis does not authorize production routing
+- trusted infrastructure is still not production default
+- legacy planner ownership remains intact
+
+## Conclusion
+
+Approval blockers are visible for governance review, while production routing remains unchanged.


### PR DESCRIPTION
Adds deterministic approval blocker diagnosis across v3.1 governance layers so missing approval readiness can be explained without enabling production planner routing.