### PR TITLE
v3.1: add controlled consumption parity snapshot

### DIFF
--- a/backend/app/planner_adapters/v3_1/__init__.py
+++ b/backend/app/planner_adapters/v3_1/__init__.py
@@ -69,6 +69,10 @@ from .controlled_consumption_output_validation import (
     CONTROLLED_CONSUMPTION_OUTPUT_VALIDATION_STATUSES,
     validate_controlled_consumption_output,
 )
+from .controlled_consumption_parity_snapshot import (
+    CONTROLLED_CONSUMPTION_PARITY_STATUSES,
+    build_controlled_consumption_parity_snapshot,
+)
 from .approval_manifest_diff_audit import (
     APPROVAL_MANIFEST_DIFF_CLASSIFICATIONS,
     audit_approval_manifest_diffs,
@@ -107,6 +111,7 @@ __all__ = [
     "MANIFEST_CONSUMPTION_ELIGIBILITY_STATUSES",
     "CONTROLLED_TEST_CONSUMPTION_STATUSES",
     "CONTROLLED_CONSUMPTION_OUTPUT_VALIDATION_STATUSES",
+    "CONTROLLED_CONSUMPTION_PARITY_STATUSES",
     "APPROVAL_MANIFEST_DIFF_CLASSIFICATIONS",
     "SERIALIZED_APPROVAL_MANIFEST_STATUSES",
     "SUPPORTED_TRUSTED_SHADOW_DOMAINS",
@@ -133,6 +138,7 @@ __all__ = [
     "evaluate_manifest_consumption_eligibility",
     "build_controlled_test_consumption",
     "validate_controlled_consumption_output",
+    "build_controlled_consumption_parity_snapshot",
     "audit_approval_manifest_diffs",
     "discover_default_reviewed_fixture_input_sources",
     "deterministic_hash",

--- a/backend/app/planner_adapters/v3_1/controlled_consumption_parity_snapshot.py
+++ b/backend/app/planner_adapters/v3_1/controlled_consumption_parity_snapshot.py
@@ -1,0 +1,260 @@
+"""Controlled consumption parity snapshot infrastructure for v3.1 governance.
+
+Parity snapshots compare validated controlled-test consumption output against
+planner-adjacent baseline snapshots. They are observational only and cannot
+authorize production routing.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from copy import deepcopy
+from typing import Any
+
+from .approval_manifest_serialization import NON_PRODUCTION_AUTHORIZATION_STATE
+from .trusted_shadow_consumption import deterministic_hash
+
+
+CONTROLLED_CONSUMPTION_PARITY_STATUSES = (
+    "parity_confirmed",
+    "blocked_missing_validated_output",
+    "blocked_missing_baseline_snapshot",
+    "blocked_identity_mismatch",
+    "blocked_fixture_set_mismatch",
+    "blocked_manifest_trace_mismatch",
+    "blocked_invalid_authorization_state",
+)
+STABLE_CONTROLLED_CONSUMPTION_PARITY_TOKEN = "v3_1_phase_19_controlled_consumption_parity_snapshot_token"
+
+
+def build_controlled_consumption_parity_snapshot(
+    *,
+    controlled_consumption_output_validation: dict[str, Any] | list[dict[str, Any]],
+    planner_snapshot_baselines: dict[str, Any] | list[dict[str, Any]],
+    run_id: str = "v3_1_phase_19_controlled_consumption_parity_snapshot",
+) -> dict[str, Any]:
+    """Build deterministic parity records for controlled-test output."""
+
+    validation_records = _validation_records(controlled_consumption_output_validation)
+    baseline_snapshots = _baseline_snapshots(planner_snapshot_baselines)
+    selected_baseline = _selected_baseline_snapshot(baseline_snapshots)
+
+    parity_records = [
+        _parity_record(record=record, baseline=selected_baseline)
+        for record in sorted(validation_records, key=_validation_sort_key)
+    ]
+    if not parity_records:
+        parity_records = [_missing_validated_output_record(baseline=selected_baseline)]
+
+    counts = Counter(record["parity_status"] for record in parity_records)
+    blocker_reasons = Counter(reason for record in parity_records for reason in record["blockers"])
+    validation_hash = controlled_consumption_output_validation.get("deterministic_hash") if isinstance(controlled_consumption_output_validation, dict) else None
+    baseline_hash = planner_snapshot_baselines.get("deterministic_hash") if isinstance(planner_snapshot_baselines, dict) else None
+    envelope = {
+        "schema_version": "v3_1.controlled_consumption_parity_snapshot.1",
+        "run": {
+            "run_id": run_id,
+            "validated_output_record_count": len(validation_records),
+            "planner_snapshot_count": len(baseline_snapshots),
+            "controlled_consumption_output_validation_hash": validation_hash,
+            "planner_snapshot_baselines_hash": baseline_hash,
+        },
+        "summary": {
+            "records_evaluated": len(parity_records),
+            "parity_confirmed_count": counts["parity_confirmed"],
+            "blocked_count": len(parity_records) - counts["parity_confirmed"],
+            "production_affected_count": 0,
+            "production_output_affected": False,
+            "production_behavior_changed": False,
+            "production_default_routing_authorized": False,
+            "runtime_manifest_consumption_enabled": False,
+            "runtime_production_consumption_enabled": False,
+            "deterministic": True,
+        },
+        "parity_status_counts": {
+            status: counts[status]
+            for status in CONTROLLED_CONSUMPTION_PARITY_STATUSES
+        },
+        "blocker_reason_counts": dict(sorted(blocker_reasons.items())),
+        "baseline_comparison_summary": {
+            "baseline_snapshots_available": len(baseline_snapshots),
+            "baseline_candidate_count": sum(1 for snapshot in baseline_snapshots if snapshot.get("baseline_candidate") is True),
+            "comparison_eligible_count": sum(1 for snapshot in baseline_snapshots if snapshot.get("comparison_eligible") is True),
+            "selected_baseline_id": selected_baseline.get("snapshot_id") if selected_baseline else None,
+            "validated_output_count": len(validation_records),
+            "production_routing_authorized": False,
+        },
+        "parity_records": parity_records,
+        "safety_confirmations": {
+            "parity_authorizes_production_routing": False,
+            "parity_is_production_approval": False,
+            "runtime_manifest_consumption_enabled": False,
+            "runtime_production_consumption_enabled": False,
+            "legacy_planner_ownership_preserved": True,
+            "production_output_affected": False,
+            "production_behavior_changed": False,
+            "production_planner_routing_changed": False,
+            "trusted_data_default_truth": False,
+        },
+        "metadata": {
+            "source": "v3_1_controlled_consumption_parity_snapshot",
+            "observational_only": True,
+            "controlled_test_only": True,
+            "production_consumer": False,
+            "production_behavior_changed": False,
+            "planner_remap_performed": False,
+            "production_default_routing_authorized": False,
+            "stable_generation_token": STABLE_CONTROLLED_CONSUMPTION_PARITY_TOKEN,
+            "deterministic_serializer": "json_sort_keys_sha256",
+        },
+    }
+    envelope["deterministic_hash"] = deterministic_hash(envelope)
+    return envelope
+
+
+def _validation_records(value: dict[str, Any] | list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if isinstance(value, list):
+        return [deepcopy(row) for row in value]
+    return [deepcopy(row) for row in value.get("validation_records", [])]
+
+
+def _baseline_snapshots(value: dict[str, Any] | list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if isinstance(value, list):
+        return [deepcopy(row) for row in value]
+    return [deepcopy(row) for row in value.get("snapshots", [])]
+
+
+def _selected_baseline_snapshot(snapshots: list[dict[str, Any]]) -> dict[str, Any] | None:
+    eligible = [
+        snapshot
+        for snapshot in snapshots
+        if snapshot.get("baseline_candidate") is True
+        or snapshot.get("baseline_readiness") == "baseline_candidate"
+        or snapshot.get("comparison_eligible") is True
+    ]
+    if not eligible:
+        return None
+    return sorted(eligible, key=_baseline_sort_key)[0]
+
+
+def _baseline_sort_key(snapshot: dict[str, Any]) -> tuple[int, str, str]:
+    priority = 0 if snapshot.get("baseline_candidate") is True or snapshot.get("baseline_readiness") == "baseline_candidate" else 1
+    return (
+        priority,
+        str(snapshot.get("stable_key") or ""),
+        str(snapshot.get("snapshot_id") or ""),
+    )
+
+
+def _validation_sort_key(record: dict[str, Any]) -> tuple[str, str, str]:
+    return (
+        str(record.get("fixture_set_id") or ""),
+        str(record.get("manifest_id") or ""),
+        str(record.get("validation_record_id") or ""),
+    )
+
+
+def _parity_record(*, record: dict[str, Any], baseline: dict[str, Any] | None) -> dict[str, Any]:
+    blockers = _blockers(record=record, baseline=baseline)
+    status = blockers[0] if blockers else "parity_confirmed"
+    seed = {
+        "validation_record_id": record.get("validation_record_id"),
+        "manifest_id": record.get("manifest_id"),
+        "fixture_set_id": record.get("fixture_set_id"),
+        "baseline_id": baseline.get("snapshot_id") if baseline else None,
+        "status": status,
+        "token": STABLE_CONTROLLED_CONSUMPTION_PARITY_TOKEN,
+    }
+    return {
+        "parity_record_id": f"v3_1_controlled_parity_{deterministic_hash(seed)[:16]}",
+        "manifest_id": record.get("manifest_id"),
+        "fixture_set_id": record.get("fixture_set_id"),
+        "baseline_id": baseline.get("snapshot_id") if baseline else None,
+        "parity_status": status,
+        "blockers": blockers,
+        "comparison_summary": _comparison_summary(record=record, baseline=baseline),
+        "parity_authorizes_production_routing": False,
+        "production_output_affected": False,
+        "metadata": {
+            "observational_only": True,
+            "controlled_test_only": True,
+            "production_consumer": False,
+            "planner_remap_performed": False,
+        },
+    }
+
+
+def _missing_validated_output_record(*, baseline: dict[str, Any] | None) -> dict[str, Any]:
+    seed = {
+        "missing_validated_output": True,
+        "baseline_id": baseline.get("snapshot_id") if baseline else None,
+        "token": STABLE_CONTROLLED_CONSUMPTION_PARITY_TOKEN,
+    }
+    blockers = ["blocked_missing_validated_output"]
+    if baseline is None:
+        blockers.append("blocked_missing_baseline_snapshot")
+    return {
+        "parity_record_id": f"v3_1_controlled_parity_{deterministic_hash(seed)[:16]}",
+        "manifest_id": None,
+        "fixture_set_id": None,
+        "baseline_id": baseline.get("snapshot_id") if baseline else None,
+        "parity_status": "blocked_missing_validated_output",
+        "blockers": blockers,
+        "comparison_summary": {
+            "validated_output_present": False,
+            "baseline_snapshot_present": baseline is not None,
+            "controlled_identity_present": False,
+            "fixture_set_trace_present": False,
+            "manifest_trace_present": False,
+            "authorization_state": None,
+            "baseline_candidate_snapshot": bool(baseline and baseline.get("baseline_candidate") is True),
+            "production_routing_authorized": False,
+        },
+        "parity_authorizes_production_routing": False,
+        "production_output_affected": False,
+        "metadata": {
+            "observational_only": True,
+            "controlled_test_only": True,
+            "production_consumer": False,
+            "planner_remap_performed": False,
+        },
+    }
+
+
+def _blockers(*, record: dict[str, Any], baseline: dict[str, Any] | None) -> list[str]:
+    blockers: list[str] = []
+    if record.get("validation_status") != "valid_controlled_test_output":
+        blockers.append("blocked_missing_validated_output")
+    if baseline is None:
+        blockers.append("blocked_missing_baseline_snapshot")
+    if (record.get("traceability_summary") or {}).get("authorization_state") != NON_PRODUCTION_AUTHORIZATION_STATE:
+        blockers.append("blocked_invalid_authorization_state")
+    if not record.get("manifest_id"):
+        blockers.append("blocked_manifest_trace_mismatch")
+    if not record.get("fixture_set_id"):
+        blockers.append("blocked_fixture_set_mismatch")
+    if baseline is not None:
+        if baseline.get("expected_validation_record_id") and baseline.get("expected_validation_record_id") != record.get("validation_record_id"):
+            blockers.append("blocked_identity_mismatch")
+        if baseline.get("expected_fixture_set_id") and baseline.get("expected_fixture_set_id") != record.get("fixture_set_id"):
+            blockers.append("blocked_fixture_set_mismatch")
+        if baseline.get("expected_manifest_id") and baseline.get("expected_manifest_id") != record.get("manifest_id"):
+            blockers.append("blocked_manifest_trace_mismatch")
+    return sorted(set(blockers), key=blockers.index)
+
+
+def _comparison_summary(*, record: dict[str, Any], baseline: dict[str, Any] | None) -> dict[str, Any]:
+    traceability = record.get("traceability_summary") or {}
+    return {
+        "validated_output_present": record.get("validation_status") == "valid_controlled_test_output",
+        "baseline_snapshot_present": baseline is not None,
+        "baseline_expected_identity_present": bool(baseline and (baseline.get("snapshot_id") or baseline.get("stable_key"))),
+        "controlled_identity_present": bool(record.get("validation_record_id")),
+        "fixture_set_trace_present": bool(record.get("fixture_set_id") and traceability.get("fixture_set_trace_present") is True),
+        "manifest_trace_present": bool(record.get("manifest_id") and traceability.get("manifest_trace_present") is True),
+        "authorization_state": traceability.get("authorization_state"),
+        "baseline_candidate_snapshot": bool(baseline and baseline.get("baseline_candidate") is True),
+        "baseline_readiness": baseline.get("baseline_readiness") if baseline else None,
+        "baseline_stable_key": baseline.get("stable_key") if baseline else None,
+        "production_routing_authorized": False,
+    }

--- a/backend/scripts/report_v3_1_controlled_consumption_parity_snapshot.py
+++ b/backend/scripts/report_v3_1_controlled_consumption_parity_snapshot.py
@@ -1,0 +1,178 @@
+"""Generate the v3.1 controlled consumption parity snapshot report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.planner_adapters.v3_1.controlled_consumption_parity_snapshot import build_controlled_consumption_parity_snapshot  # noqa: E402
+
+
+DETERMINISTIC_GENERATED_AT = "2026-05-15T00:00:00+00:00"
+
+
+def build_v3_1_controlled_consumption_parity_snapshot_report() -> dict[str, Any]:
+    repo_root = Path(__file__).resolve().parents[2]
+    validation = _read_json(repo_root / "docs" / "generated" / "v3_1_controlled_consumption_output_validation_report.json")[
+        "controlled_consumption_output_validation"
+    ]
+    baselines = _read_json(repo_root / "docs" / "generated" / "v3_1_planner_snapshot_baselines_report.json")[
+        "planner_snapshot_baselines"
+    ]
+    parity = build_controlled_consumption_parity_snapshot(
+        controlled_consumption_output_validation=validation,
+        planner_snapshot_baselines=baselines,
+    )
+    repeated = build_controlled_consumption_parity_snapshot(
+        controlled_consumption_output_validation=validation,
+        planner_snapshot_baselines=baselines,
+    )
+    report = {
+        "schema_version": "v3_1.controlled_consumption_parity_snapshot_report.1",
+        "generated_at": DETERMINISTIC_GENERATED_AT,
+        "phase": "v3.1_phase_19_controlled_consumption_parity_snapshot",
+        "recommendation": "OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING",
+        "production_default_routing_authorized": False,
+        "runtime_manifest_consumption_enabled": False,
+        "runtime_production_consumption_enabled": False,
+        "summary": {
+            **parity["summary"],
+            "deterministic": parity["deterministic_hash"] == repeated["deterministic_hash"],
+        },
+        "controlled_consumption_parity_snapshot": parity,
+        "deterministic_guarantees": {
+            "passed": parity["deterministic_hash"] == repeated["deterministic_hash"],
+            "sample_hash": parity["deterministic_hash"],
+            "repeated_hash": repeated["deterministic_hash"],
+            "timestamp_excluded_from_hash": True,
+            "json_sort_keys": True,
+        },
+        "phase_19_boundaries": [
+            "parity analysis is test-only governance metadata",
+            "parity confirmation is not production approval",
+            "parity confirmation does not authorize production routing",
+            "runtime manifest consumption remains disabled",
+            "legacy planner ownership remains intact",
+        ],
+        "metadata": {
+            "source": "v3_1_controlled_consumption_parity_snapshot_report",
+            "observational_only": True,
+            "controlled_test_only": True,
+            "production_behavior_changed": False,
+            "production_default_routing_authorized": False,
+            "planner_remap_performed": False,
+        },
+    }
+    return _normalize_generated_at(report)
+
+
+def write_report(report: dict[str, Any], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_markdown(report: dict[str, Any], output_path: Path) -> None:
+    parity = report["controlled_consumption_parity_snapshot"]
+    summary = report["summary"]
+    baseline = parity["baseline_comparison_summary"]
+    lines = [
+        "# V3.1 Controlled Consumption Parity Snapshot",
+        "",
+        "Phase 19 compares validated controlled-test consumption output against planner-adjacent baseline snapshots.",
+        "Parity confirmation is not production approval and does not authorize routing.",
+        "",
+        "## Recommendation",
+        "",
+        f"- Recommendation: `{report['recommendation']}`",
+        f"- Production default routing authorized: `{str(report['production_default_routing_authorized']).lower()}`",
+        f"- Runtime production consumption enabled: `{str(report['runtime_production_consumption_enabled']).lower()}`",
+        f"- Runtime manifest consumption enabled: `{str(report['runtime_manifest_consumption_enabled']).lower()}`",
+        "",
+        "## Summary",
+        "",
+        f"- Records evaluated: `{summary['records_evaluated']}`",
+        f"- Parity confirmed: `{summary['parity_confirmed_count']}`",
+        f"- Blocked: `{summary['blocked_count']}`",
+        f"- Production affected: `{summary['production_affected_count']}`",
+        f"- Deterministic: `{str(summary['deterministic']).lower()}`",
+        "",
+        "## Blocker Reasons",
+        "",
+        "| Reason | Count |",
+        "| --- | ---: |",
+    ]
+    for reason, count in parity["blocker_reason_counts"].items():
+        lines.append(f"| `{reason}` | `{count}` |")
+    lines.extend(
+        [
+            "",
+            "## Baseline Comparison Summary",
+            "",
+            f"- Baseline snapshots available: `{baseline['baseline_snapshots_available']}`",
+            f"- Baseline candidates: `{baseline['baseline_candidate_count']}`",
+            f"- Comparison eligible snapshots: `{baseline['comparison_eligible_count']}`",
+            f"- Selected baseline: `{baseline['selected_baseline_id'] or ''}`",
+            f"- Validated outputs: `{baseline['validated_output_count']}`",
+            f"- Production routing authorized: `{str(baseline['production_routing_authorized']).lower()}`",
+            "",
+            "## Parity Records",
+            "",
+            "| Record | Manifest | Fixture Set | Baseline | Parity |",
+            "| --- | --- | --- | --- | --- |",
+        ]
+    )
+    for row in parity["parity_records"]:
+        lines.append(
+            f"| `{row['parity_record_id']}` | `{row['manifest_id'] or ''}` | `{row['fixture_set_id'] or ''}` | `{row['baseline_id'] or ''}` | `{row['parity_status']}` |"
+        )
+    lines.extend(["", "## Phase 19 Boundaries", ""])
+    lines.extend(f"- {item}" for item in report["phase_19_boundaries"])
+    lines.extend(
+        [
+            "",
+            "## Conclusion",
+            "",
+            "Controlled consumption parity snapshots are available for governance review, while production routing remains unchanged.",
+        ]
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _normalize_generated_at(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: DETERMINISTIC_GENERATED_AT if key == "generated_at" else _normalize_generated_at(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_normalize_generated_at(item) for item in value]
+    return deepcopy(value)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", default="docs/generated/v3_1_controlled_consumption_parity_snapshot_report.json")
+    parser.add_argument("--markdown-output", default="docs/migration/V3_1_CONTROLLED_CONSUMPTION_PARITY_SNAPSHOT.md")
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[2]
+    report = build_v3_1_controlled_consumption_parity_snapshot_report()
+    write_report(report, repo_root / args.output)
+    write_markdown(report, repo_root / args.markdown_output)
+    print(json.dumps(report["summary"], indent=2, sort_keys=True))
+    print(report["recommendation"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_v3_1_controlled_consumption_parity_snapshot.py
+++ b/backend/tests/test_v3_1_controlled_consumption_parity_snapshot.py
@@ -1,0 +1,170 @@
+from app.planner_adapters.v3_1.controlled_consumption_parity_snapshot import build_controlled_consumption_parity_snapshot
+from scripts.report_v3_1_controlled_consumption_parity_snapshot import build_v3_1_controlled_consumption_parity_snapshot_report
+
+
+def test_matching_validated_output_and_baseline_confirms_parity():
+    result = build_controlled_consumption_parity_snapshot(
+        controlled_consumption_output_validation=_validation([_validation_record("manifest_a", "set_a")]),
+        planner_snapshot_baselines=_baselines([_baseline()]),
+    )
+
+    record = result["parity_records"][0]
+    assert record["parity_status"] == "parity_confirmed"
+    assert result["summary"]["parity_confirmed_count"] == 1
+
+
+def test_missing_validated_output_blocks():
+    result = build_controlled_consumption_parity_snapshot(
+        controlled_consumption_output_validation=_validation([]),
+        planner_snapshot_baselines=_baselines([_baseline()]),
+    )
+
+    assert result["parity_records"][0]["parity_status"] == "blocked_missing_validated_output"
+
+
+def test_missing_baseline_snapshot_blocks():
+    result = build_controlled_consumption_parity_snapshot(
+        controlled_consumption_output_validation=_validation([_validation_record("manifest_a", "set_a")]),
+        planner_snapshot_baselines=_baselines([]),
+    )
+
+    assert result["parity_records"][0]["parity_status"] == "blocked_missing_baseline_snapshot"
+
+
+def test_identity_mismatch_blocks():
+    baseline = _baseline(expected_validation_record_id="different_record")
+    result = build_controlled_consumption_parity_snapshot(
+        controlled_consumption_output_validation=_validation([_validation_record("manifest_a", "set_a")]),
+        planner_snapshot_baselines=_baselines([baseline]),
+    )
+
+    assert result["parity_records"][0]["parity_status"] == "blocked_identity_mismatch"
+
+
+def test_fixture_set_mismatch_blocks():
+    baseline = _baseline(expected_fixture_set_id="different_set")
+    result = build_controlled_consumption_parity_snapshot(
+        controlled_consumption_output_validation=_validation([_validation_record("manifest_a", "set_a")]),
+        planner_snapshot_baselines=_baselines([baseline]),
+    )
+
+    assert result["parity_records"][0]["parity_status"] == "blocked_fixture_set_mismatch"
+
+
+def test_manifest_trace_mismatch_blocks():
+    baseline = _baseline(expected_manifest_id="different_manifest")
+    result = build_controlled_consumption_parity_snapshot(
+        controlled_consumption_output_validation=_validation([_validation_record("manifest_a", "set_a")]),
+        planner_snapshot_baselines=_baselines([baseline]),
+    )
+
+    assert result["parity_records"][0]["parity_status"] == "blocked_manifest_trace_mismatch"
+
+
+def test_invalid_authorization_state_blocks():
+    result = build_controlled_consumption_parity_snapshot(
+        controlled_consumption_output_validation=_validation(
+            [_validation_record("manifest_a", "set_a", authorization_state="production_authoritative")]
+        ),
+        planner_snapshot_baselines=_baselines([_baseline()]),
+    )
+
+    assert result["parity_records"][0]["parity_status"] == "blocked_invalid_authorization_state"
+
+
+def test_deterministic_ordering():
+    records = [_validation_record("manifest_b", "set_b"), _validation_record("manifest_a", "set_a")]
+    first = build_controlled_consumption_parity_snapshot(
+        controlled_consumption_output_validation=_validation(records),
+        planner_snapshot_baselines=_baselines([_baseline(snapshot_id="baseline_b", stable_key="b"), _baseline(snapshot_id="baseline_a", stable_key="a")]),
+    )
+    second = build_controlled_consumption_parity_snapshot(
+        controlled_consumption_output_validation=_validation(list(reversed(records))),
+        planner_snapshot_baselines=_baselines([_baseline(snapshot_id="baseline_a", stable_key="a"), _baseline(snapshot_id="baseline_b", stable_key="b")]),
+    )
+
+    assert first["deterministic_hash"] == second["deterministic_hash"]
+    assert [row["manifest_id"] for row in first["parity_records"]] == ["manifest_a", "manifest_b"]
+    assert first["baseline_comparison_summary"]["selected_baseline_id"] == "baseline_a"
+
+
+def test_stable_report_generation():
+    first = build_v3_1_controlled_consumption_parity_snapshot_report()
+    second = build_v3_1_controlled_consumption_parity_snapshot_report()
+
+    assert first["deterministic_guarantees"]["passed"] is True
+    assert first["controlled_consumption_parity_snapshot"]["deterministic_hash"] == second["controlled_consumption_parity_snapshot"]["deterministic_hash"]
+    assert first["summary"] == second["summary"]
+
+
+def test_no_production_routing_enablement():
+    result = build_controlled_consumption_parity_snapshot(
+        controlled_consumption_output_validation=_validation([_validation_record("manifest_a", "set_a")]),
+        planner_snapshot_baselines=_baselines([_baseline()]),
+    )
+    record = result["parity_records"][0]
+
+    assert result["safety_confirmations"]["parity_authorizes_production_routing"] is False
+    assert result["safety_confirmations"]["parity_is_production_approval"] is False
+    assert result["summary"]["runtime_manifest_consumption_enabled"] is False
+    assert record["parity_authorizes_production_routing"] is False
+
+
+def _validation(records):
+    return {
+        "schema_version": "v3_1.controlled_consumption_output_validation.1",
+        "deterministic_hash": "validation-hash",
+        "summary": {
+            "runtime_manifest_consumption_enabled": False,
+            "runtime_production_consumption_enabled": False,
+        },
+        "validation_records": records,
+    }
+
+
+def _validation_record(manifest_id, fixture_set_id, authorization_state="non_production_authoritative", status="valid_controlled_test_output"):
+    return {
+        "validation_record_id": f"validation_{manifest_id}_{fixture_set_id}",
+        "manifest_id": manifest_id,
+        "fixture_set_id": fixture_set_id,
+        "controlled_consumption_status": "consumed_in_controlled_test",
+        "validation_status": status,
+        "blockers": [],
+        "traceability_summary": {
+            "manifest_trace_present": bool(manifest_id),
+            "fixture_set_trace_present": bool(fixture_set_id),
+            "authorization_state": authorization_state,
+            "runtime_consumption_enabled": False,
+            "not_production_consumption": True,
+        },
+        "validation_authorizes_production_routing": False,
+        "production_output_affected": False,
+    }
+
+
+def _baselines(snapshots):
+    return {
+        "schema_version": "v3_1.planner_snapshot_baselines.1",
+        "deterministic_hash": "baseline-hash",
+        "snapshots": snapshots,
+    }
+
+
+def _baseline(
+    snapshot_id="baseline_a",
+    stable_key="a",
+    expected_validation_record_id=None,
+    expected_fixture_set_id=None,
+    expected_manifest_id=None,
+):
+    return {
+        "snapshot_id": snapshot_id,
+        "stable_key": stable_key,
+        "baseline_readiness": "baseline_candidate",
+        "baseline_candidate": True,
+        "comparison_eligible": True,
+        "expected_validation_record_id": expected_validation_record_id,
+        "expected_fixture_set_id": expected_fixture_set_id,
+        "expected_manifest_id": expected_manifest_id,
+        "production_output_affected": False,
+    }

--- a/docs/generated/v3_1_controlled_consumption_parity_snapshot_report.json
+++ b/docs/generated/v3_1_controlled_consumption_parity_snapshot_report.json
@@ -1,0 +1,137 @@
+{
+  "controlled_consumption_parity_snapshot": {
+    "baseline_comparison_summary": {
+      "baseline_candidate_count": 1,
+      "baseline_snapshots_available": 5,
+      "comparison_eligible_count": 2,
+      "production_routing_authorized": false,
+      "selected_baseline_id": "v3_1_snapshot_472bcd4c1169053b",
+      "validated_output_count": 1
+    },
+    "blocker_reason_counts": {},
+    "deterministic_hash": "5e5744d7474cc3e8ca26e1163178c65744e46a07f01674bc4b11acbec486b20c",
+    "metadata": {
+      "controlled_test_only": true,
+      "deterministic_serializer": "json_sort_keys_sha256",
+      "observational_only": true,
+      "planner_remap_performed": false,
+      "production_behavior_changed": false,
+      "production_consumer": false,
+      "production_default_routing_authorized": false,
+      "source": "v3_1_controlled_consumption_parity_snapshot",
+      "stable_generation_token": "v3_1_phase_19_controlled_consumption_parity_snapshot_token"
+    },
+    "parity_records": [
+      {
+        "baseline_id": "v3_1_snapshot_472bcd4c1169053b",
+        "blockers": [],
+        "comparison_summary": {
+          "authorization_state": "non_production_authoritative",
+          "baseline_candidate_snapshot": true,
+          "baseline_expected_identity_present": true,
+          "baseline_readiness": "baseline_candidate",
+          "baseline_snapshot_present": true,
+          "baseline_stable_key": "affix",
+          "controlled_identity_present": true,
+          "fixture_set_trace_present": true,
+          "manifest_trace_present": true,
+          "production_routing_authorized": false,
+          "validated_output_present": true
+        },
+        "fixture_set_id": "v3_1_fixture_set_6d3b668a84cfbb69",
+        "manifest_id": "v3_1_admission_manifest_198a3e2110f9e5e4",
+        "metadata": {
+          "controlled_test_only": true,
+          "observational_only": true,
+          "planner_remap_performed": false,
+          "production_consumer": false
+        },
+        "parity_authorizes_production_routing": false,
+        "parity_record_id": "v3_1_controlled_parity_4a6a864a7cd4c63a",
+        "parity_status": "parity_confirmed",
+        "production_output_affected": false
+      }
+    ],
+    "parity_status_counts": {
+      "blocked_fixture_set_mismatch": 0,
+      "blocked_identity_mismatch": 0,
+      "blocked_invalid_authorization_state": 0,
+      "blocked_manifest_trace_mismatch": 0,
+      "blocked_missing_baseline_snapshot": 0,
+      "blocked_missing_validated_output": 0,
+      "parity_confirmed": 1
+    },
+    "run": {
+      "controlled_consumption_output_validation_hash": "3364892148b06185a66ca86a64243a32ab54324995ed8752be795bed78300677",
+      "planner_snapshot_baselines_hash": "5b7a5ff8a33eb491d345ecf660fdd933e422e4aab475f835b6ab82d9c9097398",
+      "planner_snapshot_count": 5,
+      "run_id": "v3_1_phase_19_controlled_consumption_parity_snapshot",
+      "validated_output_record_count": 1
+    },
+    "safety_confirmations": {
+      "legacy_planner_ownership_preserved": true,
+      "parity_authorizes_production_routing": false,
+      "parity_is_production_approval": false,
+      "production_behavior_changed": false,
+      "production_output_affected": false,
+      "production_planner_routing_changed": false,
+      "runtime_manifest_consumption_enabled": false,
+      "runtime_production_consumption_enabled": false,
+      "trusted_data_default_truth": false
+    },
+    "schema_version": "v3_1.controlled_consumption_parity_snapshot.1",
+    "summary": {
+      "blocked_count": 0,
+      "deterministic": true,
+      "parity_confirmed_count": 1,
+      "production_affected_count": 0,
+      "production_behavior_changed": false,
+      "production_default_routing_authorized": false,
+      "production_output_affected": false,
+      "records_evaluated": 1,
+      "runtime_manifest_consumption_enabled": false,
+      "runtime_production_consumption_enabled": false
+    }
+  },
+  "deterministic_guarantees": {
+    "json_sort_keys": true,
+    "passed": true,
+    "repeated_hash": "5e5744d7474cc3e8ca26e1163178c65744e46a07f01674bc4b11acbec486b20c",
+    "sample_hash": "5e5744d7474cc3e8ca26e1163178c65744e46a07f01674bc4b11acbec486b20c",
+    "timestamp_excluded_from_hash": true
+  },
+  "generated_at": "2026-05-15T00:00:00+00:00",
+  "metadata": {
+    "controlled_test_only": true,
+    "observational_only": true,
+    "planner_remap_performed": false,
+    "production_behavior_changed": false,
+    "production_default_routing_authorized": false,
+    "source": "v3_1_controlled_consumption_parity_snapshot_report"
+  },
+  "phase": "v3.1_phase_19_controlled_consumption_parity_snapshot",
+  "phase_19_boundaries": [
+    "parity analysis is test-only governance metadata",
+    "parity confirmation is not production approval",
+    "parity confirmation does not authorize production routing",
+    "runtime manifest consumption remains disabled",
+    "legacy planner ownership remains intact"
+  ],
+  "production_default_routing_authorized": false,
+  "recommendation": "OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING",
+  "runtime_manifest_consumption_enabled": false,
+  "runtime_production_consumption_enabled": false,
+  "schema_version": "v3_1.controlled_consumption_parity_snapshot_report.1",
+  "summary": {
+    "blocked_count": 0,
+    "deterministic": true,
+    "parity_confirmed_count": 1,
+    "production_affected_count": 0,
+    "production_behavior_changed": false,
+    "production_default_routing_authorized": false,
+    "production_output_affected": false,
+    "records_evaluated": 1,
+    "runtime_manifest_consumption_enabled": false,
+    "runtime_production_consumption_enabled": false
+  }
+}

--- a/docs/migration/V3_1_CONTROLLED_CONSUMPTION_PARITY_SNAPSHOT.md
+++ b/docs/migration/V3_1_CONTROLLED_CONSUMPTION_PARITY_SNAPSHOT.md
@@ -1,0 +1,51 @@
+# V3.1 Controlled Consumption Parity Snapshot
+
+Phase 19 compares validated controlled-test consumption output against planner-adjacent baseline snapshots.
+Parity confirmation is not production approval and does not authorize routing.
+
+## Recommendation
+
+- Recommendation: `OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING`
+- Production default routing authorized: `false`
+- Runtime production consumption enabled: `false`
+- Runtime manifest consumption enabled: `false`
+
+## Summary
+
+- Records evaluated: `1`
+- Parity confirmed: `1`
+- Blocked: `0`
+- Production affected: `0`
+- Deterministic: `true`
+
+## Blocker Reasons
+
+| Reason | Count |
+| --- | ---: |
+
+## Baseline Comparison Summary
+
+- Baseline snapshots available: `5`
+- Baseline candidates: `1`
+- Comparison eligible snapshots: `2`
+- Selected baseline: `v3_1_snapshot_472bcd4c1169053b`
+- Validated outputs: `1`
+- Production routing authorized: `false`
+
+## Parity Records
+
+| Record | Manifest | Fixture Set | Baseline | Parity |
+| --- | --- | --- | --- | --- |
+| `v3_1_controlled_parity_4a6a864a7cd4c63a` | `v3_1_admission_manifest_198a3e2110f9e5e4` | `v3_1_fixture_set_6d3b668a84cfbb69` | `v3_1_snapshot_472bcd4c1169053b` | `parity_confirmed` |
+
+## Phase 19 Boundaries
+
+- parity analysis is test-only governance metadata
+- parity confirmation is not production approval
+- parity confirmation does not authorize production routing
+- runtime manifest consumption remains disabled
+- legacy planner ownership remains intact
+
+## Conclusion
+
+Controlled consumption parity snapshots are available for governance review, while production routing remains unchanged.


### PR DESCRIPTION
Adds deterministic parity snapshot reporting for validated controlled consumption outputs against baseline planner snapshots while preserving production routing isolation.