### PR TITLE
v3.1: add fixture source admission policy

### DIFF
--- a/backend/app/planner_adapters/v3_1/__init__.py
+++ b/backend/app/planner_adapters/v3_1/__init__.py
@@ -29,6 +29,10 @@ from .fixture_set_readiness_gate import (
     FIXTURE_SET_READINESS_CLASSIFICATIONS,
     build_fixture_set_readiness_gate,
 )
+from .fixture_source_admission_policy import (
+    FIXTURE_SOURCE_ADMISSION_STATUSES,
+    evaluate_fixture_source_admission_policy,
+)
 from .approval_manifest_candidates import (
     APPROVAL_MANIFEST_CANDIDATE_STATUSES,
     build_approval_manifest_candidates,
@@ -65,6 +69,7 @@ __all__ = [
     "REVIEW_POLICY_OUTCOMES",
     "REVIEWED_FIXTURE_INPUT_STATUSES",
     "FIXTURE_SET_READINESS_CLASSIFICATIONS",
+    "FIXTURE_SOURCE_ADMISSION_STATUSES",
     "APPROVAL_MANIFEST_CANDIDATE_STATUSES",
     "APPROVAL_BLOCKER_CLASSIFICATIONS",
     "APPROVAL_MANIFEST_DIFF_CLASSIFICATIONS",
@@ -83,6 +88,7 @@ __all__ = [
     "build_sample_dual_run_inputs",
     "build_default_trusted_repository_probes",
     "build_fixture_set_readiness_gate",
+    "evaluate_fixture_source_admission_policy",
     "build_approval_manifest_candidates",
     "build_approval_blocker_diagnosis",
     "audit_approval_manifest_diffs",

--- a/backend/app/planner_adapters/v3_1/fixture_source_admission_policy.py
+++ b/backend/app/planner_adapters/v3_1/fixture_source_admission_policy.py
@@ -1,0 +1,199 @@
+"""Deterministic fixture source admission policy.
+
+Admission means a fixture source is eligible for governance review. It does not
+approve fixture sets, serialize production-authoritative manifests, or authorize
+production routing.
+"""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from copy import deepcopy
+from typing import Any
+
+from .reviewed_fixture_inputs import SUPPORTED_SOURCE_TYPES
+from .trusted_shadow_consumption import deterministic_hash
+
+
+FIXTURE_SOURCE_ADMISSION_STATUSES = (
+    "admitted_for_review",
+    "blocked_unknown_source",
+    "blocked_missing_metadata",
+    "blocked_missing_review_evidence",
+    "blocked_unstable_identity",
+    "blocked_unsupported_schema",
+)
+STABLE_FIXTURE_SOURCE_ADMISSION_TOKEN = "v3_1_phase_11_fixture_source_admission_policy_token"
+
+
+def evaluate_fixture_source_admission_policy(
+    *,
+    reviewed_fixture_inputs: dict[str, Any] | list[dict[str, Any]],
+    run_id: str = "v3_1_phase_11_fixture_source_admission_policy",
+) -> dict[str, Any]:
+    """Evaluate reviewed fixture input sources for governance-review admission."""
+
+    records = _source_records(reviewed_fixture_inputs)
+    evaluations = [_evaluate_source(source) for source in records]
+    evaluations = sorted(evaluations, key=lambda row: (row["source_id"], row["source_type"], row["admission_id"]))
+    counts = Counter(row["admission_status"] for row in evaluations)
+    block_reasons = Counter(reason for row in evaluations if row["admission_status"] != "admitted_for_review" for reason in row["block_reasons"])
+    source_hash = reviewed_fixture_inputs.get("deterministic_hash") if isinstance(reviewed_fixture_inputs, dict) else None
+    source_schema = reviewed_fixture_inputs.get("schema_version") if isinstance(reviewed_fixture_inputs, dict) else None
+    envelope = {
+        "schema_version": "v3_1.fixture_source_admission_policy.1",
+        "run": {
+            "run_id": run_id,
+            "source_count": len(evaluations),
+            "reviewed_fixture_inputs_hash": source_hash,
+            "reviewed_fixture_inputs_schema": source_schema,
+        },
+        "summary": {
+            "total_sources_evaluated": len(evaluations),
+            "admitted_for_review_count": counts["admitted_for_review"],
+            "blocked_count": len(evaluations) - counts["admitted_for_review"],
+            "production_affected_count": 0,
+            "production_output_affected": False,
+            "production_behavior_changed": False,
+            "production_default_routing_authorized": False,
+            "trusted_data_default_truth": False,
+            "deterministic": True,
+        },
+        "admission_status_counts": {
+            status: counts[status]
+            for status in FIXTURE_SOURCE_ADMISSION_STATUSES
+        },
+        "block_reason_counts": dict(sorted(block_reasons.items())),
+        "source_admission_records": evaluations,
+        "source_evidence_summaries": [
+            {
+                "source_id": row["source_id"],
+                "source_type": row["source_type"],
+                "admission_status": row["admission_status"],
+                "evidence_summary": deepcopy(row["evidence_summary"]),
+            }
+            for row in evaluations
+        ],
+        "recommended_next_governance_action": _recommended_action(evaluations),
+        "safety_confirmations": {
+            "admitted_sources_are_production_approved": False,
+            "admission_policy_authorizes_production_routing": False,
+            "legacy_planner_ownership_preserved": True,
+            "production_output_affected": False,
+            "production_behavior_changed": False,
+            "runtime_state_mutated": False,
+            "trusted_data_default_truth": False,
+        },
+        "metadata": {
+            "source": "v3_1_fixture_source_admission_policy",
+            "observational_only": True,
+            "production_consumer": False,
+            "production_behavior_changed": False,
+            "planner_remap_performed": False,
+            "production_default_routing_authorized": False,
+            "stable_generation_token": STABLE_FIXTURE_SOURCE_ADMISSION_TOKEN,
+            "deterministic_serializer": "json_sort_keys_sha256",
+        },
+    }
+    envelope["deterministic_hash"] = deterministic_hash(envelope)
+    return envelope
+
+
+def _source_records(reviewed_fixture_inputs: dict[str, Any] | list[dict[str, Any]]) -> list[dict[str, Any]]:
+    inputs = reviewed_fixture_inputs.get("normalized_fixture_inputs", []) if isinstance(reviewed_fixture_inputs, dict) else reviewed_fixture_inputs
+    grouped: dict[tuple[str, str, str], list[dict[str, Any]]] = defaultdict(list)
+    for record in inputs:
+        key = (
+            str(record.get("source_id") or ""),
+            str(record.get("source_type") or ""),
+            str(record.get("source_path") or ""),
+        )
+        grouped[key].append(deepcopy(record))
+    return [
+        {
+            "source_id": source_id,
+            "source_type": source_type,
+            "source_path": source_path,
+            "records": sorted(records, key=lambda row: str(row.get("normalized_fixture_id") or "")),
+        }
+        for (source_id, source_type, source_path), records in sorted(grouped.items())
+    ]
+
+
+def _evaluate_source(source: dict[str, Any]) -> dict[str, Any]:
+    status, block_reasons = _admission_status(source)
+    evidence = _evidence_summary(source)
+    source_id = source["source_id"]
+    source_type = source["source_type"]
+    seed = {
+        "source_id": source_id,
+        "source_type": source_type,
+        "source_path": source["source_path"],
+        "token": STABLE_FIXTURE_SOURCE_ADMISSION_TOKEN,
+    }
+    return {
+        "admission_id": f"v3_1_source_admission_{deterministic_hash(seed)[:16]}",
+        "source_id": source_id,
+        "source_type": source_type,
+        "source_path": source["source_path"],
+        "admission_status": status,
+        "evidence_summary": evidence,
+        "block_reasons": block_reasons,
+        "non_production_authorization": {
+            "source_is_production_approved": False,
+            "source_authorizes_production_routing": False,
+            "legacy_planner_ownership_preserved": True,
+            "trusted_default_routing": False,
+        },
+        "production_output_affected": False,
+        "metadata": {
+            "observational_only": True,
+            "production_consumer": False,
+            "planner_remap_performed": False,
+        },
+    }
+
+
+def _admission_status(source: dict[str, Any]) -> tuple[str, list[str]]:
+    source_id = source["source_id"].strip()
+    source_type = source["source_type"].strip()
+    source_path = source["source_path"].strip()
+    records = source["records"]
+    if not source_id or source_id == "unknown":
+        return "blocked_unknown_source", ["unknown_source_id"]
+    if not source_path:
+        return "blocked_missing_metadata", ["missing_source_path"]
+    if not source_type:
+        return "blocked_missing_metadata", ["missing_source_type"]
+    if source_type not in SUPPORTED_SOURCE_TYPES:
+        return "blocked_unsupported_schema", [f"unsupported_source_type_{source_type}"]
+    if any(not row.get("normalized_fixture_id") or not row.get("source_fixture_id") for row in records):
+        return "blocked_unstable_identity", ["fixture_source_identity_unstable"]
+    if not any(row.get("payload_digest") or row.get("reason_codes") for row in records):
+        return "blocked_missing_review_evidence", ["missing_review_evidence"]
+    return "admitted_for_review", ["source_identity_schema_and_evidence_present"]
+
+
+def _evidence_summary(source: dict[str, Any]) -> dict[str, Any]:
+    records = source["records"]
+    status_counts = Counter(str(row.get("status") or "unknown") for row in records)
+    return {
+        "record_count": len(records),
+        "reviewed_record_count": status_counts["reviewed"],
+        "unsupported_record_count": status_counts["unsupported"],
+        "malformed_record_count": status_counts["malformed"],
+        "duplicate_record_count": status_counts["duplicate"],
+        "missing_source_record_count": status_counts["missing_source"],
+        "payload_digest_count": sum(1 for row in records if row.get("payload_digest")),
+        "reason_code_count": sum(len(row.get("reason_codes") or []) for row in records),
+        "normalized_fixture_ids": sorted(str(row.get("normalized_fixture_id") or "") for row in records),
+    }
+
+
+def _recommended_action(evaluations: list[dict[str, Any]]) -> str:
+    blocked = [row for row in evaluations if row["admission_status"] != "admitted_for_review"]
+    if not evaluations:
+        return "provide reviewed fixture input sources before source admission can be evaluated"
+    if blocked:
+        return "resolve blocked source admission reasons before relying on source admission for governance review"
+    return "use admitted sources as governance-review inputs only; do not authorize production routing"

--- a/backend/scripts/report_v3_1_fixture_source_admission_policy.py
+++ b/backend/scripts/report_v3_1_fixture_source_admission_policy.py
@@ -1,0 +1,148 @@
+"""Generate the v3.1 fixture source admission policy report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.planner_adapters.v3_1.fixture_source_admission_policy import evaluate_fixture_source_admission_policy  # noqa: E402
+
+
+DETERMINISTIC_GENERATED_AT = "2026-05-15T00:00:00+00:00"
+
+
+def build_v3_1_fixture_source_admission_policy_report() -> dict[str, Any]:
+    repo_root = Path(__file__).resolve().parents[2]
+    reviewed_inputs = _read_json(repo_root / "docs" / "generated" / "v3_1_reviewed_fixture_inputs_report.json")["reviewed_fixture_inputs"]
+    admission = evaluate_fixture_source_admission_policy(reviewed_fixture_inputs=reviewed_inputs)
+    repeated = evaluate_fixture_source_admission_policy(reviewed_fixture_inputs=reviewed_inputs)
+    report = {
+        "schema_version": "v3_1.fixture_source_admission_policy_report.1",
+        "generated_at": DETERMINISTIC_GENERATED_AT,
+        "phase": "v3.1_phase_11_fixture_source_admission_policy",
+        "recommendation": "OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING",
+        "production_default_routing_authorized": False,
+        "summary": {
+            **admission["summary"],
+            "deterministic": admission["deterministic_hash"] == repeated["deterministic_hash"],
+        },
+        "fixture_source_admission_policy": admission,
+        "deterministic_guarantees": {
+            "passed": admission["deterministic_hash"] == repeated["deterministic_hash"],
+            "sample_hash": admission["deterministic_hash"],
+            "repeated_hash": repeated["deterministic_hash"],
+            "timestamp_excluded_from_hash": True,
+            "json_sort_keys": True,
+        },
+        "phase_11_boundaries": [
+            "source admission is observational governance metadata only",
+            "admitted sources are eligible for governance review only",
+            "admitted sources are not production-approved",
+            "source admission does not authorize production routing",
+            "legacy planner ownership remains intact",
+        ],
+        "metadata": {
+            "source": "v3_1_fixture_source_admission_policy_report",
+            "observational_only": True,
+            "production_behavior_changed": False,
+            "production_default_routing_authorized": False,
+            "planner_remap_performed": False,
+        },
+    }
+    return _normalize_generated_at(report)
+
+
+def write_report(report: dict[str, Any], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_markdown(report: dict[str, Any], output_path: Path) -> None:
+    admission = report["fixture_source_admission_policy"]
+    summary = report["summary"]
+    lines = [
+        "# V3.1 Fixture Source Admission Policy",
+        "",
+        "Phase 11 defines source-level governance admission for reviewed fixture inputs.",
+        "Admitted sources are eligible for governance review only and are not production-approved.",
+        "",
+        "## Recommendation",
+        "",
+        f"- Recommendation: `{report['recommendation']}`",
+        f"- Production default routing authorized: `{str(report['production_default_routing_authorized']).lower()}`",
+        "",
+        "## Summary",
+        "",
+        f"- Total sources evaluated: `{summary['total_sources_evaluated']}`",
+        f"- Admitted for review: `{summary['admitted_for_review_count']}`",
+        f"- Blocked: `{summary['blocked_count']}`",
+        f"- Production affected: `{summary['production_affected_count']}`",
+        f"- Deterministic: `{str(summary['deterministic']).lower()}`",
+        "",
+        "## Block Reasons",
+        "",
+        "| Reason | Count |",
+        "| --- | ---: |",
+    ]
+    for reason, count in admission["block_reason_counts"].items():
+        lines.append(f"| `{reason}` | `{count}` |")
+    lines.extend(["", "## Source Evidence", "", "| Source | Type | Status | Records | Reviewed | Unsupported |", "| --- | --- | --- | ---: | ---: | ---: |"])
+    for row in admission["source_admission_records"]:
+        evidence = row["evidence_summary"]
+        lines.append(
+            f"| `{row['source_id']}` | `{row['source_type']}` | `{row['admission_status']}` | `{evidence['record_count']}` | `{evidence['reviewed_record_count']}` | `{evidence['unsupported_record_count']}` |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Recommended Next Governance Action",
+            "",
+            admission["recommended_next_governance_action"],
+            "",
+            "## Phase 11 Boundaries",
+            "",
+        ]
+    )
+    lines.extend(f"- {item}" for item in report["phase_11_boundaries"])
+    lines.extend(["", "## Conclusion", "", "Fixture source admission is available for governance review, while production routing remains unchanged."])
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _normalize_generated_at(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: DETERMINISTIC_GENERATED_AT if key == "generated_at" else _normalize_generated_at(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_normalize_generated_at(item) for item in value]
+    return deepcopy(value)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", default="docs/generated/v3_1_fixture_source_admission_policy_report.json")
+    parser.add_argument("--markdown-output", default="docs/migration/V3_1_FIXTURE_SOURCE_ADMISSION_POLICY.md")
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[2]
+    report = build_v3_1_fixture_source_admission_policy_report()
+    write_report(report, repo_root / args.output)
+    write_markdown(report, repo_root / args.markdown_output)
+    print(json.dumps(report["summary"], indent=2, sort_keys=True))
+    print(report["recommendation"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_v3_1_fixture_source_admission_policy.py
+++ b/backend/tests/test_v3_1_fixture_source_admission_policy.py
@@ -1,0 +1,110 @@
+from app.planner_adapters.v3_1.fixture_source_admission_policy import evaluate_fixture_source_admission_policy
+from scripts.report_v3_1_fixture_source_admission_policy import build_v3_1_fixture_source_admission_policy_report
+
+
+def test_supported_source_admitted_for_review():
+    result = evaluate_fixture_source_admission_policy(reviewed_fixture_inputs=[_record("source_a", "baseline_fixture_workflows")])
+
+    row = result["source_admission_records"][0]
+    assert row["admission_status"] == "admitted_for_review"
+    assert row["non_production_authorization"]["source_is_production_approved"] is False
+    assert result["summary"]["admitted_for_review_count"] == 1
+
+
+def test_unknown_source_blocked():
+    result = evaluate_fixture_source_admission_policy(reviewed_fixture_inputs=[_record("", "baseline_fixture_workflows")])
+
+    assert result["source_admission_records"][0]["admission_status"] == "blocked_unknown_source"
+    assert result["block_reason_counts"]["unknown_source_id"] == 1
+
+
+def test_missing_metadata_blocked():
+    result = evaluate_fixture_source_admission_policy(reviewed_fixture_inputs=[_record("source_a", "baseline_fixture_workflows", source_path="")])
+
+    assert result["source_admission_records"][0]["admission_status"] == "blocked_missing_metadata"
+    assert result["block_reason_counts"]["missing_source_path"] == 1
+
+
+def test_missing_review_evidence_blocked():
+    result = evaluate_fixture_source_admission_policy(
+        reviewed_fixture_inputs=[_record("source_a", "baseline_fixture_workflows", payload_digest=None, reason_codes=[])]
+    )
+
+    assert result["source_admission_records"][0]["admission_status"] == "blocked_missing_review_evidence"
+    assert result["block_reason_counts"]["missing_review_evidence"] == 1
+
+
+def test_unstable_identity_blocked():
+    result = evaluate_fixture_source_admission_policy(
+        reviewed_fixture_inputs=[_record("source_a", "baseline_fixture_workflows", source_fixture_id=None)]
+    )
+
+    assert result["source_admission_records"][0]["admission_status"] == "blocked_unstable_identity"
+    assert result["block_reason_counts"]["fixture_source_identity_unstable"] == 1
+
+
+def test_unsupported_schema_blocked():
+    result = evaluate_fixture_source_admission_policy(reviewed_fixture_inputs=[_record("source_a", "unknown_schema")])
+
+    assert result["source_admission_records"][0]["admission_status"] == "blocked_unsupported_schema"
+    assert result["block_reason_counts"]["unsupported_source_type_unknown_schema"] == 1
+
+
+def test_deterministic_ordering():
+    first = evaluate_fixture_source_admission_policy(
+        reviewed_fixture_inputs=[_record("source_b", "persisted_fixture_sets"), _record("source_a", "baseline_fixture_workflows")]
+    )
+    second = evaluate_fixture_source_admission_policy(
+        reviewed_fixture_inputs=[_record("source_a", "baseline_fixture_workflows"), _record("source_b", "persisted_fixture_sets")]
+    )
+
+    assert first["deterministic_hash"] == second["deterministic_hash"]
+    assert [row["source_id"] for row in first["source_admission_records"]] == ["source_a", "source_b"]
+
+
+def test_stable_report_generation():
+    first = build_v3_1_fixture_source_admission_policy_report()
+    second = build_v3_1_fixture_source_admission_policy_report()
+
+    assert first["deterministic_guarantees"]["passed"] is True
+    assert first["fixture_source_admission_policy"]["deterministic_hash"] == second["fixture_source_admission_policy"]["deterministic_hash"]
+    assert first["summary"] == second["summary"]
+
+
+def test_no_production_routing_enablement():
+    result = evaluate_fixture_source_admission_policy(reviewed_fixture_inputs=[_record("source_a", "baseline_fixture_workflows")])
+    row = result["source_admission_records"][0]
+
+    assert result["safety_confirmations"]["admitted_sources_are_production_approved"] is False
+    assert result["safety_confirmations"]["admission_policy_authorizes_production_routing"] is False
+    assert row["non_production_authorization"]["source_authorizes_production_routing"] is False
+    assert row["production_output_affected"] is False
+
+
+def _record(
+    source_id,
+    source_type,
+    *,
+    source_path="fixture:source",
+    normalized_fixture_id="fixture_a",
+    source_fixture_id="fixture_a",
+    payload_digest="digest",
+    reason_codes=None,
+):
+    return {
+        "normalized_fixture_id": normalized_fixture_id,
+        "source_fixture_id": source_fixture_id,
+        "source_id": source_id,
+        "source_type": source_type,
+        "source_path": source_path,
+        "status": "reviewed",
+        "reason_codes": ["approval_state_pending_review"] if reason_codes is None else reason_codes,
+        "payload_digest": payload_digest,
+        "production_output_affected": False,
+        "production_routing_authorized": False,
+        "metadata": {
+            "observational_only": True,
+            "production_consumer": False,
+            "planner_remap_performed": False,
+        },
+    }

--- a/docs/generated/v3_1_fixture_source_admission_policy_report.json
+++ b/docs/generated/v3_1_fixture_source_admission_policy_report.json
@@ -1,0 +1,207 @@
+{
+  "deterministic_guarantees": {
+    "json_sort_keys": true,
+    "passed": true,
+    "repeated_hash": "e45176c79cec01924368d35333c35857e969b396456814f38a56be5d3af00ffe",
+    "sample_hash": "e45176c79cec01924368d35333c35857e969b396456814f38a56be5d3af00ffe",
+    "timestamp_excluded_from_hash": true
+  },
+  "fixture_source_admission_policy": {
+    "admission_status_counts": {
+      "admitted_for_review": 2,
+      "blocked_missing_metadata": 0,
+      "blocked_missing_review_evidence": 0,
+      "blocked_unknown_source": 0,
+      "blocked_unstable_identity": 0,
+      "blocked_unsupported_schema": 0
+    },
+    "block_reason_counts": {},
+    "deterministic_hash": "e45176c79cec01924368d35333c35857e969b396456814f38a56be5d3af00ffe",
+    "metadata": {
+      "deterministic_serializer": "json_sort_keys_sha256",
+      "observational_only": true,
+      "planner_remap_performed": false,
+      "production_behavior_changed": false,
+      "production_consumer": false,
+      "production_default_routing_authorized": false,
+      "source": "v3_1_fixture_source_admission_policy",
+      "stable_generation_token": "v3_1_phase_11_fixture_source_admission_policy_token"
+    },
+    "recommended_next_governance_action": "use admitted sources as governance-review inputs only; do not authorize production routing",
+    "run": {
+      "reviewed_fixture_inputs_hash": "bcc71a0573a2de21ed29ab1a7cae6ac04323875d4abccc85e387f4f266f6e077",
+      "reviewed_fixture_inputs_schema": "v3_1.reviewed_fixture_inputs.1",
+      "run_id": "v3_1_phase_11_fixture_source_admission_policy",
+      "source_count": 2
+    },
+    "safety_confirmations": {
+      "admission_policy_authorizes_production_routing": false,
+      "admitted_sources_are_production_approved": false,
+      "legacy_planner_ownership_preserved": true,
+      "production_behavior_changed": false,
+      "production_output_affected": false,
+      "runtime_state_mutated": false,
+      "trusted_data_default_truth": false
+    },
+    "schema_version": "v3_1.fixture_source_admission_policy.1",
+    "source_admission_records": [
+      {
+        "admission_id": "v3_1_source_admission_c4faee3ebd353435",
+        "admission_status": "admitted_for_review",
+        "block_reasons": [
+          "source_identity_schema_and_evidence_present"
+        ],
+        "evidence_summary": {
+          "duplicate_record_count": 0,
+          "malformed_record_count": 0,
+          "missing_source_record_count": 0,
+          "normalized_fixture_ids": [
+            "v3_1_fixture_6c378a420c0a4ced",
+            "v3_1_fixture_756415e2e7d3feb2",
+            "v3_1_fixture_8118751ba1b46140",
+            "v3_1_fixture_9c3d260c0dda7b4f",
+            "v3_1_fixture_b82b601f9b088bb8"
+          ],
+          "payload_digest_count": 5,
+          "reason_code_count": 5,
+          "record_count": 5,
+          "reviewed_record_count": 2,
+          "unsupported_record_count": 3
+        },
+        "metadata": {
+          "observational_only": true,
+          "planner_remap_performed": false,
+          "production_consumer": false
+        },
+        "non_production_authorization": {
+          "legacy_planner_ownership_preserved": true,
+          "source_authorizes_production_routing": false,
+          "source_is_production_approved": false,
+          "trusted_default_routing": false
+        },
+        "production_output_affected": false,
+        "source_id": "v3_1_baseline_fixture_workflows_report",
+        "source_path": "D:\\Forge\\le-the-forge\\docs\\generated\\v3_1_baseline_fixture_workflows_report.json",
+        "source_type": "baseline_fixture_workflows"
+      },
+      {
+        "admission_id": "v3_1_source_admission_0df21f3446faece3",
+        "admission_status": "admitted_for_review",
+        "block_reasons": [
+          "source_identity_schema_and_evidence_present"
+        ],
+        "evidence_summary": {
+          "duplicate_record_count": 0,
+          "malformed_record_count": 0,
+          "missing_source_record_count": 0,
+          "normalized_fixture_ids": [
+            "v3_1_fixture_set_6d3b668a84cfbb69"
+          ],
+          "payload_digest_count": 1,
+          "reason_code_count": 1,
+          "record_count": 1,
+          "reviewed_record_count": 0,
+          "unsupported_record_count": 1
+        },
+        "metadata": {
+          "observational_only": true,
+          "planner_remap_performed": false,
+          "production_consumer": false
+        },
+        "non_production_authorization": {
+          "legacy_planner_ownership_preserved": true,
+          "source_authorizes_production_routing": false,
+          "source_is_production_approved": false,
+          "trusted_default_routing": false
+        },
+        "production_output_affected": false,
+        "source_id": "v3_1_persisted_fixture_sets_report",
+        "source_path": "D:\\Forge\\le-the-forge\\docs\\generated\\v3_1_persisted_fixture_sets_report.json",
+        "source_type": "persisted_fixture_sets"
+      }
+    ],
+    "source_evidence_summaries": [
+      {
+        "admission_status": "admitted_for_review",
+        "evidence_summary": {
+          "duplicate_record_count": 0,
+          "malformed_record_count": 0,
+          "missing_source_record_count": 0,
+          "normalized_fixture_ids": [
+            "v3_1_fixture_6c378a420c0a4ced",
+            "v3_1_fixture_756415e2e7d3feb2",
+            "v3_1_fixture_8118751ba1b46140",
+            "v3_1_fixture_9c3d260c0dda7b4f",
+            "v3_1_fixture_b82b601f9b088bb8"
+          ],
+          "payload_digest_count": 5,
+          "reason_code_count": 5,
+          "record_count": 5,
+          "reviewed_record_count": 2,
+          "unsupported_record_count": 3
+        },
+        "source_id": "v3_1_baseline_fixture_workflows_report",
+        "source_type": "baseline_fixture_workflows"
+      },
+      {
+        "admission_status": "admitted_for_review",
+        "evidence_summary": {
+          "duplicate_record_count": 0,
+          "malformed_record_count": 0,
+          "missing_source_record_count": 0,
+          "normalized_fixture_ids": [
+            "v3_1_fixture_set_6d3b668a84cfbb69"
+          ],
+          "payload_digest_count": 1,
+          "reason_code_count": 1,
+          "record_count": 1,
+          "reviewed_record_count": 0,
+          "unsupported_record_count": 1
+        },
+        "source_id": "v3_1_persisted_fixture_sets_report",
+        "source_type": "persisted_fixture_sets"
+      }
+    ],
+    "summary": {
+      "admitted_for_review_count": 2,
+      "blocked_count": 0,
+      "deterministic": true,
+      "production_affected_count": 0,
+      "production_behavior_changed": false,
+      "production_default_routing_authorized": false,
+      "production_output_affected": false,
+      "total_sources_evaluated": 2,
+      "trusted_data_default_truth": false
+    }
+  },
+  "generated_at": "2026-05-15T00:00:00+00:00",
+  "metadata": {
+    "observational_only": true,
+    "planner_remap_performed": false,
+    "production_behavior_changed": false,
+    "production_default_routing_authorized": false,
+    "source": "v3_1_fixture_source_admission_policy_report"
+  },
+  "phase": "v3.1_phase_11_fixture_source_admission_policy",
+  "phase_11_boundaries": [
+    "source admission is observational governance metadata only",
+    "admitted sources are eligible for governance review only",
+    "admitted sources are not production-approved",
+    "source admission does not authorize production routing",
+    "legacy planner ownership remains intact"
+  ],
+  "production_default_routing_authorized": false,
+  "recommendation": "OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING",
+  "schema_version": "v3_1.fixture_source_admission_policy_report.1",
+  "summary": {
+    "admitted_for_review_count": 2,
+    "blocked_count": 0,
+    "deterministic": true,
+    "production_affected_count": 0,
+    "production_behavior_changed": false,
+    "production_default_routing_authorized": false,
+    "production_output_affected": false,
+    "total_sources_evaluated": 2,
+    "trusted_data_default_truth": false
+  }
+}

--- a/docs/migration/V3_1_FIXTURE_SOURCE_ADMISSION_POLICY.md
+++ b/docs/migration/V3_1_FIXTURE_SOURCE_ADMISSION_POLICY.md
@@ -1,0 +1,45 @@
+# V3.1 Fixture Source Admission Policy
+
+Phase 11 defines source-level governance admission for reviewed fixture inputs.
+Admitted sources are eligible for governance review only and are not production-approved.
+
+## Recommendation
+
+- Recommendation: `OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING`
+- Production default routing authorized: `false`
+
+## Summary
+
+- Total sources evaluated: `2`
+- Admitted for review: `2`
+- Blocked: `0`
+- Production affected: `0`
+- Deterministic: `true`
+
+## Block Reasons
+
+| Reason | Count |
+| --- | ---: |
+
+## Source Evidence
+
+| Source | Type | Status | Records | Reviewed | Unsupported |
+| --- | --- | --- | ---: | ---: | ---: |
+| `v3_1_baseline_fixture_workflows_report` | `baseline_fixture_workflows` | `admitted_for_review` | `5` | `2` | `3` |
+| `v3_1_persisted_fixture_sets_report` | `persisted_fixture_sets` | `admitted_for_review` | `1` | `0` | `1` |
+
+## Recommended Next Governance Action
+
+use admitted sources as governance-review inputs only; do not authorize production routing
+
+## Phase 11 Boundaries
+
+- source admission is observational governance metadata only
+- admitted sources are eligible for governance review only
+- admitted sources are not production-approved
+- source admission does not authorize production routing
+- legacy planner ownership remains intact
+
+## Conclusion
+
+Fixture source admission is available for governance review, while production routing remains unchanged.


### PR DESCRIPTION
Adds deterministic fixture source admission policy reporting so reviewed sources can become eligible for governance review without approving production routing.