### PR TITLE
v3.1: add admission-aware readiness gate

### DIFF
--- a/backend/app/planner_adapters/v3_1/__init__.py
+++ b/backend/app/planner_adapters/v3_1/__init__.py
@@ -45,6 +45,10 @@ from .admission_aware_policy_evaluation import (
     ADMISSION_AWARE_POLICY_STATUSES,
     build_admission_aware_policy_evaluation,
 )
+from .admission_aware_readiness_gate import (
+    ADMISSION_AWARE_READINESS_STATUSES,
+    build_admission_aware_readiness_gate,
+)
 from .approval_manifest_diff_audit import (
     APPROVAL_MANIFEST_DIFF_CLASSIFICATIONS,
     audit_approval_manifest_diffs,
@@ -77,6 +81,7 @@ __all__ = [
     "APPROVAL_MANIFEST_CANDIDATE_STATUSES",
     "APPROVAL_BLOCKER_CLASSIFICATIONS",
     "ADMISSION_AWARE_POLICY_STATUSES",
+    "ADMISSION_AWARE_READINESS_STATUSES",
     "APPROVAL_MANIFEST_DIFF_CLASSIFICATIONS",
     "SERIALIZED_APPROVAL_MANIFEST_STATUSES",
     "SUPPORTED_TRUSTED_SHADOW_DOMAINS",
@@ -97,6 +102,7 @@ __all__ = [
     "build_approval_manifest_candidates",
     "build_approval_blocker_diagnosis",
     "build_admission_aware_policy_evaluation",
+    "build_admission_aware_readiness_gate",
     "audit_approval_manifest_diffs",
     "discover_default_reviewed_fixture_input_sources",
     "deterministic_hash",

--- a/backend/app/planner_adapters/v3_1/admission_aware_readiness_gate.py
+++ b/backend/app/planner_adapters/v3_1/admission_aware_readiness_gate.py
@@ -1,0 +1,276 @@
+"""Admission-aware readiness gate re-evaluation for v3.1 governance.
+
+This module re-evaluates readiness records after source admission and
+admission-aware policy evaluation. It remains observational and never approves
+production routing.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from copy import deepcopy
+from typing import Any
+
+from .trusted_shadow_consumption import deterministic_hash
+
+
+ADMISSION_AWARE_READINESS_STATUSES = (
+    "ready_for_approval_review",
+    "blocked_missing_inputs",
+    "blocked_policy_failure",
+    "blocked_malformed_inputs",
+    "blocked_duplicate_inputs",
+    "blocked_insufficient_review",
+    "blocked_missing_admission_aware_policy",
+    "blocked_invalid_admission_policy_state",
+)
+STABLE_ADMISSION_AWARE_READINESS_TOKEN = "v3_1_phase_13_admission_aware_readiness_gate_token"
+VALID_ADMISSION_POLICY_STATES = frozenset(
+    {
+        "policy_satisfied_for_review",
+        "blocked_source_not_admitted",
+        "blocked_policy_failure",
+        "blocked_missing_admission_record",
+        "blocked_missing_fixture_input",
+        "blocked_invalid_review_state",
+    }
+)
+
+
+def build_admission_aware_readiness_gate(
+    *,
+    fixture_set_readiness_gate: dict[str, Any],
+    admission_aware_policy_evaluation: dict[str, Any],
+    reviewed_fixture_inputs: dict[str, Any],
+    persisted_fixture_sets: dict[str, Any],
+    run_id: str = "v3_1_phase_13_admission_aware_readiness_gate",
+) -> dict[str, Any]:
+    """Build deterministic admission-aware readiness records."""
+
+    policy_by_set = {
+        str(row.get("fixture_set_id") or ""): deepcopy(row)
+        for row in admission_aware_policy_evaluation.get("admission_aware_policy_records", [])
+    }
+    fixture_set_by_id = {
+        str(row.get("fixture_set_id") or ""): deepcopy(row)
+        for row in persisted_fixture_sets.get("fixture_sets", [])
+    }
+    input_by_id = _reviewed_inputs_by_id(reviewed_fixture_inputs.get("normalized_fixture_inputs", []))
+    records = [
+        _admission_aware_record(
+            readiness_record=row,
+            admission_policy=policy_by_set.get(str(row.get("fixture_set_id") or "")),
+            fixture_set=fixture_set_by_id.get(str(row.get("fixture_set_id") or "")),
+            input_by_id=input_by_id,
+        )
+        for row in sorted(fixture_set_readiness_gate.get("readiness_records", []), key=lambda item: str(item.get("fixture_set_id") or ""))
+    ]
+    counts = Counter(row["admission_aware_readiness_status"] for row in records)
+    blocker_reasons = Counter(reason for row in records for reason in row["remaining_blockers"])
+    reclassification = Counter(row["readiness_reclassification"] for row in records)
+    envelope = {
+        "schema_version": "v3_1.admission_aware_readiness_gate.1",
+        "run": {
+            "run_id": run_id,
+            "record_count": len(records),
+            "fixture_set_readiness_gate_hash": fixture_set_readiness_gate.get("deterministic_hash"),
+            "admission_aware_policy_evaluation_hash": admission_aware_policy_evaluation.get("deterministic_hash"),
+            "reviewed_fixture_inputs_hash": reviewed_fixture_inputs.get("deterministic_hash"),
+            "persisted_fixture_sets_hash": persisted_fixture_sets.get("deterministic_hash"),
+        },
+        "summary": {
+            "records_evaluated": len(records),
+            "ready_for_approval_review_count": counts["ready_for_approval_review"],
+            "blocked_count": len(records) - counts["ready_for_approval_review"],
+            "production_affected_count": 0,
+            "production_output_affected": False,
+            "production_behavior_changed": False,
+            "production_default_routing_authorized": False,
+            "trusted_data_default_truth": False,
+            "deterministic": True,
+        },
+        "admission_aware_readiness_counts": {
+            status: counts[status]
+            for status in ADMISSION_AWARE_READINESS_STATUSES
+        },
+        "blocker_reason_counts": dict(sorted(blocker_reasons.items())),
+        "readiness_reclassification_summary": dict(sorted(reclassification.items())),
+        "remaining_blocker_summary": [
+            {"reason": reason, "count": count}
+            for reason, count in sorted(blocker_reasons.items(), key=lambda item: (-item[1], item[0]))
+        ],
+        "admission_aware_readiness_records": records,
+        "safety_confirmations": {
+            "ready_for_approval_review_is_production_approval": False,
+            "admission_aware_readiness_authorizes_production_routing": False,
+            "legacy_planner_ownership_preserved": True,
+            "production_output_affected": False,
+            "production_behavior_changed": False,
+            "runtime_state_mutated": False,
+            "trusted_data_default_truth": False,
+            "remaining_blockers_hidden": False,
+        },
+        "metadata": {
+            "source": "v3_1_admission_aware_readiness_gate",
+            "observational_only": True,
+            "production_consumer": False,
+            "production_behavior_changed": False,
+            "planner_remap_performed": False,
+            "production_default_routing_authorized": False,
+            "stable_generation_token": STABLE_ADMISSION_AWARE_READINESS_TOKEN,
+            "deterministic_serializer": "json_sort_keys_sha256",
+        },
+    }
+    envelope["deterministic_hash"] = deterministic_hash(envelope)
+    return envelope
+
+
+def _admission_aware_record(
+    *,
+    readiness_record: dict[str, Any],
+    admission_policy: dict[str, Any] | None,
+    fixture_set: dict[str, Any] | None,
+    input_by_id: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    original_status = readiness_record.get("readiness_classification")
+    original_blockers = list(readiness_record.get("block_reason_codes") or [])
+    admission_policy_status = admission_policy.get("admission_aware_policy_status") if admission_policy else None
+    fixture_set_id = readiness_record.get("fixture_set_id")
+    final_status, remaining_blockers, reclassification = _final_status(
+        readiness_record=readiness_record,
+        admission_policy=admission_policy,
+        fixture_set=fixture_set,
+        input_by_id=input_by_id,
+        original_blockers=original_blockers,
+    )
+    seed = {
+        "fixture_set_id": fixture_set_id,
+        "original_status": original_status,
+        "admission_policy_status": admission_policy_status,
+        "final_status": final_status,
+        "token": STABLE_ADMISSION_AWARE_READINESS_TOKEN,
+    }
+    return {
+        "admission_aware_readiness_id": f"v3_1_admission_readiness_{deterministic_hash(seed)[:16]}",
+        "fixture_set_id": fixture_set_id,
+        "set_key": readiness_record.get("set_key") or (fixture_set or {}).get("set_key"),
+        "original_readiness_status": original_status,
+        "original_block_reason_codes": original_blockers,
+        "admission_aware_policy_status": admission_policy_status,
+        "final_admission_aware_readiness_status": final_status,
+        "admission_aware_readiness_status": final_status,
+        "remaining_blockers": remaining_blockers,
+        "readiness_reclassification": reclassification,
+        "associated_fixture_ids": list(readiness_record.get("associated_fixture_ids") or (fixture_set or {}).get("associated_fixture_ids") or []),
+        "non_production_authorization": {
+            "ready_for_approval_review_is_production_approval": False,
+            "readiness_authorizes_production_routing": False,
+            "legacy_planner_ownership_preserved": True,
+            "trusted_default_routing": False,
+        },
+        "production_output_affected": False,
+        "metadata": {
+            "observational_only": True,
+            "production_consumer": False,
+            "planner_remap_performed": False,
+        },
+    }
+
+
+def _final_status(
+    *,
+    readiness_record: dict[str, Any],
+    admission_policy: dict[str, Any] | None,
+    fixture_set: dict[str, Any] | None,
+    input_by_id: dict[str, dict[str, Any]],
+    original_blockers: list[str],
+) -> tuple[str, list[str], str]:
+    non_policy_status = _explicit_non_policy_status(readiness_record.get("readiness_classification"))
+    if non_policy_status:
+        return non_policy_status, original_blockers or [non_policy_status], "non_policy_readiness_blocker_preserved"
+
+    input_status = _input_status_blocker(readiness_record=readiness_record, fixture_set=fixture_set, input_by_id=input_by_id)
+    if input_status:
+        return input_status[0], input_status[1], "non_policy_input_blocker_preserved"
+
+    if admission_policy is None:
+        return "blocked_missing_admission_aware_policy", ["missing_admission_aware_policy_record"], "missing_admission_aware_policy"
+
+    admission_status = admission_policy.get("admission_aware_policy_status")
+    if admission_status not in VALID_ADMISSION_POLICY_STATES:
+        return "blocked_invalid_admission_policy_state", [f"invalid_admission_policy_state_{admission_status or 'missing'}"], "invalid_admission_policy_state"
+    if admission_status != "policy_satisfied_for_review":
+        blockers = list(admission_policy.get("remaining_blockers") or [f"admission_policy_{admission_status}"])
+        return "blocked_policy_failure", blockers, "admission_policy_blocker_preserved"
+
+    remaining_non_policy = [reason for reason in original_blockers if not str(reason).startswith("policy_")]
+    if remaining_non_policy:
+        return _status_from_reason(remaining_non_policy[0]), sorted(set(remaining_non_policy)), "non_policy_readiness_blocker_preserved"
+
+    if readiness_record.get("readiness_classification") == "ready_for_approval_review":
+        return "ready_for_approval_review", [], "already_ready"
+    return "ready_for_approval_review", [], "policy_blocker_cleared_by_admission_aware_policy"
+
+
+def _explicit_non_policy_status(status: Any) -> str | None:
+    if status in {
+        "blocked_missing_inputs",
+        "blocked_malformed_inputs",
+        "blocked_duplicate_inputs",
+        "blocked_insufficient_review",
+    }:
+        return str(status)
+    return None
+
+
+def _input_status_blocker(
+    *,
+    readiness_record: dict[str, Any],
+    fixture_set: dict[str, Any] | None,
+    input_by_id: dict[str, dict[str, Any]],
+) -> tuple[str, list[str]] | None:
+    fixture_ids = list(readiness_record.get("associated_fixture_ids") or (fixture_set or {}).get("associated_fixture_ids") or [])
+    if not fixture_ids:
+        return "blocked_missing_inputs", ["missing_fixture_set_membership"]
+    statuses = Counter()
+    for fixture_id in fixture_ids:
+        row = input_by_id.get(_normalize_id(str(fixture_id)))
+        if row is None:
+            statuses["missing_source"] += 1
+        else:
+            statuses[str(row.get("status") or "missing_source")] += 1
+    if statuses["missing_source"]:
+        return "blocked_missing_inputs", ["missing_reviewed_fixture_input"]
+    if statuses["malformed"]:
+        return "blocked_malformed_inputs", ["malformed_reviewed_fixture_input"]
+    if statuses["duplicate"]:
+        return "blocked_duplicate_inputs", ["duplicate_reviewed_fixture_input"]
+    return None
+
+
+def _status_from_reason(reason: str) -> str:
+    if "missing" in reason:
+        return "blocked_missing_inputs"
+    if "malformed" in reason:
+        return "blocked_malformed_inputs"
+    if "duplicate" in reason:
+        return "blocked_duplicate_inputs"
+    if "policy" in reason:
+        return "blocked_policy_failure"
+    return "blocked_insufficient_review"
+
+
+def _reviewed_inputs_by_id(inputs: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    result: dict[str, dict[str, Any]] = {}
+    for row in sorted(inputs, key=lambda item: str(item.get("normalized_fixture_id") or "")):
+        normalized_id = _normalize_id(str(row.get("normalized_fixture_id") or ""))
+        source_fixture_id = _normalize_id(str(row.get("source_fixture_id") or ""))
+        if normalized_id:
+            result[normalized_id] = deepcopy(row)
+        if source_fixture_id:
+            result[source_fixture_id] = deepcopy(row)
+    return result
+
+
+def _normalize_id(value: str) -> str:
+    return "_".join(value.strip().lower().replace("\\", "/").replace(":", "_").split())

--- a/backend/scripts/report_v3_1_admission_aware_readiness_gate.py
+++ b/backend/scripts/report_v3_1_admission_aware_readiness_gate.py
@@ -1,0 +1,154 @@
+"""Generate the v3.1 admission-aware readiness gate report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.planner_adapters.v3_1.admission_aware_readiness_gate import build_admission_aware_readiness_gate  # noqa: E402
+
+
+DETERMINISTIC_GENERATED_AT = "2026-05-15T00:00:00+00:00"
+
+
+def build_v3_1_admission_aware_readiness_gate_report() -> dict[str, Any]:
+    repo_root = Path(__file__).resolve().parents[2]
+    generated = repo_root / "docs" / "generated"
+    readiness = _read_json(generated / "v3_1_fixture_set_readiness_gate_report.json")["fixture_set_readiness_gate"]
+    policy = _read_json(generated / "v3_1_admission_aware_policy_evaluation_report.json")["admission_aware_policy_evaluation"]
+    reviewed_inputs = _read_json(generated / "v3_1_reviewed_fixture_inputs_report.json")["reviewed_fixture_inputs"]
+    fixture_sets = _read_json(generated / "v3_1_persisted_fixture_sets_report.json")["persisted_fixture_sets"]
+    gate = build_admission_aware_readiness_gate(
+        fixture_set_readiness_gate=readiness,
+        admission_aware_policy_evaluation=policy,
+        reviewed_fixture_inputs=reviewed_inputs,
+        persisted_fixture_sets=fixture_sets,
+    )
+    repeated = build_admission_aware_readiness_gate(
+        fixture_set_readiness_gate=readiness,
+        admission_aware_policy_evaluation=policy,
+        reviewed_fixture_inputs=reviewed_inputs,
+        persisted_fixture_sets=fixture_sets,
+    )
+    report = {
+        "schema_version": "v3_1.admission_aware_readiness_gate_report.1",
+        "generated_at": DETERMINISTIC_GENERATED_AT,
+        "phase": "v3.1_phase_13_admission_aware_readiness_gate",
+        "recommendation": "OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING",
+        "production_default_routing_authorized": False,
+        "summary": {
+            **gate["summary"],
+            "deterministic": gate["deterministic_hash"] == repeated["deterministic_hash"],
+        },
+        "admission_aware_readiness_gate": gate,
+        "deterministic_guarantees": {
+            "passed": gate["deterministic_hash"] == repeated["deterministic_hash"],
+            "sample_hash": gate["deterministic_hash"],
+            "repeated_hash": repeated["deterministic_hash"],
+            "timestamp_excluded_from_hash": True,
+            "json_sort_keys": True,
+        },
+        "phase_13_boundaries": [
+            "admission-aware readiness is observational governance metadata only",
+            "ready_for_approval_review is not production approval",
+            "admission-aware readiness does not authorize production routing",
+            "remaining non-policy blockers stay visible",
+            "legacy planner ownership remains intact",
+        ],
+        "metadata": {
+            "source": "v3_1_admission_aware_readiness_gate_report",
+            "observational_only": True,
+            "production_behavior_changed": False,
+            "production_default_routing_authorized": False,
+            "planner_remap_performed": False,
+        },
+    }
+    return _normalize_generated_at(report)
+
+
+def write_report(report: dict[str, Any], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_markdown(report: dict[str, Any], output_path: Path) -> None:
+    gate = report["admission_aware_readiness_gate"]
+    summary = report["summary"]
+    lines = [
+        "# V3.1 Admission-Aware Readiness Gate",
+        "",
+        "Phase 13 re-evaluates readiness after source admission and admission-aware policy review.",
+        "Ready-for-approval-review records are not production approvals and do not authorize routing.",
+        "",
+        "## Recommendation",
+        "",
+        f"- Recommendation: `{report['recommendation']}`",
+        f"- Production default routing authorized: `{str(report['production_default_routing_authorized']).lower()}`",
+        "",
+        "## Summary",
+        "",
+        f"- Records evaluated: `{summary['records_evaluated']}`",
+        f"- Ready for approval review: `{summary['ready_for_approval_review_count']}`",
+        f"- Blocked: `{summary['blocked_count']}`",
+        f"- Production affected: `{summary['production_affected_count']}`",
+        f"- Deterministic: `{str(summary['deterministic']).lower()}`",
+        "",
+        "## Blocker Reasons",
+        "",
+        "| Reason | Count |",
+        "| --- | ---: |",
+    ]
+    for reason, count in gate["blocker_reason_counts"].items():
+        lines.append(f"| `{reason}` | `{count}` |")
+    lines.extend(["", "## Readiness Reclassification", "", "| Reclassification | Count |", "| --- | ---: |"])
+    for item, count in gate["readiness_reclassification_summary"].items():
+        lines.append(f"| `{item}` | `{count}` |")
+    lines.extend(["", "## Admission-Aware Records", "", "| Record | Fixture Set | Original | Policy | Final |", "| --- | --- | --- | --- | --- |"])
+    for row in gate["admission_aware_readiness_records"]:
+        lines.append(
+            f"| `{row['admission_aware_readiness_id']}` | `{row['fixture_set_id']}` | `{row['original_readiness_status']}` | `{row['admission_aware_policy_status'] or ''}` | `{row['final_admission_aware_readiness_status']}` |"
+        )
+    lines.extend(["", "## Phase 13 Boundaries", ""])
+    lines.extend(f"- {item}" for item in report["phase_13_boundaries"])
+    lines.extend(["", "## Conclusion", "", "Admission-aware readiness is available for governance review, while production routing remains unchanged."])
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _normalize_generated_at(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: DETERMINISTIC_GENERATED_AT if key == "generated_at" else _normalize_generated_at(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_normalize_generated_at(item) for item in value]
+    return deepcopy(value)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", default="docs/generated/v3_1_admission_aware_readiness_gate_report.json")
+    parser.add_argument("--markdown-output", default="docs/migration/V3_1_ADMISSION_AWARE_READINESS_GATE.md")
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[2]
+    report = build_v3_1_admission_aware_readiness_gate_report()
+    write_report(report, repo_root / args.output)
+    write_markdown(report, repo_root / args.markdown_output)
+    print(json.dumps(report["summary"], indent=2, sort_keys=True))
+    print(report["recommendation"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_v3_1_admission_aware_readiness_gate.py
+++ b/backend/tests/test_v3_1_admission_aware_readiness_gate.py
@@ -1,0 +1,180 @@
+from app.planner_adapters.v3_1.admission_aware_readiness_gate import build_admission_aware_readiness_gate
+from scripts.report_v3_1_admission_aware_readiness_gate import build_v3_1_admission_aware_readiness_gate_report
+
+
+def test_policy_satisfied_for_review_unblocks_policy_readiness_failure():
+    result = build_admission_aware_readiness_gate(
+        fixture_set_readiness_gate=_readiness([_readiness_record("set_a", "blocked_policy_failure", ["policy_unsupported"])]),
+        admission_aware_policy_evaluation=_policy([_policy_record("set_a", "policy_satisfied_for_review")]),
+        reviewed_fixture_inputs=_inputs([_input("fixture_a")]),
+        persisted_fixture_sets=_sets([_set("set_a", ["fixture_a"])]),
+    )
+
+    row = result["admission_aware_readiness_records"][0]
+    assert row["final_admission_aware_readiness_status"] == "ready_for_approval_review"
+    assert row["remaining_blockers"] == []
+    assert row["readiness_reclassification"] == "policy_blocker_cleared_by_admission_aware_policy"
+
+
+def test_unrelated_readiness_blockers_remain_blocked():
+    result = build_admission_aware_readiness_gate(
+        fixture_set_readiness_gate=_readiness([_readiness_record("set_a", "blocked_insufficient_review", ["workflow_not_review_ready"])]),
+        admission_aware_policy_evaluation=_policy([_policy_record("set_a", "policy_satisfied_for_review")]),
+        reviewed_fixture_inputs=_inputs([_input("fixture_a")]),
+        persisted_fixture_sets=_sets([_set("set_a", ["fixture_a"])]),
+    )
+
+    row = result["admission_aware_readiness_records"][0]
+    assert row["final_admission_aware_readiness_status"] == "blocked_insufficient_review"
+    assert row["remaining_blockers"] == ["workflow_not_review_ready"]
+
+
+def test_missing_admission_aware_policy_blocks():
+    result = build_admission_aware_readiness_gate(
+        fixture_set_readiness_gate=_readiness([_readiness_record("set_a", "blocked_policy_failure", ["policy_unsupported"])]),
+        admission_aware_policy_evaluation=_policy([]),
+        reviewed_fixture_inputs=_inputs([_input("fixture_a")]),
+        persisted_fixture_sets=_sets([_set("set_a", ["fixture_a"])]),
+    )
+
+    assert result["admission_aware_readiness_records"][0]["final_admission_aware_readiness_status"] == "blocked_missing_admission_aware_policy"
+
+
+def test_invalid_admission_policy_state_blocks():
+    result = build_admission_aware_readiness_gate(
+        fixture_set_readiness_gate=_readiness([_readiness_record("set_a", "blocked_policy_failure", ["policy_unsupported"])]),
+        admission_aware_policy_evaluation=_policy([_policy_record("set_a", "unexpected_state")]),
+        reviewed_fixture_inputs=_inputs([_input("fixture_a")]),
+        persisted_fixture_sets=_sets([_set("set_a", ["fixture_a"])]),
+    )
+
+    row = result["admission_aware_readiness_records"][0]
+    assert row["final_admission_aware_readiness_status"] == "blocked_invalid_admission_policy_state"
+    assert row["remaining_blockers"] == ["invalid_admission_policy_state_unexpected_state"]
+
+
+def test_policy_failure_state_remains_blocked():
+    result = build_admission_aware_readiness_gate(
+        fixture_set_readiness_gate=_readiness([_readiness_record("set_a", "blocked_policy_failure", ["policy_blocked"])]),
+        admission_aware_policy_evaluation=_policy([_policy_record("set_a", "blocked_policy_failure", ["blocked_fixture_set_visible"])]),
+        reviewed_fixture_inputs=_inputs([_input("fixture_a")]),
+        persisted_fixture_sets=_sets([_set("set_a", ["fixture_a"])]),
+    )
+
+    assert result["admission_aware_readiness_records"][0]["final_admission_aware_readiness_status"] == "blocked_policy_failure"
+
+
+def test_deterministic_ordering():
+    first = build_admission_aware_readiness_gate(
+        fixture_set_readiness_gate=_readiness([
+            _readiness_record("set_b", "blocked_policy_failure", ["policy_unsupported"], ["fixture_b"]),
+            _readiness_record("set_a", "blocked_policy_failure", ["policy_unsupported"], ["fixture_a"]),
+        ]),
+        admission_aware_policy_evaluation=_policy([_policy_record("set_b"), _policy_record("set_a")]),
+        reviewed_fixture_inputs=_inputs([_input("fixture_b"), _input("fixture_a")]),
+        persisted_fixture_sets=_sets([_set("set_b", ["fixture_b"]), _set("set_a", ["fixture_a"])]),
+    )
+    second = build_admission_aware_readiness_gate(
+        fixture_set_readiness_gate=_readiness([
+            _readiness_record("set_a", "blocked_policy_failure", ["policy_unsupported"], ["fixture_a"]),
+            _readiness_record("set_b", "blocked_policy_failure", ["policy_unsupported"], ["fixture_b"]),
+        ]),
+        admission_aware_policy_evaluation=_policy([_policy_record("set_a"), _policy_record("set_b")]),
+        reviewed_fixture_inputs=_inputs([_input("fixture_a"), _input("fixture_b")]),
+        persisted_fixture_sets=_sets([_set("set_a", ["fixture_a"]), _set("set_b", ["fixture_b"])]),
+    )
+
+    assert first["deterministic_hash"] == second["deterministic_hash"]
+    assert [row["fixture_set_id"] for row in first["admission_aware_readiness_records"]] == ["set_a", "set_b"]
+
+
+def test_stable_report_generation():
+    first = build_v3_1_admission_aware_readiness_gate_report()
+    second = build_v3_1_admission_aware_readiness_gate_report()
+
+    assert first["deterministic_guarantees"]["passed"] is True
+    assert first["admission_aware_readiness_gate"]["deterministic_hash"] == second["admission_aware_readiness_gate"]["deterministic_hash"]
+    assert first["summary"] == second["summary"]
+
+
+def test_no_production_routing_enablement():
+    result = build_admission_aware_readiness_gate(
+        fixture_set_readiness_gate=_readiness([_readiness_record("set_a", "blocked_policy_failure", ["policy_unsupported"])]),
+        admission_aware_policy_evaluation=_policy([_policy_record("set_a")]),
+        reviewed_fixture_inputs=_inputs([_input("fixture_a")]),
+        persisted_fixture_sets=_sets([_set("set_a", ["fixture_a"])]),
+    )
+    row = result["admission_aware_readiness_records"][0]
+
+    assert result["safety_confirmations"]["ready_for_approval_review_is_production_approval"] is False
+    assert result["safety_confirmations"]["admission_aware_readiness_authorizes_production_routing"] is False
+    assert row["non_production_authorization"]["readiness_authorizes_production_routing"] is False
+    assert row["production_output_affected"] is False
+
+
+def _readiness(records):
+    return {
+        "schema_version": "v3_1.fixture_set_readiness_gate.1",
+        "deterministic_hash": "readiness-hash",
+        "readiness_records": records,
+    }
+
+
+def _readiness_record(set_id, status, blockers, fixture_ids=None):
+    fixture_ids = fixture_ids or ["fixture_a"]
+    return {
+        "fixture_set_id": set_id,
+        "set_key": set_id,
+        "readiness_classification": status,
+        "associated_fixture_ids": fixture_ids,
+        "block_reason_codes": blockers,
+        "production_output_affected": False,
+    }
+
+
+def _policy(records):
+    return {
+        "schema_version": "v3_1.admission_aware_policy_evaluation.1",
+        "deterministic_hash": "policy-hash",
+        "admission_aware_policy_records": records,
+    }
+
+
+def _policy_record(set_id, status="policy_satisfied_for_review", blockers=None):
+    return {
+        "fixture_set_id": set_id,
+        "admission_aware_policy_status": status,
+        "remaining_blockers": blockers or [],
+    }
+
+
+def _inputs(records):
+    return {
+        "schema_version": "v3_1.reviewed_fixture_inputs.1",
+        "deterministic_hash": "inputs-hash",
+        "normalized_fixture_inputs": records,
+    }
+
+
+def _input(fixture_id, status="reviewed"):
+    return {
+        "normalized_fixture_id": fixture_id,
+        "source_fixture_id": fixture_id,
+        "status": status,
+    }
+
+
+def _sets(records):
+    return {
+        "schema_version": "v3_1.persisted_fixture_sets.1",
+        "deterministic_hash": "sets-hash",
+        "fixture_sets": records,
+    }
+
+
+def _set(set_id, fixture_ids):
+    return {
+        "fixture_set_id": set_id,
+        "set_key": set_id,
+        "associated_fixture_ids": fixture_ids,
+    }

--- a/docs/generated/v3_1_admission_aware_readiness_gate_report.json
+++ b/docs/generated/v3_1_admission_aware_readiness_gate_report.json
@@ -1,0 +1,132 @@
+{
+  "admission_aware_readiness_gate": {
+    "admission_aware_readiness_counts": {
+      "blocked_duplicate_inputs": 0,
+      "blocked_insufficient_review": 0,
+      "blocked_invalid_admission_policy_state": 0,
+      "blocked_malformed_inputs": 0,
+      "blocked_missing_admission_aware_policy": 0,
+      "blocked_missing_inputs": 0,
+      "blocked_policy_failure": 0,
+      "ready_for_approval_review": 1
+    },
+    "admission_aware_readiness_records": [
+      {
+        "admission_aware_policy_status": "policy_satisfied_for_review",
+        "admission_aware_readiness_id": "v3_1_admission_readiness_218e9d16d2f25668",
+        "admission_aware_readiness_status": "ready_for_approval_review",
+        "associated_fixture_ids": [
+          "v3_1_fixture_6c378a420c0a4ced",
+          "v3_1_fixture_756415e2e7d3feb2",
+          "v3_1_fixture_8118751ba1b46140",
+          "v3_1_fixture_9c3d260c0dda7b4f",
+          "v3_1_fixture_b82b601f9b088bb8"
+        ],
+        "final_admission_aware_readiness_status": "ready_for_approval_review",
+        "fixture_set_id": "v3_1_fixture_set_6d3b668a84cfbb69",
+        "metadata": {
+          "observational_only": true,
+          "planner_remap_performed": false,
+          "production_consumer": false
+        },
+        "non_production_authorization": {
+          "legacy_planner_ownership_preserved": true,
+          "readiness_authorizes_production_routing": false,
+          "ready_for_approval_review_is_production_approval": false,
+          "trusted_default_routing": false
+        },
+        "original_block_reason_codes": [
+          "policy_unsupported"
+        ],
+        "original_readiness_status": "blocked_policy_failure",
+        "production_output_affected": false,
+        "readiness_reclassification": "policy_blocker_cleared_by_admission_aware_policy",
+        "remaining_blockers": [],
+        "set_key": "sample_migration_readiness_set"
+      }
+    ],
+    "blocker_reason_counts": {},
+    "deterministic_hash": "d6542e54b2c8517241c3711ce5cf6e93793ad99db6977f7ebc9675cbd24fa8cc",
+    "metadata": {
+      "deterministic_serializer": "json_sort_keys_sha256",
+      "observational_only": true,
+      "planner_remap_performed": false,
+      "production_behavior_changed": false,
+      "production_consumer": false,
+      "production_default_routing_authorized": false,
+      "source": "v3_1_admission_aware_readiness_gate",
+      "stable_generation_token": "v3_1_phase_13_admission_aware_readiness_gate_token"
+    },
+    "readiness_reclassification_summary": {
+      "policy_blocker_cleared_by_admission_aware_policy": 1
+    },
+    "remaining_blocker_summary": [],
+    "run": {
+      "admission_aware_policy_evaluation_hash": "e12700ae0a732d421457a52756aeab67c214eb581557468417f87778e8a4f0ba",
+      "fixture_set_readiness_gate_hash": "85dbb478983263c00b093882c9a141e93b186dc688aedcfa6094b50a40040db2",
+      "persisted_fixture_sets_hash": "87bb0f1888fa99a2bb2bd99fa7806a365d1e4cceaefbd72118fae064d600116e",
+      "record_count": 1,
+      "reviewed_fixture_inputs_hash": "bcc71a0573a2de21ed29ab1a7cae6ac04323875d4abccc85e387f4f266f6e077",
+      "run_id": "v3_1_phase_13_admission_aware_readiness_gate"
+    },
+    "safety_confirmations": {
+      "admission_aware_readiness_authorizes_production_routing": false,
+      "legacy_planner_ownership_preserved": true,
+      "production_behavior_changed": false,
+      "production_output_affected": false,
+      "ready_for_approval_review_is_production_approval": false,
+      "remaining_blockers_hidden": false,
+      "runtime_state_mutated": false,
+      "trusted_data_default_truth": false
+    },
+    "schema_version": "v3_1.admission_aware_readiness_gate.1",
+    "summary": {
+      "blocked_count": 0,
+      "deterministic": true,
+      "production_affected_count": 0,
+      "production_behavior_changed": false,
+      "production_default_routing_authorized": false,
+      "production_output_affected": false,
+      "ready_for_approval_review_count": 1,
+      "records_evaluated": 1,
+      "trusted_data_default_truth": false
+    }
+  },
+  "deterministic_guarantees": {
+    "json_sort_keys": true,
+    "passed": true,
+    "repeated_hash": "d6542e54b2c8517241c3711ce5cf6e93793ad99db6977f7ebc9675cbd24fa8cc",
+    "sample_hash": "d6542e54b2c8517241c3711ce5cf6e93793ad99db6977f7ebc9675cbd24fa8cc",
+    "timestamp_excluded_from_hash": true
+  },
+  "generated_at": "2026-05-15T00:00:00+00:00",
+  "metadata": {
+    "observational_only": true,
+    "planner_remap_performed": false,
+    "production_behavior_changed": false,
+    "production_default_routing_authorized": false,
+    "source": "v3_1_admission_aware_readiness_gate_report"
+  },
+  "phase": "v3.1_phase_13_admission_aware_readiness_gate",
+  "phase_13_boundaries": [
+    "admission-aware readiness is observational governance metadata only",
+    "ready_for_approval_review is not production approval",
+    "admission-aware readiness does not authorize production routing",
+    "remaining non-policy blockers stay visible",
+    "legacy planner ownership remains intact"
+  ],
+  "production_default_routing_authorized": false,
+  "recommendation": "OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING",
+  "schema_version": "v3_1.admission_aware_readiness_gate_report.1",
+  "summary": {
+    "blocked_count": 0,
+    "deterministic": true,
+    "production_affected_count": 0,
+    "production_behavior_changed": false,
+    "production_default_routing_authorized": false,
+    "production_output_affected": false,
+    "ready_for_approval_review_count": 1,
+    "records_evaluated": 1,
+    "trusted_data_default_truth": false
+  }
+}

--- a/docs/migration/V3_1_ADMISSION_AWARE_READINESS_GATE.md
+++ b/docs/migration/V3_1_ADMISSION_AWARE_READINESS_GATE.md
@@ -1,0 +1,46 @@
+# V3.1 Admission-Aware Readiness Gate
+
+Phase 13 re-evaluates readiness after source admission and admission-aware policy review.
+Ready-for-approval-review records are not production approvals and do not authorize routing.
+
+## Recommendation
+
+- Recommendation: `OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING`
+- Production default routing authorized: `false`
+
+## Summary
+
+- Records evaluated: `1`
+- Ready for approval review: `1`
+- Blocked: `0`
+- Production affected: `0`
+- Deterministic: `true`
+
+## Blocker Reasons
+
+| Reason | Count |
+| --- | ---: |
+
+## Readiness Reclassification
+
+| Reclassification | Count |
+| --- | ---: |
+| `policy_blocker_cleared_by_admission_aware_policy` | `1` |
+
+## Admission-Aware Records
+
+| Record | Fixture Set | Original | Policy | Final |
+| --- | --- | --- | --- | --- |
+| `v3_1_admission_readiness_218e9d16d2f25668` | `v3_1_fixture_set_6d3b668a84cfbb69` | `blocked_policy_failure` | `policy_satisfied_for_review` | `ready_for_approval_review` |
+
+## Phase 13 Boundaries
+
+- admission-aware readiness is observational governance metadata only
+- ready_for_approval_review is not production approval
+- admission-aware readiness does not authorize production routing
+- remaining non-policy blockers stay visible
+- legacy planner ownership remains intact
+
+## Conclusion
+
+Admission-aware readiness is available for governance review, while production routing remains unchanged.


### PR DESCRIPTION
Adds deterministic admission-aware readiness gate re-evaluation so fixture sets with admitted sources and satisfied review policy can become approval-review candidates without authorizing production planner routing.