### PR TITLE
v3.1: validate controlled consumption output

### DIFF
--- a/backend/app/planner_adapters/v3_1/__init__.py
+++ b/backend/app/planner_adapters/v3_1/__init__.py
@@ -65,6 +65,10 @@ from .controlled_test_consumption import (
     CONTROLLED_TEST_CONSUMPTION_STATUSES,
     build_controlled_test_consumption,
 )
+from .controlled_consumption_output_validation import (
+    CONTROLLED_CONSUMPTION_OUTPUT_VALIDATION_STATUSES,
+    validate_controlled_consumption_output,
+)
 from .approval_manifest_diff_audit import (
     APPROVAL_MANIFEST_DIFF_CLASSIFICATIONS,
     audit_approval_manifest_diffs,
@@ -102,6 +106,7 @@ __all__ = [
     "ADMISSION_AWARE_SERIALIZED_MANIFEST_STATUSES",
     "MANIFEST_CONSUMPTION_ELIGIBILITY_STATUSES",
     "CONTROLLED_TEST_CONSUMPTION_STATUSES",
+    "CONTROLLED_CONSUMPTION_OUTPUT_VALIDATION_STATUSES",
     "APPROVAL_MANIFEST_DIFF_CLASSIFICATIONS",
     "SERIALIZED_APPROVAL_MANIFEST_STATUSES",
     "SUPPORTED_TRUSTED_SHADOW_DOMAINS",
@@ -127,6 +132,7 @@ __all__ = [
     "serialize_admission_aware_manifest_candidates",
     "evaluate_manifest_consumption_eligibility",
     "build_controlled_test_consumption",
+    "validate_controlled_consumption_output",
     "audit_approval_manifest_diffs",
     "discover_default_reviewed_fixture_input_sources",
     "deterministic_hash",

--- a/backend/app/planner_adapters/v3_1/controlled_consumption_output_validation.py
+++ b/backend/app/planner_adapters/v3_1/controlled_consumption_output_validation.py
@@ -1,0 +1,211 @@
+"""Controlled consumption output validation for v3.1 governance.
+
+Validation is test-only/governance-only. It verifies controlled-test output
+traceability and production isolation without authorizing production routing.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from copy import deepcopy
+from typing import Any
+
+from .approval_manifest_serialization import NON_PRODUCTION_AUTHORIZATION_STATE
+from .trusted_shadow_consumption import deterministic_hash
+
+
+CONTROLLED_CONSUMPTION_OUTPUT_VALIDATION_STATUSES = (
+    "valid_controlled_test_output",
+    "blocked_missing_consumption_record",
+    "blocked_missing_manifest_trace",
+    "blocked_missing_fixture_set_trace",
+    "blocked_invalid_authorization_state",
+    "blocked_runtime_consumption_enabled",
+    "blocked_invalid_consumption_status",
+)
+STABLE_CONTROLLED_OUTPUT_VALIDATION_TOKEN = "v3_1_phase_18_controlled_consumption_output_validation_token"
+
+
+def validate_controlled_consumption_output(
+    *,
+    controlled_test_consumption: dict[str, Any] | list[dict[str, Any]],
+    run_id: str = "v3_1_phase_18_controlled_consumption_output_validation",
+) -> dict[str, Any]:
+    """Validate controlled-test consumption records deterministically."""
+
+    records = _consumption_records(controlled_test_consumption)
+    runtime_enabled = _runtime_consumption_enabled(controlled_test_consumption)
+    validation_records = [
+        _validation_record(record=record, runtime_enabled=runtime_enabled)
+        for record in sorted(records, key=_consumption_sort_key)
+    ]
+    if not validation_records:
+        validation_records = [_missing_record(runtime_enabled=runtime_enabled)]
+    counts = Counter(row["validation_status"] for row in validation_records)
+    blocker_reasons = Counter(reason for row in validation_records for reason in row["blockers"])
+    traceability = {
+        "manifest_trace_count": sum(1 for row in validation_records if row["traceability_summary"]["manifest_trace_present"]),
+        "fixture_set_trace_count": sum(1 for row in validation_records if row["traceability_summary"]["fixture_set_trace_present"]),
+        "authorization_trace_count": sum(1 for row in validation_records if row["traceability_summary"]["authorization_state"] == NON_PRODUCTION_AUTHORIZATION_STATE),
+    }
+    source_hash = controlled_test_consumption.get("deterministic_hash") if isinstance(controlled_test_consumption, dict) else None
+    source_schema = controlled_test_consumption.get("schema_version") if isinstance(controlled_test_consumption, dict) else None
+    envelope = {
+        "schema_version": "v3_1.controlled_consumption_output_validation.1",
+        "run": {
+            "run_id": run_id,
+            "controlled_consumption_record_count": len(records),
+            "controlled_test_consumption_hash": source_hash,
+            "controlled_test_consumption_schema": source_schema,
+        },
+        "summary": {
+            "records_evaluated": len(validation_records),
+            "valid_count": counts["valid_controlled_test_output"],
+            "blocked_count": len(validation_records) - counts["valid_controlled_test_output"],
+            "runtime_manifest_consumption_enabled": False,
+            "runtime_production_consumption_enabled": False,
+            "production_affected_count": 0,
+            "production_output_affected": False,
+            "production_behavior_changed": False,
+            "production_default_routing_authorized": False,
+            "trusted_data_default_truth": False,
+            "deterministic": True,
+        },
+        "validation_status_counts": {
+            status: counts[status]
+            for status in CONTROLLED_CONSUMPTION_OUTPUT_VALIDATION_STATUSES
+        },
+        "blocker_reason_counts": dict(sorted(blocker_reasons.items())),
+        "traceability_summary": traceability,
+        "validation_records": validation_records,
+        "safety_confirmations": {
+            "validation_authorizes_production_routing": False,
+            "validation_is_production_approval": False,
+            "runtime_manifest_consumption_enabled": False,
+            "runtime_production_consumption_enabled": False,
+            "legacy_planner_ownership_preserved": True,
+            "production_output_affected": False,
+            "production_behavior_changed": False,
+            "production_planner_routing_changed": False,
+            "trusted_data_default_truth": False,
+        },
+        "metadata": {
+            "source": "v3_1_controlled_consumption_output_validation",
+            "observational_only": True,
+            "controlled_test_only": True,
+            "production_consumer": False,
+            "production_behavior_changed": False,
+            "planner_remap_performed": False,
+            "production_default_routing_authorized": False,
+            "stable_generation_token": STABLE_CONTROLLED_OUTPUT_VALIDATION_TOKEN,
+            "deterministic_serializer": "json_sort_keys_sha256",
+        },
+    }
+    envelope["deterministic_hash"] = deterministic_hash(envelope)
+    return envelope
+
+
+def _consumption_records(value: dict[str, Any] | list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if isinstance(value, list):
+        return [deepcopy(row) for row in value]
+    return [deepcopy(row) for row in value.get("controlled_consumption_records", [])]
+
+
+def _runtime_consumption_enabled(value: dict[str, Any] | list[dict[str, Any]]) -> bool:
+    if not isinstance(value, dict):
+        return False
+    summary = value.get("summary") or {}
+    safety = value.get("safety_confirmations") or {}
+    return bool(summary.get("runtime_manifest_consumption_enabled") or summary.get("runtime_production_consumption_enabled") or safety.get("runtime_manifest_consumption_enabled") or safety.get("runtime_production_consumption_enabled"))
+
+
+def _consumption_sort_key(record: dict[str, Any]) -> tuple[str, str]:
+    return (
+        str(record.get("fixture_set_id") or ""),
+        str(record.get("manifest_id") or ""),
+    )
+
+
+def _validation_record(*, record: dict[str, Any], runtime_enabled: bool) -> dict[str, Any]:
+    blockers = _blockers(record=record, runtime_enabled=runtime_enabled)
+    status = blockers[0] if blockers else "valid_controlled_test_output"
+    seed = {
+        "manifest_id": record.get("manifest_id"),
+        "fixture_set_id": record.get("fixture_set_id"),
+        "status": status,
+        "token": STABLE_CONTROLLED_OUTPUT_VALIDATION_TOKEN,
+    }
+    return {
+        "validation_record_id": f"v3_1_controlled_output_validation_{deterministic_hash(seed)[:16]}",
+        "manifest_id": record.get("manifest_id"),
+        "fixture_set_id": record.get("fixture_set_id"),
+        "controlled_consumption_status": record.get("controlled_consumption_status"),
+        "validation_status": status,
+        "blockers": blockers,
+        "traceability_summary": _traceability_summary(record=record, runtime_enabled=runtime_enabled),
+        "validation_authorizes_production_routing": False,
+        "production_output_affected": False,
+        "metadata": {
+            "observational_only": True,
+            "controlled_test_only": True,
+            "production_consumer": False,
+            "planner_remap_performed": False,
+        },
+    }
+
+
+def _missing_record(*, runtime_enabled: bool) -> dict[str, Any]:
+    seed = {"missing_consumption_record": True, "token": STABLE_CONTROLLED_OUTPUT_VALIDATION_TOKEN}
+    blockers = ["blocked_missing_consumption_record"]
+    if runtime_enabled:
+        blockers.append("blocked_runtime_consumption_enabled")
+    return {
+        "validation_record_id": f"v3_1_controlled_output_validation_{deterministic_hash(seed)[:16]}",
+        "manifest_id": None,
+        "fixture_set_id": None,
+        "controlled_consumption_status": None,
+        "validation_status": blockers[0],
+        "blockers": blockers,
+        "traceability_summary": {
+            "manifest_trace_present": False,
+            "fixture_set_trace_present": False,
+            "authorization_state": None,
+            "runtime_consumption_enabled": runtime_enabled,
+            "not_production_consumption": False,
+        },
+        "validation_authorizes_production_routing": False,
+        "production_output_affected": False,
+        "metadata": {
+            "observational_only": True,
+            "controlled_test_only": True,
+            "production_consumer": False,
+            "planner_remap_performed": False,
+        },
+    }
+
+
+def _blockers(*, record: dict[str, Any], runtime_enabled: bool) -> list[str]:
+    blockers: list[str] = []
+    if not record.get("manifest_id"):
+        blockers.append("blocked_missing_manifest_trace")
+    if not record.get("fixture_set_id"):
+        blockers.append("blocked_missing_fixture_set_trace")
+    if record.get("authorization_state") != NON_PRODUCTION_AUTHORIZATION_STATE:
+        blockers.append("blocked_invalid_authorization_state")
+    if runtime_enabled:
+        blockers.append("blocked_runtime_consumption_enabled")
+    if record.get("controlled_consumption_status") != "consumed_in_controlled_test":
+        blockers.append("blocked_invalid_consumption_status")
+    if record.get("controlled_consumption_authorizes_production_routing") is not False or record.get("not_production_consumption") is not True:
+        blockers.append("blocked_invalid_authorization_state")
+    return sorted(set(blockers), key=blockers.index)
+
+
+def _traceability_summary(*, record: dict[str, Any], runtime_enabled: bool) -> dict[str, Any]:
+    return {
+        "manifest_trace_present": bool(record.get("manifest_id")),
+        "fixture_set_trace_present": bool(record.get("fixture_set_id")),
+        "authorization_state": record.get("authorization_state"),
+        "runtime_consumption_enabled": runtime_enabled,
+        "not_production_consumption": record.get("not_production_consumption") is True,
+    }

--- a/backend/scripts/report_v3_1_controlled_consumption_output_validation.py
+++ b/backend/scripts/report_v3_1_controlled_consumption_output_validation.py
@@ -1,0 +1,159 @@
+"""Generate the v3.1 controlled consumption output validation report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.planner_adapters.v3_1.controlled_consumption_output_validation import validate_controlled_consumption_output  # noqa: E402
+
+
+DETERMINISTIC_GENERATED_AT = "2026-05-15T00:00:00+00:00"
+
+
+def build_v3_1_controlled_consumption_output_validation_report() -> dict[str, Any]:
+    repo_root = Path(__file__).resolve().parents[2]
+    consumption = _read_json(repo_root / "docs" / "generated" / "v3_1_controlled_test_consumption_report.json")[
+        "controlled_test_consumption"
+    ]
+    validation = validate_controlled_consumption_output(controlled_test_consumption=consumption)
+    repeated = validate_controlled_consumption_output(controlled_test_consumption=consumption)
+    report = {
+        "schema_version": "v3_1.controlled_consumption_output_validation_report.1",
+        "generated_at": DETERMINISTIC_GENERATED_AT,
+        "phase": "v3.1_phase_18_controlled_consumption_output_validation",
+        "recommendation": "OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING",
+        "production_default_routing_authorized": False,
+        "runtime_manifest_consumption_enabled": False,
+        "runtime_production_consumption_enabled": False,
+        "summary": {
+            **validation["summary"],
+            "deterministic": validation["deterministic_hash"] == repeated["deterministic_hash"],
+        },
+        "controlled_consumption_output_validation": validation,
+        "deterministic_guarantees": {
+            "passed": validation["deterministic_hash"] == repeated["deterministic_hash"],
+            "sample_hash": validation["deterministic_hash"],
+            "repeated_hash": repeated["deterministic_hash"],
+            "timestamp_excluded_from_hash": True,
+            "json_sort_keys": True,
+        },
+        "phase_18_boundaries": [
+            "validation is test-only governance metadata",
+            "validation is not production approval",
+            "validation does not authorize production routing",
+            "runtime manifest consumption remains disabled",
+            "legacy planner ownership remains intact",
+        ],
+        "metadata": {
+            "source": "v3_1_controlled_consumption_output_validation_report",
+            "observational_only": True,
+            "controlled_test_only": True,
+            "production_behavior_changed": False,
+            "production_default_routing_authorized": False,
+            "planner_remap_performed": False,
+        },
+    }
+    return _normalize_generated_at(report)
+
+
+def write_report(report: dict[str, Any], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_markdown(report: dict[str, Any], output_path: Path) -> None:
+    validation = report["controlled_consumption_output_validation"]
+    summary = report["summary"]
+    lines = [
+        "# V3.1 Controlled Consumption Output Validation",
+        "",
+        "Phase 18 validates controlled-test consumption output traceability and production isolation.",
+        "Validation is not production approval and does not authorize routing.",
+        "",
+        "## Recommendation",
+        "",
+        f"- Recommendation: `{report['recommendation']}`",
+        f"- Production default routing authorized: `{str(report['production_default_routing_authorized']).lower()}`",
+        f"- Runtime production consumption enabled: `{str(report['runtime_production_consumption_enabled']).lower()}`",
+        f"- Runtime manifest consumption enabled: `{str(report['runtime_manifest_consumption_enabled']).lower()}`",
+        "",
+        "## Summary",
+        "",
+        f"- Records evaluated: `{summary['records_evaluated']}`",
+        f"- Valid: `{summary['valid_count']}`",
+        f"- Blocked: `{summary['blocked_count']}`",
+        f"- Production affected: `{summary['production_affected_count']}`",
+        f"- Deterministic: `{str(summary['deterministic']).lower()}`",
+        "",
+        "## Blocker Reasons",
+        "",
+        "| Reason | Count |",
+        "| --- | ---: |",
+    ]
+    for reason, count in validation["blocker_reason_counts"].items():
+        lines.append(f"| `{reason}` | `{count}` |")
+    trace = validation["traceability_summary"]
+    lines.extend(
+        [
+            "",
+            "## Traceability Summary",
+            "",
+            f"- Manifest traces: `{trace['manifest_trace_count']}`",
+            f"- Fixture-set traces: `{trace['fixture_set_trace_count']}`",
+            f"- Authorization traces: `{trace['authorization_trace_count']}`",
+            "",
+            "## Validation Records",
+            "",
+            "| Record | Manifest | Fixture Set | Consumption | Validation |",
+            "| --- | --- | --- | --- | --- |",
+        ]
+    )
+    for row in validation["validation_records"]:
+        lines.append(
+            f"| `{row['validation_record_id']}` | `{row['manifest_id'] or ''}` | `{row['fixture_set_id'] or ''}` | `{row['controlled_consumption_status'] or ''}` | `{row['validation_status']}` |"
+        )
+    lines.extend(["", "## Phase 18 Boundaries", ""])
+    lines.extend(f"- {item}" for item in report["phase_18_boundaries"])
+    lines.extend(["", "## Conclusion", "", "Controlled consumption output validation is available for governance review, while production routing remains unchanged."])
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _normalize_generated_at(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: DETERMINISTIC_GENERATED_AT if key == "generated_at" else _normalize_generated_at(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_normalize_generated_at(item) for item in value]
+    return deepcopy(value)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", default="docs/generated/v3_1_controlled_consumption_output_validation_report.json")
+    parser.add_argument("--markdown-output", default="docs/migration/V3_1_CONTROLLED_CONSUMPTION_OUTPUT_VALIDATION.md")
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[2]
+    report = build_v3_1_controlled_consumption_output_validation_report()
+    write_report(report, repo_root / args.output)
+    write_markdown(report, repo_root / args.markdown_output)
+    print(json.dumps(report["summary"], indent=2, sort_keys=True))
+    print(report["recommendation"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_v3_1_controlled_consumption_output_validation.py
+++ b/backend/tests/test_v3_1_controlled_consumption_output_validation.py
@@ -1,0 +1,107 @@
+from app.planner_adapters.v3_1.controlled_consumption_output_validation import validate_controlled_consumption_output
+from scripts.report_v3_1_controlled_consumption_output_validation import build_v3_1_controlled_consumption_output_validation_report
+
+
+def test_valid_controlled_consumption_output_passes():
+    result = validate_controlled_consumption_output(controlled_test_consumption=_consumption([_record("manifest_a", "set_a")]))
+
+    record = result["validation_records"][0]
+    assert record["validation_status"] == "valid_controlled_test_output"
+    assert result["summary"]["valid_count"] == 1
+
+
+def test_missing_manifest_trace_blocks():
+    result = validate_controlled_consumption_output(controlled_test_consumption=_consumption([_record(None, "set_a")]))
+
+    assert result["validation_records"][0]["validation_status"] == "blocked_missing_manifest_trace"
+
+
+def test_missing_fixture_set_trace_blocks():
+    result = validate_controlled_consumption_output(controlled_test_consumption=_consumption([_record("manifest_a", None)]))
+
+    assert result["validation_records"][0]["validation_status"] == "blocked_missing_fixture_set_trace"
+
+
+def test_invalid_authorization_state_blocks():
+    result = validate_controlled_consumption_output(
+        controlled_test_consumption=_consumption([_record("manifest_a", "set_a", authorization_state="production_authoritative")])
+    )
+
+    assert result["validation_records"][0]["validation_status"] == "blocked_invalid_authorization_state"
+
+
+def test_runtime_consumption_enabled_blocks():
+    payload = _consumption([_record("manifest_a", "set_a")])
+    payload["summary"]["runtime_manifest_consumption_enabled"] = True
+    result = validate_controlled_consumption_output(controlled_test_consumption=payload)
+
+    assert result["validation_records"][0]["validation_status"] == "blocked_runtime_consumption_enabled"
+
+
+def test_invalid_consumption_status_blocks():
+    result = validate_controlled_consumption_output(
+        controlled_test_consumption=_consumption([_record("manifest_a", "set_a", status="blocked_not_eligible")])
+    )
+
+    assert result["validation_records"][0]["validation_status"] == "blocked_invalid_consumption_status"
+
+
+def test_missing_consumption_record_blocks():
+    result = validate_controlled_consumption_output(controlled_test_consumption=_consumption([]))
+
+    assert result["validation_records"][0]["validation_status"] == "blocked_missing_consumption_record"
+
+
+def test_deterministic_ordering():
+    first = validate_controlled_consumption_output(controlled_test_consumption=_consumption([_record("manifest_b", "set_b"), _record("manifest_a", "set_a")]))
+    second = validate_controlled_consumption_output(controlled_test_consumption=_consumption([_record("manifest_a", "set_a"), _record("manifest_b", "set_b")]))
+
+    assert first["deterministic_hash"] == second["deterministic_hash"]
+    assert [row["manifest_id"] for row in first["validation_records"]] == ["manifest_a", "manifest_b"]
+
+
+def test_stable_report_generation():
+    first = build_v3_1_controlled_consumption_output_validation_report()
+    second = build_v3_1_controlled_consumption_output_validation_report()
+
+    assert first["deterministic_guarantees"]["passed"] is True
+    assert first["controlled_consumption_output_validation"]["deterministic_hash"] == second["controlled_consumption_output_validation"]["deterministic_hash"]
+    assert first["summary"] == second["summary"]
+
+
+def test_no_production_routing_enablement():
+    result = validate_controlled_consumption_output(controlled_test_consumption=_consumption([_record("manifest_a", "set_a")]))
+    record = result["validation_records"][0]
+
+    assert result["safety_confirmations"]["validation_authorizes_production_routing"] is False
+    assert result["safety_confirmations"]["validation_is_production_approval"] is False
+    assert result["summary"]["runtime_manifest_consumption_enabled"] is False
+    assert record["validation_authorizes_production_routing"] is False
+
+
+def _consumption(records):
+    return {
+        "schema_version": "v3_1.controlled_test_consumption.1",
+        "deterministic_hash": "consumption-hash",
+        "summary": {
+            "runtime_manifest_consumption_enabled": False,
+            "runtime_production_consumption_enabled": False,
+        },
+        "safety_confirmations": {
+            "runtime_manifest_consumption_enabled": False,
+            "runtime_production_consumption_enabled": False,
+        },
+        "controlled_consumption_records": records,
+    }
+
+
+def _record(manifest_id, fixture_set_id, authorization_state="non_production_authoritative", status="consumed_in_controlled_test"):
+    return {
+        "manifest_id": manifest_id,
+        "fixture_set_id": fixture_set_id,
+        "controlled_consumption_status": status,
+        "authorization_state": authorization_state,
+        "controlled_consumption_authorizes_production_routing": False,
+        "not_production_consumption": True,
+        "production_output_affected": False,
+    }

--- a/docs/generated/v3_1_controlled_consumption_output_validation_report.json
+++ b/docs/generated/v3_1_controlled_consumption_output_validation_report.json
@@ -1,0 +1,129 @@
+{
+  "controlled_consumption_output_validation": {
+    "blocker_reason_counts": {},
+    "deterministic_hash": "3364892148b06185a66ca86a64243a32ab54324995ed8752be795bed78300677",
+    "metadata": {
+      "controlled_test_only": true,
+      "deterministic_serializer": "json_sort_keys_sha256",
+      "observational_only": true,
+      "planner_remap_performed": false,
+      "production_behavior_changed": false,
+      "production_consumer": false,
+      "production_default_routing_authorized": false,
+      "source": "v3_1_controlled_consumption_output_validation",
+      "stable_generation_token": "v3_1_phase_18_controlled_consumption_output_validation_token"
+    },
+    "run": {
+      "controlled_consumption_record_count": 1,
+      "controlled_test_consumption_hash": "f08b0dd2a540a8f4da38a059b3c0def3d029747cb1416201946a1795e6d30c04",
+      "controlled_test_consumption_schema": "v3_1.controlled_test_consumption.1",
+      "run_id": "v3_1_phase_18_controlled_consumption_output_validation"
+    },
+    "safety_confirmations": {
+      "legacy_planner_ownership_preserved": true,
+      "production_behavior_changed": false,
+      "production_output_affected": false,
+      "production_planner_routing_changed": false,
+      "runtime_manifest_consumption_enabled": false,
+      "runtime_production_consumption_enabled": false,
+      "trusted_data_default_truth": false,
+      "validation_authorizes_production_routing": false,
+      "validation_is_production_approval": false
+    },
+    "schema_version": "v3_1.controlled_consumption_output_validation.1",
+    "summary": {
+      "blocked_count": 0,
+      "deterministic": true,
+      "production_affected_count": 0,
+      "production_behavior_changed": false,
+      "production_default_routing_authorized": false,
+      "production_output_affected": false,
+      "records_evaluated": 1,
+      "runtime_manifest_consumption_enabled": false,
+      "runtime_production_consumption_enabled": false,
+      "trusted_data_default_truth": false,
+      "valid_count": 1
+    },
+    "traceability_summary": {
+      "authorization_trace_count": 1,
+      "fixture_set_trace_count": 1,
+      "manifest_trace_count": 1
+    },
+    "validation_records": [
+      {
+        "blockers": [],
+        "controlled_consumption_status": "consumed_in_controlled_test",
+        "fixture_set_id": "v3_1_fixture_set_6d3b668a84cfbb69",
+        "manifest_id": "v3_1_admission_manifest_198a3e2110f9e5e4",
+        "metadata": {
+          "controlled_test_only": true,
+          "observational_only": true,
+          "planner_remap_performed": false,
+          "production_consumer": false
+        },
+        "production_output_affected": false,
+        "traceability_summary": {
+          "authorization_state": "non_production_authoritative",
+          "fixture_set_trace_present": true,
+          "manifest_trace_present": true,
+          "not_production_consumption": true,
+          "runtime_consumption_enabled": false
+        },
+        "validation_authorizes_production_routing": false,
+        "validation_record_id": "v3_1_controlled_output_validation_f3354f757d6050bb",
+        "validation_status": "valid_controlled_test_output"
+      }
+    ],
+    "validation_status_counts": {
+      "blocked_invalid_authorization_state": 0,
+      "blocked_invalid_consumption_status": 0,
+      "blocked_missing_consumption_record": 0,
+      "blocked_missing_fixture_set_trace": 0,
+      "blocked_missing_manifest_trace": 0,
+      "blocked_runtime_consumption_enabled": 0,
+      "valid_controlled_test_output": 1
+    }
+  },
+  "deterministic_guarantees": {
+    "json_sort_keys": true,
+    "passed": true,
+    "repeated_hash": "3364892148b06185a66ca86a64243a32ab54324995ed8752be795bed78300677",
+    "sample_hash": "3364892148b06185a66ca86a64243a32ab54324995ed8752be795bed78300677",
+    "timestamp_excluded_from_hash": true
+  },
+  "generated_at": "2026-05-15T00:00:00+00:00",
+  "metadata": {
+    "controlled_test_only": true,
+    "observational_only": true,
+    "planner_remap_performed": false,
+    "production_behavior_changed": false,
+    "production_default_routing_authorized": false,
+    "source": "v3_1_controlled_consumption_output_validation_report"
+  },
+  "phase": "v3.1_phase_18_controlled_consumption_output_validation",
+  "phase_18_boundaries": [
+    "validation is test-only governance metadata",
+    "validation is not production approval",
+    "validation does not authorize production routing",
+    "runtime manifest consumption remains disabled",
+    "legacy planner ownership remains intact"
+  ],
+  "production_default_routing_authorized": false,
+  "recommendation": "OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING",
+  "runtime_manifest_consumption_enabled": false,
+  "runtime_production_consumption_enabled": false,
+  "schema_version": "v3_1.controlled_consumption_output_validation_report.1",
+  "summary": {
+    "blocked_count": 0,
+    "deterministic": true,
+    "production_affected_count": 0,
+    "production_behavior_changed": false,
+    "production_default_routing_authorized": false,
+    "production_output_affected": false,
+    "records_evaluated": 1,
+    "runtime_manifest_consumption_enabled": false,
+    "runtime_production_consumption_enabled": false,
+    "trusted_data_default_truth": false,
+    "valid_count": 1
+  }
+}

--- a/docs/migration/V3_1_CONTROLLED_CONSUMPTION_OUTPUT_VALIDATION.md
+++ b/docs/migration/V3_1_CONTROLLED_CONSUMPTION_OUTPUT_VALIDATION.md
@@ -1,0 +1,48 @@
+# V3.1 Controlled Consumption Output Validation
+
+Phase 18 validates controlled-test consumption output traceability and production isolation.
+Validation is not production approval and does not authorize routing.
+
+## Recommendation
+
+- Recommendation: `OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING`
+- Production default routing authorized: `false`
+- Runtime production consumption enabled: `false`
+- Runtime manifest consumption enabled: `false`
+
+## Summary
+
+- Records evaluated: `1`
+- Valid: `1`
+- Blocked: `0`
+- Production affected: `0`
+- Deterministic: `true`
+
+## Blocker Reasons
+
+| Reason | Count |
+| --- | ---: |
+
+## Traceability Summary
+
+- Manifest traces: `1`
+- Fixture-set traces: `1`
+- Authorization traces: `1`
+
+## Validation Records
+
+| Record | Manifest | Fixture Set | Consumption | Validation |
+| --- | --- | --- | --- | --- |
+| `v3_1_controlled_output_validation_f3354f757d6050bb` | `v3_1_admission_manifest_198a3e2110f9e5e4` | `v3_1_fixture_set_6d3b668a84cfbb69` | `consumed_in_controlled_test` | `valid_controlled_test_output` |
+
+## Phase 18 Boundaries
+
+- validation is test-only governance metadata
+- validation is not production approval
+- validation does not authorize production routing
+- runtime manifest consumption remains disabled
+- legacy planner ownership remains intact
+
+## Conclusion
+
+Controlled consumption output validation is available for governance review, while production routing remains unchanged.


### PR DESCRIPTION
Adds deterministic validation for controlled test consumption outputs, ensuring traceability, non-production authorization, and production routing isolation remain intact.