### PR TITLE
v3.1: add admission-aware policy evaluation

### DIFF
--- a/backend/app/planner_adapters/v3_1/__init__.py
+++ b/backend/app/planner_adapters/v3_1/__init__.py
@@ -41,6 +41,10 @@ from .approval_blocker_diagnosis import (
     APPROVAL_BLOCKER_CLASSIFICATIONS,
     build_approval_blocker_diagnosis,
 )
+from .admission_aware_policy_evaluation import (
+    ADMISSION_AWARE_POLICY_STATUSES,
+    build_admission_aware_policy_evaluation,
+)
 from .approval_manifest_diff_audit import (
     APPROVAL_MANIFEST_DIFF_CLASSIFICATIONS,
     audit_approval_manifest_diffs,
@@ -72,6 +76,7 @@ __all__ = [
     "FIXTURE_SOURCE_ADMISSION_STATUSES",
     "APPROVAL_MANIFEST_CANDIDATE_STATUSES",
     "APPROVAL_BLOCKER_CLASSIFICATIONS",
+    "ADMISSION_AWARE_POLICY_STATUSES",
     "APPROVAL_MANIFEST_DIFF_CLASSIFICATIONS",
     "SERIALIZED_APPROVAL_MANIFEST_STATUSES",
     "SUPPORTED_TRUSTED_SHADOW_DOMAINS",
@@ -91,6 +96,7 @@ __all__ = [
     "evaluate_fixture_source_admission_policy",
     "build_approval_manifest_candidates",
     "build_approval_blocker_diagnosis",
+    "build_admission_aware_policy_evaluation",
     "audit_approval_manifest_diffs",
     "discover_default_reviewed_fixture_input_sources",
     "deterministic_hash",

--- a/backend/app/planner_adapters/v3_1/admission_aware_policy_evaluation.py
+++ b/backend/app/planner_adapters/v3_1/admission_aware_policy_evaluation.py
@@ -1,0 +1,247 @@
+"""Admission-aware policy evaluation bridge for v3.1 governance.
+
+This bridge lets downstream governance account for fixture source admission
+status without approving fixture sets or authorizing production routing.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from copy import deepcopy
+from typing import Any
+
+from .trusted_shadow_consumption import deterministic_hash
+
+
+ADMISSION_AWARE_POLICY_STATUSES = (
+    "policy_satisfied_for_review",
+    "blocked_source_not_admitted",
+    "blocked_policy_failure",
+    "blocked_missing_admission_record",
+    "blocked_missing_fixture_input",
+    "blocked_invalid_review_state",
+)
+STABLE_ADMISSION_AWARE_POLICY_TOKEN = "v3_1_phase_12_admission_aware_policy_evaluation_token"
+
+
+def build_admission_aware_policy_evaluation(
+    *,
+    fixture_source_admission_policy: dict[str, Any],
+    reviewed_fixture_inputs: dict[str, Any],
+    review_policy_evaluation: dict[str, Any],
+    run_id: str = "v3_1_phase_12_admission_aware_policy_evaluation",
+) -> dict[str, Any]:
+    """Build deterministic admission-aware policy records."""
+
+    admission_by_source = {
+        str(row.get("source_id") or ""): deepcopy(row)
+        for row in fixture_source_admission_policy.get("source_admission_records", [])
+    }
+    fixture_inputs = _fixture_inputs_by_id(reviewed_fixture_inputs.get("normalized_fixture_inputs", []))
+    records = [
+        _record_for_policy_evaluation(evaluation, fixture_inputs, admission_by_source)
+        for evaluation in sorted(review_policy_evaluation.get("evaluations", []), key=lambda row: str(row.get("fixture_set_id") or row.get("fixture_id") or ""))
+    ]
+    counts = Counter(row["admission_aware_policy_status"] for row in records)
+    blocker_reasons = Counter(reason for row in records for reason in row["remaining_blockers"])
+    source_admission_impacts = Counter(row["source_admission_impact"] for row in records)
+    envelope = {
+        "schema_version": "v3_1.admission_aware_policy_evaluation.1",
+        "run": {
+            "run_id": run_id,
+            "record_count": len(records),
+            "fixture_source_admission_hash": fixture_source_admission_policy.get("deterministic_hash"),
+            "reviewed_fixture_inputs_hash": reviewed_fixture_inputs.get("deterministic_hash"),
+            "review_policy_evaluation_hash": review_policy_evaluation.get("deterministic_hash"),
+        },
+        "summary": {
+            "records_evaluated": len(records),
+            "satisfied_for_review_count": counts["policy_satisfied_for_review"],
+            "blocked_count": len(records) - counts["policy_satisfied_for_review"],
+            "production_affected_count": 0,
+            "production_output_affected": False,
+            "production_behavior_changed": False,
+            "production_default_routing_authorized": False,
+            "trusted_data_default_truth": False,
+            "deterministic": True,
+        },
+        "admission_aware_status_counts": {
+            status: counts[status]
+            for status in ADMISSION_AWARE_POLICY_STATUSES
+        },
+        "blocker_reason_counts": dict(sorted(blocker_reasons.items())),
+        "source_admission_impact_summary": dict(sorted(source_admission_impacts.items())),
+        "remaining_blocker_summary": [
+            {"reason": reason, "count": count}
+            for reason, count in sorted(blocker_reasons.items(), key=lambda item: (-item[1], item[0]))
+        ],
+        "admission_aware_policy_records": records,
+        "safety_confirmations": {
+            "satisfied_for_review_is_production_approval": False,
+            "admission_aware_policy_authorizes_production_routing": False,
+            "legacy_planner_ownership_preserved": True,
+            "production_output_affected": False,
+            "production_behavior_changed": False,
+            "runtime_state_mutated": False,
+            "trusted_data_default_truth": False,
+            "remaining_blockers_hidden": False,
+        },
+        "metadata": {
+            "source": "v3_1_admission_aware_policy_evaluation",
+            "observational_only": True,
+            "production_consumer": False,
+            "production_behavior_changed": False,
+            "planner_remap_performed": False,
+            "production_default_routing_authorized": False,
+            "stable_generation_token": STABLE_ADMISSION_AWARE_POLICY_TOKEN,
+            "deterministic_serializer": "json_sort_keys_sha256",
+        },
+    }
+    envelope["deterministic_hash"] = deterministic_hash(envelope)
+    return envelope
+
+
+def _record_for_policy_evaluation(
+    evaluation: dict[str, Any],
+    fixture_inputs: dict[str, dict[str, Any]],
+    admission_by_source: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    fixture_id = evaluation.get("fixture_id")
+    fixture_set_id = evaluation.get("fixture_set_id")
+    key = str(fixture_set_id or fixture_id or "")
+    fixture_input = fixture_inputs.get(key)
+    if not fixture_input:
+        return _policy_record(
+            evaluation=evaluation,
+            fixture_input=None,
+            admission=None,
+            status="blocked_missing_fixture_input",
+            blockers=["missing_reviewed_fixture_input"],
+            impact="missing_fixture_input",
+        )
+
+    source_id = str(fixture_input.get("source_id") or "")
+    admission = admission_by_source.get(source_id)
+    if not admission:
+        return _policy_record(
+            evaluation=evaluation,
+            fixture_input=fixture_input,
+            admission=None,
+            status="blocked_missing_admission_record",
+            blockers=["missing_source_admission_record"],
+            impact="missing_admission_record",
+        )
+
+    if fixture_input.get("status") in {"malformed", "duplicate", "missing_source"}:
+        return _policy_record(
+            evaluation=evaluation,
+            fixture_input=fixture_input,
+            admission=admission,
+            status="blocked_invalid_review_state",
+            blockers=[f"invalid_review_state_{fixture_input.get('status')}"],
+            impact="invalid_review_state",
+        )
+
+    admission_status = admission.get("admission_status")
+    if admission_status != "admitted_for_review":
+        return _policy_record(
+            evaluation=evaluation,
+            fixture_input=fixture_input,
+            admission=admission,
+            status="blocked_source_not_admitted",
+            blockers=list(admission.get("block_reasons") or [f"source_admission_{admission_status}"]),
+            impact="source_not_admitted",
+        )
+
+    original_policy = evaluation.get("policy_outcome")
+    reason_codes = list(evaluation.get("deterministic_reason_codes") or [])
+    if original_policy == "passes_policy":
+        return _policy_record(
+            evaluation=evaluation,
+            fixture_input=fixture_input,
+            admission=admission,
+            status="policy_satisfied_for_review",
+            blockers=[],
+            impact="already_policy_satisfied",
+        )
+    if _is_source_unsupported_failure(original_policy, reason_codes):
+        return _policy_record(
+            evaluation=evaluation,
+            fixture_input=fixture_input,
+            admission=admission,
+            status="policy_satisfied_for_review",
+            blockers=[],
+            impact="unsupported_source_reclassified_by_admission",
+        )
+    return _policy_record(
+        evaluation=evaluation,
+        fixture_input=fixture_input,
+        admission=admission,
+        status="blocked_policy_failure",
+        blockers=reason_codes or [f"policy_outcome_{original_policy or 'missing'}"],
+        impact="non_source_policy_failure_preserved",
+    )
+
+
+def _policy_record(
+    *,
+    evaluation: dict[str, Any],
+    fixture_input: dict[str, Any] | None,
+    admission: dict[str, Any] | None,
+    status: str,
+    blockers: list[str],
+    impact: str,
+) -> dict[str, Any]:
+    fixture_id = evaluation.get("fixture_id")
+    fixture_set_id = evaluation.get("fixture_set_id")
+    source_id = fixture_input.get("source_id") if fixture_input else None
+    seed = {
+        "fixture_id": fixture_id,
+        "fixture_set_id": fixture_set_id,
+        "source_id": source_id,
+        "status": status,
+        "token": STABLE_ADMISSION_AWARE_POLICY_TOKEN,
+    }
+    return {
+        "admission_aware_policy_id": f"v3_1_admission_policy_{deterministic_hash(seed)[:16]}",
+        "fixture_id": fixture_id,
+        "fixture_set_id": fixture_set_id,
+        "source_id": source_id,
+        "original_policy_status": evaluation.get("policy_outcome"),
+        "original_reason_codes": list(evaluation.get("deterministic_reason_codes") or []),
+        "fixture_input_status": fixture_input.get("status") if fixture_input else None,
+        "admission_status": admission.get("admission_status") if admission else None,
+        "admission_aware_policy_status": status,
+        "remaining_blockers": sorted(set(blockers)),
+        "source_admission_impact": impact,
+        "non_production_authorization": {
+            "satisfied_for_review_is_production_approval": False,
+            "policy_authorizes_production_routing": False,
+            "legacy_planner_ownership_preserved": True,
+            "trusted_default_routing": False,
+        },
+        "production_output_affected": False,
+        "metadata": {
+            "observational_only": True,
+            "production_consumer": False,
+            "planner_remap_performed": False,
+        },
+    }
+
+
+def _fixture_inputs_by_id(inputs: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    result: dict[str, dict[str, Any]] = {}
+    for row in sorted(inputs, key=lambda item: str(item.get("normalized_fixture_id") or "")):
+        normalized_id = str(row.get("normalized_fixture_id") or "")
+        source_fixture_id = str(row.get("source_fixture_id") or "")
+        if normalized_id:
+            result[normalized_id] = deepcopy(row)
+        if source_fixture_id:
+            result[source_fixture_id] = deepcopy(row)
+    return result
+
+
+def _is_source_unsupported_failure(policy_status: Any, reason_codes: list[str]) -> bool:
+    if policy_status != "unsupported":
+        return False
+    return bool(reason_codes) and all("unsupported_fixture" in reason for reason in reason_codes)

--- a/backend/scripts/report_v3_1_admission_aware_policy_evaluation.py
+++ b/backend/scripts/report_v3_1_admission_aware_policy_evaluation.py
@@ -1,0 +1,151 @@
+"""Generate the v3.1 admission-aware policy evaluation report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.planner_adapters.v3_1.admission_aware_policy_evaluation import build_admission_aware_policy_evaluation  # noqa: E402
+
+
+DETERMINISTIC_GENERATED_AT = "2026-05-15T00:00:00+00:00"
+
+
+def build_v3_1_admission_aware_policy_evaluation_report() -> dict[str, Any]:
+    repo_root = Path(__file__).resolve().parents[2]
+    generated = repo_root / "docs" / "generated"
+    admission = _read_json(generated / "v3_1_fixture_source_admission_policy_report.json")["fixture_source_admission_policy"]
+    reviewed_inputs = _read_json(generated / "v3_1_reviewed_fixture_inputs_report.json")["reviewed_fixture_inputs"]
+    policy = _read_json(generated / "v3_1_review_policy_evaluation_report.json")["review_policy_evaluation"]
+    evaluation = build_admission_aware_policy_evaluation(
+        fixture_source_admission_policy=admission,
+        reviewed_fixture_inputs=reviewed_inputs,
+        review_policy_evaluation=policy,
+    )
+    repeated = build_admission_aware_policy_evaluation(
+        fixture_source_admission_policy=admission,
+        reviewed_fixture_inputs=reviewed_inputs,
+        review_policy_evaluation=policy,
+    )
+    report = {
+        "schema_version": "v3_1.admission_aware_policy_evaluation_report.1",
+        "generated_at": DETERMINISTIC_GENERATED_AT,
+        "phase": "v3.1_phase_12_admission_aware_policy_evaluation",
+        "recommendation": "OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING",
+        "production_default_routing_authorized": False,
+        "summary": {
+            **evaluation["summary"],
+            "deterministic": evaluation["deterministic_hash"] == repeated["deterministic_hash"],
+        },
+        "admission_aware_policy_evaluation": evaluation,
+        "deterministic_guarantees": {
+            "passed": evaluation["deterministic_hash"] == repeated["deterministic_hash"],
+            "sample_hash": evaluation["deterministic_hash"],
+            "repeated_hash": repeated["deterministic_hash"],
+            "timestamp_excluded_from_hash": True,
+            "json_sort_keys": True,
+        },
+        "phase_12_boundaries": [
+            "admission-aware policy evaluation is observational governance metadata only",
+            "policy_satisfied_for_review is not production approval",
+            "admission-aware policy does not authorize production routing",
+            "non-source policy failures remain visible",
+            "legacy planner ownership remains intact",
+        ],
+        "metadata": {
+            "source": "v3_1_admission_aware_policy_evaluation_report",
+            "observational_only": True,
+            "production_behavior_changed": False,
+            "production_default_routing_authorized": False,
+            "planner_remap_performed": False,
+        },
+    }
+    return _normalize_generated_at(report)
+
+
+def write_report(report: dict[str, Any], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_markdown(report: dict[str, Any], output_path: Path) -> None:
+    evaluation = report["admission_aware_policy_evaluation"]
+    summary = report["summary"]
+    lines = [
+        "# V3.1 Admission-Aware Policy Evaluation",
+        "",
+        "Phase 12 lets governance policy evaluation account for fixture source admission.",
+        "Satisfied-for-review records are not production approvals and do not authorize routing.",
+        "",
+        "## Recommendation",
+        "",
+        f"- Recommendation: `{report['recommendation']}`",
+        f"- Production default routing authorized: `{str(report['production_default_routing_authorized']).lower()}`",
+        "",
+        "## Summary",
+        "",
+        f"- Records evaluated: `{summary['records_evaluated']}`",
+        f"- Satisfied for review: `{summary['satisfied_for_review_count']}`",
+        f"- Blocked: `{summary['blocked_count']}`",
+        f"- Production affected: `{summary['production_affected_count']}`",
+        f"- Deterministic: `{str(summary['deterministic']).lower()}`",
+        "",
+        "## Blocker Reasons",
+        "",
+        "| Reason | Count |",
+        "| --- | ---: |",
+    ]
+    for reason, count in evaluation["blocker_reason_counts"].items():
+        lines.append(f"| `{reason}` | `{count}` |")
+    lines.extend(["", "## Source Admission Impact", "", "| Impact | Count |", "| --- | ---: |"])
+    for impact, count in evaluation["source_admission_impact_summary"].items():
+        lines.append(f"| `{impact}` | `{count}` |")
+    lines.extend(["", "## Admission-Aware Records", "", "| Record | Fixture Set | Source | Original Policy | Admission | Status |", "| --- | --- | --- | --- | --- | --- |"])
+    for row in evaluation["admission_aware_policy_records"]:
+        lines.append(
+            f"| `{row['admission_aware_policy_id']}` | `{row['fixture_set_id'] or ''}` | `{row['source_id'] or ''}` | `{row['original_policy_status']}` | `{row['admission_status'] or ''}` | `{row['admission_aware_policy_status']}` |"
+        )
+    lines.extend(["", "## Phase 12 Boundaries", ""])
+    lines.extend(f"- {item}" for item in report["phase_12_boundaries"])
+    lines.extend(["", "## Conclusion", "", "Admission-aware policy evaluation is available for governance review, while production routing remains unchanged."])
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _normalize_generated_at(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: DETERMINISTIC_GENERATED_AT if key == "generated_at" else _normalize_generated_at(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_normalize_generated_at(item) for item in value]
+    return deepcopy(value)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", default="docs/generated/v3_1_admission_aware_policy_evaluation_report.json")
+    parser.add_argument("--markdown-output", default="docs/migration/V3_1_ADMISSION_AWARE_POLICY_EVALUATION.md")
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[2]
+    report = build_v3_1_admission_aware_policy_evaluation_report()
+    write_report(report, repo_root / args.output)
+    write_markdown(report, repo_root / args.markdown_output)
+    print(json.dumps(report["summary"], indent=2, sort_keys=True))
+    print(report["recommendation"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_v3_1_admission_aware_policy_evaluation.py
+++ b/backend/tests/test_v3_1_admission_aware_policy_evaluation.py
@@ -1,0 +1,164 @@
+from app.planner_adapters.v3_1.admission_aware_policy_evaluation import build_admission_aware_policy_evaluation
+from scripts.report_v3_1_admission_aware_policy_evaluation import build_v3_1_admission_aware_policy_evaluation_report
+
+
+def test_admitted_source_converts_unsupported_source_blocker_to_satisfied_for_review():
+    result = build_admission_aware_policy_evaluation(
+        fixture_source_admission_policy=_admission([_admission_record("source_a", "admitted_for_review")]),
+        reviewed_fixture_inputs=_inputs([_input("set_a", "source_a", status="unsupported")]),
+        review_policy_evaluation=_policy([_policy_record("set_a", "unsupported", ["unsupported_fixture_set_visible"])]),
+    )
+
+    row = result["admission_aware_policy_records"][0]
+    assert row["admission_aware_policy_status"] == "policy_satisfied_for_review"
+    assert row["remaining_blockers"] == []
+    assert row["source_admission_impact"] == "unsupported_source_reclassified_by_admission"
+
+
+def test_non_admitted_source_remains_blocked():
+    result = build_admission_aware_policy_evaluation(
+        fixture_source_admission_policy=_admission([_admission_record("source_a", "blocked_missing_review_evidence")]),
+        reviewed_fixture_inputs=_inputs([_input("set_a", "source_a")]),
+        review_policy_evaluation=_policy([_policy_record("set_a", "unsupported", ["unsupported_fixture_set_visible"])]),
+    )
+
+    assert result["admission_aware_policy_records"][0]["admission_aware_policy_status"] == "blocked_source_not_admitted"
+
+
+def test_missing_admission_record_blocks():
+    result = build_admission_aware_policy_evaluation(
+        fixture_source_admission_policy=_admission([]),
+        reviewed_fixture_inputs=_inputs([_input("set_a", "source_a")]),
+        review_policy_evaluation=_policy([_policy_record("set_a", "unsupported", ["unsupported_fixture_set_visible"])]),
+    )
+
+    assert result["admission_aware_policy_records"][0]["admission_aware_policy_status"] == "blocked_missing_admission_record"
+
+
+def test_missing_fixture_input_blocks():
+    result = build_admission_aware_policy_evaluation(
+        fixture_source_admission_policy=_admission([_admission_record("source_a", "admitted_for_review")]),
+        reviewed_fixture_inputs=_inputs([]),
+        review_policy_evaluation=_policy([_policy_record("set_a", "unsupported", ["unsupported_fixture_set_visible"])]),
+    )
+
+    assert result["admission_aware_policy_records"][0]["admission_aware_policy_status"] == "blocked_missing_fixture_input"
+
+
+def test_unrelated_policy_failures_remain_blocked():
+    result = build_admission_aware_policy_evaluation(
+        fixture_source_admission_policy=_admission([_admission_record("source_a", "admitted_for_review")]),
+        reviewed_fixture_inputs=_inputs([_input("set_a", "source_a")]),
+        review_policy_evaluation=_policy([_policy_record("set_a", "blocked", ["blocked_fixture_set_visible"])]),
+    )
+
+    row = result["admission_aware_policy_records"][0]
+    assert row["admission_aware_policy_status"] == "blocked_policy_failure"
+    assert row["remaining_blockers"] == ["blocked_fixture_set_visible"]
+
+
+def test_invalid_review_state_blocks():
+    result = build_admission_aware_policy_evaluation(
+        fixture_source_admission_policy=_admission([_admission_record("source_a", "admitted_for_review")]),
+        reviewed_fixture_inputs=_inputs([_input("set_a", "source_a", status="malformed")]),
+        review_policy_evaluation=_policy([_policy_record("set_a", "unsupported", ["unsupported_fixture_set_visible"])]),
+    )
+
+    assert result["admission_aware_policy_records"][0]["admission_aware_policy_status"] == "blocked_invalid_review_state"
+
+
+def test_deterministic_ordering():
+    first = build_admission_aware_policy_evaluation(
+        fixture_source_admission_policy=_admission([_admission_record("source_b"), _admission_record("source_a")]),
+        reviewed_fixture_inputs=_inputs([_input("set_b", "source_b"), _input("set_a", "source_a")]),
+        review_policy_evaluation=_policy([
+            _policy_record("set_b", "unsupported", ["unsupported_fixture_set_visible"]),
+            _policy_record("set_a", "unsupported", ["unsupported_fixture_set_visible"]),
+        ]),
+    )
+    second = build_admission_aware_policy_evaluation(
+        fixture_source_admission_policy=_admission([_admission_record("source_a"), _admission_record("source_b")]),
+        reviewed_fixture_inputs=_inputs([_input("set_a", "source_a"), _input("set_b", "source_b")]),
+        review_policy_evaluation=_policy([
+            _policy_record("set_a", "unsupported", ["unsupported_fixture_set_visible"]),
+            _policy_record("set_b", "unsupported", ["unsupported_fixture_set_visible"]),
+        ]),
+    )
+
+    assert first["deterministic_hash"] == second["deterministic_hash"]
+    assert [row["fixture_set_id"] for row in first["admission_aware_policy_records"]] == ["set_a", "set_b"]
+
+
+def test_stable_report_generation():
+    first = build_v3_1_admission_aware_policy_evaluation_report()
+    second = build_v3_1_admission_aware_policy_evaluation_report()
+
+    assert first["deterministic_guarantees"]["passed"] is True
+    assert first["admission_aware_policy_evaluation"]["deterministic_hash"] == second["admission_aware_policy_evaluation"]["deterministic_hash"]
+    assert first["summary"] == second["summary"]
+
+
+def test_no_production_routing_enablement():
+    result = build_admission_aware_policy_evaluation(
+        fixture_source_admission_policy=_admission([_admission_record("source_a")]),
+        reviewed_fixture_inputs=_inputs([_input("set_a", "source_a")]),
+        review_policy_evaluation=_policy([_policy_record("set_a", "unsupported", ["unsupported_fixture_set_visible"])]),
+    )
+    row = result["admission_aware_policy_records"][0]
+
+    assert result["safety_confirmations"]["satisfied_for_review_is_production_approval"] is False
+    assert result["safety_confirmations"]["admission_aware_policy_authorizes_production_routing"] is False
+    assert row["non_production_authorization"]["policy_authorizes_production_routing"] is False
+    assert row["production_output_affected"] is False
+
+
+def _admission(records):
+    return {
+        "schema_version": "v3_1.fixture_source_admission_policy.1",
+        "deterministic_hash": "admission-hash",
+        "source_admission_records": records,
+    }
+
+
+def _admission_record(source_id, status="admitted_for_review"):
+    return {
+        "source_id": source_id,
+        "source_type": "persisted_fixture_sets",
+        "admission_status": status,
+        "block_reasons": ["source_identity_schema_and_evidence_present"] if status == "admitted_for_review" else [status],
+    }
+
+
+def _inputs(records):
+    return {
+        "schema_version": "v3_1.reviewed_fixture_inputs.1",
+        "deterministic_hash": "inputs-hash",
+        "normalized_fixture_inputs": records,
+    }
+
+
+def _input(fixture_id, source_id, status="reviewed"):
+    return {
+        "normalized_fixture_id": fixture_id,
+        "source_fixture_id": fixture_id,
+        "source_id": source_id,
+        "source_type": "persisted_fixture_sets",
+        "status": status,
+    }
+
+
+def _policy(records):
+    return {
+        "schema_version": "v3_1.review_policy_evaluation.1",
+        "deterministic_hash": "policy-hash",
+        "evaluations": records,
+    }
+
+
+def _policy_record(fixture_set_id, outcome, reasons):
+    return {
+        "fixture_set_id": fixture_set_id,
+        "policy_outcome": outcome,
+        "deterministic_reason_codes": reasons,
+        "production_output_affected": False,
+    }

--- a/docs/generated/v3_1_admission_aware_policy_evaluation_report.json
+++ b/docs/generated/v3_1_admission_aware_policy_evaluation_report.json
@@ -1,0 +1,123 @@
+{
+  "admission_aware_policy_evaluation": {
+    "admission_aware_policy_records": [
+      {
+        "admission_aware_policy_id": "v3_1_admission_policy_20cf367c12da66bc",
+        "admission_aware_policy_status": "policy_satisfied_for_review",
+        "admission_status": "admitted_for_review",
+        "fixture_id": null,
+        "fixture_input_status": "unsupported",
+        "fixture_set_id": "v3_1_fixture_set_6d3b668a84cfbb69",
+        "metadata": {
+          "observational_only": true,
+          "planner_remap_performed": false,
+          "production_consumer": false
+        },
+        "non_production_authorization": {
+          "legacy_planner_ownership_preserved": true,
+          "policy_authorizes_production_routing": false,
+          "satisfied_for_review_is_production_approval": false,
+          "trusted_default_routing": false
+        },
+        "original_policy_status": "unsupported",
+        "original_reason_codes": [
+          "unsupported_fixture_set_visible"
+        ],
+        "production_output_affected": false,
+        "remaining_blockers": [],
+        "source_admission_impact": "unsupported_source_reclassified_by_admission",
+        "source_id": "v3_1_persisted_fixture_sets_report"
+      }
+    ],
+    "admission_aware_status_counts": {
+      "blocked_invalid_review_state": 0,
+      "blocked_missing_admission_record": 0,
+      "blocked_missing_fixture_input": 0,
+      "blocked_policy_failure": 0,
+      "blocked_source_not_admitted": 0,
+      "policy_satisfied_for_review": 1
+    },
+    "blocker_reason_counts": {},
+    "deterministic_hash": "e12700ae0a732d421457a52756aeab67c214eb581557468417f87778e8a4f0ba",
+    "metadata": {
+      "deterministic_serializer": "json_sort_keys_sha256",
+      "observational_only": true,
+      "planner_remap_performed": false,
+      "production_behavior_changed": false,
+      "production_consumer": false,
+      "production_default_routing_authorized": false,
+      "source": "v3_1_admission_aware_policy_evaluation",
+      "stable_generation_token": "v3_1_phase_12_admission_aware_policy_evaluation_token"
+    },
+    "remaining_blocker_summary": [],
+    "run": {
+      "fixture_source_admission_hash": "e45176c79cec01924368d35333c35857e969b396456814f38a56be5d3af00ffe",
+      "record_count": 1,
+      "review_policy_evaluation_hash": "e4c4d8158ed053e7f882796308ae244780a41a203a6c44608789c091cddab766",
+      "reviewed_fixture_inputs_hash": "bcc71a0573a2de21ed29ab1a7cae6ac04323875d4abccc85e387f4f266f6e077",
+      "run_id": "v3_1_phase_12_admission_aware_policy_evaluation"
+    },
+    "safety_confirmations": {
+      "admission_aware_policy_authorizes_production_routing": false,
+      "legacy_planner_ownership_preserved": true,
+      "production_behavior_changed": false,
+      "production_output_affected": false,
+      "remaining_blockers_hidden": false,
+      "runtime_state_mutated": false,
+      "satisfied_for_review_is_production_approval": false,
+      "trusted_data_default_truth": false
+    },
+    "schema_version": "v3_1.admission_aware_policy_evaluation.1",
+    "source_admission_impact_summary": {
+      "unsupported_source_reclassified_by_admission": 1
+    },
+    "summary": {
+      "blocked_count": 0,
+      "deterministic": true,
+      "production_affected_count": 0,
+      "production_behavior_changed": false,
+      "production_default_routing_authorized": false,
+      "production_output_affected": false,
+      "records_evaluated": 1,
+      "satisfied_for_review_count": 1,
+      "trusted_data_default_truth": false
+    }
+  },
+  "deterministic_guarantees": {
+    "json_sort_keys": true,
+    "passed": true,
+    "repeated_hash": "e12700ae0a732d421457a52756aeab67c214eb581557468417f87778e8a4f0ba",
+    "sample_hash": "e12700ae0a732d421457a52756aeab67c214eb581557468417f87778e8a4f0ba",
+    "timestamp_excluded_from_hash": true
+  },
+  "generated_at": "2026-05-15T00:00:00+00:00",
+  "metadata": {
+    "observational_only": true,
+    "planner_remap_performed": false,
+    "production_behavior_changed": false,
+    "production_default_routing_authorized": false,
+    "source": "v3_1_admission_aware_policy_evaluation_report"
+  },
+  "phase": "v3.1_phase_12_admission_aware_policy_evaluation",
+  "phase_12_boundaries": [
+    "admission-aware policy evaluation is observational governance metadata only",
+    "policy_satisfied_for_review is not production approval",
+    "admission-aware policy does not authorize production routing",
+    "non-source policy failures remain visible",
+    "legacy planner ownership remains intact"
+  ],
+  "production_default_routing_authorized": false,
+  "recommendation": "OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING",
+  "schema_version": "v3_1.admission_aware_policy_evaluation_report.1",
+  "summary": {
+    "blocked_count": 0,
+    "deterministic": true,
+    "production_affected_count": 0,
+    "production_behavior_changed": false,
+    "production_default_routing_authorized": false,
+    "production_output_affected": false,
+    "records_evaluated": 1,
+    "satisfied_for_review_count": 1,
+    "trusted_data_default_truth": false
+  }
+}

--- a/docs/migration/V3_1_ADMISSION_AWARE_POLICY_EVALUATION.md
+++ b/docs/migration/V3_1_ADMISSION_AWARE_POLICY_EVALUATION.md
@@ -1,0 +1,46 @@
+# V3.1 Admission-Aware Policy Evaluation
+
+Phase 12 lets governance policy evaluation account for fixture source admission.
+Satisfied-for-review records are not production approvals and do not authorize routing.
+
+## Recommendation
+
+- Recommendation: `OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING`
+- Production default routing authorized: `false`
+
+## Summary
+
+- Records evaluated: `1`
+- Satisfied for review: `1`
+- Blocked: `0`
+- Production affected: `0`
+- Deterministic: `true`
+
+## Blocker Reasons
+
+| Reason | Count |
+| --- | ---: |
+
+## Source Admission Impact
+
+| Impact | Count |
+| --- | ---: |
+| `unsupported_source_reclassified_by_admission` | `1` |
+
+## Admission-Aware Records
+
+| Record | Fixture Set | Source | Original Policy | Admission | Status |
+| --- | --- | --- | --- | --- | --- |
+| `v3_1_admission_policy_20cf367c12da66bc` | `v3_1_fixture_set_6d3b668a84cfbb69` | `v3_1_persisted_fixture_sets_report` | `unsupported` | `admitted_for_review` | `policy_satisfied_for_review` |
+
+## Phase 12 Boundaries
+
+- admission-aware policy evaluation is observational governance metadata only
+- policy_satisfied_for_review is not production approval
+- admission-aware policy does not authorize production routing
+- non-source policy failures remain visible
+- legacy planner ownership remains intact
+
+## Conclusion
+
+Admission-aware policy evaluation is available for governance review, while production routing remains unchanged.


### PR DESCRIPTION
Adds deterministic admission-aware policy evaluation so admitted fixture sources can satisfy governance review policy without authorizing production planner routing.