### PR TITLE
v3.1: add manifest consumption eligibility gate

### DIFF
--- a/backend/app/planner_adapters/v3_1/__init__.py
+++ b/backend/app/planner_adapters/v3_1/__init__.py
@@ -57,6 +57,10 @@ from .admission_aware_manifest_serialization import (
     ADMISSION_AWARE_SERIALIZED_MANIFEST_STATUSES,
     serialize_admission_aware_manifest_candidates,
 )
+from .manifest_consumption_eligibility import (
+    MANIFEST_CONSUMPTION_ELIGIBILITY_STATUSES,
+    evaluate_manifest_consumption_eligibility,
+)
 from .approval_manifest_diff_audit import (
     APPROVAL_MANIFEST_DIFF_CLASSIFICATIONS,
     audit_approval_manifest_diffs,
@@ -92,6 +96,7 @@ __all__ = [
     "ADMISSION_AWARE_READINESS_STATUSES",
     "ADMISSION_AWARE_MANIFEST_CANDIDATE_STATUSES",
     "ADMISSION_AWARE_SERIALIZED_MANIFEST_STATUSES",
+    "MANIFEST_CONSUMPTION_ELIGIBILITY_STATUSES",
     "APPROVAL_MANIFEST_DIFF_CLASSIFICATIONS",
     "SERIALIZED_APPROVAL_MANIFEST_STATUSES",
     "SUPPORTED_TRUSTED_SHADOW_DOMAINS",
@@ -115,6 +120,7 @@ __all__ = [
     "build_admission_aware_readiness_gate",
     "build_admission_aware_manifest_candidates",
     "serialize_admission_aware_manifest_candidates",
+    "evaluate_manifest_consumption_eligibility",
     "audit_approval_manifest_diffs",
     "discover_default_reviewed_fixture_input_sources",
     "deterministic_hash",

--- a/backend/app/planner_adapters/v3_1/manifest_consumption_eligibility.py
+++ b/backend/app/planner_adapters/v3_1/manifest_consumption_eligibility.py
@@ -1,0 +1,232 @@
+"""Manifest consumption eligibility gate for v3.1 governance.
+
+Eligibility here means a non-production-authoritative manifest is structurally
+eligible for future controlled test consumption only. It never authorizes
+runtime routing or production planner ownership changes.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from copy import deepcopy
+from typing import Any
+
+from .approval_manifest_serialization import NON_PRODUCTION_AUTHORIZATION_STATE
+from .trusted_shadow_consumption import deterministic_hash
+
+
+MANIFEST_CONSUMPTION_ELIGIBILITY_STATUSES = (
+    "eligible_for_controlled_test_consumption",
+    "blocked_missing_manifest",
+    "blocked_invalid_authorization_state",
+    "blocked_missing_identity",
+    "blocked_missing_hash",
+    "blocked_missing_source_summary",
+    "blocked_missing_policy_summary",
+    "blocked_missing_readiness_summary",
+    "blocked_missing_candidate_summary",
+    "blocked_unstable_manifest_hash",
+)
+STABLE_MANIFEST_CONSUMPTION_ELIGIBILITY_TOKEN = "v3_1_phase_16_manifest_consumption_eligibility_token"
+
+
+def evaluate_manifest_consumption_eligibility(
+    *,
+    admission_aware_manifest_serialization: dict[str, Any] | list[dict[str, Any]],
+    run_id: str = "v3_1_phase_16_manifest_consumption_eligibility",
+) -> dict[str, Any]:
+    """Evaluate manifests for controlled-test-consumption eligibility."""
+
+    manifests = _manifest_records(admission_aware_manifest_serialization)
+    records = [_eligibility_record(manifest) for manifest in sorted(manifests, key=_manifest_sort_key)]
+    if not records:
+        records = [_missing_manifest_record()]
+    counts = Counter(row["eligibility_status"] for row in records)
+    blocker_reasons = Counter(reason for row in records for reason in row["blockers"])
+    source_hash = admission_aware_manifest_serialization.get("deterministic_hash") if isinstance(admission_aware_manifest_serialization, dict) else None
+    source_schema = admission_aware_manifest_serialization.get("schema_version") if isinstance(admission_aware_manifest_serialization, dict) else None
+    envelope = {
+        "schema_version": "v3_1.manifest_consumption_eligibility.1",
+        "run": {
+            "run_id": run_id,
+            "manifest_count": len(manifests),
+            "source_serialization_hash": source_hash,
+            "source_serialization_schema": source_schema,
+        },
+        "summary": {
+            "manifests_evaluated": len(records),
+            "eligible_count": counts["eligible_for_controlled_test_consumption"],
+            "blocked_count": len(records) - counts["eligible_for_controlled_test_consumption"],
+            "production_affected_count": 0,
+            "production_output_affected": False,
+            "production_behavior_changed": False,
+            "production_default_routing_authorized": False,
+            "manifest_runtime_consumption_enabled": False,
+            "trusted_data_default_truth": False,
+            "deterministic": True,
+        },
+        "eligibility_status_counts": {
+            status: counts[status]
+            for status in MANIFEST_CONSUMPTION_ELIGIBILITY_STATUSES
+        },
+        "blocker_reason_counts": dict(sorted(blocker_reasons.items())),
+        "eligibility_summary": {
+            "eligible_for_controlled_test_consumption_only": counts["eligible_for_controlled_test_consumption"],
+            "blocked_from_controlled_test_consumption": len(records) - counts["eligible_for_controlled_test_consumption"],
+            "production_routing_authorized": False,
+            "runtime_consumption_enabled": False,
+        },
+        "eligibility_records": records,
+        "safety_confirmations": {
+            "eligibility_authorizes_production_routing": False,
+            "eligibility_enables_runtime_consumption": False,
+            "eligible_manifests_are_production_approved": False,
+            "eligible_manifests_are_production_authoritative": False,
+            "legacy_planner_ownership_preserved": True,
+            "production_output_affected": False,
+            "production_behavior_changed": False,
+            "runtime_state_mutated": False,
+            "trusted_data_default_truth": False,
+        },
+        "metadata": {
+            "source": "v3_1_manifest_consumption_eligibility",
+            "observational_only": True,
+            "production_consumer": False,
+            "production_behavior_changed": False,
+            "planner_remap_performed": False,
+            "production_default_routing_authorized": False,
+            "controlled_test_consumption_only": True,
+            "stable_generation_token": STABLE_MANIFEST_CONSUMPTION_ELIGIBILITY_TOKEN,
+            "deterministic_serializer": "json_sort_keys_sha256",
+        },
+    }
+    envelope["deterministic_hash"] = deterministic_hash(envelope)
+    return envelope
+
+
+def _manifest_records(value: dict[str, Any] | list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if isinstance(value, list):
+        return [deepcopy(row) for row in value]
+    return [deepcopy(row) for row in value.get("serialized_manifests", [])]
+
+
+def _manifest_sort_key(manifest: dict[str, Any]) -> tuple[str, str]:
+    return (
+        str(manifest.get("fixture_set_id") or ""),
+        str(manifest.get("manifest_id") or ""),
+    )
+
+
+def _eligibility_record(manifest: dict[str, Any]) -> dict[str, Any]:
+    audit = _required_field_audit(manifest)
+    blockers = _blockers(manifest=manifest, audit=audit)
+    status = blockers[0] if blockers else "eligible_for_controlled_test_consumption"
+    manifest_id = manifest.get("manifest_id")
+    seed = {
+        "manifest_id": manifest_id,
+        "fixture_set_id": manifest.get("fixture_set_id"),
+        "status": status,
+        "token": STABLE_MANIFEST_CONSUMPTION_ELIGIBILITY_TOKEN,
+    }
+    return {
+        "eligibility_record_id": f"v3_1_manifest_eligibility_{deterministic_hash(seed)[:16]}",
+        "manifest_id": manifest_id,
+        "fixture_set_id": manifest.get("fixture_set_id"),
+        "authorization_state": (manifest.get("authorization_status") or {}).get("authorization_state"),
+        "eligibility_status": status,
+        "blockers": blockers,
+        "required_field_audit": audit,
+        "generated_hash": manifest.get("generated_hash"),
+        "controlled_test_consumption_only": True,
+        "eligibility_authorizes_production_routing": False,
+        "production_output_affected": False,
+        "metadata": {
+            "observational_only": True,
+            "production_consumer": False,
+            "planner_remap_performed": False,
+        },
+    }
+
+
+def _missing_manifest_record() -> dict[str, Any]:
+    seed = {
+        "missing_manifest": True,
+        "token": STABLE_MANIFEST_CONSUMPTION_ELIGIBILITY_TOKEN,
+    }
+    return {
+        "eligibility_record_id": f"v3_1_manifest_eligibility_{deterministic_hash(seed)[:16]}",
+        "manifest_id": None,
+        "fixture_set_id": None,
+        "authorization_state": None,
+        "eligibility_status": "blocked_missing_manifest",
+        "blockers": ["blocked_missing_manifest"],
+        "required_field_audit": {
+            "manifest_present": False,
+            "identity_present": False,
+            "generated_hash_present": False,
+            "generated_hash_stable": False,
+            "source_summary_present": False,
+            "policy_summary_present": False,
+            "readiness_summary_present": False,
+            "candidate_summary_present": False,
+            "non_production_authoritative": False,
+        },
+        "generated_hash": None,
+        "controlled_test_consumption_only": True,
+        "eligibility_authorizes_production_routing": False,
+        "production_output_affected": False,
+        "metadata": {
+            "observational_only": True,
+            "production_consumer": False,
+            "planner_remap_performed": False,
+        },
+    }
+
+
+def _blockers(*, manifest: dict[str, Any], audit: dict[str, bool]) -> list[str]:
+    ordered_checks = [
+        ("blocked_invalid_authorization_state", not audit["non_production_authoritative"]),
+        ("blocked_missing_identity", not audit["identity_present"]),
+        ("blocked_missing_hash", not audit["generated_hash_present"]),
+        ("blocked_missing_source_summary", not audit["source_summary_present"]),
+        ("blocked_missing_policy_summary", not audit["policy_summary_present"]),
+        ("blocked_missing_readiness_summary", not audit["readiness_summary_present"]),
+        ("blocked_missing_candidate_summary", not audit["candidate_summary_present"]),
+        ("blocked_unstable_manifest_hash", audit["generated_hash_present"] and not audit["generated_hash_stable"]),
+    ]
+    return [reason for reason, blocked in ordered_checks if blocked]
+
+
+def _required_field_audit(manifest: dict[str, Any]) -> dict[str, bool]:
+    return {
+        "manifest_present": True,
+        "identity_present": bool(manifest.get("manifest_id") and manifest.get("fixture_set_id")),
+        "generated_hash_present": bool(manifest.get("generated_hash")),
+        "generated_hash_stable": _generated_hash_is_stable(manifest),
+        "source_summary_present": bool(manifest.get("source_summary")),
+        "policy_summary_present": bool(manifest.get("policy_summary")),
+        "readiness_summary_present": bool(manifest.get("readiness_summary")),
+        "candidate_summary_present": bool(manifest.get("candidate_summary")),
+        "non_production_authoritative": _is_non_production_authoritative(manifest),
+    }
+
+
+def _is_non_production_authoritative(manifest: dict[str, Any]) -> bool:
+    authorization = manifest.get("authorization_status") or {}
+    return (
+        manifest.get("non_production_authoritative") is True
+        and authorization.get("authorization_state") == NON_PRODUCTION_AUTHORIZATION_STATE
+        and authorization.get("manifest_authorizes_production_routing") is False
+        and authorization.get("manifest_is_production_approved") is False
+        and authorization.get("manifest_is_production_authoritative") is False
+    )
+
+
+def _generated_hash_is_stable(manifest: dict[str, Any]) -> bool:
+    current_hash = manifest.get("generated_hash")
+    if not current_hash:
+        return False
+    payload = deepcopy(manifest)
+    payload.pop("generated_hash", None)
+    expected = deterministic_hash({"admission_aware_serialized_manifest": payload})
+    return current_hash == expected

--- a/backend/scripts/report_v3_1_manifest_consumption_eligibility.py
+++ b/backend/scripts/report_v3_1_manifest_consumption_eligibility.py
@@ -1,0 +1,143 @@
+"""Generate the v3.1 manifest consumption eligibility report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.planner_adapters.v3_1.manifest_consumption_eligibility import evaluate_manifest_consumption_eligibility  # noqa: E402
+
+
+DETERMINISTIC_GENERATED_AT = "2026-05-15T00:00:00+00:00"
+
+
+def build_v3_1_manifest_consumption_eligibility_report() -> dict[str, Any]:
+    repo_root = Path(__file__).resolve().parents[2]
+    serialization = _read_json(repo_root / "docs" / "generated" / "v3_1_admission_aware_manifest_serialization_report.json")[
+        "admission_aware_manifest_serialization"
+    ]
+    eligibility = evaluate_manifest_consumption_eligibility(admission_aware_manifest_serialization=serialization)
+    repeated = evaluate_manifest_consumption_eligibility(admission_aware_manifest_serialization=serialization)
+    report = {
+        "schema_version": "v3_1.manifest_consumption_eligibility_report.1",
+        "generated_at": DETERMINISTIC_GENERATED_AT,
+        "phase": "v3.1_phase_16_manifest_consumption_eligibility",
+        "recommendation": "OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING",
+        "production_default_routing_authorized": False,
+        "runtime_manifest_consumption_enabled": False,
+        "controlled_test_consumption_only": True,
+        "summary": {
+            **eligibility["summary"],
+            "deterministic": eligibility["deterministic_hash"] == repeated["deterministic_hash"],
+        },
+        "manifest_consumption_eligibility": eligibility,
+        "deterministic_guarantees": {
+            "passed": eligibility["deterministic_hash"] == repeated["deterministic_hash"],
+            "sample_hash": eligibility["deterministic_hash"],
+            "repeated_hash": repeated["deterministic_hash"],
+            "timestamp_excluded_from_hash": True,
+            "json_sort_keys": True,
+        },
+        "phase_16_boundaries": [
+            "eligibility is for controlled test consumption only",
+            "eligibility does not authorize production routing",
+            "eligible manifests are not production approvals",
+            "runtime manifest consumption remains disabled",
+            "legacy planner ownership remains intact",
+        ],
+        "metadata": {
+            "source": "v3_1_manifest_consumption_eligibility_report",
+            "observational_only": True,
+            "production_behavior_changed": False,
+            "production_default_routing_authorized": False,
+            "planner_remap_performed": False,
+            "controlled_test_consumption_only": True,
+        },
+    }
+    return _normalize_generated_at(report)
+
+
+def write_report(report: dict[str, Any], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_markdown(report: dict[str, Any], output_path: Path) -> None:
+    eligibility = report["manifest_consumption_eligibility"]
+    summary = report["summary"]
+    lines = [
+        "# V3.1 Manifest Consumption Eligibility",
+        "",
+        "Phase 16 evaluates non-production-authoritative manifests for controlled test consumption eligibility only.",
+        "Eligibility does not authorize production routing or runtime manifest consumption.",
+        "",
+        "## Recommendation",
+        "",
+        f"- Recommendation: `{report['recommendation']}`",
+        f"- Production default routing authorized: `{str(report['production_default_routing_authorized']).lower()}`",
+        f"- Runtime manifest consumption enabled: `{str(report['runtime_manifest_consumption_enabled']).lower()}`",
+        "",
+        "## Summary",
+        "",
+        f"- Manifests evaluated: `{summary['manifests_evaluated']}`",
+        f"- Eligible: `{summary['eligible_count']}`",
+        f"- Blocked: `{summary['blocked_count']}`",
+        f"- Production affected: `{summary['production_affected_count']}`",
+        f"- Deterministic: `{str(summary['deterministic']).lower()}`",
+        "",
+        "## Blocker Reasons",
+        "",
+        "| Reason | Count |",
+        "| --- | ---: |",
+    ]
+    for reason, count in eligibility["blocker_reason_counts"].items():
+        lines.append(f"| `{reason}` | `{count}` |")
+    lines.extend(["", "## Eligibility Records", "", "| Record | Manifest | Fixture Set | Status | Authorization |", "| --- | --- | --- | --- | --- |"])
+    for row in eligibility["eligibility_records"]:
+        lines.append(
+            f"| `{row['eligibility_record_id']}` | `{row['manifest_id'] or ''}` | `{row['fixture_set_id'] or ''}` | `{row['eligibility_status']}` | `{row['authorization_state'] or ''}` |"
+        )
+    lines.extend(["", "## Phase 16 Boundaries", ""])
+    lines.extend(f"- {item}" for item in report["phase_16_boundaries"])
+    lines.extend(["", "## Conclusion", "", "Manifest eligibility is available for controlled test planning only, while production routing remains unchanged."])
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _normalize_generated_at(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: DETERMINISTIC_GENERATED_AT if key == "generated_at" else _normalize_generated_at(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_normalize_generated_at(item) for item in value]
+    return deepcopy(value)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", default="docs/generated/v3_1_manifest_consumption_eligibility_report.json")
+    parser.add_argument("--markdown-output", default="docs/migration/V3_1_MANIFEST_CONSUMPTION_ELIGIBILITY.md")
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[2]
+    report = build_v3_1_manifest_consumption_eligibility_report()
+    write_report(report, repo_root / args.output)
+    write_markdown(report, repo_root / args.markdown_output)
+    print(json.dumps(report["summary"], indent=2, sort_keys=True))
+    print(report["recommendation"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_v3_1_manifest_consumption_eligibility.py
+++ b/backend/tests/test_v3_1_manifest_consumption_eligibility.py
@@ -1,0 +1,137 @@
+from copy import deepcopy
+
+from app.planner_adapters.v3_1.manifest_consumption_eligibility import evaluate_manifest_consumption_eligibility
+from app.planner_adapters.v3_1.trusted_shadow_consumption import deterministic_hash
+from scripts.report_v3_1_manifest_consumption_eligibility import build_v3_1_manifest_consumption_eligibility_report
+
+
+def test_valid_non_production_manifest_becomes_eligible():
+    result = evaluate_manifest_consumption_eligibility(admission_aware_manifest_serialization=_serialization([_manifest("set_a")]))
+
+    record = result["eligibility_records"][0]
+    assert record["eligibility_status"] == "eligible_for_controlled_test_consumption"
+    assert record["blockers"] == []
+    assert result["summary"]["eligible_count"] == 1
+
+
+def test_invalid_authorization_state_blocks():
+    manifest = _manifest("set_a")
+    manifest["authorization_status"]["authorization_state"] = "production_authoritative"
+    manifest["generated_hash"] = _hash_manifest(manifest)
+    result = evaluate_manifest_consumption_eligibility(admission_aware_manifest_serialization=_serialization([manifest]))
+
+    assert result["eligibility_records"][0]["eligibility_status"] == "blocked_invalid_authorization_state"
+    assert "blocked_invalid_authorization_state" in result["eligibility_records"][0]["blockers"]
+
+
+def test_missing_required_fields_block():
+    manifest = _manifest("set_a")
+    manifest.pop("source_summary")
+    manifest.pop("policy_summary")
+    manifest.pop("readiness_summary")
+    manifest.pop("candidate_summary")
+    manifest["generated_hash"] = _hash_manifest(manifest)
+    result = evaluate_manifest_consumption_eligibility(admission_aware_manifest_serialization=_serialization([manifest]))
+
+    record = result["eligibility_records"][0]
+    assert record["eligibility_status"] == "blocked_missing_source_summary"
+    assert "blocked_missing_policy_summary" in record["blockers"]
+    assert "blocked_missing_readiness_summary" in record["blockers"]
+    assert "blocked_missing_candidate_summary" in record["blockers"]
+
+
+def test_missing_hash_blocks():
+    manifest = _manifest("set_a")
+    manifest.pop("generated_hash")
+    result = evaluate_manifest_consumption_eligibility(admission_aware_manifest_serialization=_serialization([manifest]))
+
+    assert result["eligibility_records"][0]["eligibility_status"] == "blocked_missing_hash"
+
+
+def test_unstable_hash_blocks():
+    manifest = _manifest("set_a")
+    manifest["generated_hash"] = "unstable"
+    result = evaluate_manifest_consumption_eligibility(admission_aware_manifest_serialization=_serialization([manifest]))
+
+    assert result["eligibility_records"][0]["eligibility_status"] == "blocked_unstable_manifest_hash"
+
+
+def test_missing_manifest_blocks():
+    result = evaluate_manifest_consumption_eligibility(admission_aware_manifest_serialization=_serialization([]))
+
+    assert result["eligibility_records"][0]["eligibility_status"] == "blocked_missing_manifest"
+    assert result["summary"]["blocked_count"] == 1
+
+
+def test_deterministic_ordering():
+    first = evaluate_manifest_consumption_eligibility(admission_aware_manifest_serialization=_serialization([_manifest("set_b"), _manifest("set_a")]))
+    second = evaluate_manifest_consumption_eligibility(admission_aware_manifest_serialization=_serialization([_manifest("set_a"), _manifest("set_b")]))
+
+    assert first["deterministic_hash"] == second["deterministic_hash"]
+    assert [row["fixture_set_id"] for row in first["eligibility_records"]] == ["set_a", "set_b"]
+
+
+def test_stable_report_generation():
+    first = build_v3_1_manifest_consumption_eligibility_report()
+    second = build_v3_1_manifest_consumption_eligibility_report()
+
+    assert first["deterministic_guarantees"]["passed"] is True
+    assert first["manifest_consumption_eligibility"]["deterministic_hash"] == second["manifest_consumption_eligibility"]["deterministic_hash"]
+    assert first["summary"] == second["summary"]
+
+
+def test_no_production_routing_enablement():
+    result = evaluate_manifest_consumption_eligibility(admission_aware_manifest_serialization=_serialization([_manifest("set_a")]))
+    record = result["eligibility_records"][0]
+
+    assert result["safety_confirmations"]["eligibility_authorizes_production_routing"] is False
+    assert result["safety_confirmations"]["eligibility_enables_runtime_consumption"] is False
+    assert result["summary"]["manifest_runtime_consumption_enabled"] is False
+    assert record["controlled_test_consumption_only"] is True
+    assert record["eligibility_authorizes_production_routing"] is False
+
+
+def _serialization(manifests):
+    return {
+        "schema_version": "v3_1.admission_aware_manifest_serialization.1",
+        "deterministic_hash": "serialization-hash",
+        "serialized_manifests": manifests,
+    }
+
+
+def _manifest(set_id):
+    manifest = {
+        "manifest_id": f"manifest_{set_id}",
+        "manifest_candidate_id": f"candidate_{set_id}",
+        "fixture_set_id": set_id,
+        "serialization_status": "serialized_manifest",
+        "source_summary": {"set_key": set_id, "associated_fixture_ids": [f"fixture_{set_id}"]},
+        "policy_summary": {"admission_aware_policy_status": "policy_satisfied_for_review", "valid_policy_state": True},
+        "readiness_summary": {"admission_aware_readiness_status": "ready_for_approval_review", "remaining_blockers": []},
+        "candidate_summary": {"candidate_status": "candidate_ready", "original_vs_admission_aware": "excluded_not_ready_to_candidate_ready"},
+        "authorization_status": {
+            "authorization_state": "non_production_authoritative",
+            "manifest_authorizes_production_routing": False,
+            "manifest_is_production_approved": False,
+            "manifest_is_production_authoritative": False,
+            "legacy_planner_ownership_preserved": True,
+            "trusted_default_routing": False,
+        },
+        "non_production_authoritative": True,
+        "reason_codes": ["admission_aware_candidate_ready_serialized_non_authoritative_manifest"],
+        "production_output_affected": False,
+        "metadata": {
+            "observational_only": True,
+            "production_consumer": False,
+            "planner_remap_performed": False,
+            "stable_generation_token": "v3_1_phase_15_admission_aware_manifest_serialization_token",
+        },
+    }
+    manifest["generated_hash"] = _hash_manifest(manifest)
+    return manifest
+
+
+def _hash_manifest(manifest):
+    payload = deepcopy(manifest)
+    payload.pop("generated_hash", None)
+    return deterministic_hash({"admission_aware_serialized_manifest": payload})

--- a/docs/generated/v3_1_manifest_consumption_eligibility_report.json
+++ b/docs/generated/v3_1_manifest_consumption_eligibility_report.json
@@ -1,0 +1,136 @@
+{
+  "controlled_test_consumption_only": true,
+  "deterministic_guarantees": {
+    "json_sort_keys": true,
+    "passed": true,
+    "repeated_hash": "e5776401439dbe2ac5feef32f9c0ae924d7769f691ea3e90fcb1774f39fcbbf4",
+    "sample_hash": "e5776401439dbe2ac5feef32f9c0ae924d7769f691ea3e90fcb1774f39fcbbf4",
+    "timestamp_excluded_from_hash": true
+  },
+  "generated_at": "2026-05-15T00:00:00+00:00",
+  "manifest_consumption_eligibility": {
+    "blocker_reason_counts": {},
+    "deterministic_hash": "e5776401439dbe2ac5feef32f9c0ae924d7769f691ea3e90fcb1774f39fcbbf4",
+    "eligibility_records": [
+      {
+        "authorization_state": "non_production_authoritative",
+        "blockers": [],
+        "controlled_test_consumption_only": true,
+        "eligibility_authorizes_production_routing": false,
+        "eligibility_record_id": "v3_1_manifest_eligibility_7ba501d6d4a04a67",
+        "eligibility_status": "eligible_for_controlled_test_consumption",
+        "fixture_set_id": "v3_1_fixture_set_6d3b668a84cfbb69",
+        "generated_hash": "9230965160579e9025fb5d8e357b60bca37dbeb6f2fe4a426a7654d472393659",
+        "manifest_id": "v3_1_admission_manifest_198a3e2110f9e5e4",
+        "metadata": {
+          "observational_only": true,
+          "planner_remap_performed": false,
+          "production_consumer": false
+        },
+        "production_output_affected": false,
+        "required_field_audit": {
+          "candidate_summary_present": true,
+          "generated_hash_present": true,
+          "generated_hash_stable": true,
+          "identity_present": true,
+          "manifest_present": true,
+          "non_production_authoritative": true,
+          "policy_summary_present": true,
+          "readiness_summary_present": true,
+          "source_summary_present": true
+        }
+      }
+    ],
+    "eligibility_status_counts": {
+      "blocked_invalid_authorization_state": 0,
+      "blocked_missing_candidate_summary": 0,
+      "blocked_missing_hash": 0,
+      "blocked_missing_identity": 0,
+      "blocked_missing_manifest": 0,
+      "blocked_missing_policy_summary": 0,
+      "blocked_missing_readiness_summary": 0,
+      "blocked_missing_source_summary": 0,
+      "blocked_unstable_manifest_hash": 0,
+      "eligible_for_controlled_test_consumption": 1
+    },
+    "eligibility_summary": {
+      "blocked_from_controlled_test_consumption": 0,
+      "eligible_for_controlled_test_consumption_only": 1,
+      "production_routing_authorized": false,
+      "runtime_consumption_enabled": false
+    },
+    "metadata": {
+      "controlled_test_consumption_only": true,
+      "deterministic_serializer": "json_sort_keys_sha256",
+      "observational_only": true,
+      "planner_remap_performed": false,
+      "production_behavior_changed": false,
+      "production_consumer": false,
+      "production_default_routing_authorized": false,
+      "source": "v3_1_manifest_consumption_eligibility",
+      "stable_generation_token": "v3_1_phase_16_manifest_consumption_eligibility_token"
+    },
+    "run": {
+      "manifest_count": 1,
+      "run_id": "v3_1_phase_16_manifest_consumption_eligibility",
+      "source_serialization_hash": "8fa65134e7e0bf7f839c2ad01b22b26b7fc59c26787f23b7c13331fc5654ecda",
+      "source_serialization_schema": "v3_1.admission_aware_manifest_serialization.1"
+    },
+    "safety_confirmations": {
+      "eligibility_authorizes_production_routing": false,
+      "eligibility_enables_runtime_consumption": false,
+      "eligible_manifests_are_production_approved": false,
+      "eligible_manifests_are_production_authoritative": false,
+      "legacy_planner_ownership_preserved": true,
+      "production_behavior_changed": false,
+      "production_output_affected": false,
+      "runtime_state_mutated": false,
+      "trusted_data_default_truth": false
+    },
+    "schema_version": "v3_1.manifest_consumption_eligibility.1",
+    "summary": {
+      "blocked_count": 0,
+      "deterministic": true,
+      "eligible_count": 1,
+      "manifest_runtime_consumption_enabled": false,
+      "manifests_evaluated": 1,
+      "production_affected_count": 0,
+      "production_behavior_changed": false,
+      "production_default_routing_authorized": false,
+      "production_output_affected": false,
+      "trusted_data_default_truth": false
+    }
+  },
+  "metadata": {
+    "controlled_test_consumption_only": true,
+    "observational_only": true,
+    "planner_remap_performed": false,
+    "production_behavior_changed": false,
+    "production_default_routing_authorized": false,
+    "source": "v3_1_manifest_consumption_eligibility_report"
+  },
+  "phase": "v3.1_phase_16_manifest_consumption_eligibility",
+  "phase_16_boundaries": [
+    "eligibility is for controlled test consumption only",
+    "eligibility does not authorize production routing",
+    "eligible manifests are not production approvals",
+    "runtime manifest consumption remains disabled",
+    "legacy planner ownership remains intact"
+  ],
+  "production_default_routing_authorized": false,
+  "recommendation": "OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING",
+  "runtime_manifest_consumption_enabled": false,
+  "schema_version": "v3_1.manifest_consumption_eligibility_report.1",
+  "summary": {
+    "blocked_count": 0,
+    "deterministic": true,
+    "eligible_count": 1,
+    "manifest_runtime_consumption_enabled": false,
+    "manifests_evaluated": 1,
+    "production_affected_count": 0,
+    "production_behavior_changed": false,
+    "production_default_routing_authorized": false,
+    "production_output_affected": false,
+    "trusted_data_default_truth": false
+  }
+}

--- a/docs/migration/V3_1_MANIFEST_CONSUMPTION_ELIGIBILITY.md
+++ b/docs/migration/V3_1_MANIFEST_CONSUMPTION_ELIGIBILITY.md
@@ -1,0 +1,41 @@
+# V3.1 Manifest Consumption Eligibility
+
+Phase 16 evaluates non-production-authoritative manifests for controlled test consumption eligibility only.
+Eligibility does not authorize production routing or runtime manifest consumption.
+
+## Recommendation
+
+- Recommendation: `OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING`
+- Production default routing authorized: `false`
+- Runtime manifest consumption enabled: `false`
+
+## Summary
+
+- Manifests evaluated: `1`
+- Eligible: `1`
+- Blocked: `0`
+- Production affected: `0`
+- Deterministic: `true`
+
+## Blocker Reasons
+
+| Reason | Count |
+| --- | ---: |
+
+## Eligibility Records
+
+| Record | Manifest | Fixture Set | Status | Authorization |
+| --- | --- | --- | --- | --- |
+| `v3_1_manifest_eligibility_7ba501d6d4a04a67` | `v3_1_admission_manifest_198a3e2110f9e5e4` | `v3_1_fixture_set_6d3b668a84cfbb69` | `eligible_for_controlled_test_consumption` | `non_production_authoritative` |
+
+## Phase 16 Boundaries
+
+- eligibility is for controlled test consumption only
+- eligibility does not authorize production routing
+- eligible manifests are not production approvals
+- runtime manifest consumption remains disabled
+- legacy planner ownership remains intact
+
+## Conclusion
+
+Manifest eligibility is available for controlled test planning only, while production routing remains unchanged.


### PR DESCRIPTION
Adds deterministic manifest consumption eligibility gating for controlled test consumption while preserving non-production authorization and preventing planner routing changes.