### PR TITLE
v3.1: refresh manifest candidates with admission-aware readiness

### DIFF
--- a/backend/app/planner_adapters/v3_1/__init__.py
+++ b/backend/app/planner_adapters/v3_1/__init__.py
@@ -49,6 +49,10 @@ from .admission_aware_readiness_gate import (
     ADMISSION_AWARE_READINESS_STATUSES,
     build_admission_aware_readiness_gate,
 )
+from .admission_aware_manifest_candidates import (
+    ADMISSION_AWARE_MANIFEST_CANDIDATE_STATUSES,
+    build_admission_aware_manifest_candidates,
+)
 from .approval_manifest_diff_audit import (
     APPROVAL_MANIFEST_DIFF_CLASSIFICATIONS,
     audit_approval_manifest_diffs,
@@ -82,6 +86,7 @@ __all__ = [
     "APPROVAL_BLOCKER_CLASSIFICATIONS",
     "ADMISSION_AWARE_POLICY_STATUSES",
     "ADMISSION_AWARE_READINESS_STATUSES",
+    "ADMISSION_AWARE_MANIFEST_CANDIDATE_STATUSES",
     "APPROVAL_MANIFEST_DIFF_CLASSIFICATIONS",
     "SERIALIZED_APPROVAL_MANIFEST_STATUSES",
     "SUPPORTED_TRUSTED_SHADOW_DOMAINS",
@@ -103,6 +108,7 @@ __all__ = [
     "build_approval_blocker_diagnosis",
     "build_admission_aware_policy_evaluation",
     "build_admission_aware_readiness_gate",
+    "build_admission_aware_manifest_candidates",
     "audit_approval_manifest_diffs",
     "discover_default_reviewed_fixture_input_sources",
     "deterministic_hash",

--- a/backend/app/planner_adapters/v3_1/admission_aware_manifest_candidates.py
+++ b/backend/app/planner_adapters/v3_1/admission_aware_manifest_candidates.py
@@ -1,0 +1,236 @@
+"""Admission-aware approval manifest candidate refresh.
+
+This layer refreshes manifest candidates from admission-aware readiness records.
+It is governance-only and never makes candidates production-authoritative.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from copy import deepcopy
+from typing import Any
+
+from .trusted_shadow_consumption import deterministic_hash
+
+
+ADMISSION_AWARE_MANIFEST_CANDIDATE_STATUSES = (
+    "candidate_ready",
+    "excluded_not_ready",
+    "excluded_missing_admission_readiness",
+    "excluded_invalid_readiness_state",
+)
+VALID_ADMISSION_AWARE_READINESS_STATES = frozenset(
+    {
+        "ready_for_approval_review",
+        "blocked_missing_inputs",
+        "blocked_policy_failure",
+        "blocked_malformed_inputs",
+        "blocked_duplicate_inputs",
+        "blocked_insufficient_review",
+        "blocked_missing_admission_aware_policy",
+        "blocked_invalid_admission_policy_state",
+    }
+)
+STABLE_ADMISSION_AWARE_MANIFEST_TOKEN = "v3_1_phase_14_admission_aware_manifest_candidates_token"
+
+
+def build_admission_aware_manifest_candidates(
+    *,
+    admission_aware_readiness_gate: dict[str, Any],
+    approval_manifest_candidates: dict[str, Any] | None = None,
+    run_id: str = "v3_1_phase_14_admission_aware_manifest_candidates",
+) -> dict[str, Any]:
+    """Build deterministic refreshed manifest candidate records."""
+
+    original_by_set = {
+        str(row.get("fixture_set_id") or ""): deepcopy(row)
+        for row in (approval_manifest_candidates or {}).get("manifest_candidates", [])
+    }
+    records = [
+        _candidate_record(readiness_record=row, original_candidate=original_by_set.get(str(row.get("fixture_set_id") or "")))
+        for row in sorted(
+            admission_aware_readiness_gate.get("admission_aware_readiness_records", []),
+            key=lambda item: str(item.get("fixture_set_id") or ""),
+        )
+    ]
+    if not records and original_by_set:
+        records = [
+            _missing_readiness_record(original_candidate=row)
+            for row in sorted(original_by_set.values(), key=lambda item: str(item.get("fixture_set_id") or ""))
+        ]
+    counts = Counter(row["candidate_status"] for row in records)
+    exclusion_reasons = Counter(reason for row in records if row["candidate_status"] != "candidate_ready" for reason in row["reason_codes"])
+    refresh = Counter(row["candidate_refresh_status"] for row in records)
+    comparison = Counter(row["original_vs_admission_aware"] for row in records)
+    envelope = {
+        "schema_version": "v3_1.admission_aware_manifest_candidates.1",
+        "run": {
+            "run_id": run_id,
+            "admission_aware_readiness_record_count": len(admission_aware_readiness_gate.get("admission_aware_readiness_records", [])),
+            "original_candidate_record_count": len(original_by_set),
+            "admission_aware_readiness_hash": admission_aware_readiness_gate.get("deterministic_hash"),
+            "original_candidate_hash": (approval_manifest_candidates or {}).get("deterministic_hash"),
+        },
+        "summary": {
+            "admission_aware_readiness_records_evaluated": len(records),
+            "candidate_ready_count": counts["candidate_ready"],
+            "excluded_count": len(records) - counts["candidate_ready"],
+            "production_affected_count": 0,
+            "production_output_affected": False,
+            "production_behavior_changed": False,
+            "production_default_routing_authorized": False,
+            "trusted_data_default_truth": False,
+            "deterministic": True,
+        },
+        "candidate_status_counts": {
+            status: counts[status]
+            for status in ADMISSION_AWARE_MANIFEST_CANDIDATE_STATUSES
+        },
+        "exclusion_reason_counts": dict(sorted(exclusion_reasons.items())),
+        "candidate_refresh_summary": dict(sorted(refresh.items())),
+        "original_vs_admission_aware_comparison": dict(sorted(comparison.items())),
+        "manifest_candidates": records,
+        "candidate_ready_manifest": [record for record in records if record["candidate_status"] == "candidate_ready"],
+        "input_consumption": {
+            "admission_aware_readiness_hash": admission_aware_readiness_gate.get("deterministic_hash"),
+            "admission_aware_readiness_schema": admission_aware_readiness_gate.get("schema_version"),
+            "original_candidate_hash": (approval_manifest_candidates or {}).get("deterministic_hash"),
+            "original_candidate_schema": (approval_manifest_candidates or {}).get("schema_version"),
+        },
+        "safety_confirmations": {
+            "candidate_ready_is_production_approval": False,
+            "admission_aware_candidates_authorize_production_routing": False,
+            "admission_aware_candidates_are_production_authoritative": False,
+            "legacy_planner_ownership_preserved": True,
+            "production_output_affected": False,
+            "production_behavior_changed": False,
+            "runtime_state_mutated": False,
+            "trusted_data_default_truth": False,
+        },
+        "metadata": {
+            "source": "v3_1_admission_aware_manifest_candidates",
+            "observational_only": True,
+            "production_consumer": False,
+            "production_behavior_changed": False,
+            "planner_remap_performed": False,
+            "production_default_routing_authorized": False,
+            "stable_generation_token": STABLE_ADMISSION_AWARE_MANIFEST_TOKEN,
+            "deterministic_serializer": "json_sort_keys_sha256",
+        },
+    }
+    envelope["deterministic_hash"] = deterministic_hash(envelope)
+    return envelope
+
+
+def _candidate_record(readiness_record: dict[str, Any], original_candidate: dict[str, Any] | None) -> dict[str, Any]:
+    status, reasons = _candidate_status(readiness_record)
+    fixture_set_id = str(readiness_record.get("fixture_set_id") or "")
+    seed = {
+        "fixture_set_id": fixture_set_id,
+        "admission_aware_readiness_id": readiness_record.get("admission_aware_readiness_id"),
+        "token": STABLE_ADMISSION_AWARE_MANIFEST_TOKEN,
+    }
+    original_status = (original_candidate or {}).get("candidate_status")
+    return {
+        "manifest_candidate_id": f"v3_1_admission_manifest_candidate_{deterministic_hash(seed)[:16]}",
+        "fixture_set_id": readiness_record.get("fixture_set_id"),
+        "candidate_status": status,
+        "original_candidate_status": original_status,
+        "candidate_refresh_status": _refresh_status(status=status, original_status=original_status),
+        "original_vs_admission_aware": _comparison_status(status=status, original_status=original_status),
+        "readiness_reclassification": readiness_record.get("readiness_reclassification"),
+        "source_summary": {
+            "set_key": readiness_record.get("set_key"),
+            "associated_fixture_ids": list(readiness_record.get("associated_fixture_ids") or []),
+        },
+        "policy_summary": {
+            "admission_aware_policy_status": readiness_record.get("admission_aware_policy_status"),
+            "valid_policy_state": readiness_record.get("admission_aware_policy_status") == "policy_satisfied_for_review",
+        },
+        "readiness_summary": {
+            "original_readiness_status": readiness_record.get("original_readiness_status"),
+            "admission_aware_readiness_status": readiness_record.get("final_admission_aware_readiness_status")
+            or readiness_record.get("admission_aware_readiness_status"),
+            "remaining_blockers": list(readiness_record.get("remaining_blockers") or []),
+            "original_block_reason_codes": list(readiness_record.get("original_block_reason_codes") or []),
+        },
+        "authorization_status": _non_production_authorization(),
+        "non_production_authoritative": True,
+        "reason_codes": reasons,
+        "production_output_affected": False,
+        "metadata": {
+            "observational_only": True,
+            "production_consumer": False,
+            "planner_remap_performed": False,
+        },
+    }
+
+
+def _missing_readiness_record(original_candidate: dict[str, Any]) -> dict[str, Any]:
+    fixture_set_id = str(original_candidate.get("fixture_set_id") or "")
+    seed = {
+        "fixture_set_id": fixture_set_id,
+        "missing_admission_readiness": True,
+        "token": STABLE_ADMISSION_AWARE_MANIFEST_TOKEN,
+    }
+    original_status = original_candidate.get("candidate_status")
+    return {
+        "manifest_candidate_id": f"v3_1_admission_manifest_candidate_{deterministic_hash(seed)[:16]}",
+        "fixture_set_id": original_candidate.get("fixture_set_id"),
+        "candidate_status": "excluded_missing_admission_readiness",
+        "original_candidate_status": original_status,
+        "candidate_refresh_status": "missing_admission_aware_readiness",
+        "original_vs_admission_aware": "excluded_by_missing_admission_readiness",
+        "readiness_reclassification": None,
+        "source_summary": deepcopy(original_candidate.get("source_summary") or {}),
+        "policy_summary": deepcopy(original_candidate.get("policy_summary") or {}),
+        "readiness_summary": deepcopy(original_candidate.get("readiness_summary") or {}),
+        "authorization_status": _non_production_authorization(),
+        "non_production_authoritative": True,
+        "reason_codes": ["missing_admission_aware_readiness_record"],
+        "production_output_affected": False,
+        "metadata": {
+            "observational_only": True,
+            "production_consumer": False,
+            "planner_remap_performed": False,
+        },
+    }
+
+
+def _candidate_status(readiness_record: dict[str, Any]) -> tuple[str, list[str]]:
+    readiness = readiness_record.get("final_admission_aware_readiness_status") or readiness_record.get("admission_aware_readiness_status")
+    if not readiness:
+        return "excluded_missing_admission_readiness", ["missing_admission_aware_readiness_status"]
+    if readiness not in VALID_ADMISSION_AWARE_READINESS_STATES:
+        return "excluded_invalid_readiness_state", [f"invalid_admission_aware_readiness_state_{readiness}"]
+    if readiness != "ready_for_approval_review":
+        return "excluded_not_ready", list(readiness_record.get("remaining_blockers") or [f"readiness_{readiness}"])
+    return "candidate_ready", ["admission_aware_ready_for_approval_review"]
+
+
+def _refresh_status(*, status: str, original_status: Any) -> str:
+    if status == "candidate_ready" and original_status == "candidate_ready":
+        return "remained_candidate_ready"
+    if status == "candidate_ready":
+        return "promoted_to_candidate_ready_for_review"
+    if original_status == "candidate_ready":
+        return "demoted_from_candidate_ready"
+    return "remained_excluded"
+
+
+def _comparison_status(*, status: str, original_status: Any) -> str:
+    if original_status is None:
+        return "new_admission_aware_candidate"
+    if status == original_status:
+        return "unchanged"
+    return f"{original_status}_to_{status}"
+
+
+def _non_production_authorization() -> dict[str, Any]:
+    return {
+        "candidate_is_production_approved": False,
+        "candidate_authorizes_production_routing": False,
+        "candidate_is_production_authoritative": False,
+        "legacy_planner_ownership_preserved": True,
+        "trusted_default_routing": False,
+    }

--- a/backend/scripts/report_v3_1_admission_aware_manifest_candidates.py
+++ b/backend/scripts/report_v3_1_admission_aware_manifest_candidates.py
@@ -1,0 +1,151 @@
+"""Generate the v3.1 admission-aware manifest candidate refresh report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.planner_adapters.v3_1.admission_aware_manifest_candidates import build_admission_aware_manifest_candidates  # noqa: E402
+
+
+DETERMINISTIC_GENERATED_AT = "2026-05-15T00:00:00+00:00"
+
+
+def build_v3_1_admission_aware_manifest_candidates_report() -> dict[str, Any]:
+    repo_root = Path(__file__).resolve().parents[2]
+    generated = repo_root / "docs" / "generated"
+    readiness = _read_json(generated / "v3_1_admission_aware_readiness_gate_report.json")["admission_aware_readiness_gate"]
+    original = _read_json(generated / "v3_1_approval_manifest_candidates_report.json")["approval_manifest_candidates"]
+    candidates = build_admission_aware_manifest_candidates(
+        admission_aware_readiness_gate=readiness,
+        approval_manifest_candidates=original,
+    )
+    repeated = build_admission_aware_manifest_candidates(
+        admission_aware_readiness_gate=readiness,
+        approval_manifest_candidates=original,
+    )
+    report = {
+        "schema_version": "v3_1.admission_aware_manifest_candidates_report.1",
+        "generated_at": DETERMINISTIC_GENERATED_AT,
+        "phase": "v3.1_phase_14_admission_aware_manifest_candidates",
+        "recommendation": "OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING",
+        "production_default_routing_authorized": False,
+        "summary": {
+            **candidates["summary"],
+            "deterministic": candidates["deterministic_hash"] == repeated["deterministic_hash"],
+        },
+        "admission_aware_manifest_candidates": candidates,
+        "deterministic_guarantees": {
+            "passed": candidates["deterministic_hash"] == repeated["deterministic_hash"],
+            "sample_hash": candidates["deterministic_hash"],
+            "repeated_hash": repeated["deterministic_hash"],
+            "timestamp_excluded_from_hash": True,
+            "json_sort_keys": True,
+        },
+        "phase_14_boundaries": [
+            "admission-aware candidates are observational governance artifacts",
+            "candidate_ready is not production approval",
+            "candidate_ready does not authorize production routing",
+            "candidates are explicitly non-production-authoritative",
+            "legacy planner ownership remains intact",
+        ],
+        "metadata": {
+            "source": "v3_1_admission_aware_manifest_candidates_report",
+            "observational_only": True,
+            "production_behavior_changed": False,
+            "production_default_routing_authorized": False,
+            "planner_remap_performed": False,
+        },
+    }
+    return _normalize_generated_at(report)
+
+
+def write_report(report: dict[str, Any], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_markdown(report: dict[str, Any], output_path: Path) -> None:
+    candidates = report["admission_aware_manifest_candidates"]
+    summary = report["summary"]
+    lines = [
+        "# V3.1 Admission-Aware Manifest Candidates",
+        "",
+        "Phase 14 refreshes manifest candidates from admission-aware readiness results.",
+        "Candidate-ready records are not production approvals and do not authorize routing.",
+        "",
+        "## Recommendation",
+        "",
+        f"- Recommendation: `{report['recommendation']}`",
+        f"- Production default routing authorized: `{str(report['production_default_routing_authorized']).lower()}`",
+        "",
+        "## Summary",
+        "",
+        f"- Admission-aware readiness records evaluated: `{summary['admission_aware_readiness_records_evaluated']}`",
+        f"- Candidate ready: `{summary['candidate_ready_count']}`",
+        f"- Excluded: `{summary['excluded_count']}`",
+        f"- Production affected: `{summary['production_affected_count']}`",
+        f"- Deterministic: `{str(summary['deterministic']).lower()}`",
+        "",
+        "## Exclusion Reasons",
+        "",
+        "| Reason | Count |",
+        "| --- | ---: |",
+    ]
+    for reason, count in candidates["exclusion_reason_counts"].items():
+        lines.append(f"| `{reason}` | `{count}` |")
+    lines.extend(["", "## Candidate Refresh Summary", "", "| Refresh | Count |", "| --- | ---: |"])
+    for item, count in candidates["candidate_refresh_summary"].items():
+        lines.append(f"| `{item}` | `{count}` |")
+    lines.extend(["", "## Original Vs Admission-Aware", "", "| Comparison | Count |", "| --- | ---: |"])
+    for item, count in candidates["original_vs_admission_aware_comparison"].items():
+        lines.append(f"| `{item}` | `{count}` |")
+    lines.extend(["", "## Refreshed Candidates", "", "| Candidate | Fixture Set | Original | Refreshed | Reclassification |", "| --- | --- | --- | --- | --- |"])
+    for row in candidates["manifest_candidates"]:
+        lines.append(
+            f"| `{row['manifest_candidate_id']}` | `{row['fixture_set_id']}` | `{row['original_candidate_status'] or ''}` | `{row['candidate_status']}` | `{row['readiness_reclassification'] or ''}` |"
+        )
+    lines.extend(["", "## Phase 14 Boundaries", ""])
+    lines.extend(f"- {item}" for item in report["phase_14_boundaries"])
+    lines.extend(["", "## Conclusion", "", "Admission-aware manifest candidates are available for governance review, while production routing remains unchanged."])
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _normalize_generated_at(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: DETERMINISTIC_GENERATED_AT if key == "generated_at" else _normalize_generated_at(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_normalize_generated_at(item) for item in value]
+    return deepcopy(value)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", default="docs/generated/v3_1_admission_aware_manifest_candidates_report.json")
+    parser.add_argument("--markdown-output", default="docs/migration/V3_1_ADMISSION_AWARE_MANIFEST_CANDIDATES.md")
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[2]
+    report = build_v3_1_admission_aware_manifest_candidates_report()
+    write_report(report, repo_root / args.output)
+    write_markdown(report, repo_root / args.markdown_output)
+    print(json.dumps(report["summary"], indent=2, sort_keys=True))
+    print(report["recommendation"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_v3_1_admission_aware_manifest_candidates.py
+++ b/backend/tests/test_v3_1_admission_aware_manifest_candidates.py
@@ -1,0 +1,136 @@
+from app.planner_adapters.v3_1.admission_aware_manifest_candidates import build_admission_aware_manifest_candidates
+from scripts.report_v3_1_admission_aware_manifest_candidates import build_v3_1_admission_aware_manifest_candidates_report
+
+
+def test_ready_for_approval_review_becomes_candidate_ready():
+    result = build_admission_aware_manifest_candidates(
+        admission_aware_readiness_gate=_readiness([_readiness_record("set_a", "ready_for_approval_review")]),
+        approval_manifest_candidates=_original([_candidate("set_a", "excluded_not_ready")]),
+    )
+
+    row = result["manifest_candidates"][0]
+    assert row["candidate_status"] == "candidate_ready"
+    assert row["original_candidate_status"] == "excluded_not_ready"
+    assert row["candidate_refresh_status"] == "promoted_to_candidate_ready_for_review"
+
+
+def test_blocked_readiness_remains_excluded():
+    result = build_admission_aware_manifest_candidates(
+        admission_aware_readiness_gate=_readiness([_readiness_record("set_a", "blocked_policy_failure", ["policy_blocked"])]),
+        approval_manifest_candidates=_original([_candidate("set_a", "excluded_not_ready")]),
+    )
+
+    row = result["manifest_candidates"][0]
+    assert row["candidate_status"] == "excluded_not_ready"
+    assert result["exclusion_reason_counts"]["policy_blocked"] == 1
+
+
+def test_missing_admission_aware_readiness_blocks():
+    result = build_admission_aware_manifest_candidates(
+        admission_aware_readiness_gate=_readiness([]),
+        approval_manifest_candidates=_original([_candidate("set_a", "excluded_not_ready")]),
+    )
+
+    row = result["manifest_candidates"][0]
+    assert row["candidate_status"] == "excluded_missing_admission_readiness"
+    assert row["reason_codes"] == ["missing_admission_aware_readiness_record"]
+
+
+def test_invalid_readiness_state_blocks():
+    result = build_admission_aware_manifest_candidates(
+        admission_aware_readiness_gate=_readiness([_readiness_record("set_a", "unexpected_state")]),
+        approval_manifest_candidates=_original([]),
+    )
+
+    row = result["manifest_candidates"][0]
+    assert row["candidate_status"] == "excluded_invalid_readiness_state"
+    assert row["reason_codes"] == ["invalid_admission_aware_readiness_state_unexpected_state"]
+
+
+def test_deterministic_ordering():
+    first = build_admission_aware_manifest_candidates(
+        admission_aware_readiness_gate=_readiness([
+            _readiness_record("set_b", "ready_for_approval_review"),
+            _readiness_record("set_a", "ready_for_approval_review"),
+        ]),
+        approval_manifest_candidates=_original([_candidate("set_b", "excluded_not_ready"), _candidate("set_a", "excluded_not_ready")]),
+    )
+    second = build_admission_aware_manifest_candidates(
+        admission_aware_readiness_gate=_readiness([
+            _readiness_record("set_a", "ready_for_approval_review"),
+            _readiness_record("set_b", "ready_for_approval_review"),
+        ]),
+        approval_manifest_candidates=_original([_candidate("set_a", "excluded_not_ready"), _candidate("set_b", "excluded_not_ready")]),
+    )
+
+    assert first["deterministic_hash"] == second["deterministic_hash"]
+    assert [row["fixture_set_id"] for row in first["manifest_candidates"]] == ["set_a", "set_b"]
+
+
+def test_stable_report_generation():
+    first = build_v3_1_admission_aware_manifest_candidates_report()
+    second = build_v3_1_admission_aware_manifest_candidates_report()
+
+    assert first["deterministic_guarantees"]["passed"] is True
+    assert first["admission_aware_manifest_candidates"]["deterministic_hash"] == second["admission_aware_manifest_candidates"]["deterministic_hash"]
+    assert first["summary"] == second["summary"]
+
+
+def test_no_production_routing_enablement():
+    result = build_admission_aware_manifest_candidates(
+        admission_aware_readiness_gate=_readiness([_readiness_record("set_a", "ready_for_approval_review")]),
+        approval_manifest_candidates=_original([_candidate("set_a", "excluded_not_ready")]),
+    )
+    row = result["manifest_candidates"][0]
+
+    assert result["safety_confirmations"]["candidate_ready_is_production_approval"] is False
+    assert result["safety_confirmations"]["admission_aware_candidates_authorize_production_routing"] is False
+    assert row["authorization_status"]["candidate_authorizes_production_routing"] is False
+    assert row["authorization_status"]["candidate_is_production_approved"] is False
+    assert row["non_production_authoritative"] is True
+
+
+def _readiness(records):
+    return {
+        "schema_version": "v3_1.admission_aware_readiness_gate.1",
+        "deterministic_hash": "readiness-hash",
+        "admission_aware_readiness_records": records,
+    }
+
+
+def _readiness_record(set_id, status, blockers=None):
+    return {
+        "admission_aware_readiness_id": f"readiness_{set_id}",
+        "fixture_set_id": set_id,
+        "set_key": set_id,
+        "final_admission_aware_readiness_status": status,
+        "admission_aware_readiness_status": status,
+        "admission_aware_policy_status": "policy_satisfied_for_review",
+        "readiness_reclassification": "policy_blocker_cleared_by_admission_aware_policy",
+        "remaining_blockers": blockers or [],
+        "associated_fixture_ids": [f"fixture_{set_id}"],
+        "original_readiness_status": "blocked_policy_failure",
+        "original_block_reason_codes": ["policy_unsupported"],
+        "production_output_affected": False,
+    }
+
+
+def _original(records):
+    return {
+        "schema_version": "v3_1.approval_manifest_candidates.1",
+        "deterministic_hash": "candidate-hash",
+        "manifest_candidates": records,
+    }
+
+
+def _candidate(set_id, status):
+    return {
+        "manifest_candidate_id": f"candidate_{set_id}",
+        "fixture_set_id": set_id,
+        "candidate_status": status,
+        "source_summary": {"set_key": set_id},
+        "policy_summary": {"policy_outcome": "unsupported"},
+        "readiness_summary": {"readiness_classification": "blocked_policy_failure"},
+        "reason_codes": ["policy_unsupported"],
+        "production_output_affected": False,
+    }

--- a/docs/generated/v3_1_admission_aware_manifest_candidates_report.json
+++ b/docs/generated/v3_1_admission_aware_manifest_candidates_report.json
@@ -1,0 +1,200 @@
+{
+  "admission_aware_manifest_candidates": {
+    "candidate_ready_manifest": [
+      {
+        "authorization_status": {
+          "candidate_authorizes_production_routing": false,
+          "candidate_is_production_approved": false,
+          "candidate_is_production_authoritative": false,
+          "legacy_planner_ownership_preserved": true,
+          "trusted_default_routing": false
+        },
+        "candidate_refresh_status": "promoted_to_candidate_ready_for_review",
+        "candidate_status": "candidate_ready",
+        "fixture_set_id": "v3_1_fixture_set_6d3b668a84cfbb69",
+        "manifest_candidate_id": "v3_1_admission_manifest_candidate_701e7dd28773d5d1",
+        "metadata": {
+          "observational_only": true,
+          "planner_remap_performed": false,
+          "production_consumer": false
+        },
+        "non_production_authoritative": true,
+        "original_candidate_status": "excluded_not_ready",
+        "original_vs_admission_aware": "excluded_not_ready_to_candidate_ready",
+        "policy_summary": {
+          "admission_aware_policy_status": "policy_satisfied_for_review",
+          "valid_policy_state": true
+        },
+        "production_output_affected": false,
+        "readiness_reclassification": "policy_blocker_cleared_by_admission_aware_policy",
+        "readiness_summary": {
+          "admission_aware_readiness_status": "ready_for_approval_review",
+          "original_block_reason_codes": [
+            "policy_unsupported"
+          ],
+          "original_readiness_status": "blocked_policy_failure",
+          "remaining_blockers": []
+        },
+        "reason_codes": [
+          "admission_aware_ready_for_approval_review"
+        ],
+        "source_summary": {
+          "associated_fixture_ids": [
+            "v3_1_fixture_6c378a420c0a4ced",
+            "v3_1_fixture_756415e2e7d3feb2",
+            "v3_1_fixture_8118751ba1b46140",
+            "v3_1_fixture_9c3d260c0dda7b4f",
+            "v3_1_fixture_b82b601f9b088bb8"
+          ],
+          "set_key": "sample_migration_readiness_set"
+        }
+      }
+    ],
+    "candidate_refresh_summary": {
+      "promoted_to_candidate_ready_for_review": 1
+    },
+    "candidate_status_counts": {
+      "candidate_ready": 1,
+      "excluded_invalid_readiness_state": 0,
+      "excluded_missing_admission_readiness": 0,
+      "excluded_not_ready": 0
+    },
+    "deterministic_hash": "8a0d679bc854e320f04e678c298cc3481e66b90b5b260bdcf6f410b4f1dd9464",
+    "exclusion_reason_counts": {},
+    "input_consumption": {
+      "admission_aware_readiness_hash": "d6542e54b2c8517241c3711ce5cf6e93793ad99db6977f7ebc9675cbd24fa8cc",
+      "admission_aware_readiness_schema": "v3_1.admission_aware_readiness_gate.1",
+      "original_candidate_hash": "26e84f9a9f25f9ad94ddd70e449d328623079c6e651702eaef70285fa445db27",
+      "original_candidate_schema": "v3_1.approval_manifest_candidates.1"
+    },
+    "manifest_candidates": [
+      {
+        "authorization_status": {
+          "candidate_authorizes_production_routing": false,
+          "candidate_is_production_approved": false,
+          "candidate_is_production_authoritative": false,
+          "legacy_planner_ownership_preserved": true,
+          "trusted_default_routing": false
+        },
+        "candidate_refresh_status": "promoted_to_candidate_ready_for_review",
+        "candidate_status": "candidate_ready",
+        "fixture_set_id": "v3_1_fixture_set_6d3b668a84cfbb69",
+        "manifest_candidate_id": "v3_1_admission_manifest_candidate_701e7dd28773d5d1",
+        "metadata": {
+          "observational_only": true,
+          "planner_remap_performed": false,
+          "production_consumer": false
+        },
+        "non_production_authoritative": true,
+        "original_candidate_status": "excluded_not_ready",
+        "original_vs_admission_aware": "excluded_not_ready_to_candidate_ready",
+        "policy_summary": {
+          "admission_aware_policy_status": "policy_satisfied_for_review",
+          "valid_policy_state": true
+        },
+        "production_output_affected": false,
+        "readiness_reclassification": "policy_blocker_cleared_by_admission_aware_policy",
+        "readiness_summary": {
+          "admission_aware_readiness_status": "ready_for_approval_review",
+          "original_block_reason_codes": [
+            "policy_unsupported"
+          ],
+          "original_readiness_status": "blocked_policy_failure",
+          "remaining_blockers": []
+        },
+        "reason_codes": [
+          "admission_aware_ready_for_approval_review"
+        ],
+        "source_summary": {
+          "associated_fixture_ids": [
+            "v3_1_fixture_6c378a420c0a4ced",
+            "v3_1_fixture_756415e2e7d3feb2",
+            "v3_1_fixture_8118751ba1b46140",
+            "v3_1_fixture_9c3d260c0dda7b4f",
+            "v3_1_fixture_b82b601f9b088bb8"
+          ],
+          "set_key": "sample_migration_readiness_set"
+        }
+      }
+    ],
+    "metadata": {
+      "deterministic_serializer": "json_sort_keys_sha256",
+      "observational_only": true,
+      "planner_remap_performed": false,
+      "production_behavior_changed": false,
+      "production_consumer": false,
+      "production_default_routing_authorized": false,
+      "source": "v3_1_admission_aware_manifest_candidates",
+      "stable_generation_token": "v3_1_phase_14_admission_aware_manifest_candidates_token"
+    },
+    "original_vs_admission_aware_comparison": {
+      "excluded_not_ready_to_candidate_ready": 1
+    },
+    "run": {
+      "admission_aware_readiness_hash": "d6542e54b2c8517241c3711ce5cf6e93793ad99db6977f7ebc9675cbd24fa8cc",
+      "admission_aware_readiness_record_count": 1,
+      "original_candidate_hash": "26e84f9a9f25f9ad94ddd70e449d328623079c6e651702eaef70285fa445db27",
+      "original_candidate_record_count": 1,
+      "run_id": "v3_1_phase_14_admission_aware_manifest_candidates"
+    },
+    "safety_confirmations": {
+      "admission_aware_candidates_are_production_authoritative": false,
+      "admission_aware_candidates_authorize_production_routing": false,
+      "candidate_ready_is_production_approval": false,
+      "legacy_planner_ownership_preserved": true,
+      "production_behavior_changed": false,
+      "production_output_affected": false,
+      "runtime_state_mutated": false,
+      "trusted_data_default_truth": false
+    },
+    "schema_version": "v3_1.admission_aware_manifest_candidates.1",
+    "summary": {
+      "admission_aware_readiness_records_evaluated": 1,
+      "candidate_ready_count": 1,
+      "deterministic": true,
+      "excluded_count": 0,
+      "production_affected_count": 0,
+      "production_behavior_changed": false,
+      "production_default_routing_authorized": false,
+      "production_output_affected": false,
+      "trusted_data_default_truth": false
+    }
+  },
+  "deterministic_guarantees": {
+    "json_sort_keys": true,
+    "passed": true,
+    "repeated_hash": "8a0d679bc854e320f04e678c298cc3481e66b90b5b260bdcf6f410b4f1dd9464",
+    "sample_hash": "8a0d679bc854e320f04e678c298cc3481e66b90b5b260bdcf6f410b4f1dd9464",
+    "timestamp_excluded_from_hash": true
+  },
+  "generated_at": "2026-05-15T00:00:00+00:00",
+  "metadata": {
+    "observational_only": true,
+    "planner_remap_performed": false,
+    "production_behavior_changed": false,
+    "production_default_routing_authorized": false,
+    "source": "v3_1_admission_aware_manifest_candidates_report"
+  },
+  "phase": "v3.1_phase_14_admission_aware_manifest_candidates",
+  "phase_14_boundaries": [
+    "admission-aware candidates are observational governance artifacts",
+    "candidate_ready is not production approval",
+    "candidate_ready does not authorize production routing",
+    "candidates are explicitly non-production-authoritative",
+    "legacy planner ownership remains intact"
+  ],
+  "production_default_routing_authorized": false,
+  "recommendation": "OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING",
+  "schema_version": "v3_1.admission_aware_manifest_candidates_report.1",
+  "summary": {
+    "admission_aware_readiness_records_evaluated": 1,
+    "candidate_ready_count": 1,
+    "deterministic": true,
+    "excluded_count": 0,
+    "production_affected_count": 0,
+    "production_behavior_changed": false,
+    "production_default_routing_authorized": false,
+    "production_output_affected": false,
+    "trusted_data_default_truth": false
+  }
+}

--- a/docs/migration/V3_1_ADMISSION_AWARE_MANIFEST_CANDIDATES.md
+++ b/docs/migration/V3_1_ADMISSION_AWARE_MANIFEST_CANDIDATES.md
@@ -1,0 +1,52 @@
+# V3.1 Admission-Aware Manifest Candidates
+
+Phase 14 refreshes manifest candidates from admission-aware readiness results.
+Candidate-ready records are not production approvals and do not authorize routing.
+
+## Recommendation
+
+- Recommendation: `OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING`
+- Production default routing authorized: `false`
+
+## Summary
+
+- Admission-aware readiness records evaluated: `1`
+- Candidate ready: `1`
+- Excluded: `0`
+- Production affected: `0`
+- Deterministic: `true`
+
+## Exclusion Reasons
+
+| Reason | Count |
+| --- | ---: |
+
+## Candidate Refresh Summary
+
+| Refresh | Count |
+| --- | ---: |
+| `promoted_to_candidate_ready_for_review` | `1` |
+
+## Original Vs Admission-Aware
+
+| Comparison | Count |
+| --- | ---: |
+| `excluded_not_ready_to_candidate_ready` | `1` |
+
+## Refreshed Candidates
+
+| Candidate | Fixture Set | Original | Refreshed | Reclassification |
+| --- | --- | --- | --- | --- |
+| `v3_1_admission_manifest_candidate_701e7dd28773d5d1` | `v3_1_fixture_set_6d3b668a84cfbb69` | `excluded_not_ready` | `candidate_ready` | `policy_blocker_cleared_by_admission_aware_policy` |
+
+## Phase 14 Boundaries
+
+- admission-aware candidates are observational governance artifacts
+- candidate_ready is not production approval
+- candidate_ready does not authorize production routing
+- candidates are explicitly non-production-authoritative
+- legacy planner ownership remains intact
+
+## Conclusion
+
+Admission-aware manifest candidates are available for governance review, while production routing remains unchanged.


### PR DESCRIPTION
Adds deterministic admission-aware manifest candidate refresh so readiness-cleared fixture sets can become candidate-ready without approving production planner routing.