### PR TITLE
v3.1: add controlled consumption semantic parity audit

### DIFF
--- a/backend/app/planner_adapters/v3_1/__init__.py
+++ b/backend/app/planner_adapters/v3_1/__init__.py
@@ -73,6 +73,10 @@ from .controlled_consumption_parity_snapshot import (
     CONTROLLED_CONSUMPTION_PARITY_STATUSES,
     build_controlled_consumption_parity_snapshot,
 )
+from .controlled_consumption_semantic_parity import (
+    CONTROLLED_CONSUMPTION_SEMANTIC_PARITY_STATUSES,
+    build_controlled_consumption_semantic_parity,
+)
 from .approval_manifest_diff_audit import (
     APPROVAL_MANIFEST_DIFF_CLASSIFICATIONS,
     audit_approval_manifest_diffs,
@@ -112,6 +116,7 @@ __all__ = [
     "CONTROLLED_TEST_CONSUMPTION_STATUSES",
     "CONTROLLED_CONSUMPTION_OUTPUT_VALIDATION_STATUSES",
     "CONTROLLED_CONSUMPTION_PARITY_STATUSES",
+    "CONTROLLED_CONSUMPTION_SEMANTIC_PARITY_STATUSES",
     "APPROVAL_MANIFEST_DIFF_CLASSIFICATIONS",
     "SERIALIZED_APPROVAL_MANIFEST_STATUSES",
     "SUPPORTED_TRUSTED_SHADOW_DOMAINS",
@@ -139,6 +144,7 @@ __all__ = [
     "build_controlled_test_consumption",
     "validate_controlled_consumption_output",
     "build_controlled_consumption_parity_snapshot",
+    "build_controlled_consumption_semantic_parity",
     "audit_approval_manifest_diffs",
     "discover_default_reviewed_fixture_input_sources",
     "deterministic_hash",

--- a/backend/app/planner_adapters/v3_1/controlled_consumption_semantic_parity.py
+++ b/backend/app/planner_adapters/v3_1/controlled_consumption_semantic_parity.py
@@ -1,0 +1,313 @@
+"""Controlled consumption semantic parity audit for v3.1 governance.
+
+Semantic parity extends structural parity by comparing controlled-test output
+against optional planner baseline semantic expectations. Missing semantic
+metadata is reported explicitly and never authorizes production routing.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from copy import deepcopy
+from typing import Any
+
+from .approval_manifest_serialization import NON_PRODUCTION_AUTHORIZATION_STATE
+from .trusted_shadow_consumption import deterministic_hash
+
+
+CONTROLLED_CONSUMPTION_SEMANTIC_PARITY_STATUSES = (
+    "semantic_parity_confirmed",
+    "semantic_parity_partial",
+    "blocked_missing_structural_parity",
+    "blocked_missing_controlled_output",
+    "blocked_missing_baseline_semantics",
+    "blocked_semantic_mismatch",
+    "blocked_invalid_authorization_state",
+)
+STABLE_CONTROLLED_SEMANTIC_PARITY_TOKEN = "v3_1_phase_20_controlled_consumption_semantic_parity_token"
+
+
+def build_controlled_consumption_semantic_parity(
+    *,
+    controlled_consumption_parity_snapshot: dict[str, Any] | list[dict[str, Any]],
+    controlled_consumption_output_validation: dict[str, Any] | list[dict[str, Any]],
+    planner_snapshot_baselines: dict[str, Any] | list[dict[str, Any]],
+    run_id: str = "v3_1_phase_20_controlled_consumption_semantic_parity",
+) -> dict[str, Any]:
+    """Build deterministic semantic parity audit records."""
+
+    parity_records = _parity_records(controlled_consumption_parity_snapshot)
+    validation_records = _validation_records(controlled_consumption_output_validation)
+    baseline_snapshots = _baseline_snapshots(planner_snapshot_baselines)
+    validation_by_key = {_validation_key(record): record for record in validation_records}
+    baseline_by_id = {
+        str(snapshot.get("snapshot_id")): snapshot
+        for snapshot in baseline_snapshots
+        if snapshot.get("snapshot_id")
+    }
+    semantic_records = [
+        _semantic_record(
+            parity_record=record,
+            validation_record=validation_by_key.get(_parity_key(record)),
+            baseline_snapshot=baseline_by_id.get(str(record.get("baseline_id"))),
+        )
+        for record in sorted(parity_records, key=_parity_sort_key)
+    ]
+    if not semantic_records:
+        semantic_records = [_missing_structural_parity_record()]
+
+    counts = Counter(record["semantic_parity_status"] for record in semantic_records)
+    blocker_reasons = Counter(reason for record in semantic_records for reason in record["blockers"])
+    unavailable_fields = Counter(field for record in semantic_records for field in record["unavailable_fields"])
+    mismatched_fields = Counter(field for record in semantic_records for field in record["mismatched_fields"])
+    parity_hash = controlled_consumption_parity_snapshot.get("deterministic_hash") if isinstance(controlled_consumption_parity_snapshot, dict) else None
+    validation_hash = controlled_consumption_output_validation.get("deterministic_hash") if isinstance(controlled_consumption_output_validation, dict) else None
+    baseline_hash = planner_snapshot_baselines.get("deterministic_hash") if isinstance(planner_snapshot_baselines, dict) else None
+    envelope = {
+        "schema_version": "v3_1.controlled_consumption_semantic_parity.1",
+        "run": {
+            "run_id": run_id,
+            "structural_parity_record_count": len(parity_records),
+            "validated_output_record_count": len(validation_records),
+            "planner_snapshot_count": len(baseline_snapshots),
+            "controlled_consumption_parity_snapshot_hash": parity_hash,
+            "controlled_consumption_output_validation_hash": validation_hash,
+            "planner_snapshot_baselines_hash": baseline_hash,
+        },
+        "summary": {
+            "records_evaluated": len(semantic_records),
+            "semantic_parity_confirmed_count": counts["semantic_parity_confirmed"],
+            "semantic_parity_partial_count": counts["semantic_parity_partial"],
+            "blocked_count": len(semantic_records) - counts["semantic_parity_confirmed"] - counts["semantic_parity_partial"],
+            "production_affected_count": 0,
+            "production_output_affected": False,
+            "production_behavior_changed": False,
+            "production_default_routing_authorized": False,
+            "runtime_manifest_consumption_enabled": False,
+            "runtime_production_consumption_enabled": False,
+            "deterministic": True,
+        },
+        "semantic_parity_status_counts": {
+            status: counts[status]
+            for status in CONTROLLED_CONSUMPTION_SEMANTIC_PARITY_STATUSES
+        },
+        "blocker_reason_counts": dict(sorted(blocker_reasons.items())),
+        "unavailable_semantic_field_counts": dict(sorted(unavailable_fields.items())),
+        "mismatched_semantic_field_counts": dict(sorted(mismatched_fields.items())),
+        "semantic_parity_records": semantic_records,
+        "safety_confirmations": {
+            "semantic_parity_authorizes_production_routing": False,
+            "semantic_parity_is_production_approval": False,
+            "runtime_manifest_consumption_enabled": False,
+            "runtime_production_consumption_enabled": False,
+            "legacy_planner_ownership_preserved": True,
+            "production_output_affected": False,
+            "production_behavior_changed": False,
+            "production_planner_routing_changed": False,
+            "trusted_data_default_truth": False,
+        },
+        "metadata": {
+            "source": "v3_1_controlled_consumption_semantic_parity",
+            "observational_only": True,
+            "controlled_test_only": True,
+            "production_consumer": False,
+            "production_behavior_changed": False,
+            "planner_remap_performed": False,
+            "production_default_routing_authorized": False,
+            "stable_generation_token": STABLE_CONTROLLED_SEMANTIC_PARITY_TOKEN,
+            "deterministic_serializer": "json_sort_keys_sha256",
+        },
+    }
+    envelope["deterministic_hash"] = deterministic_hash(envelope)
+    return envelope
+
+
+def _parity_records(value: dict[str, Any] | list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if isinstance(value, list):
+        return [deepcopy(row) for row in value]
+    return [deepcopy(row) for row in value.get("parity_records", [])]
+
+
+def _validation_records(value: dict[str, Any] | list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if isinstance(value, list):
+        return [deepcopy(row) for row in value]
+    return [deepcopy(row) for row in value.get("validation_records", [])]
+
+
+def _baseline_snapshots(value: dict[str, Any] | list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if isinstance(value, list):
+        return [deepcopy(row) for row in value]
+    return [deepcopy(row) for row in value.get("snapshots", [])]
+
+
+def _semantic_record(
+    *,
+    parity_record: dict[str, Any],
+    validation_record: dict[str, Any] | None,
+    baseline_snapshot: dict[str, Any] | None,
+) -> dict[str, Any]:
+    compared_fields, unavailable_fields, mismatched_fields = _semantic_field_audit(
+        validation_record=validation_record,
+        baseline_snapshot=baseline_snapshot,
+    )
+    blockers = _blockers(
+        parity_record=parity_record,
+        validation_record=validation_record,
+        baseline_snapshot=baseline_snapshot,
+        unavailable_fields=unavailable_fields,
+        mismatched_fields=mismatched_fields,
+    )
+    status = _status(
+        blockers=blockers,
+        compared_fields=compared_fields,
+        unavailable_fields=unavailable_fields,
+    )
+    seed = {
+        "parity_record_id": parity_record.get("parity_record_id"),
+        "manifest_id": parity_record.get("manifest_id"),
+        "fixture_set_id": parity_record.get("fixture_set_id"),
+        "baseline_id": parity_record.get("baseline_id"),
+        "status": status,
+        "token": STABLE_CONTROLLED_SEMANTIC_PARITY_TOKEN,
+    }
+    return {
+        "semantic_parity_record_id": f"v3_1_controlled_semantic_parity_{deterministic_hash(seed)[:16]}",
+        "manifest_id": parity_record.get("manifest_id"),
+        "fixture_set_id": parity_record.get("fixture_set_id"),
+        "baseline_id": parity_record.get("baseline_id"),
+        "structural_parity_status": parity_record.get("parity_status"),
+        "semantic_parity_status": status,
+        "compared_fields": compared_fields,
+        "unavailable_fields": unavailable_fields,
+        "mismatched_fields": mismatched_fields,
+        "blockers": blockers,
+        "semantic_parity_authorizes_production_routing": False,
+        "production_output_affected": False,
+        "metadata": {
+            "observational_only": True,
+            "controlled_test_only": True,
+            "production_consumer": False,
+            "planner_remap_performed": False,
+        },
+    }
+
+
+def _missing_structural_parity_record() -> dict[str, Any]:
+    seed = {"missing_structural_parity": True, "token": STABLE_CONTROLLED_SEMANTIC_PARITY_TOKEN}
+    return {
+        "semantic_parity_record_id": f"v3_1_controlled_semantic_parity_{deterministic_hash(seed)[:16]}",
+        "manifest_id": None,
+        "fixture_set_id": None,
+        "baseline_id": None,
+        "structural_parity_status": None,
+        "semantic_parity_status": "blocked_missing_structural_parity",
+        "compared_fields": [],
+        "unavailable_fields": [],
+        "mismatched_fields": [],
+        "blockers": ["blocked_missing_structural_parity"],
+        "semantic_parity_authorizes_production_routing": False,
+        "production_output_affected": False,
+        "metadata": {
+            "observational_only": True,
+            "controlled_test_only": True,
+            "production_consumer": False,
+            "planner_remap_performed": False,
+        },
+    }
+
+
+def _semantic_field_audit(
+    *,
+    validation_record: dict[str, Any] | None,
+    baseline_snapshot: dict[str, Any] | None,
+) -> tuple[list[dict[str, Any]], list[str], list[str]]:
+    baseline_semantics = _baseline_semantics(baseline_snapshot)
+    controlled_semantics = _controlled_semantics(validation_record)
+    if not baseline_semantics:
+        return [], ["baseline_semantics"], []
+    compared_fields: list[dict[str, Any]] = []
+    unavailable_fields: list[str] = []
+    mismatched_fields: list[str] = []
+    for field in sorted(baseline_semantics):
+        expected = baseline_semantics[field]
+        if field not in controlled_semantics:
+            unavailable_fields.append(field)
+            continue
+        actual = controlled_semantics[field]
+        matches = actual == expected
+        compared_fields.append({"field": field, "expected": expected, "actual": actual, "matches": matches})
+        if not matches:
+            mismatched_fields.append(field)
+    return compared_fields, unavailable_fields, mismatched_fields
+
+
+def _blockers(
+    *,
+    parity_record: dict[str, Any],
+    validation_record: dict[str, Any] | None,
+    baseline_snapshot: dict[str, Any] | None,
+    unavailable_fields: list[str],
+    mismatched_fields: list[str],
+) -> list[str]:
+    blockers: list[str] = []
+    if parity_record.get("parity_status") != "parity_confirmed":
+        blockers.append("blocked_missing_structural_parity")
+    if validation_record is None:
+        blockers.append("blocked_missing_controlled_output")
+    if _authorization_state(validation_record) != NON_PRODUCTION_AUTHORIZATION_STATE:
+        blockers.append("blocked_invalid_authorization_state")
+    if not _baseline_semantics(baseline_snapshot) and (baseline_snapshot or {}).get("semantic_required") is True:
+        blockers.append("blocked_missing_baseline_semantics")
+    if mismatched_fields:
+        blockers.append("blocked_semantic_mismatch")
+    return sorted(set(blockers), key=blockers.index)
+
+
+def _status(*, blockers: list[str], compared_fields: list[dict[str, Any]], unavailable_fields: list[str]) -> str:
+    if blockers:
+        return blockers[0]
+    if unavailable_fields or not compared_fields:
+        return "semantic_parity_partial"
+    return "semantic_parity_confirmed"
+
+
+def _baseline_semantics(snapshot: dict[str, Any] | None) -> dict[str, Any]:
+    if not snapshot:
+        return {}
+    for key in ("semantic_expectations", "expected_semantics", "baseline_semantics"):
+        value = snapshot.get(key)
+        if isinstance(value, dict):
+            return deepcopy(value)
+    return {}
+
+
+def _controlled_semantics(record: dict[str, Any] | None) -> dict[str, Any]:
+    if not record:
+        return {}
+    for key in ("controlled_semantics", "semantic_output", "output_semantics", "controlled_output_semantics"):
+        value = record.get(key)
+        if isinstance(value, dict):
+            return deepcopy(value)
+    return {}
+
+
+def _authorization_state(record: dict[str, Any] | None) -> str | None:
+    if not record:
+        return None
+    return (record.get("traceability_summary") or {}).get("authorization_state")
+
+
+def _parity_key(record: dict[str, Any]) -> tuple[str, str]:
+    return (str(record.get("manifest_id") or ""), str(record.get("fixture_set_id") or ""))
+
+
+def _validation_key(record: dict[str, Any]) -> tuple[str, str]:
+    return (str(record.get("manifest_id") or ""), str(record.get("fixture_set_id") or ""))
+
+
+def _parity_sort_key(record: dict[str, Any]) -> tuple[str, str, str]:
+    return (
+        str(record.get("fixture_set_id") or ""),
+        str(record.get("manifest_id") or ""),
+        str(record.get("parity_record_id") or ""),
+    )

--- a/backend/scripts/report_v3_1_controlled_consumption_semantic_parity.py
+++ b/backend/scripts/report_v3_1_controlled_consumption_semantic_parity.py
@@ -1,0 +1,181 @@
+"""Generate the v3.1 controlled consumption semantic parity report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.planner_adapters.v3_1.controlled_consumption_semantic_parity import build_controlled_consumption_semantic_parity  # noqa: E402
+
+
+DETERMINISTIC_GENERATED_AT = "2026-05-15T00:00:00+00:00"
+
+
+def build_v3_1_controlled_consumption_semantic_parity_report() -> dict[str, Any]:
+    repo_root = Path(__file__).resolve().parents[2]
+    parity = _read_json(repo_root / "docs" / "generated" / "v3_1_controlled_consumption_parity_snapshot_report.json")[
+        "controlled_consumption_parity_snapshot"
+    ]
+    validation = _read_json(repo_root / "docs" / "generated" / "v3_1_controlled_consumption_output_validation_report.json")[
+        "controlled_consumption_output_validation"
+    ]
+    baselines = _read_json(repo_root / "docs" / "generated" / "v3_1_planner_snapshot_baselines_report.json")[
+        "planner_snapshot_baselines"
+    ]
+    semantic = build_controlled_consumption_semantic_parity(
+        controlled_consumption_parity_snapshot=parity,
+        controlled_consumption_output_validation=validation,
+        planner_snapshot_baselines=baselines,
+    )
+    repeated = build_controlled_consumption_semantic_parity(
+        controlled_consumption_parity_snapshot=parity,
+        controlled_consumption_output_validation=validation,
+        planner_snapshot_baselines=baselines,
+    )
+    report = {
+        "schema_version": "v3_1.controlled_consumption_semantic_parity_report.1",
+        "generated_at": DETERMINISTIC_GENERATED_AT,
+        "phase": "v3.1_phase_20_controlled_consumption_semantic_parity_audit",
+        "recommendation": "OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING",
+        "production_default_routing_authorized": False,
+        "runtime_manifest_consumption_enabled": False,
+        "runtime_production_consumption_enabled": False,
+        "summary": {
+            **semantic["summary"],
+            "deterministic": semantic["deterministic_hash"] == repeated["deterministic_hash"],
+        },
+        "controlled_consumption_semantic_parity": semantic,
+        "deterministic_guarantees": {
+            "passed": semantic["deterministic_hash"] == repeated["deterministic_hash"],
+            "sample_hash": semantic["deterministic_hash"],
+            "repeated_hash": repeated["deterministic_hash"],
+            "timestamp_excluded_from_hash": True,
+            "json_sort_keys": True,
+        },
+        "phase_20_boundaries": [
+            "semantic parity audit is test-only governance metadata",
+            "semantic parity confirmation is not production approval",
+            "semantic parity confirmation does not authorize production routing",
+            "unavailable semantic fields remain visible",
+            "runtime manifest consumption remains disabled",
+            "legacy planner ownership remains intact",
+        ],
+        "metadata": {
+            "source": "v3_1_controlled_consumption_semantic_parity_report",
+            "observational_only": True,
+            "controlled_test_only": True,
+            "production_behavior_changed": False,
+            "production_default_routing_authorized": False,
+            "planner_remap_performed": False,
+        },
+    }
+    return _normalize_generated_at(report)
+
+
+def write_report(report: dict[str, Any], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_markdown(report: dict[str, Any], output_path: Path) -> None:
+    semantic = report["controlled_consumption_semantic_parity"]
+    summary = report["summary"]
+    lines = [
+        "# V3.1 Controlled Consumption Semantic Parity",
+        "",
+        "Phase 20 audits controlled-test output against available planner baseline semantics.",
+        "Semantic parity is not production approval and does not authorize routing.",
+        "",
+        "## Recommendation",
+        "",
+        f"- Recommendation: `{report['recommendation']}`",
+        f"- Production default routing authorized: `{str(report['production_default_routing_authorized']).lower()}`",
+        f"- Runtime production consumption enabled: `{str(report['runtime_production_consumption_enabled']).lower()}`",
+        f"- Runtime manifest consumption enabled: `{str(report['runtime_manifest_consumption_enabled']).lower()}`",
+        "",
+        "## Summary",
+        "",
+        f"- Records evaluated: `{summary['records_evaluated']}`",
+        f"- Semantic parity confirmed: `{summary['semantic_parity_confirmed_count']}`",
+        f"- Semantic parity partial: `{summary['semantic_parity_partial_count']}`",
+        f"- Blocked: `{summary['blocked_count']}`",
+        f"- Production affected: `{summary['production_affected_count']}`",
+        f"- Deterministic: `{str(summary['deterministic']).lower()}`",
+        "",
+        "## Unavailable Semantic Fields",
+        "",
+        "| Field | Count |",
+        "| --- | ---: |",
+    ]
+    for field, count in semantic["unavailable_semantic_field_counts"].items():
+        lines.append(f"| `{field}` | `{count}` |")
+    lines.extend(["", "## Mismatch Summary", "", "| Field | Count |", "| --- | ---: |"])
+    for field, count in semantic["mismatched_semantic_field_counts"].items():
+        lines.append(f"| `{field}` | `{count}` |")
+    lines.extend(["", "## Blocker Reasons", "", "| Reason | Count |", "| --- | ---: |"])
+    for reason, count in semantic["blocker_reason_counts"].items():
+        lines.append(f"| `{reason}` | `{count}` |")
+    lines.extend(
+        [
+            "",
+            "## Semantic Parity Records",
+            "",
+            "| Record | Manifest | Fixture Set | Baseline | Structural | Semantic |",
+            "| --- | --- | --- | --- | --- | --- |",
+        ]
+    )
+    for row in semantic["semantic_parity_records"]:
+        lines.append(
+            f"| `{row['semantic_parity_record_id']}` | `{row['manifest_id'] or ''}` | `{row['fixture_set_id'] or ''}` | `{row['baseline_id'] or ''}` | `{row['structural_parity_status'] or ''}` | `{row['semantic_parity_status']}` |"
+        )
+    lines.extend(["", "## Phase 20 Boundaries", ""])
+    lines.extend(f"- {item}" for item in report["phase_20_boundaries"])
+    lines.extend(
+        [
+            "",
+            "## Conclusion",
+            "",
+            "Controlled consumption semantic parity is available for governance review, while production routing remains unchanged.",
+        ]
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _normalize_generated_at(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: DETERMINISTIC_GENERATED_AT if key == "generated_at" else _normalize_generated_at(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_normalize_generated_at(item) for item in value]
+    return deepcopy(value)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", default="docs/generated/v3_1_controlled_consumption_semantic_parity_report.json")
+    parser.add_argument("--markdown-output", default="docs/migration/V3_1_CONTROLLED_CONSUMPTION_SEMANTIC_PARITY.md")
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[2]
+    report = build_v3_1_controlled_consumption_semantic_parity_report()
+    write_report(report, repo_root / args.output)
+    write_markdown(report, repo_root / args.markdown_output)
+    print(json.dumps(report["summary"], indent=2, sort_keys=True))
+    print(report["recommendation"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_v3_1_controlled_consumption_semantic_parity.py
+++ b/backend/tests/test_v3_1_controlled_consumption_semantic_parity.py
@@ -1,0 +1,203 @@
+from app.planner_adapters.v3_1.controlled_consumption_semantic_parity import build_controlled_consumption_semantic_parity
+from scripts.report_v3_1_controlled_consumption_semantic_parity import build_v3_1_controlled_consumption_semantic_parity_report
+
+
+def test_matching_semantic_fields_confirm_parity():
+    result = build_controlled_consumption_semantic_parity(
+        controlled_consumption_parity_snapshot=_parity([_parity_record()]),
+        controlled_consumption_output_validation=_validation([_validation_record(semantics={"domain": "affix", "count": 1})]),
+        planner_snapshot_baselines=_baselines([_baseline(semantics={"domain": "affix", "count": 1})]),
+    )
+
+    record = result["semantic_parity_records"][0]
+    assert record["semantic_parity_status"] == "semantic_parity_confirmed"
+    assert result["summary"]["semantic_parity_confirmed_count"] == 1
+
+
+def test_missing_optional_semantic_fields_produce_partial():
+    result = build_controlled_consumption_semantic_parity(
+        controlled_consumption_parity_snapshot=_parity([_parity_record()]),
+        controlled_consumption_output_validation=_validation([_validation_record()]),
+        planner_snapshot_baselines=_baselines([_baseline()]),
+    )
+
+    record = result["semantic_parity_records"][0]
+    assert record["semantic_parity_status"] == "semantic_parity_partial"
+    assert record["unavailable_fields"] == ["baseline_semantics"]
+
+
+def test_missing_required_baseline_semantics_blocks():
+    result = build_controlled_consumption_semantic_parity(
+        controlled_consumption_parity_snapshot=_parity([_parity_record()]),
+        controlled_consumption_output_validation=_validation([_validation_record()]),
+        planner_snapshot_baselines=_baselines([_baseline(semantic_required=True)]),
+    )
+
+    assert result["semantic_parity_records"][0]["semantic_parity_status"] == "blocked_missing_baseline_semantics"
+
+
+def test_structural_parity_failure_blocks_semantic_parity():
+    result = build_controlled_consumption_semantic_parity(
+        controlled_consumption_parity_snapshot=_parity([_parity_record(status="blocked_missing_baseline_snapshot")]),
+        controlled_consumption_output_validation=_validation([_validation_record(semantics={"domain": "affix"})]),
+        planner_snapshot_baselines=_baselines([_baseline(semantics={"domain": "affix"})]),
+    )
+
+    assert result["semantic_parity_records"][0]["semantic_parity_status"] == "blocked_missing_structural_parity"
+
+
+def test_missing_controlled_output_blocks():
+    result = build_controlled_consumption_semantic_parity(
+        controlled_consumption_parity_snapshot=_parity([_parity_record()]),
+        controlled_consumption_output_validation=_validation([]),
+        planner_snapshot_baselines=_baselines([_baseline(semantics={"domain": "affix"})]),
+    )
+
+    assert result["semantic_parity_records"][0]["semantic_parity_status"] == "blocked_missing_controlled_output"
+
+
+def test_semantic_mismatch_blocks():
+    result = build_controlled_consumption_semantic_parity(
+        controlled_consumption_parity_snapshot=_parity([_parity_record()]),
+        controlled_consumption_output_validation=_validation([_validation_record(semantics={"domain": "item"})]),
+        planner_snapshot_baselines=_baselines([_baseline(semantics={"domain": "affix"})]),
+    )
+
+    record = result["semantic_parity_records"][0]
+    assert record["semantic_parity_status"] == "blocked_semantic_mismatch"
+    assert record["mismatched_fields"] == ["domain"]
+
+
+def test_invalid_authorization_state_blocks():
+    result = build_controlled_consumption_semantic_parity(
+        controlled_consumption_parity_snapshot=_parity([_parity_record()]),
+        controlled_consumption_output_validation=_validation([_validation_record(authorization_state="production_authoritative", semantics={"domain": "affix"})]),
+        planner_snapshot_baselines=_baselines([_baseline(semantics={"domain": "affix"})]),
+    )
+
+    assert result["semantic_parity_records"][0]["semantic_parity_status"] == "blocked_invalid_authorization_state"
+
+
+def test_deterministic_ordering():
+    first = build_controlled_consumption_semantic_parity(
+        controlled_consumption_parity_snapshot=_parity([_parity_record("manifest_b", "set_b"), _parity_record("manifest_a", "set_a")]),
+        controlled_consumption_output_validation=_validation(
+            [
+                _validation_record("manifest_b", "set_b", semantics={"domain": "affix"}),
+                _validation_record("manifest_a", "set_a", semantics={"domain": "affix"}),
+            ]
+        ),
+        planner_snapshot_baselines=_baselines([_baseline("baseline_a", semantics={"domain": "affix"})]),
+    )
+    second = build_controlled_consumption_semantic_parity(
+        controlled_consumption_parity_snapshot=_parity([_parity_record("manifest_a", "set_a"), _parity_record("manifest_b", "set_b")]),
+        controlled_consumption_output_validation=_validation(
+            [
+                _validation_record("manifest_a", "set_a", semantics={"domain": "affix"}),
+                _validation_record("manifest_b", "set_b", semantics={"domain": "affix"}),
+            ]
+        ),
+        planner_snapshot_baselines=_baselines([_baseline("baseline_a", semantics={"domain": "affix"})]),
+    )
+
+    assert first["deterministic_hash"] == second["deterministic_hash"]
+    assert [row["manifest_id"] for row in first["semantic_parity_records"]] == ["manifest_a", "manifest_b"]
+
+
+def test_stable_report_generation():
+    first = build_v3_1_controlled_consumption_semantic_parity_report()
+    second = build_v3_1_controlled_consumption_semantic_parity_report()
+
+    assert first["deterministic_guarantees"]["passed"] is True
+    assert first["controlled_consumption_semantic_parity"]["deterministic_hash"] == second["controlled_consumption_semantic_parity"]["deterministic_hash"]
+    assert first["summary"] == second["summary"]
+
+
+def test_no_production_routing_enablement():
+    result = build_controlled_consumption_semantic_parity(
+        controlled_consumption_parity_snapshot=_parity([_parity_record()]),
+        controlled_consumption_output_validation=_validation([_validation_record(semantics={"domain": "affix"})]),
+        planner_snapshot_baselines=_baselines([_baseline(semantics={"domain": "affix"})]),
+    )
+    record = result["semantic_parity_records"][0]
+
+    assert result["safety_confirmations"]["semantic_parity_authorizes_production_routing"] is False
+    assert result["safety_confirmations"]["semantic_parity_is_production_approval"] is False
+    assert result["summary"]["runtime_manifest_consumption_enabled"] is False
+    assert record["semantic_parity_authorizes_production_routing"] is False
+
+
+def _parity(records):
+    return {
+        "schema_version": "v3_1.controlled_consumption_parity_snapshot.1",
+        "deterministic_hash": "parity-hash",
+        "parity_records": records,
+    }
+
+
+def _parity_record(manifest_id="manifest_a", fixture_set_id="set_a", status="parity_confirmed"):
+    return {
+        "parity_record_id": f"parity_{manifest_id}_{fixture_set_id}",
+        "manifest_id": manifest_id,
+        "fixture_set_id": fixture_set_id,
+        "baseline_id": "baseline_a",
+        "parity_status": status,
+        "blockers": [] if status == "parity_confirmed" else [status],
+        "parity_authorizes_production_routing": False,
+        "production_output_affected": False,
+    }
+
+
+def _validation(records):
+    return {
+        "schema_version": "v3_1.controlled_consumption_output_validation.1",
+        "deterministic_hash": "validation-hash",
+        "validation_records": records,
+    }
+
+
+def _validation_record(
+    manifest_id="manifest_a",
+    fixture_set_id="set_a",
+    authorization_state="non_production_authoritative",
+    semantics=None,
+):
+    return {
+        "validation_record_id": f"validation_{manifest_id}_{fixture_set_id}",
+        "manifest_id": manifest_id,
+        "fixture_set_id": fixture_set_id,
+        "validation_status": "valid_controlled_test_output",
+        "traceability_summary": {
+            "manifest_trace_present": bool(manifest_id),
+            "fixture_set_trace_present": bool(fixture_set_id),
+            "authorization_state": authorization_state,
+            "runtime_consumption_enabled": False,
+            "not_production_consumption": True,
+        },
+        "controlled_semantics": semantics or {},
+        "validation_authorizes_production_routing": False,
+        "production_output_affected": False,
+    }
+
+
+def _baselines(snapshots):
+    return {
+        "schema_version": "v3_1.planner_snapshot_baselines.1",
+        "deterministic_hash": "baseline-hash",
+        "snapshots": snapshots,
+    }
+
+
+def _baseline(snapshot_id="baseline_a", semantics=None, semantic_required=False):
+    baseline = {
+        "snapshot_id": snapshot_id,
+        "stable_key": "affix",
+        "baseline_readiness": "baseline_candidate",
+        "baseline_candidate": True,
+        "comparison_eligible": True,
+        "semantic_required": semantic_required,
+        "production_output_affected": False,
+    }
+    if semantics is not None:
+        baseline["semantic_expectations"] = semantics
+    return baseline

--- a/docs/generated/v3_1_controlled_consumption_semantic_parity_report.json
+++ b/docs/generated/v3_1_controlled_consumption_semantic_parity_report.json
@@ -1,0 +1,131 @@
+{
+  "controlled_consumption_semantic_parity": {
+    "blocker_reason_counts": {},
+    "deterministic_hash": "47279660e764a52abdd3e61f0e157f89af79d8b3d74d124dcd329535b83beb22",
+    "metadata": {
+      "controlled_test_only": true,
+      "deterministic_serializer": "json_sort_keys_sha256",
+      "observational_only": true,
+      "planner_remap_performed": false,
+      "production_behavior_changed": false,
+      "production_consumer": false,
+      "production_default_routing_authorized": false,
+      "source": "v3_1_controlled_consumption_semantic_parity",
+      "stable_generation_token": "v3_1_phase_20_controlled_consumption_semantic_parity_token"
+    },
+    "mismatched_semantic_field_counts": {},
+    "run": {
+      "controlled_consumption_output_validation_hash": "3364892148b06185a66ca86a64243a32ab54324995ed8752be795bed78300677",
+      "controlled_consumption_parity_snapshot_hash": "5e5744d7474cc3e8ca26e1163178c65744e46a07f01674bc4b11acbec486b20c",
+      "planner_snapshot_baselines_hash": "5b7a5ff8a33eb491d345ecf660fdd933e422e4aab475f835b6ab82d9c9097398",
+      "planner_snapshot_count": 5,
+      "run_id": "v3_1_phase_20_controlled_consumption_semantic_parity",
+      "structural_parity_record_count": 1,
+      "validated_output_record_count": 1
+    },
+    "safety_confirmations": {
+      "legacy_planner_ownership_preserved": true,
+      "production_behavior_changed": false,
+      "production_output_affected": false,
+      "production_planner_routing_changed": false,
+      "runtime_manifest_consumption_enabled": false,
+      "runtime_production_consumption_enabled": false,
+      "semantic_parity_authorizes_production_routing": false,
+      "semantic_parity_is_production_approval": false,
+      "trusted_data_default_truth": false
+    },
+    "schema_version": "v3_1.controlled_consumption_semantic_parity.1",
+    "semantic_parity_records": [
+      {
+        "baseline_id": "v3_1_snapshot_472bcd4c1169053b",
+        "blockers": [],
+        "compared_fields": [],
+        "fixture_set_id": "v3_1_fixture_set_6d3b668a84cfbb69",
+        "manifest_id": "v3_1_admission_manifest_198a3e2110f9e5e4",
+        "metadata": {
+          "controlled_test_only": true,
+          "observational_only": true,
+          "planner_remap_performed": false,
+          "production_consumer": false
+        },
+        "mismatched_fields": [],
+        "production_output_affected": false,
+        "semantic_parity_authorizes_production_routing": false,
+        "semantic_parity_record_id": "v3_1_controlled_semantic_parity_e499bdc33dccd64e",
+        "semantic_parity_status": "semantic_parity_partial",
+        "structural_parity_status": "parity_confirmed",
+        "unavailable_fields": [
+          "baseline_semantics"
+        ]
+      }
+    ],
+    "semantic_parity_status_counts": {
+      "blocked_invalid_authorization_state": 0,
+      "blocked_missing_baseline_semantics": 0,
+      "blocked_missing_controlled_output": 0,
+      "blocked_missing_structural_parity": 0,
+      "blocked_semantic_mismatch": 0,
+      "semantic_parity_confirmed": 0,
+      "semantic_parity_partial": 1
+    },
+    "summary": {
+      "blocked_count": 0,
+      "deterministic": true,
+      "production_affected_count": 0,
+      "production_behavior_changed": false,
+      "production_default_routing_authorized": false,
+      "production_output_affected": false,
+      "records_evaluated": 1,
+      "runtime_manifest_consumption_enabled": false,
+      "runtime_production_consumption_enabled": false,
+      "semantic_parity_confirmed_count": 0,
+      "semantic_parity_partial_count": 1
+    },
+    "unavailable_semantic_field_counts": {
+      "baseline_semantics": 1
+    }
+  },
+  "deterministic_guarantees": {
+    "json_sort_keys": true,
+    "passed": true,
+    "repeated_hash": "47279660e764a52abdd3e61f0e157f89af79d8b3d74d124dcd329535b83beb22",
+    "sample_hash": "47279660e764a52abdd3e61f0e157f89af79d8b3d74d124dcd329535b83beb22",
+    "timestamp_excluded_from_hash": true
+  },
+  "generated_at": "2026-05-15T00:00:00+00:00",
+  "metadata": {
+    "controlled_test_only": true,
+    "observational_only": true,
+    "planner_remap_performed": false,
+    "production_behavior_changed": false,
+    "production_default_routing_authorized": false,
+    "source": "v3_1_controlled_consumption_semantic_parity_report"
+  },
+  "phase": "v3.1_phase_20_controlled_consumption_semantic_parity_audit",
+  "phase_20_boundaries": [
+    "semantic parity audit is test-only governance metadata",
+    "semantic parity confirmation is not production approval",
+    "semantic parity confirmation does not authorize production routing",
+    "unavailable semantic fields remain visible",
+    "runtime manifest consumption remains disabled",
+    "legacy planner ownership remains intact"
+  ],
+  "production_default_routing_authorized": false,
+  "recommendation": "OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING",
+  "runtime_manifest_consumption_enabled": false,
+  "runtime_production_consumption_enabled": false,
+  "schema_version": "v3_1.controlled_consumption_semantic_parity_report.1",
+  "summary": {
+    "blocked_count": 0,
+    "deterministic": true,
+    "production_affected_count": 0,
+    "production_behavior_changed": false,
+    "production_default_routing_authorized": false,
+    "production_output_affected": false,
+    "records_evaluated": 1,
+    "runtime_manifest_consumption_enabled": false,
+    "runtime_production_consumption_enabled": false,
+    "semantic_parity_confirmed_count": 0,
+    "semantic_parity_partial_count": 1
+  }
+}

--- a/docs/migration/V3_1_CONTROLLED_CONSUMPTION_SEMANTIC_PARITY.md
+++ b/docs/migration/V3_1_CONTROLLED_CONSUMPTION_SEMANTIC_PARITY.md
@@ -1,0 +1,55 @@
+# V3.1 Controlled Consumption Semantic Parity
+
+Phase 20 audits controlled-test output against available planner baseline semantics.
+Semantic parity is not production approval and does not authorize routing.
+
+## Recommendation
+
+- Recommendation: `OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING`
+- Production default routing authorized: `false`
+- Runtime production consumption enabled: `false`
+- Runtime manifest consumption enabled: `false`
+
+## Summary
+
+- Records evaluated: `1`
+- Semantic parity confirmed: `0`
+- Semantic parity partial: `1`
+- Blocked: `0`
+- Production affected: `0`
+- Deterministic: `true`
+
+## Unavailable Semantic Fields
+
+| Field | Count |
+| --- | ---: |
+| `baseline_semantics` | `1` |
+
+## Mismatch Summary
+
+| Field | Count |
+| --- | ---: |
+
+## Blocker Reasons
+
+| Reason | Count |
+| --- | ---: |
+
+## Semantic Parity Records
+
+| Record | Manifest | Fixture Set | Baseline | Structural | Semantic |
+| --- | --- | --- | --- | --- | --- |
+| `v3_1_controlled_semantic_parity_e499bdc33dccd64e` | `v3_1_admission_manifest_198a3e2110f9e5e4` | `v3_1_fixture_set_6d3b668a84cfbb69` | `v3_1_snapshot_472bcd4c1169053b` | `parity_confirmed` | `semantic_parity_partial` |
+
+## Phase 20 Boundaries
+
+- semantic parity audit is test-only governance metadata
+- semantic parity confirmation is not production approval
+- semantic parity confirmation does not authorize production routing
+- unavailable semantic fields remain visible
+- runtime manifest consumption remains disabled
+- legacy planner ownership remains intact
+
+## Conclusion
+
+Controlled consumption semantic parity is available for governance review, while production routing remains unchanged.


### PR DESCRIPTION
Adds deterministic semantic parity auditing for controlled consumption outputs against available planner baseline semantics while preserving production routing isolation.