### PR TITLE
v3.1: serialize admission-aware manifests

### DIFF
--- a/backend/app/planner_adapters/v3_1/__init__.py
+++ b/backend/app/planner_adapters/v3_1/__init__.py
@@ -53,6 +53,10 @@ from .admission_aware_manifest_candidates import (
     ADMISSION_AWARE_MANIFEST_CANDIDATE_STATUSES,
     build_admission_aware_manifest_candidates,
 )
+from .admission_aware_manifest_serialization import (
+    ADMISSION_AWARE_SERIALIZED_MANIFEST_STATUSES,
+    serialize_admission_aware_manifest_candidates,
+)
 from .approval_manifest_diff_audit import (
     APPROVAL_MANIFEST_DIFF_CLASSIFICATIONS,
     audit_approval_manifest_diffs,
@@ -87,6 +91,7 @@ __all__ = [
     "ADMISSION_AWARE_POLICY_STATUSES",
     "ADMISSION_AWARE_READINESS_STATUSES",
     "ADMISSION_AWARE_MANIFEST_CANDIDATE_STATUSES",
+    "ADMISSION_AWARE_SERIALIZED_MANIFEST_STATUSES",
     "APPROVAL_MANIFEST_DIFF_CLASSIFICATIONS",
     "SERIALIZED_APPROVAL_MANIFEST_STATUSES",
     "SUPPORTED_TRUSTED_SHADOW_DOMAINS",
@@ -109,6 +114,7 @@ __all__ = [
     "build_admission_aware_policy_evaluation",
     "build_admission_aware_readiness_gate",
     "build_admission_aware_manifest_candidates",
+    "serialize_admission_aware_manifest_candidates",
     "audit_approval_manifest_diffs",
     "discover_default_reviewed_fixture_input_sources",
     "deterministic_hash",

--- a/backend/app/planner_adapters/v3_1/admission_aware_manifest_serialization.py
+++ b/backend/app/planner_adapters/v3_1/admission_aware_manifest_serialization.py
@@ -1,0 +1,196 @@
+"""Admission-aware manifest serialization for v3.1 governance.
+
+This module serializes admission-aware candidate-ready records into
+non-production-authoritative manifests. It does not approve fixture sets or
+authorize production routing.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from copy import deepcopy
+from typing import Any
+
+from .approval_manifest_serialization import NON_PRODUCTION_AUTHORIZATION_STATE
+from .trusted_shadow_consumption import deterministic_hash
+
+
+ADMISSION_AWARE_SERIALIZED_MANIFEST_STATUSES = (
+    "serialized_manifest",
+    "excluded_not_ready",
+    "excluded_missing_candidate_status",
+    "excluded_invalid_candidate_state",
+)
+STABLE_ADMISSION_AWARE_SERIALIZATION_TOKEN = "v3_1_phase_15_admission_aware_manifest_serialization_token"
+
+
+def serialize_admission_aware_manifest_candidates(
+    *,
+    admission_aware_manifest_candidates: dict[str, Any] | list[dict[str, Any]],
+    run_id: str = "v3_1_phase_15_admission_aware_manifest_serialization",
+) -> dict[str, Any]:
+    """Serialize admission-aware candidate-ready records in deterministic order."""
+
+    candidates = _candidate_records(admission_aware_manifest_candidates)
+    records = [_serialization_record(candidate) for candidate in sorted(candidates, key=_candidate_sort_key)]
+    counts = Counter(row["serialization_status"] for row in records)
+    exclusion_reasons = Counter(
+        reason
+        for row in records
+        if row["serialization_status"] != "serialized_manifest"
+        for reason in row["reason_codes"]
+    )
+    serialized = [row for row in records if row["serialization_status"] == "serialized_manifest"]
+    excluded = [row for row in records if row["serialization_status"] != "serialized_manifest"]
+    source_hash = admission_aware_manifest_candidates.get("deterministic_hash") if isinstance(admission_aware_manifest_candidates, dict) else None
+    source_schema = admission_aware_manifest_candidates.get("schema_version") if isinstance(admission_aware_manifest_candidates, dict) else None
+    comparison = Counter(row["candidate_summary"].get("original_vs_admission_aware") for row in serialized)
+    envelope = {
+        "schema_version": "v3_1.admission_aware_manifest_serialization.1",
+        "run": {
+            "run_id": run_id,
+            "candidate_record_count": len(records),
+            "source_candidate_hash": source_hash,
+        },
+        "summary": {
+            "admission_aware_candidates_evaluated": len(records),
+            "serialized_manifest_count": len(serialized),
+            "excluded_count": len(excluded),
+            "production_affected_count": 0,
+            "production_output_affected": False,
+            "production_behavior_changed": False,
+            "production_default_routing_authorized": False,
+            "trusted_data_default_truth": False,
+            "deterministic": True,
+        },
+        "serialization_status_counts": {
+            status: counts[status]
+            for status in ADMISSION_AWARE_SERIALIZED_MANIFEST_STATUSES
+        },
+        "exclusion_reason_counts": dict(sorted(exclusion_reasons.items())),
+        "original_vs_admission_aware_comparison": dict(sorted(comparison.items())),
+        "serialized_manifests": serialized,
+        "excluded_candidates": excluded,
+        "input_consumption": {
+            "admission_aware_manifest_candidate_hash": source_hash,
+            "admission_aware_manifest_candidate_schema": source_schema,
+        },
+        "safety_confirmations": {
+            "serialized_manifests_are_production_approval": False,
+            "admission_aware_manifests_authorize_production_routing": False,
+            "admission_aware_manifests_are_production_authoritative": False,
+            "all_manifests_non_production_authoritative": all(
+                row.get("authorization_status", {}).get("authorization_state") == NON_PRODUCTION_AUTHORIZATION_STATE
+                and row.get("non_production_authoritative") is True
+                for row in serialized
+            ),
+            "legacy_planner_ownership_preserved": True,
+            "production_output_affected": False,
+            "production_behavior_changed": False,
+            "runtime_state_mutated": False,
+            "trusted_data_default_truth": False,
+        },
+        "metadata": {
+            "source": "v3_1_admission_aware_manifest_serialization",
+            "observational_only": True,
+            "production_consumer": False,
+            "production_behavior_changed": False,
+            "planner_remap_performed": False,
+            "production_default_routing_authorized": False,
+            "stable_generation_token": STABLE_ADMISSION_AWARE_SERIALIZATION_TOKEN,
+            "deterministic_serializer": "json_sort_keys_sha256",
+        },
+    }
+    envelope["deterministic_hash"] = deterministic_hash(envelope)
+    return envelope
+
+
+def _candidate_records(value: dict[str, Any] | list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if isinstance(value, list):
+        return [deepcopy(row) for row in value]
+    return [deepcopy(row) for row in value.get("manifest_candidates", [])]
+
+
+def _candidate_sort_key(candidate: dict[str, Any]) -> tuple[str, str]:
+    return (
+        str(candidate.get("fixture_set_id") or ""),
+        str(candidate.get("manifest_candidate_id") or ""),
+    )
+
+
+def _serialization_record(candidate: dict[str, Any]) -> dict[str, Any]:
+    status, reason_codes = _serialization_status(candidate)
+    if status != "serialized_manifest":
+        return {
+            "manifest_candidate_id": candidate.get("manifest_candidate_id"),
+            "fixture_set_id": candidate.get("fixture_set_id"),
+            "serialization_status": status,
+            "candidate_summary": _candidate_summary(candidate),
+            "authorization_status": _authorization_status(),
+            "reason_codes": reason_codes,
+            "production_output_affected": False,
+            "metadata": {
+                "observational_only": True,
+                "production_consumer": False,
+                "planner_remap_performed": False,
+            },
+        }
+
+    fixture_set_id = str(candidate.get("fixture_set_id") or "")
+    candidate_id = str(candidate.get("manifest_candidate_id") or "")
+    manifest_id = f"v3_1_admission_manifest_{deterministic_hash({'fixture_set_id': fixture_set_id, 'candidate_id': candidate_id, 'token': STABLE_ADMISSION_AWARE_SERIALIZATION_TOKEN})[:16]}"
+    manifest = {
+        "manifest_id": manifest_id,
+        "manifest_candidate_id": candidate.get("manifest_candidate_id"),
+        "fixture_set_id": candidate.get("fixture_set_id"),
+        "serialization_status": status,
+        "source_summary": deepcopy(candidate.get("source_summary") or {}),
+        "policy_summary": deepcopy(candidate.get("policy_summary") or {}),
+        "readiness_summary": deepcopy(candidate.get("readiness_summary") or {}),
+        "candidate_summary": _candidate_summary(candidate),
+        "authorization_status": _authorization_status(),
+        "non_production_authoritative": True,
+        "reason_codes": reason_codes,
+        "production_output_affected": False,
+        "metadata": {
+            "observational_only": True,
+            "production_consumer": False,
+            "planner_remap_performed": False,
+            "stable_generation_token": STABLE_ADMISSION_AWARE_SERIALIZATION_TOKEN,
+        },
+    }
+    manifest["generated_hash"] = deterministic_hash({"admission_aware_serialized_manifest": manifest})
+    return manifest
+
+
+def _serialization_status(candidate: dict[str, Any]) -> tuple[str, list[str]]:
+    status = candidate.get("candidate_status")
+    if not status:
+        return "excluded_missing_candidate_status", ["missing_candidate_status"]
+    if status == "candidate_ready":
+        return "serialized_manifest", ["admission_aware_candidate_ready_serialized_non_authoritative_manifest"]
+    if status in {"excluded_not_ready", "excluded_missing_admission_readiness", "excluded_invalid_readiness_state"}:
+        return "excluded_not_ready", list(candidate.get("reason_codes") or [f"candidate_status_{status}"])
+    return "excluded_invalid_candidate_state", [f"invalid_candidate_state_{status}"]
+
+
+def _candidate_summary(candidate: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "candidate_status": candidate.get("candidate_status"),
+        "original_candidate_status": candidate.get("original_candidate_status"),
+        "candidate_refresh_status": candidate.get("candidate_refresh_status"),
+        "original_vs_admission_aware": candidate.get("original_vs_admission_aware"),
+        "readiness_reclassification": candidate.get("readiness_reclassification"),
+        "candidate_is_non_production_authoritative": bool(candidate.get("non_production_authoritative", True)),
+    }
+
+
+def _authorization_status() -> dict[str, Any]:
+    return {
+        "authorization_state": NON_PRODUCTION_AUTHORIZATION_STATE,
+        "manifest_authorizes_production_routing": False,
+        "manifest_is_production_approved": False,
+        "manifest_is_production_authoritative": False,
+        "legacy_planner_ownership_preserved": True,
+        "trusted_default_routing": False,
+    }

--- a/backend/scripts/report_v3_1_admission_aware_manifest_serialization.py
+++ b/backend/scripts/report_v3_1_admission_aware_manifest_serialization.py
@@ -1,0 +1,142 @@
+"""Generate the v3.1 admission-aware manifest serialization report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.planner_adapters.v3_1.admission_aware_manifest_serialization import serialize_admission_aware_manifest_candidates  # noqa: E402
+
+
+DETERMINISTIC_GENERATED_AT = "2026-05-15T00:00:00+00:00"
+
+
+def build_v3_1_admission_aware_manifest_serialization_report() -> dict[str, Any]:
+    repo_root = Path(__file__).resolve().parents[2]
+    candidates = _read_json(repo_root / "docs" / "generated" / "v3_1_admission_aware_manifest_candidates_report.json")[
+        "admission_aware_manifest_candidates"
+    ]
+    serialization = serialize_admission_aware_manifest_candidates(admission_aware_manifest_candidates=candidates)
+    repeated = serialize_admission_aware_manifest_candidates(admission_aware_manifest_candidates=candidates)
+    report = {
+        "schema_version": "v3_1.admission_aware_manifest_serialization_report.1",
+        "generated_at": DETERMINISTIC_GENERATED_AT,
+        "phase": "v3.1_phase_15_admission_aware_manifest_serialization",
+        "recommendation": "OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING",
+        "production_default_routing_authorized": False,
+        "summary": {
+            **serialization["summary"],
+            "deterministic": serialization["deterministic_hash"] == repeated["deterministic_hash"],
+        },
+        "admission_aware_manifest_serialization": serialization,
+        "deterministic_guarantees": {
+            "passed": serialization["deterministic_hash"] == repeated["deterministic_hash"],
+            "sample_hash": serialization["deterministic_hash"],
+            "repeated_hash": repeated["deterministic_hash"],
+            "timestamp_excluded_from_hash": True,
+            "json_sort_keys": True,
+        },
+        "phase_15_boundaries": [
+            "admission-aware serialized manifests are observational governance artifacts",
+            "serialized manifests are not production approvals",
+            "serialized manifests do not authorize production routing",
+            "every manifest is explicitly non-production-authoritative",
+            "legacy planner ownership remains intact",
+        ],
+        "metadata": {
+            "source": "v3_1_admission_aware_manifest_serialization_report",
+            "observational_only": True,
+            "production_behavior_changed": False,
+            "production_default_routing_authorized": False,
+            "planner_remap_performed": False,
+        },
+    }
+    return _normalize_generated_at(report)
+
+
+def write_report(report: dict[str, Any], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_markdown(report: dict[str, Any], output_path: Path) -> None:
+    serialization = report["admission_aware_manifest_serialization"]
+    summary = report["summary"]
+    lines = [
+        "# V3.1 Admission-Aware Manifest Serialization",
+        "",
+        "Phase 15 serializes admission-aware candidate-ready fixture sets into non-production-authoritative manifests.",
+        "Serialized manifests are not production approvals and do not authorize routing.",
+        "",
+        "## Recommendation",
+        "",
+        f"- Recommendation: `{report['recommendation']}`",
+        f"- Production default routing authorized: `{str(report['production_default_routing_authorized']).lower()}`",
+        "",
+        "## Summary",
+        "",
+        f"- Admission-aware candidates evaluated: `{summary['admission_aware_candidates_evaluated']}`",
+        f"- Serialized manifests: `{summary['serialized_manifest_count']}`",
+        f"- Excluded: `{summary['excluded_count']}`",
+        f"- Production affected: `{summary['production_affected_count']}`",
+        f"- Deterministic: `{str(summary['deterministic']).lower()}`",
+        "",
+        "## Exclusion Reasons",
+        "",
+        "| Reason | Count |",
+        "| --- | ---: |",
+    ]
+    for reason, count in serialization["exclusion_reason_counts"].items():
+        lines.append(f"| `{reason}` | `{count}` |")
+    lines.extend(["", "## Original Vs Admission-Aware", "", "| Comparison | Count |", "| --- | ---: |"])
+    for item, count in serialization["original_vs_admission_aware_comparison"].items():
+        lines.append(f"| `{item}` | `{count}` |")
+    lines.extend(["", "## Serialized Manifests", "", "| Manifest | Fixture Set | Candidate | Authorization State |", "| --- | --- | --- | --- |"])
+    for row in serialization["serialized_manifests"]:
+        lines.append(
+            f"| `{row['manifest_id']}` | `{row['fixture_set_id']}` | `{row['manifest_candidate_id']}` | `{row['authorization_status']['authorization_state']}` |"
+        )
+    lines.extend(["", "## Phase 15 Boundaries", ""])
+    lines.extend(f"- {item}" for item in report["phase_15_boundaries"])
+    lines.extend(["", "## Conclusion", "", "Admission-aware manifest serialization is available for governance review, while production routing remains unchanged."])
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _normalize_generated_at(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: DETERMINISTIC_GENERATED_AT if key == "generated_at" else _normalize_generated_at(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_normalize_generated_at(item) for item in value]
+    return deepcopy(value)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", default="docs/generated/v3_1_admission_aware_manifest_serialization_report.json")
+    parser.add_argument("--markdown-output", default="docs/migration/V3_1_ADMISSION_AWARE_MANIFEST_SERIALIZATION.md")
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[2]
+    report = build_v3_1_admission_aware_manifest_serialization_report()
+    write_report(report, repo_root / args.output)
+    write_markdown(report, repo_root / args.markdown_output)
+    print(json.dumps(report["summary"], indent=2, sort_keys=True))
+    print(report["recommendation"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_v3_1_admission_aware_manifest_serialization.py
+++ b/backend/tests/test_v3_1_admission_aware_manifest_serialization.py
@@ -1,0 +1,103 @@
+from app.planner_adapters.v3_1.admission_aware_manifest_serialization import serialize_admission_aware_manifest_candidates
+from scripts.report_v3_1_admission_aware_manifest_serialization import build_v3_1_admission_aware_manifest_serialization_report
+
+
+def test_candidate_ready_records_serialize():
+    result = serialize_admission_aware_manifest_candidates(admission_aware_manifest_candidates=_candidates([_candidate("set_a")]))
+
+    assert result["summary"]["serialized_manifest_count"] == 1
+    manifest = result["serialized_manifests"][0]
+    assert manifest["fixture_set_id"] == "set_a"
+    assert manifest["non_production_authoritative"] is True
+    assert manifest["candidate_summary"]["original_vs_admission_aware"] == "excluded_not_ready_to_candidate_ready"
+
+
+def test_non_ready_records_are_excluded():
+    result = serialize_admission_aware_manifest_candidates(
+        admission_aware_manifest_candidates=_candidates([_candidate("set_a", status="excluded_not_ready", reasons=["still_blocked"])])
+    )
+
+    assert result["summary"]["serialized_manifest_count"] == 0
+    assert result["summary"]["excluded_count"] == 1
+    assert result["excluded_candidates"][0]["serialization_status"] == "excluded_not_ready"
+    assert result["exclusion_reason_counts"]["still_blocked"] == 1
+
+
+def test_manifest_hashes_remain_stable():
+    first = serialize_admission_aware_manifest_candidates(admission_aware_manifest_candidates=_candidates([_candidate("set_a")]))
+    second = serialize_admission_aware_manifest_candidates(admission_aware_manifest_candidates=_candidates([_candidate("set_a")]))
+
+    assert first["serialized_manifests"][0]["generated_hash"] == second["serialized_manifests"][0]["generated_hash"]
+    assert first["deterministic_hash"] == second["deterministic_hash"]
+
+
+def test_deterministic_ordering():
+    first = serialize_admission_aware_manifest_candidates(admission_aware_manifest_candidates=_candidates([_candidate("set_b"), _candidate("set_a")]))
+    second = serialize_admission_aware_manifest_candidates(admission_aware_manifest_candidates=_candidates([_candidate("set_a"), _candidate("set_b")]))
+
+    assert first["deterministic_hash"] == second["deterministic_hash"]
+    assert [row["fixture_set_id"] for row in first["serialized_manifests"]] == ["set_a", "set_b"]
+
+
+def test_stable_report_generation():
+    first = build_v3_1_admission_aware_manifest_serialization_report()
+    second = build_v3_1_admission_aware_manifest_serialization_report()
+
+    assert first["deterministic_guarantees"]["passed"] is True
+    assert first["admission_aware_manifest_serialization"]["deterministic_hash"] == second["admission_aware_manifest_serialization"]["deterministic_hash"]
+    assert first["summary"] == second["summary"]
+
+
+def test_all_manifests_remain_non_production_authoritative():
+    result = serialize_admission_aware_manifest_candidates(admission_aware_manifest_candidates=_candidates([_candidate("set_a")]))
+    manifest = result["serialized_manifests"][0]
+
+    assert result["safety_confirmations"]["all_manifests_non_production_authoritative"] is True
+    assert manifest["authorization_status"]["authorization_state"] == "non_production_authoritative"
+    assert manifest["authorization_status"]["manifest_is_production_authoritative"] is False
+    assert manifest["non_production_authoritative"] is True
+
+
+def test_no_production_routing_enablement():
+    result = serialize_admission_aware_manifest_candidates(admission_aware_manifest_candidates=_candidates([_candidate("set_a")]))
+    manifest = result["serialized_manifests"][0]
+
+    assert result["safety_confirmations"]["admission_aware_manifests_authorize_production_routing"] is False
+    assert result["safety_confirmations"]["serialized_manifests_are_production_approval"] is False
+    assert manifest["authorization_status"]["manifest_authorizes_production_routing"] is False
+    assert manifest["authorization_status"]["manifest_is_production_approved"] is False
+
+
+def _candidates(records):
+    return {
+        "schema_version": "v3_1.admission_aware_manifest_candidates.1",
+        "deterministic_hash": "candidate-hash",
+        "manifest_candidates": records,
+    }
+
+
+def _candidate(set_id, status="candidate_ready", reasons=None):
+    return {
+        "manifest_candidate_id": f"candidate_{set_id}",
+        "fixture_set_id": set_id,
+        "candidate_status": status,
+        "original_candidate_status": "excluded_not_ready",
+        "candidate_refresh_status": "promoted_to_candidate_ready_for_review",
+        "original_vs_admission_aware": "excluded_not_ready_to_candidate_ready",
+        "readiness_reclassification": "policy_blocker_cleared_by_admission_aware_policy",
+        "source_summary": {
+            "set_key": set_id,
+            "associated_fixture_ids": [f"fixture_{set_id}"],
+        },
+        "policy_summary": {
+            "admission_aware_policy_status": "policy_satisfied_for_review",
+            "valid_policy_state": True,
+        },
+        "readiness_summary": {
+            "admission_aware_readiness_status": "ready_for_approval_review",
+            "remaining_blockers": [],
+        },
+        "non_production_authoritative": True,
+        "reason_codes": reasons or ["admission_aware_ready_for_approval_review"],
+        "production_output_affected": False,
+    }

--- a/docs/generated/v3_1_admission_aware_manifest_serialization_report.json
+++ b/docs/generated/v3_1_admission_aware_manifest_serialization_report.json
@@ -1,0 +1,153 @@
+{
+  "admission_aware_manifest_serialization": {
+    "deterministic_hash": "8fa65134e7e0bf7f839c2ad01b22b26b7fc59c26787f23b7c13331fc5654ecda",
+    "excluded_candidates": [],
+    "exclusion_reason_counts": {},
+    "input_consumption": {
+      "admission_aware_manifest_candidate_hash": "8a0d679bc854e320f04e678c298cc3481e66b90b5b260bdcf6f410b4f1dd9464",
+      "admission_aware_manifest_candidate_schema": "v3_1.admission_aware_manifest_candidates.1"
+    },
+    "metadata": {
+      "deterministic_serializer": "json_sort_keys_sha256",
+      "observational_only": true,
+      "planner_remap_performed": false,
+      "production_behavior_changed": false,
+      "production_consumer": false,
+      "production_default_routing_authorized": false,
+      "source": "v3_1_admission_aware_manifest_serialization",
+      "stable_generation_token": "v3_1_phase_15_admission_aware_manifest_serialization_token"
+    },
+    "original_vs_admission_aware_comparison": {
+      "excluded_not_ready_to_candidate_ready": 1
+    },
+    "run": {
+      "candidate_record_count": 1,
+      "run_id": "v3_1_phase_15_admission_aware_manifest_serialization",
+      "source_candidate_hash": "8a0d679bc854e320f04e678c298cc3481e66b90b5b260bdcf6f410b4f1dd9464"
+    },
+    "safety_confirmations": {
+      "admission_aware_manifests_are_production_authoritative": false,
+      "admission_aware_manifests_authorize_production_routing": false,
+      "all_manifests_non_production_authoritative": true,
+      "legacy_planner_ownership_preserved": true,
+      "production_behavior_changed": false,
+      "production_output_affected": false,
+      "runtime_state_mutated": false,
+      "serialized_manifests_are_production_approval": false,
+      "trusted_data_default_truth": false
+    },
+    "schema_version": "v3_1.admission_aware_manifest_serialization.1",
+    "serialization_status_counts": {
+      "excluded_invalid_candidate_state": 0,
+      "excluded_missing_candidate_status": 0,
+      "excluded_not_ready": 0,
+      "serialized_manifest": 1
+    },
+    "serialized_manifests": [
+      {
+        "authorization_status": {
+          "authorization_state": "non_production_authoritative",
+          "legacy_planner_ownership_preserved": true,
+          "manifest_authorizes_production_routing": false,
+          "manifest_is_production_approved": false,
+          "manifest_is_production_authoritative": false,
+          "trusted_default_routing": false
+        },
+        "candidate_summary": {
+          "candidate_is_non_production_authoritative": true,
+          "candidate_refresh_status": "promoted_to_candidate_ready_for_review",
+          "candidate_status": "candidate_ready",
+          "original_candidate_status": "excluded_not_ready",
+          "original_vs_admission_aware": "excluded_not_ready_to_candidate_ready",
+          "readiness_reclassification": "policy_blocker_cleared_by_admission_aware_policy"
+        },
+        "fixture_set_id": "v3_1_fixture_set_6d3b668a84cfbb69",
+        "generated_hash": "9230965160579e9025fb5d8e357b60bca37dbeb6f2fe4a426a7654d472393659",
+        "manifest_candidate_id": "v3_1_admission_manifest_candidate_701e7dd28773d5d1",
+        "manifest_id": "v3_1_admission_manifest_198a3e2110f9e5e4",
+        "metadata": {
+          "observational_only": true,
+          "planner_remap_performed": false,
+          "production_consumer": false,
+          "stable_generation_token": "v3_1_phase_15_admission_aware_manifest_serialization_token"
+        },
+        "non_production_authoritative": true,
+        "policy_summary": {
+          "admission_aware_policy_status": "policy_satisfied_for_review",
+          "valid_policy_state": true
+        },
+        "production_output_affected": false,
+        "readiness_summary": {
+          "admission_aware_readiness_status": "ready_for_approval_review",
+          "original_block_reason_codes": [
+            "policy_unsupported"
+          ],
+          "original_readiness_status": "blocked_policy_failure",
+          "remaining_blockers": []
+        },
+        "reason_codes": [
+          "admission_aware_candidate_ready_serialized_non_authoritative_manifest"
+        ],
+        "serialization_status": "serialized_manifest",
+        "source_summary": {
+          "associated_fixture_ids": [
+            "v3_1_fixture_6c378a420c0a4ced",
+            "v3_1_fixture_756415e2e7d3feb2",
+            "v3_1_fixture_8118751ba1b46140",
+            "v3_1_fixture_9c3d260c0dda7b4f",
+            "v3_1_fixture_b82b601f9b088bb8"
+          ],
+          "set_key": "sample_migration_readiness_set"
+        }
+      }
+    ],
+    "summary": {
+      "admission_aware_candidates_evaluated": 1,
+      "deterministic": true,
+      "excluded_count": 0,
+      "production_affected_count": 0,
+      "production_behavior_changed": false,
+      "production_default_routing_authorized": false,
+      "production_output_affected": false,
+      "serialized_manifest_count": 1,
+      "trusted_data_default_truth": false
+    }
+  },
+  "deterministic_guarantees": {
+    "json_sort_keys": true,
+    "passed": true,
+    "repeated_hash": "8fa65134e7e0bf7f839c2ad01b22b26b7fc59c26787f23b7c13331fc5654ecda",
+    "sample_hash": "8fa65134e7e0bf7f839c2ad01b22b26b7fc59c26787f23b7c13331fc5654ecda",
+    "timestamp_excluded_from_hash": true
+  },
+  "generated_at": "2026-05-15T00:00:00+00:00",
+  "metadata": {
+    "observational_only": true,
+    "planner_remap_performed": false,
+    "production_behavior_changed": false,
+    "production_default_routing_authorized": false,
+    "source": "v3_1_admission_aware_manifest_serialization_report"
+  },
+  "phase": "v3.1_phase_15_admission_aware_manifest_serialization",
+  "phase_15_boundaries": [
+    "admission-aware serialized manifests are observational governance artifacts",
+    "serialized manifests are not production approvals",
+    "serialized manifests do not authorize production routing",
+    "every manifest is explicitly non-production-authoritative",
+    "legacy planner ownership remains intact"
+  ],
+  "production_default_routing_authorized": false,
+  "recommendation": "OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING",
+  "schema_version": "v3_1.admission_aware_manifest_serialization_report.1",
+  "summary": {
+    "admission_aware_candidates_evaluated": 1,
+    "deterministic": true,
+    "excluded_count": 0,
+    "production_affected_count": 0,
+    "production_behavior_changed": false,
+    "production_default_routing_authorized": false,
+    "production_output_affected": false,
+    "serialized_manifest_count": 1,
+    "trusted_data_default_truth": false
+  }
+}

--- a/docs/migration/V3_1_ADMISSION_AWARE_MANIFEST_SERIALIZATION.md
+++ b/docs/migration/V3_1_ADMISSION_AWARE_MANIFEST_SERIALIZATION.md
@@ -1,0 +1,46 @@
+# V3.1 Admission-Aware Manifest Serialization
+
+Phase 15 serializes admission-aware candidate-ready fixture sets into non-production-authoritative manifests.
+Serialized manifests are not production approvals and do not authorize routing.
+
+## Recommendation
+
+- Recommendation: `OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING`
+- Production default routing authorized: `false`
+
+## Summary
+
+- Admission-aware candidates evaluated: `1`
+- Serialized manifests: `1`
+- Excluded: `0`
+- Production affected: `0`
+- Deterministic: `true`
+
+## Exclusion Reasons
+
+| Reason | Count |
+| --- | ---: |
+
+## Original Vs Admission-Aware
+
+| Comparison | Count |
+| --- | ---: |
+| `excluded_not_ready_to_candidate_ready` | `1` |
+
+## Serialized Manifests
+
+| Manifest | Fixture Set | Candidate | Authorization State |
+| --- | --- | --- | --- |
+| `v3_1_admission_manifest_198a3e2110f9e5e4` | `v3_1_fixture_set_6d3b668a84cfbb69` | `v3_1_admission_manifest_candidate_701e7dd28773d5d1` | `non_production_authoritative` |
+
+## Phase 15 Boundaries
+
+- admission-aware serialized manifests are observational governance artifacts
+- serialized manifests are not production approvals
+- serialized manifests do not authorize production routing
+- every manifest is explicitly non-production-authoritative
+- legacy planner ownership remains intact
+
+## Conclusion
+
+Admission-aware manifest serialization is available for governance review, while production routing remains unchanged.


### PR DESCRIPTION
Adds deterministic admission-aware manifest serialization so candidate-ready fixture sets can produce non-production-authoritative serialized manifests without enabling production planner routing.