### PR TITLE
v3.1: add controlled test consumption adapter

### DIFF
--- a/backend/app/planner_adapters/v3_1/__init__.py
+++ b/backend/app/planner_adapters/v3_1/__init__.py
@@ -61,6 +61,10 @@ from .manifest_consumption_eligibility import (
     MANIFEST_CONSUMPTION_ELIGIBILITY_STATUSES,
     evaluate_manifest_consumption_eligibility,
 )
+from .controlled_test_consumption import (
+    CONTROLLED_TEST_CONSUMPTION_STATUSES,
+    build_controlled_test_consumption,
+)
 from .approval_manifest_diff_audit import (
     APPROVAL_MANIFEST_DIFF_CLASSIFICATIONS,
     audit_approval_manifest_diffs,
@@ -97,6 +101,7 @@ __all__ = [
     "ADMISSION_AWARE_MANIFEST_CANDIDATE_STATUSES",
     "ADMISSION_AWARE_SERIALIZED_MANIFEST_STATUSES",
     "MANIFEST_CONSUMPTION_ELIGIBILITY_STATUSES",
+    "CONTROLLED_TEST_CONSUMPTION_STATUSES",
     "APPROVAL_MANIFEST_DIFF_CLASSIFICATIONS",
     "SERIALIZED_APPROVAL_MANIFEST_STATUSES",
     "SUPPORTED_TRUSTED_SHADOW_DOMAINS",
@@ -121,6 +126,7 @@ __all__ = [
     "build_admission_aware_manifest_candidates",
     "serialize_admission_aware_manifest_candidates",
     "evaluate_manifest_consumption_eligibility",
+    "build_controlled_test_consumption",
     "audit_approval_manifest_diffs",
     "discover_default_reviewed_fixture_input_sources",
     "deterministic_hash",

--- a/backend/app/planner_adapters/v3_1/controlled_test_consumption.py
+++ b/backend/app/planner_adapters/v3_1/controlled_test_consumption.py
@@ -1,0 +1,190 @@
+"""Controlled test consumption adapter for v3.1 manifests.
+
+This module is runtime-isolated governance infrastructure. It can consume
+eligible non-production manifests only when explicitly invoked in controlled
+test mode, and it never connects to production planner routing.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from copy import deepcopy
+from typing import Any
+
+from .approval_manifest_serialization import NON_PRODUCTION_AUTHORIZATION_STATE
+from .trusted_shadow_consumption import deterministic_hash
+
+
+CONTROLLED_TEST_CONSUMPTION_STATUSES = (
+    "consumed_in_controlled_test",
+    "blocked_not_eligible",
+    "blocked_invalid_authorization_state",
+    "blocked_missing_manifest",
+    "blocked_missing_eligibility_record",
+    "blocked_runtime_consumption_disabled",
+)
+STABLE_CONTROLLED_TEST_CONSUMPTION_TOKEN = "v3_1_phase_17_controlled_test_consumption_token"
+
+
+def build_controlled_test_consumption(
+    *,
+    manifest_consumption_eligibility: dict[str, Any],
+    admission_aware_manifest_serialization: dict[str, Any],
+    controlled_test_mode: bool = False,
+    run_id: str = "v3_1_phase_17_controlled_test_consumption",
+) -> dict[str, Any]:
+    """Build controlled test consumption records from eligible manifests only."""
+
+    eligibility_by_manifest = {
+        str(row.get("manifest_id") or ""): deepcopy(row)
+        for row in manifest_consumption_eligibility.get("eligibility_records", [])
+        if row.get("manifest_id")
+    }
+    manifests_by_id = {
+        str(row.get("manifest_id") or ""): deepcopy(row)
+        for row in admission_aware_manifest_serialization.get("serialized_manifests", [])
+        if row.get("manifest_id")
+    }
+    manifest_ids = sorted(set(eligibility_by_manifest) | set(manifests_by_id))
+    if not manifest_ids:
+        manifest_ids = [""]
+    records = [
+        _consumption_record(
+            manifest_id=manifest_id,
+            eligibility=eligibility_by_manifest.get(manifest_id),
+            manifest=manifests_by_id.get(manifest_id),
+            controlled_test_mode=controlled_test_mode,
+        )
+        for manifest_id in manifest_ids
+    ]
+    counts = Counter(row["controlled_consumption_status"] for row in records)
+    blocker_reasons = Counter(reason for row in records for reason in row["blockers"])
+    envelope = {
+        "schema_version": "v3_1.controlled_test_consumption.1",
+        "run": {
+            "run_id": run_id,
+            "controlled_test_mode": controlled_test_mode,
+            "eligibility_record_count": len(eligibility_by_manifest),
+            "manifest_record_count": len(manifests_by_id),
+            "manifest_consumption_eligibility_hash": manifest_consumption_eligibility.get("deterministic_hash"),
+            "admission_aware_manifest_serialization_hash": admission_aware_manifest_serialization.get("deterministic_hash"),
+        },
+        "summary": {
+            "manifests_evaluated": len(records),
+            "controlled_test_consumed_count": counts["consumed_in_controlled_test"],
+            "blocked_count": len(records) - counts["consumed_in_controlled_test"],
+            "runtime_production_consumption_enabled": False,
+            "runtime_manifest_consumption_enabled": False,
+            "production_affected_count": 0,
+            "production_output_affected": False,
+            "production_behavior_changed": False,
+            "production_default_routing_authorized": False,
+            "trusted_data_default_truth": False,
+            "deterministic": True,
+        },
+        "controlled_consumption_status_counts": {
+            status: counts[status]
+            for status in CONTROLLED_TEST_CONSUMPTION_STATUSES
+        },
+        "blocker_reason_counts": dict(sorted(blocker_reasons.items())),
+        "controlled_consumption_records": records,
+        "safety_confirmations": {
+            "controlled_consumption_authorizes_production_routing": False,
+            "controlled_consumption_is_production_consumption": False,
+            "runtime_production_consumption_enabled": False,
+            "runtime_manifest_consumption_enabled": False,
+            "legacy_planner_ownership_preserved": True,
+            "production_output_affected": False,
+            "production_behavior_changed": False,
+            "production_planner_routing_changed": False,
+            "trusted_data_default_truth": False,
+        },
+        "metadata": {
+            "source": "v3_1_controlled_test_consumption",
+            "observational_only": True,
+            "controlled_test_only": True,
+            "production_consumer": False,
+            "production_behavior_changed": False,
+            "planner_remap_performed": False,
+            "production_default_routing_authorized": False,
+            "stable_generation_token": STABLE_CONTROLLED_TEST_CONSUMPTION_TOKEN,
+            "deterministic_serializer": "json_sort_keys_sha256",
+        },
+    }
+    envelope["deterministic_hash"] = deterministic_hash(envelope)
+    return envelope
+
+
+def _consumption_record(
+    *,
+    manifest_id: str,
+    eligibility: dict[str, Any] | None,
+    manifest: dict[str, Any] | None,
+    controlled_test_mode: bool,
+) -> dict[str, Any]:
+    status, blockers = _status(
+        eligibility=eligibility,
+        manifest=manifest,
+        controlled_test_mode=controlled_test_mode,
+    )
+    fixture_set_id = (manifest or eligibility or {}).get("fixture_set_id")
+    authorization_state = ((manifest or {}).get("authorization_status") or {}).get(
+        "authorization_state",
+        (eligibility or {}).get("authorization_state"),
+    )
+    seed = {
+        "manifest_id": manifest_id,
+        "fixture_set_id": fixture_set_id,
+        "status": status,
+        "controlled_test_mode": controlled_test_mode,
+        "token": STABLE_CONTROLLED_TEST_CONSUMPTION_TOKEN,
+    }
+    return {
+        "controlled_consumption_id": f"v3_1_controlled_consumption_{deterministic_hash(seed)[:16]}",
+        "manifest_id": manifest_id or None,
+        "fixture_set_id": fixture_set_id,
+        "eligibility_status": (eligibility or {}).get("eligibility_status"),
+        "authorization_state": authorization_state,
+        "controlled_consumption_status": status,
+        "blockers": blockers,
+        "controlled_test_mode": controlled_test_mode,
+        "not_production_consumption": True,
+        "controlled_consumption_authorizes_production_routing": False,
+        "production_output_affected": False,
+        "metadata": {
+            "observational_only": True,
+            "controlled_test_only": True,
+            "production_consumer": False,
+            "planner_remap_performed": False,
+        },
+    }
+
+
+def _status(
+    *,
+    eligibility: dict[str, Any] | None,
+    manifest: dict[str, Any] | None,
+    controlled_test_mode: bool,
+) -> tuple[str, list[str]]:
+    if not controlled_test_mode:
+        return "blocked_runtime_consumption_disabled", ["controlled_test_mode_not_enabled"]
+    if eligibility is None:
+        return "blocked_missing_eligibility_record", ["missing_manifest_eligibility_record"]
+    if manifest is None:
+        return "blocked_missing_manifest", ["missing_serialized_manifest"]
+    if eligibility.get("eligibility_status") != "eligible_for_controlled_test_consumption":
+        return "blocked_not_eligible", list(eligibility.get("blockers") or [f"eligibility_{eligibility.get('eligibility_status')}"])
+    if not _is_non_production_authoritative(manifest):
+        return "blocked_invalid_authorization_state", ["manifest_not_non_production_authoritative"]
+    return "consumed_in_controlled_test", []
+
+
+def _is_non_production_authoritative(manifest: dict[str, Any]) -> bool:
+    authorization = manifest.get("authorization_status") or {}
+    return (
+        manifest.get("non_production_authoritative") is True
+        and authorization.get("authorization_state") == NON_PRODUCTION_AUTHORIZATION_STATE
+        and authorization.get("manifest_authorizes_production_routing") is False
+        and authorization.get("manifest_is_production_approved") is False
+        and authorization.get("manifest_is_production_authoritative") is False
+    )

--- a/backend/scripts/report_v3_1_controlled_test_consumption.py
+++ b/backend/scripts/report_v3_1_controlled_test_consumption.py
@@ -1,0 +1,155 @@
+"""Generate the v3.1 controlled test consumption report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.planner_adapters.v3_1.controlled_test_consumption import build_controlled_test_consumption  # noqa: E402
+
+
+DETERMINISTIC_GENERATED_AT = "2026-05-15T00:00:00+00:00"
+
+
+def build_v3_1_controlled_test_consumption_report() -> dict[str, Any]:
+    repo_root = Path(__file__).resolve().parents[2]
+    generated = repo_root / "docs" / "generated"
+    eligibility = _read_json(generated / "v3_1_manifest_consumption_eligibility_report.json")["manifest_consumption_eligibility"]
+    serialization = _read_json(generated / "v3_1_admission_aware_manifest_serialization_report.json")[
+        "admission_aware_manifest_serialization"
+    ]
+    consumption = build_controlled_test_consumption(
+        manifest_consumption_eligibility=eligibility,
+        admission_aware_manifest_serialization=serialization,
+        controlled_test_mode=True,
+    )
+    repeated = build_controlled_test_consumption(
+        manifest_consumption_eligibility=eligibility,
+        admission_aware_manifest_serialization=serialization,
+        controlled_test_mode=True,
+    )
+    report = {
+        "schema_version": "v3_1.controlled_test_consumption_report.1",
+        "generated_at": DETERMINISTIC_GENERATED_AT,
+        "phase": "v3.1_phase_17_controlled_test_consumption",
+        "recommendation": "OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING",
+        "production_default_routing_authorized": False,
+        "runtime_production_consumption_enabled": False,
+        "runtime_manifest_consumption_enabled": False,
+        "controlled_test_mode": True,
+        "summary": {
+            **consumption["summary"],
+            "deterministic": consumption["deterministic_hash"] == repeated["deterministic_hash"],
+        },
+        "controlled_test_consumption": consumption,
+        "deterministic_guarantees": {
+            "passed": consumption["deterministic_hash"] == repeated["deterministic_hash"],
+            "sample_hash": consumption["deterministic_hash"],
+            "repeated_hash": repeated["deterministic_hash"],
+            "timestamp_excluded_from_hash": True,
+            "json_sort_keys": True,
+        },
+        "phase_17_boundaries": [
+            "controlled test consumption requires explicit test-only invocation",
+            "controlled test consumption does not authorize production routing",
+            "runtime production manifest consumption remains disabled",
+            "production planner routing remains unchanged",
+            "legacy planner ownership remains intact",
+        ],
+        "metadata": {
+            "source": "v3_1_controlled_test_consumption_report",
+            "observational_only": True,
+            "controlled_test_only": True,
+            "production_behavior_changed": False,
+            "production_default_routing_authorized": False,
+            "planner_remap_performed": False,
+        },
+    }
+    return _normalize_generated_at(report)
+
+
+def write_report(report: dict[str, Any], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_markdown(report: dict[str, Any], output_path: Path) -> None:
+    consumption = report["controlled_test_consumption"]
+    summary = report["summary"]
+    lines = [
+        "# V3.1 Controlled Test Consumption",
+        "",
+        "Phase 17 consumes eligible non-production manifests only through explicit controlled test mode.",
+        "This does not authorize production routing or runtime production manifest consumption.",
+        "",
+        "## Recommendation",
+        "",
+        f"- Recommendation: `{report['recommendation']}`",
+        f"- Production default routing authorized: `{str(report['production_default_routing_authorized']).lower()}`",
+        f"- Runtime production consumption enabled: `{str(report['runtime_production_consumption_enabled']).lower()}`",
+        f"- Runtime manifest consumption enabled: `{str(report['runtime_manifest_consumption_enabled']).lower()}`",
+        "",
+        "## Summary",
+        "",
+        f"- Manifests evaluated: `{summary['manifests_evaluated']}`",
+        f"- Controlled-test consumed: `{summary['controlled_test_consumed_count']}`",
+        f"- Blocked: `{summary['blocked_count']}`",
+        f"- Production affected: `{summary['production_affected_count']}`",
+        f"- Deterministic: `{str(summary['deterministic']).lower()}`",
+        "",
+        "## Blocker Reasons",
+        "",
+        "| Reason | Count |",
+        "| --- | ---: |",
+    ]
+    for reason, count in consumption["blocker_reason_counts"].items():
+        lines.append(f"| `{reason}` | `{count}` |")
+    lines.extend(["", "## Controlled Consumption Records", "", "| Record | Manifest | Fixture Set | Status | Authorization |", "| --- | --- | --- | --- | --- |"])
+    for row in consumption["controlled_consumption_records"]:
+        lines.append(
+            f"| `{row['controlled_consumption_id']}` | `{row['manifest_id'] or ''}` | `{row['fixture_set_id'] or ''}` | `{row['controlled_consumption_status']}` | `{row['authorization_state'] or ''}` |"
+        )
+    lines.extend(["", "## Phase 17 Boundaries", ""])
+    lines.extend(f"- {item}" for item in report["phase_17_boundaries"])
+    lines.extend(["", "## Conclusion", "", "Controlled test consumption is available for isolated governance testing only, while production routing remains unchanged."])
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _normalize_generated_at(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: DETERMINISTIC_GENERATED_AT if key == "generated_at" else _normalize_generated_at(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_normalize_generated_at(item) for item in value]
+    return deepcopy(value)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", default="docs/generated/v3_1_controlled_test_consumption_report.json")
+    parser.add_argument("--markdown-output", default="docs/migration/V3_1_CONTROLLED_TEST_CONSUMPTION.md")
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[2]
+    report = build_v3_1_controlled_test_consumption_report()
+    write_report(report, repo_root / args.output)
+    write_markdown(report, repo_root / args.markdown_output)
+    print(json.dumps(report["summary"], indent=2, sort_keys=True))
+    print(report["recommendation"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_v3_1_controlled_test_consumption.py
+++ b/backend/tests/test_v3_1_controlled_test_consumption.py
@@ -1,0 +1,147 @@
+from app.planner_adapters.v3_1.controlled_test_consumption import build_controlled_test_consumption
+from scripts.report_v3_1_controlled_test_consumption import build_v3_1_controlled_test_consumption_report
+
+
+def test_eligible_non_production_manifest_consumes_in_controlled_test_mode():
+    result = build_controlled_test_consumption(
+        manifest_consumption_eligibility=_eligibility([_eligibility_record("manifest_a", "set_a")]),
+        admission_aware_manifest_serialization=_serialization([_manifest("manifest_a", "set_a")]),
+        controlled_test_mode=True,
+    )
+
+    record = result["controlled_consumption_records"][0]
+    assert record["controlled_consumption_status"] == "consumed_in_controlled_test"
+    assert result["summary"]["controlled_test_consumed_count"] == 1
+
+
+def test_ineligible_manifest_blocks():
+    result = build_controlled_test_consumption(
+        manifest_consumption_eligibility=_eligibility([_eligibility_record("manifest_a", "set_a", status="blocked_missing_hash", blockers=["blocked_missing_hash"])]),
+        admission_aware_manifest_serialization=_serialization([_manifest("manifest_a", "set_a")]),
+        controlled_test_mode=True,
+    )
+
+    assert result["controlled_consumption_records"][0]["controlled_consumption_status"] == "blocked_not_eligible"
+
+
+def test_invalid_authorization_state_blocks():
+    manifest = _manifest("manifest_a", "set_a")
+    manifest["authorization_status"]["authorization_state"] = "production_authoritative"
+    result = build_controlled_test_consumption(
+        manifest_consumption_eligibility=_eligibility([_eligibility_record("manifest_a", "set_a")]),
+        admission_aware_manifest_serialization=_serialization([manifest]),
+        controlled_test_mode=True,
+    )
+
+    assert result["controlled_consumption_records"][0]["controlled_consumption_status"] == "blocked_invalid_authorization_state"
+
+
+def test_missing_manifest_blocks():
+    result = build_controlled_test_consumption(
+        manifest_consumption_eligibility=_eligibility([_eligibility_record("manifest_a", "set_a")]),
+        admission_aware_manifest_serialization=_serialization([]),
+        controlled_test_mode=True,
+    )
+
+    assert result["controlled_consumption_records"][0]["controlled_consumption_status"] == "blocked_missing_manifest"
+
+
+def test_missing_eligibility_record_blocks():
+    result = build_controlled_test_consumption(
+        manifest_consumption_eligibility=_eligibility([]),
+        admission_aware_manifest_serialization=_serialization([_manifest("manifest_a", "set_a")]),
+        controlled_test_mode=True,
+    )
+
+    assert result["controlled_consumption_records"][0]["controlled_consumption_status"] == "blocked_missing_eligibility_record"
+
+
+def test_runtime_consumption_disabled_without_explicit_test_mode():
+    result = build_controlled_test_consumption(
+        manifest_consumption_eligibility=_eligibility([_eligibility_record("manifest_a", "set_a")]),
+        admission_aware_manifest_serialization=_serialization([_manifest("manifest_a", "set_a")]),
+        controlled_test_mode=False,
+    )
+
+    assert result["controlled_consumption_records"][0]["controlled_consumption_status"] == "blocked_runtime_consumption_disabled"
+    assert result["summary"]["runtime_manifest_consumption_enabled"] is False
+
+
+def test_deterministic_ordering():
+    first = build_controlled_test_consumption(
+        manifest_consumption_eligibility=_eligibility([_eligibility_record("manifest_b", "set_b"), _eligibility_record("manifest_a", "set_a")]),
+        admission_aware_manifest_serialization=_serialization([_manifest("manifest_b", "set_b"), _manifest("manifest_a", "set_a")]),
+        controlled_test_mode=True,
+    )
+    second = build_controlled_test_consumption(
+        manifest_consumption_eligibility=_eligibility([_eligibility_record("manifest_a", "set_a"), _eligibility_record("manifest_b", "set_b")]),
+        admission_aware_manifest_serialization=_serialization([_manifest("manifest_a", "set_a"), _manifest("manifest_b", "set_b")]),
+        controlled_test_mode=True,
+    )
+
+    assert first["deterministic_hash"] == second["deterministic_hash"]
+    assert [row["manifest_id"] for row in first["controlled_consumption_records"]] == ["manifest_a", "manifest_b"]
+
+
+def test_stable_report_generation():
+    first = build_v3_1_controlled_test_consumption_report()
+    second = build_v3_1_controlled_test_consumption_report()
+
+    assert first["deterministic_guarantees"]["passed"] is True
+    assert first["controlled_test_consumption"]["deterministic_hash"] == second["controlled_test_consumption"]["deterministic_hash"]
+    assert first["summary"] == second["summary"]
+
+
+def test_no_production_routing_enablement():
+    result = build_controlled_test_consumption(
+        manifest_consumption_eligibility=_eligibility([_eligibility_record("manifest_a", "set_a")]),
+        admission_aware_manifest_serialization=_serialization([_manifest("manifest_a", "set_a")]),
+        controlled_test_mode=True,
+    )
+    record = result["controlled_consumption_records"][0]
+
+    assert result["safety_confirmations"]["controlled_consumption_authorizes_production_routing"] is False
+    assert result["safety_confirmations"]["controlled_consumption_is_production_consumption"] is False
+    assert result["summary"]["runtime_production_consumption_enabled"] is False
+    assert record["not_production_consumption"] is True
+    assert record["controlled_consumption_authorizes_production_routing"] is False
+
+
+def _eligibility(records):
+    return {
+        "schema_version": "v3_1.manifest_consumption_eligibility.1",
+        "deterministic_hash": "eligibility-hash",
+        "eligibility_records": records,
+    }
+
+
+def _eligibility_record(manifest_id, set_id, status="eligible_for_controlled_test_consumption", blockers=None):
+    return {
+        "manifest_id": manifest_id,
+        "fixture_set_id": set_id,
+        "eligibility_status": status,
+        "authorization_state": "non_production_authoritative",
+        "blockers": blockers or [],
+    }
+
+
+def _serialization(records):
+    return {
+        "schema_version": "v3_1.admission_aware_manifest_serialization.1",
+        "deterministic_hash": "serialization-hash",
+        "serialized_manifests": records,
+    }
+
+
+def _manifest(manifest_id, set_id):
+    return {
+        "manifest_id": manifest_id,
+        "fixture_set_id": set_id,
+        "authorization_status": {
+            "authorization_state": "non_production_authoritative",
+            "manifest_authorizes_production_routing": False,
+            "manifest_is_production_approved": False,
+            "manifest_is_production_authoritative": False,
+        },
+        "non_production_authoritative": True,
+    }

--- a/docs/generated/v3_1_controlled_test_consumption_report.json
+++ b/docs/generated/v3_1_controlled_test_consumption_report.json
@@ -1,0 +1,122 @@
+{
+  "controlled_test_consumption": {
+    "blocker_reason_counts": {},
+    "controlled_consumption_records": [
+      {
+        "authorization_state": "non_production_authoritative",
+        "blockers": [],
+        "controlled_consumption_authorizes_production_routing": false,
+        "controlled_consumption_id": "v3_1_controlled_consumption_b60ecb0bbb68340a",
+        "controlled_consumption_status": "consumed_in_controlled_test",
+        "controlled_test_mode": true,
+        "eligibility_status": "eligible_for_controlled_test_consumption",
+        "fixture_set_id": "v3_1_fixture_set_6d3b668a84cfbb69",
+        "manifest_id": "v3_1_admission_manifest_198a3e2110f9e5e4",
+        "metadata": {
+          "controlled_test_only": true,
+          "observational_only": true,
+          "planner_remap_performed": false,
+          "production_consumer": false
+        },
+        "not_production_consumption": true,
+        "production_output_affected": false
+      }
+    ],
+    "controlled_consumption_status_counts": {
+      "blocked_invalid_authorization_state": 0,
+      "blocked_missing_eligibility_record": 0,
+      "blocked_missing_manifest": 0,
+      "blocked_not_eligible": 0,
+      "blocked_runtime_consumption_disabled": 0,
+      "consumed_in_controlled_test": 1
+    },
+    "deterministic_hash": "f08b0dd2a540a8f4da38a059b3c0def3d029747cb1416201946a1795e6d30c04",
+    "metadata": {
+      "controlled_test_only": true,
+      "deterministic_serializer": "json_sort_keys_sha256",
+      "observational_only": true,
+      "planner_remap_performed": false,
+      "production_behavior_changed": false,
+      "production_consumer": false,
+      "production_default_routing_authorized": false,
+      "source": "v3_1_controlled_test_consumption",
+      "stable_generation_token": "v3_1_phase_17_controlled_test_consumption_token"
+    },
+    "run": {
+      "admission_aware_manifest_serialization_hash": "8fa65134e7e0bf7f839c2ad01b22b26b7fc59c26787f23b7c13331fc5654ecda",
+      "controlled_test_mode": true,
+      "eligibility_record_count": 1,
+      "manifest_consumption_eligibility_hash": "e5776401439dbe2ac5feef32f9c0ae924d7769f691ea3e90fcb1774f39fcbbf4",
+      "manifest_record_count": 1,
+      "run_id": "v3_1_phase_17_controlled_test_consumption"
+    },
+    "safety_confirmations": {
+      "controlled_consumption_authorizes_production_routing": false,
+      "controlled_consumption_is_production_consumption": false,
+      "legacy_planner_ownership_preserved": true,
+      "production_behavior_changed": false,
+      "production_output_affected": false,
+      "production_planner_routing_changed": false,
+      "runtime_manifest_consumption_enabled": false,
+      "runtime_production_consumption_enabled": false,
+      "trusted_data_default_truth": false
+    },
+    "schema_version": "v3_1.controlled_test_consumption.1",
+    "summary": {
+      "blocked_count": 0,
+      "controlled_test_consumed_count": 1,
+      "deterministic": true,
+      "manifests_evaluated": 1,
+      "production_affected_count": 0,
+      "production_behavior_changed": false,
+      "production_default_routing_authorized": false,
+      "production_output_affected": false,
+      "runtime_manifest_consumption_enabled": false,
+      "runtime_production_consumption_enabled": false,
+      "trusted_data_default_truth": false
+    }
+  },
+  "controlled_test_mode": true,
+  "deterministic_guarantees": {
+    "json_sort_keys": true,
+    "passed": true,
+    "repeated_hash": "f08b0dd2a540a8f4da38a059b3c0def3d029747cb1416201946a1795e6d30c04",
+    "sample_hash": "f08b0dd2a540a8f4da38a059b3c0def3d029747cb1416201946a1795e6d30c04",
+    "timestamp_excluded_from_hash": true
+  },
+  "generated_at": "2026-05-15T00:00:00+00:00",
+  "metadata": {
+    "controlled_test_only": true,
+    "observational_only": true,
+    "planner_remap_performed": false,
+    "production_behavior_changed": false,
+    "production_default_routing_authorized": false,
+    "source": "v3_1_controlled_test_consumption_report"
+  },
+  "phase": "v3.1_phase_17_controlled_test_consumption",
+  "phase_17_boundaries": [
+    "controlled test consumption requires explicit test-only invocation",
+    "controlled test consumption does not authorize production routing",
+    "runtime production manifest consumption remains disabled",
+    "production planner routing remains unchanged",
+    "legacy planner ownership remains intact"
+  ],
+  "production_default_routing_authorized": false,
+  "recommendation": "OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING",
+  "runtime_manifest_consumption_enabled": false,
+  "runtime_production_consumption_enabled": false,
+  "schema_version": "v3_1.controlled_test_consumption_report.1",
+  "summary": {
+    "blocked_count": 0,
+    "controlled_test_consumed_count": 1,
+    "deterministic": true,
+    "manifests_evaluated": 1,
+    "production_affected_count": 0,
+    "production_behavior_changed": false,
+    "production_default_routing_authorized": false,
+    "production_output_affected": false,
+    "runtime_manifest_consumption_enabled": false,
+    "runtime_production_consumption_enabled": false,
+    "trusted_data_default_truth": false
+  }
+}

--- a/docs/migration/V3_1_CONTROLLED_TEST_CONSUMPTION.md
+++ b/docs/migration/V3_1_CONTROLLED_TEST_CONSUMPTION.md
@@ -1,0 +1,42 @@
+# V3.1 Controlled Test Consumption
+
+Phase 17 consumes eligible non-production manifests only through explicit controlled test mode.
+This does not authorize production routing or runtime production manifest consumption.
+
+## Recommendation
+
+- Recommendation: `OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING`
+- Production default routing authorized: `false`
+- Runtime production consumption enabled: `false`
+- Runtime manifest consumption enabled: `false`
+
+## Summary
+
+- Manifests evaluated: `1`
+- Controlled-test consumed: `1`
+- Blocked: `0`
+- Production affected: `0`
+- Deterministic: `true`
+
+## Blocker Reasons
+
+| Reason | Count |
+| --- | ---: |
+
+## Controlled Consumption Records
+
+| Record | Manifest | Fixture Set | Status | Authorization |
+| --- | --- | --- | --- | --- |
+| `v3_1_controlled_consumption_b60ecb0bbb68340a` | `v3_1_admission_manifest_198a3e2110f9e5e4` | `v3_1_fixture_set_6d3b668a84cfbb69` | `consumed_in_controlled_test` | `non_production_authoritative` |
+
+## Phase 17 Boundaries
+
+- controlled test consumption requires explicit test-only invocation
+- controlled test consumption does not authorize production routing
+- runtime production manifest consumption remains disabled
+- production planner routing remains unchanged
+- legacy planner ownership remains intact
+
+## Conclusion
+
+Controlled test consumption is available for isolated governance testing only, while production routing remains unchanged.


### PR DESCRIPTION
Adds deterministic controlled test consumption for eligible non-production manifests while keeping production planner routing and runtime manifest consumption disabled.