### PR TITLE
v3.1: add baseline semantic expectations

### DIFF
--- a/backend/app/planner_adapters/v3_1/__init__.py
+++ b/backend/app/planner_adapters/v3_1/__init__.py
@@ -20,6 +20,10 @@ from .planner_snapshot_baselines import (
     V31PlannerSnapshotBaselines,
     build_sample_planner_snapshot_baseline_inputs,
 )
+from .baseline_semantic_expectations import (
+    BASELINE_SEMANTIC_EXPECTATION_STATUSES,
+    build_baseline_semantic_expectations,
+)
 from .review_policy_evaluation import (
     REVIEW_POLICY_OUTCOMES,
     V31ReviewPolicyEvaluation,
@@ -100,6 +104,7 @@ from .trusted_shadow_consumption import (
 __all__ = [
     "DRIFT_CLASSIFICATIONS",
     "BASELINE_READINESS_CLASSIFICATIONS",
+    "BASELINE_SEMANTIC_EXPECTATION_STATUSES",
     "FIXTURE_WORKFLOW_STATES",
     "FIXTURE_SET_LIFECYCLE_STATES",
     "REVIEW_POLICY_OUTCOMES",
@@ -131,6 +136,7 @@ __all__ = [
     "build_sample_persisted_fixture_set_inputs",
     "build_sample_review_policy_inputs",
     "build_sample_dual_run_inputs",
+    "build_baseline_semantic_expectations",
     "build_default_trusted_repository_probes",
     "build_fixture_set_readiness_gate",
     "evaluate_fixture_source_admission_policy",

--- a/backend/app/planner_adapters/v3_1/baseline_semantic_expectations.py
+++ b/backend/app/planner_adapters/v3_1/baseline_semantic_expectations.py
@@ -1,0 +1,276 @@
+"""Baseline semantic expectation enrichment for v3.1 governance.
+
+Expectation records are derived from planner-adjacent baseline snapshots. They
+preserve unavailable fields explicitly and never authorize production routing.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from copy import deepcopy
+from typing import Any
+
+from .trusted_shadow_consumption import deterministic_hash
+
+
+BASELINE_SEMANTIC_EXPECTATION_STATUSES = (
+    "semantic_expectations_available",
+    "semantic_expectations_partial",
+    "blocked_missing_baseline_snapshot",
+    "blocked_unstable_baseline_identity",
+    "blocked_missing_required_trace",
+)
+STABLE_BASELINE_SEMANTIC_EXPECTATION_TOKEN = "v3_1_phase_21_baseline_semantic_expectations_token"
+
+
+def build_baseline_semantic_expectations(
+    *,
+    planner_snapshot_baselines: dict[str, Any] | list[dict[str, Any]],
+    run_id: str = "v3_1_phase_21_baseline_semantic_expectations",
+) -> dict[str, Any]:
+    """Build deterministic semantic expectation records from baseline snapshots."""
+
+    snapshots = _baseline_snapshots(planner_snapshot_baselines)
+    expectation_records = [
+        _expectation_record(snapshot)
+        for snapshot in sorted(snapshots, key=_snapshot_sort_key)
+    ]
+    if not expectation_records:
+        expectation_records = [_missing_baseline_record()]
+
+    counts = Counter(record["semantic_expectation_status"] for record in expectation_records)
+    unavailable_fields = Counter(field for record in expectation_records for field in record["unavailable_semantic_fields"])
+    blocker_reasons = Counter(reason for record in expectation_records for reason in record["blockers"])
+    baseline_hash = planner_snapshot_baselines.get("deterministic_hash") if isinstance(planner_snapshot_baselines, dict) else None
+    envelope = {
+        "schema_version": "v3_1.baseline_semantic_expectations.1",
+        "run": {
+            "run_id": run_id,
+            "baseline_snapshot_count": len(snapshots),
+            "planner_snapshot_baselines_hash": baseline_hash,
+        },
+        "summary": {
+            "baseline_records_evaluated": len(expectation_records),
+            "expectations_available_count": counts["semantic_expectations_available"],
+            "partial_count": counts["semantic_expectations_partial"],
+            "blocked_count": (
+                counts["blocked_missing_baseline_snapshot"]
+                + counts["blocked_unstable_baseline_identity"]
+                + counts["blocked_missing_required_trace"]
+            ),
+            "production_affected_count": 0,
+            "production_output_affected": False,
+            "production_behavior_changed": False,
+            "production_default_routing_authorized": False,
+            "runtime_manifest_consumption_enabled": False,
+            "runtime_production_consumption_enabled": False,
+            "deterministic": True,
+        },
+        "semantic_expectation_status_counts": {
+            status: counts[status]
+            for status in BASELINE_SEMANTIC_EXPECTATION_STATUSES
+        },
+        "unavailable_semantic_field_counts": dict(sorted(unavailable_fields.items())),
+        "blocker_reason_counts": dict(sorted(blocker_reasons.items())),
+        "baseline_semantic_expectation_records": expectation_records,
+        "safety_confirmations": {
+            "semantic_expectations_authorize_production_routing": False,
+            "semantic_expectations_are_production_approval": False,
+            "runtime_manifest_consumption_enabled": False,
+            "runtime_production_consumption_enabled": False,
+            "legacy_planner_ownership_preserved": True,
+            "production_output_affected": False,
+            "production_behavior_changed": False,
+            "production_planner_routing_changed": False,
+            "trusted_data_default_truth": False,
+        },
+        "metadata": {
+            "source": "v3_1_baseline_semantic_expectations",
+            "observational_only": True,
+            "controlled_test_only": True,
+            "production_consumer": False,
+            "production_behavior_changed": False,
+            "planner_remap_performed": False,
+            "production_default_routing_authorized": False,
+            "stable_generation_token": STABLE_BASELINE_SEMANTIC_EXPECTATION_TOKEN,
+            "deterministic_serializer": "json_sort_keys_sha256",
+        },
+    }
+    envelope["deterministic_hash"] = deterministic_hash(envelope)
+    return envelope
+
+
+def _baseline_snapshots(value: dict[str, Any] | list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if isinstance(value, list):
+        return [deepcopy(row) for row in value]
+    return [deepcopy(row) for row in value.get("snapshots", [])]
+
+
+def _expectation_record(snapshot: dict[str, Any]) -> dict[str, Any]:
+    expected_identity_fields = _identity_fields(snapshot)
+    expected_manifest_trace_fields = _manifest_trace_fields(snapshot)
+    expected_fixture_trace_fields = _fixture_trace_fields(snapshot)
+    unavailable_fields = _unavailable_fields(
+        expected_identity_fields=expected_identity_fields,
+        expected_manifest_trace_fields=expected_manifest_trace_fields,
+        expected_fixture_trace_fields=expected_fixture_trace_fields,
+    )
+    blockers = _blockers(
+        snapshot=snapshot,
+        expected_identity_fields=expected_identity_fields,
+        expected_manifest_trace_fields=expected_manifest_trace_fields,
+        expected_fixture_trace_fields=expected_fixture_trace_fields,
+    )
+    status = _status(blockers=blockers, unavailable_fields=unavailable_fields)
+    semantic_expectations = {
+        **expected_identity_fields,
+        **expected_manifest_trace_fields,
+        **expected_fixture_trace_fields,
+    }
+    seed = {
+        "baseline_id": snapshot.get("snapshot_id"),
+        "stable_key": snapshot.get("stable_key"),
+        "status": status,
+        "token": STABLE_BASELINE_SEMANTIC_EXPECTATION_TOKEN,
+    }
+    return {
+        "baseline_semantic_expectation_id": f"v3_1_baseline_semantic_expectation_{deterministic_hash(seed)[:16]}",
+        "baseline_id": snapshot.get("snapshot_id"),
+        "fixture_set_id": expected_fixture_trace_fields.get("fixture_set_id"),
+        "expected_identity_fields": expected_identity_fields,
+        "expected_manifest_trace_fields": expected_manifest_trace_fields,
+        "expected_fixture_trace_fields": expected_fixture_trace_fields,
+        "semantic_expectations": semantic_expectations,
+        "unavailable_semantic_fields": unavailable_fields,
+        "semantic_expectation_status": status,
+        "blockers": blockers,
+        "semantic_expectations_authorize_production_routing": False,
+        "production_output_affected": False,
+        "metadata": {
+            "observational_only": True,
+            "controlled_test_only": True,
+            "production_consumer": False,
+            "planner_remap_performed": False,
+        },
+    }
+
+
+def _missing_baseline_record() -> dict[str, Any]:
+    seed = {"missing_baseline": True, "token": STABLE_BASELINE_SEMANTIC_EXPECTATION_TOKEN}
+    return {
+        "baseline_semantic_expectation_id": f"v3_1_baseline_semantic_expectation_{deterministic_hash(seed)[:16]}",
+        "baseline_id": None,
+        "fixture_set_id": None,
+        "expected_identity_fields": {},
+        "expected_manifest_trace_fields": {},
+        "expected_fixture_trace_fields": {},
+        "semantic_expectations": {},
+        "unavailable_semantic_fields": [],
+        "semantic_expectation_status": "blocked_missing_baseline_snapshot",
+        "blockers": ["blocked_missing_baseline_snapshot"],
+        "semantic_expectations_authorize_production_routing": False,
+        "production_output_affected": False,
+        "metadata": {
+            "observational_only": True,
+            "controlled_test_only": True,
+            "production_consumer": False,
+            "planner_remap_performed": False,
+        },
+    }
+
+
+def _identity_fields(snapshot: dict[str, Any]) -> dict[str, Any]:
+    fields: dict[str, Any] = {}
+    for key in ("snapshot_id", "stable_key", "snapshot_category", "baseline_readiness"):
+        if snapshot.get(key) not in (None, ""):
+            fields[key] = snapshot[key]
+    comparison = snapshot.get("dual_run_comparison_state") or {}
+    for key in ("comparison_id", "legacy_status", "trusted_shadow_status", "drift_classification", "legacy_hash", "trusted_hash"):
+        if comparison.get(key) not in (None, ""):
+            fields[key] = comparison[key]
+    return fields
+
+
+def _manifest_trace_fields(snapshot: dict[str, Any]) -> dict[str, Any]:
+    return _first_present_mapping(
+        snapshot,
+        ("expected_manifest_trace_fields", "manifest_trace_fields"),
+        ("manifest_id", "expected_manifest_id"),
+    )
+
+
+def _fixture_trace_fields(snapshot: dict[str, Any]) -> dict[str, Any]:
+    return _first_present_mapping(
+        snapshot,
+        ("expected_fixture_trace_fields", "fixture_trace_fields"),
+        ("fixture_set_id", "expected_fixture_set_id"),
+    )
+
+
+def _first_present_mapping(snapshot: dict[str, Any], mapping_keys: tuple[str, ...], scalar_keys: tuple[str, ...]) -> dict[str, Any]:
+    fields: dict[str, Any] = {}
+    for key in mapping_keys:
+        value = snapshot.get(key)
+        if isinstance(value, dict):
+            fields.update({item_key: item_value for item_key, item_value in value.items() if item_value not in (None, "")})
+    for key in scalar_keys:
+        if snapshot.get(key) not in (None, ""):
+            normalized_key = key.removeprefix("expected_")
+            fields[normalized_key] = snapshot[key]
+    semantics = snapshot.get("semantic_expectations")
+    if isinstance(semantics, dict):
+        for key in scalar_keys:
+            normalized_key = key.removeprefix("expected_")
+            if semantics.get(normalized_key) not in (None, ""):
+                fields[normalized_key] = semantics[normalized_key]
+    return fields
+
+
+def _unavailable_fields(
+    *,
+    expected_identity_fields: dict[str, Any],
+    expected_manifest_trace_fields: dict[str, Any],
+    expected_fixture_trace_fields: dict[str, Any],
+) -> list[str]:
+    unavailable: list[str] = []
+    if not expected_identity_fields.get("snapshot_id"):
+        unavailable.append("snapshot_id")
+    if not expected_identity_fields.get("stable_key"):
+        unavailable.append("stable_key")
+    if not expected_manifest_trace_fields:
+        unavailable.append("manifest_trace_fields")
+    if not expected_fixture_trace_fields:
+        unavailable.append("fixture_trace_fields")
+    return unavailable
+
+
+def _blockers(
+    *,
+    snapshot: dict[str, Any],
+    expected_identity_fields: dict[str, Any],
+    expected_manifest_trace_fields: dict[str, Any],
+    expected_fixture_trace_fields: dict[str, Any],
+) -> list[str]:
+    blockers: list[str] = []
+    if not snapshot:
+        blockers.append("blocked_missing_baseline_snapshot")
+    if not expected_identity_fields.get("snapshot_id") or not expected_identity_fields.get("stable_key"):
+        blockers.append("blocked_unstable_baseline_identity")
+    if snapshot.get("semantic_trace_required") is True and (not expected_manifest_trace_fields or not expected_fixture_trace_fields):
+        blockers.append("blocked_missing_required_trace")
+    return blockers
+
+
+def _status(*, blockers: list[str], unavailable_fields: list[str]) -> str:
+    if blockers:
+        return blockers[0]
+    if unavailable_fields:
+        return "semantic_expectations_partial"
+    return "semantic_expectations_available"
+
+
+def _snapshot_sort_key(snapshot: dict[str, Any]) -> tuple[str, str]:
+    return (
+        str(snapshot.get("stable_key") or ""),
+        str(snapshot.get("snapshot_id") or ""),
+    )

--- a/backend/scripts/report_v3_1_baseline_semantic_expectations.py
+++ b/backend/scripts/report_v3_1_baseline_semantic_expectations.py
@@ -1,0 +1,165 @@
+"""Generate the v3.1 baseline semantic expectations report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.planner_adapters.v3_1.baseline_semantic_expectations import build_baseline_semantic_expectations  # noqa: E402
+
+
+DETERMINISTIC_GENERATED_AT = "2026-05-15T00:00:00+00:00"
+
+
+def build_v3_1_baseline_semantic_expectations_report() -> dict[str, Any]:
+    repo_root = Path(__file__).resolve().parents[2]
+    baselines = _read_json(repo_root / "docs" / "generated" / "v3_1_planner_snapshot_baselines_report.json")[
+        "planner_snapshot_baselines"
+    ]
+    expectations = build_baseline_semantic_expectations(planner_snapshot_baselines=baselines)
+    repeated = build_baseline_semantic_expectations(planner_snapshot_baselines=baselines)
+    report = {
+        "schema_version": "v3_1.baseline_semantic_expectations_report.1",
+        "generated_at": DETERMINISTIC_GENERATED_AT,
+        "phase": "v3.1_phase_21_baseline_semantic_expectation_enrichment",
+        "recommendation": "OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING",
+        "production_default_routing_authorized": False,
+        "runtime_manifest_consumption_enabled": False,
+        "runtime_production_consumption_enabled": False,
+        "summary": {
+            **expectations["summary"],
+            "deterministic": expectations["deterministic_hash"] == repeated["deterministic_hash"],
+        },
+        "baseline_semantic_expectations": expectations,
+        "deterministic_guarantees": {
+            "passed": expectations["deterministic_hash"] == repeated["deterministic_hash"],
+            "sample_hash": expectations["deterministic_hash"],
+            "repeated_hash": repeated["deterministic_hash"],
+            "timestamp_excluded_from_hash": True,
+            "json_sort_keys": True,
+        },
+        "phase_21_boundaries": [
+            "semantic expectations are test-only governance metadata",
+            "semantic expectations are not production approval",
+            "semantic expectations do not authorize production routing",
+            "missing semantic fields remain visible",
+            "runtime manifest consumption remains disabled",
+            "legacy planner ownership remains intact",
+        ],
+        "metadata": {
+            "source": "v3_1_baseline_semantic_expectations_report",
+            "observational_only": True,
+            "controlled_test_only": True,
+            "production_behavior_changed": False,
+            "production_default_routing_authorized": False,
+            "planner_remap_performed": False,
+        },
+    }
+    return _normalize_generated_at(report)
+
+
+def write_report(report: dict[str, Any], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_markdown(report: dict[str, Any], output_path: Path) -> None:
+    expectations = report["baseline_semantic_expectations"]
+    summary = report["summary"]
+    lines = [
+        "# V3.1 Baseline Semantic Expectations",
+        "",
+        "Phase 21 enriches planner baseline snapshots with deterministic semantic expectation metadata where available.",
+        "Semantic expectations are not production approval and do not authorize routing.",
+        "",
+        "## Recommendation",
+        "",
+        f"- Recommendation: `{report['recommendation']}`",
+        f"- Production default routing authorized: `{str(report['production_default_routing_authorized']).lower()}`",
+        f"- Runtime production consumption enabled: `{str(report['runtime_production_consumption_enabled']).lower()}`",
+        f"- Runtime manifest consumption enabled: `{str(report['runtime_manifest_consumption_enabled']).lower()}`",
+        "",
+        "## Summary",
+        "",
+        f"- Baseline records evaluated: `{summary['baseline_records_evaluated']}`",
+        f"- Expectations available: `{summary['expectations_available_count']}`",
+        f"- Partial: `{summary['partial_count']}`",
+        f"- Blocked: `{summary['blocked_count']}`",
+        f"- Production affected: `{summary['production_affected_count']}`",
+        f"- Deterministic: `{str(summary['deterministic']).lower()}`",
+        "",
+        "## Unavailable Semantic Fields",
+        "",
+        "| Field | Count |",
+        "| --- | ---: |",
+    ]
+    for field, count in expectations["unavailable_semantic_field_counts"].items():
+        lines.append(f"| `{field}` | `{count}` |")
+    lines.extend(["", "## Blocker Reasons", "", "| Reason | Count |", "| --- | ---: |"])
+    for reason, count in expectations["blocker_reason_counts"].items():
+        lines.append(f"| `{reason}` | `{count}` |")
+    lines.extend(
+        [
+            "",
+            "## Expectation Records",
+            "",
+            "| Record | Baseline | Fixture Set | Status | Unavailable Fields |",
+            "| --- | --- | --- | --- | --- |",
+        ]
+    )
+    for row in expectations["baseline_semantic_expectation_records"]:
+        unavailable = ", ".join(row["unavailable_semantic_fields"])
+        lines.append(
+            f"| `{row['baseline_semantic_expectation_id']}` | `{row['baseline_id'] or ''}` | `{row['fixture_set_id'] or ''}` | `{row['semantic_expectation_status']}` | `{unavailable}` |"
+        )
+    lines.extend(["", "## Phase 21 Boundaries", ""])
+    lines.extend(f"- {item}" for item in report["phase_21_boundaries"])
+    lines.extend(
+        [
+            "",
+            "## Conclusion",
+            "",
+            "Baseline semantic expectations are available for governance review, while production routing remains unchanged.",
+        ]
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _normalize_generated_at(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: DETERMINISTIC_GENERATED_AT if key == "generated_at" else _normalize_generated_at(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_normalize_generated_at(item) for item in value]
+    return deepcopy(value)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", default="docs/generated/v3_1_baseline_semantic_expectations_report.json")
+    parser.add_argument("--markdown-output", default="docs/migration/V3_1_BASELINE_SEMANTIC_EXPECTATIONS.md")
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[2]
+    report = build_v3_1_baseline_semantic_expectations_report()
+    write_report(report, repo_root / args.output)
+    write_markdown(report, repo_root / args.markdown_output)
+    print(json.dumps(report["summary"], indent=2, sort_keys=True))
+    print(report["recommendation"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_v3_1_baseline_semantic_expectations.py
+++ b/backend/tests/test_v3_1_baseline_semantic_expectations.py
@@ -1,0 +1,124 @@
+from app.planner_adapters.v3_1.baseline_semantic_expectations import build_baseline_semantic_expectations
+from scripts.report_v3_1_baseline_semantic_expectations import build_v3_1_baseline_semantic_expectations_report
+
+
+def test_semantic_expectations_are_produced_when_baseline_fields_exist():
+    result = build_baseline_semantic_expectations(
+        planner_snapshot_baselines=_baselines(
+            [
+                _snapshot(
+                    expected_manifest_id="manifest_a",
+                    expected_fixture_set_id="set_a",
+                )
+            ]
+        )
+    )
+
+    record = result["baseline_semantic_expectation_records"][0]
+    assert record["semantic_expectation_status"] == "semantic_expectations_available"
+    assert record["expected_identity_fields"]["stable_key"] == "affix"
+    assert record["expected_manifest_trace_fields"]["manifest_id"] == "manifest_a"
+    assert record["expected_fixture_trace_fields"]["fixture_set_id"] == "set_a"
+
+
+def test_missing_trace_fields_produce_partial_expectations():
+    result = build_baseline_semantic_expectations(planner_snapshot_baselines=_baselines([_snapshot()]))
+
+    record = result["baseline_semantic_expectation_records"][0]
+    assert record["semantic_expectation_status"] == "semantic_expectations_partial"
+    assert record["unavailable_semantic_fields"] == ["manifest_trace_fields", "fixture_trace_fields"]
+
+
+def test_missing_baseline_blocks():
+    result = build_baseline_semantic_expectations(planner_snapshot_baselines=_baselines([]))
+
+    assert result["baseline_semantic_expectation_records"][0]["semantic_expectation_status"] == "blocked_missing_baseline_snapshot"
+
+
+def test_unstable_identity_blocks():
+    result = build_baseline_semantic_expectations(
+        planner_snapshot_baselines=_baselines([_snapshot(snapshot_id=None, stable_key=None)])
+    )
+
+    assert result["baseline_semantic_expectation_records"][0]["semantic_expectation_status"] == "blocked_unstable_baseline_identity"
+
+
+def test_missing_required_trace_blocks():
+    result = build_baseline_semantic_expectations(
+        planner_snapshot_baselines=_baselines([_snapshot(semantic_trace_required=True)])
+    )
+
+    assert result["baseline_semantic_expectation_records"][0]["semantic_expectation_status"] == "blocked_missing_required_trace"
+
+
+def test_deterministic_ordering():
+    first = build_baseline_semantic_expectations(
+        planner_snapshot_baselines=_baselines([_snapshot(snapshot_id="snapshot_b", stable_key="b"), _snapshot(snapshot_id="snapshot_a", stable_key="a")])
+    )
+    second = build_baseline_semantic_expectations(
+        planner_snapshot_baselines=_baselines([_snapshot(snapshot_id="snapshot_a", stable_key="a"), _snapshot(snapshot_id="snapshot_b", stable_key="b")])
+    )
+
+    assert first["deterministic_hash"] == second["deterministic_hash"]
+    assert [row["baseline_id"] for row in first["baseline_semantic_expectation_records"]] == ["snapshot_a", "snapshot_b"]
+
+
+def test_stable_report_generation():
+    first = build_v3_1_baseline_semantic_expectations_report()
+    second = build_v3_1_baseline_semantic_expectations_report()
+
+    assert first["deterministic_guarantees"]["passed"] is True
+    assert first["baseline_semantic_expectations"]["deterministic_hash"] == second["baseline_semantic_expectations"]["deterministic_hash"]
+    assert first["summary"] == second["summary"]
+
+
+def test_no_production_routing_enablement():
+    result = build_baseline_semantic_expectations(
+        planner_snapshot_baselines=_baselines([_snapshot(expected_manifest_id="manifest_a", expected_fixture_set_id="set_a")])
+    )
+    record = result["baseline_semantic_expectation_records"][0]
+
+    assert result["safety_confirmations"]["semantic_expectations_authorize_production_routing"] is False
+    assert result["safety_confirmations"]["semantic_expectations_are_production_approval"] is False
+    assert result["summary"]["runtime_manifest_consumption_enabled"] is False
+    assert record["semantic_expectations_authorize_production_routing"] is False
+
+
+def _baselines(snapshots):
+    return {
+        "schema_version": "v3_1.planner_snapshot_baselines.1",
+        "deterministic_hash": "baseline-hash",
+        "snapshots": snapshots,
+    }
+
+
+def _snapshot(
+    snapshot_id="snapshot_a",
+    stable_key="affix",
+    expected_manifest_id=None,
+    expected_fixture_set_id=None,
+    semantic_trace_required=False,
+):
+    snapshot = {
+        "snapshot_id": snapshot_id,
+        "stable_key": stable_key,
+        "snapshot_category": "planner_adjacent_summary",
+        "baseline_readiness": "baseline_candidate",
+        "baseline_candidate": True,
+        "comparison_eligible": True,
+        "semantic_trace_required": semantic_trace_required,
+        "dual_run_comparison_state": {
+            "comparison_id": stable_key,
+            "legacy_status": "available",
+            "trusted_shadow_status": "available",
+            "drift_classification": "equivalent",
+            "legacy_hash": "legacy-hash",
+            "trusted_hash": "trusted-hash",
+        },
+        "production_output_affected": False,
+    }
+    if expected_manifest_id is not None:
+        snapshot["expected_manifest_id"] = expected_manifest_id
+    if expected_fixture_set_id is not None:
+        snapshot["expected_fixture_set_id"] = expected_fixture_set_id
+    return snapshot

--- a/docs/generated/v3_1_baseline_semantic_expectations_report.json
+++ b/docs/generated/v3_1_baseline_semantic_expectations_report.json
@@ -1,0 +1,324 @@
+{
+  "baseline_semantic_expectations": {
+    "baseline_semantic_expectation_records": [
+      {
+        "baseline_id": "v3_1_snapshot_472bcd4c1169053b",
+        "baseline_semantic_expectation_id": "v3_1_baseline_semantic_expectation_14a1c0229a013775",
+        "blockers": [],
+        "expected_fixture_trace_fields": {},
+        "expected_identity_fields": {
+          "baseline_readiness": "baseline_candidate",
+          "comparison_id": "affix",
+          "drift_classification": "equivalent",
+          "legacy_hash": "640cf0924ea88a86b5d8eeff3f7d3b68aa94b66f91cee4739d150acb7c35570a",
+          "legacy_status": "available",
+          "snapshot_category": "planner_adjacent_summary",
+          "snapshot_id": "v3_1_snapshot_472bcd4c1169053b",
+          "stable_key": "affix",
+          "trusted_hash": "640cf0924ea88a86b5d8eeff3f7d3b68aa94b66f91cee4739d150acb7c35570a",
+          "trusted_shadow_status": "available"
+        },
+        "expected_manifest_trace_fields": {},
+        "fixture_set_id": null,
+        "metadata": {
+          "controlled_test_only": true,
+          "observational_only": true,
+          "planner_remap_performed": false,
+          "production_consumer": false
+        },
+        "production_output_affected": false,
+        "semantic_expectation_status": "semantic_expectations_partial",
+        "semantic_expectations": {
+          "baseline_readiness": "baseline_candidate",
+          "comparison_id": "affix",
+          "drift_classification": "equivalent",
+          "legacy_hash": "640cf0924ea88a86b5d8eeff3f7d3b68aa94b66f91cee4739d150acb7c35570a",
+          "legacy_status": "available",
+          "snapshot_category": "planner_adjacent_summary",
+          "snapshot_id": "v3_1_snapshot_472bcd4c1169053b",
+          "stable_key": "affix",
+          "trusted_hash": "640cf0924ea88a86b5d8eeff3f7d3b68aa94b66f91cee4739d150acb7c35570a",
+          "trusted_shadow_status": "available"
+        },
+        "semantic_expectations_authorize_production_routing": false,
+        "unavailable_semantic_fields": [
+          "manifest_trace_fields",
+          "fixture_trace_fields"
+        ]
+      },
+      {
+        "baseline_id": "v3_1_snapshot_42674d7f460ed71c",
+        "baseline_semantic_expectation_id": "v3_1_baseline_semantic_expectation_472de0e542c59be5",
+        "blockers": [],
+        "expected_fixture_trace_fields": {},
+        "expected_identity_fields": {
+          "baseline_readiness": "legacy_only",
+          "comparison_id": "idol",
+          "drift_classification": "legacy_only",
+          "legacy_hash": "dd6f78504144c7e111632e74d742da8c30376ed16c4b6dda8ccd29226bb2191b",
+          "legacy_status": "available",
+          "snapshot_category": "planner_adjacent_summary",
+          "snapshot_id": "v3_1_snapshot_42674d7f460ed71c",
+          "stable_key": "idol",
+          "trusted_shadow_status": "missing"
+        },
+        "expected_manifest_trace_fields": {},
+        "fixture_set_id": null,
+        "metadata": {
+          "controlled_test_only": true,
+          "observational_only": true,
+          "planner_remap_performed": false,
+          "production_consumer": false
+        },
+        "production_output_affected": false,
+        "semantic_expectation_status": "semantic_expectations_partial",
+        "semantic_expectations": {
+          "baseline_readiness": "legacy_only",
+          "comparison_id": "idol",
+          "drift_classification": "legacy_only",
+          "legacy_hash": "dd6f78504144c7e111632e74d742da8c30376ed16c4b6dda8ccd29226bb2191b",
+          "legacy_status": "available",
+          "snapshot_category": "planner_adjacent_summary",
+          "snapshot_id": "v3_1_snapshot_42674d7f460ed71c",
+          "stable_key": "idol",
+          "trusted_shadow_status": "missing"
+        },
+        "semantic_expectations_authorize_production_routing": false,
+        "unavailable_semantic_fields": [
+          "manifest_trace_fields",
+          "fixture_trace_fields"
+        ]
+      },
+      {
+        "baseline_id": "v3_1_snapshot_372c946743469ec5",
+        "baseline_semantic_expectation_id": "v3_1_baseline_semantic_expectation_90cd585c36aa4b63",
+        "blockers": [],
+        "expected_fixture_trace_fields": {},
+        "expected_identity_fields": {
+          "baseline_readiness": "comparison_ready",
+          "comparison_id": "item_base",
+          "drift_classification": "divergent",
+          "legacy_hash": "b032e547417db66eacea1c5124714787ab2c3c6319f550f55317408fd7950d5c",
+          "legacy_status": "available",
+          "snapshot_category": "planner_adjacent_summary",
+          "snapshot_id": "v3_1_snapshot_372c946743469ec5",
+          "stable_key": "item_base",
+          "trusted_hash": "8750aa1eacbe174b9d0c257d37220cfdaaffcc8b2e32618541873851c3da6113",
+          "trusted_shadow_status": "available"
+        },
+        "expected_manifest_trace_fields": {},
+        "fixture_set_id": null,
+        "metadata": {
+          "controlled_test_only": true,
+          "observational_only": true,
+          "planner_remap_performed": false,
+          "production_consumer": false
+        },
+        "production_output_affected": false,
+        "semantic_expectation_status": "semantic_expectations_partial",
+        "semantic_expectations": {
+          "baseline_readiness": "comparison_ready",
+          "comparison_id": "item_base",
+          "drift_classification": "divergent",
+          "legacy_hash": "b032e547417db66eacea1c5124714787ab2c3c6319f550f55317408fd7950d5c",
+          "legacy_status": "available",
+          "snapshot_category": "planner_adjacent_summary",
+          "snapshot_id": "v3_1_snapshot_372c946743469ec5",
+          "stable_key": "item_base",
+          "trusted_hash": "8750aa1eacbe174b9d0c257d37220cfdaaffcc8b2e32618541873851c3da6113",
+          "trusted_shadow_status": "available"
+        },
+        "semantic_expectations_authorize_production_routing": false,
+        "unavailable_semantic_fields": [
+          "manifest_trace_fields",
+          "fixture_trace_fields"
+        ]
+      },
+      {
+        "baseline_id": "v3_1_snapshot_7fed448d66ec5b1b",
+        "baseline_semantic_expectation_id": "v3_1_baseline_semantic_expectation_0a0981c3a1ce33a4",
+        "blockers": [],
+        "expected_fixture_trace_fields": {},
+        "expected_identity_fields": {
+          "baseline_readiness": "unsupported",
+          "comparison_id": "monolith_echo",
+          "drift_classification": "unsupported",
+          "legacy_status": "missing",
+          "snapshot_category": "planner_adjacent_summary",
+          "snapshot_id": "v3_1_snapshot_7fed448d66ec5b1b",
+          "stable_key": "monolith_echo",
+          "trusted_hash": "23d7b286bd429460b92a2a1c21b6afc34110446c5034c17363fda363aa0a7c5d",
+          "trusted_shadow_status": "unsupported"
+        },
+        "expected_manifest_trace_fields": {},
+        "fixture_set_id": null,
+        "metadata": {
+          "controlled_test_only": true,
+          "observational_only": true,
+          "planner_remap_performed": false,
+          "production_consumer": false
+        },
+        "production_output_affected": false,
+        "semantic_expectation_status": "semantic_expectations_partial",
+        "semantic_expectations": {
+          "baseline_readiness": "unsupported",
+          "comparison_id": "monolith_echo",
+          "drift_classification": "unsupported",
+          "legacy_status": "missing",
+          "snapshot_category": "planner_adjacent_summary",
+          "snapshot_id": "v3_1_snapshot_7fed448d66ec5b1b",
+          "stable_key": "monolith_echo",
+          "trusted_hash": "23d7b286bd429460b92a2a1c21b6afc34110446c5034c17363fda363aa0a7c5d",
+          "trusted_shadow_status": "unsupported"
+        },
+        "semantic_expectations_authorize_production_routing": false,
+        "unavailable_semantic_fields": [
+          "manifest_trace_fields",
+          "fixture_trace_fields"
+        ]
+      },
+      {
+        "baseline_id": "v3_1_snapshot_4d312622ce8de408",
+        "baseline_semantic_expectation_id": "v3_1_baseline_semantic_expectation_b7d18ec156adbee8",
+        "blockers": [],
+        "expected_fixture_trace_fields": {},
+        "expected_identity_fields": {
+          "baseline_readiness": "unsupported",
+          "comparison_id": "passive_skill",
+          "drift_classification": "unsupported",
+          "legacy_hash": "1c197daef20de3f47eec5e2f735ec6669869d3180cc29f35be4788511e0af0f8",
+          "legacy_status": "unsupported",
+          "snapshot_category": "planner_adjacent_summary",
+          "snapshot_id": "v3_1_snapshot_4d312622ce8de408",
+          "stable_key": "passive_skill",
+          "trusted_hash": "36060134d807a85bd4de45d03754fc36d6f73b2349587345f0f71b5548caeaee",
+          "trusted_shadow_status": "available"
+        },
+        "expected_manifest_trace_fields": {},
+        "fixture_set_id": null,
+        "metadata": {
+          "controlled_test_only": true,
+          "observational_only": true,
+          "planner_remap_performed": false,
+          "production_consumer": false
+        },
+        "production_output_affected": false,
+        "semantic_expectation_status": "semantic_expectations_partial",
+        "semantic_expectations": {
+          "baseline_readiness": "unsupported",
+          "comparison_id": "passive_skill",
+          "drift_classification": "unsupported",
+          "legacy_hash": "1c197daef20de3f47eec5e2f735ec6669869d3180cc29f35be4788511e0af0f8",
+          "legacy_status": "unsupported",
+          "snapshot_category": "planner_adjacent_summary",
+          "snapshot_id": "v3_1_snapshot_4d312622ce8de408",
+          "stable_key": "passive_skill",
+          "trusted_hash": "36060134d807a85bd4de45d03754fc36d6f73b2349587345f0f71b5548caeaee",
+          "trusted_shadow_status": "available"
+        },
+        "semantic_expectations_authorize_production_routing": false,
+        "unavailable_semantic_fields": [
+          "manifest_trace_fields",
+          "fixture_trace_fields"
+        ]
+      }
+    ],
+    "blocker_reason_counts": {},
+    "deterministic_hash": "676a8712111518f9db713b3bf1d2f3ce6ab0fbf485bc1e7dc5127ac263bcb60d",
+    "metadata": {
+      "controlled_test_only": true,
+      "deterministic_serializer": "json_sort_keys_sha256",
+      "observational_only": true,
+      "planner_remap_performed": false,
+      "production_behavior_changed": false,
+      "production_consumer": false,
+      "production_default_routing_authorized": false,
+      "source": "v3_1_baseline_semantic_expectations",
+      "stable_generation_token": "v3_1_phase_21_baseline_semantic_expectations_token"
+    },
+    "run": {
+      "baseline_snapshot_count": 5,
+      "planner_snapshot_baselines_hash": "5b7a5ff8a33eb491d345ecf660fdd933e422e4aab475f835b6ab82d9c9097398",
+      "run_id": "v3_1_phase_21_baseline_semantic_expectations"
+    },
+    "safety_confirmations": {
+      "legacy_planner_ownership_preserved": true,
+      "production_behavior_changed": false,
+      "production_output_affected": false,
+      "production_planner_routing_changed": false,
+      "runtime_manifest_consumption_enabled": false,
+      "runtime_production_consumption_enabled": false,
+      "semantic_expectations_are_production_approval": false,
+      "semantic_expectations_authorize_production_routing": false,
+      "trusted_data_default_truth": false
+    },
+    "schema_version": "v3_1.baseline_semantic_expectations.1",
+    "semantic_expectation_status_counts": {
+      "blocked_missing_baseline_snapshot": 0,
+      "blocked_missing_required_trace": 0,
+      "blocked_unstable_baseline_identity": 0,
+      "semantic_expectations_available": 0,
+      "semantic_expectations_partial": 5
+    },
+    "summary": {
+      "baseline_records_evaluated": 5,
+      "blocked_count": 0,
+      "deterministic": true,
+      "expectations_available_count": 0,
+      "partial_count": 5,
+      "production_affected_count": 0,
+      "production_behavior_changed": false,
+      "production_default_routing_authorized": false,
+      "production_output_affected": false,
+      "runtime_manifest_consumption_enabled": false,
+      "runtime_production_consumption_enabled": false
+    },
+    "unavailable_semantic_field_counts": {
+      "fixture_trace_fields": 5,
+      "manifest_trace_fields": 5
+    }
+  },
+  "deterministic_guarantees": {
+    "json_sort_keys": true,
+    "passed": true,
+    "repeated_hash": "676a8712111518f9db713b3bf1d2f3ce6ab0fbf485bc1e7dc5127ac263bcb60d",
+    "sample_hash": "676a8712111518f9db713b3bf1d2f3ce6ab0fbf485bc1e7dc5127ac263bcb60d",
+    "timestamp_excluded_from_hash": true
+  },
+  "generated_at": "2026-05-15T00:00:00+00:00",
+  "metadata": {
+    "controlled_test_only": true,
+    "observational_only": true,
+    "planner_remap_performed": false,
+    "production_behavior_changed": false,
+    "production_default_routing_authorized": false,
+    "source": "v3_1_baseline_semantic_expectations_report"
+  },
+  "phase": "v3.1_phase_21_baseline_semantic_expectation_enrichment",
+  "phase_21_boundaries": [
+    "semantic expectations are test-only governance metadata",
+    "semantic expectations are not production approval",
+    "semantic expectations do not authorize production routing",
+    "missing semantic fields remain visible",
+    "runtime manifest consumption remains disabled",
+    "legacy planner ownership remains intact"
+  ],
+  "production_default_routing_authorized": false,
+  "recommendation": "OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING",
+  "runtime_manifest_consumption_enabled": false,
+  "runtime_production_consumption_enabled": false,
+  "schema_version": "v3_1.baseline_semantic_expectations_report.1",
+  "summary": {
+    "baseline_records_evaluated": 5,
+    "blocked_count": 0,
+    "deterministic": true,
+    "expectations_available_count": 0,
+    "partial_count": 5,
+    "production_affected_count": 0,
+    "production_behavior_changed": false,
+    "production_default_routing_authorized": false,
+    "production_output_affected": false,
+    "runtime_manifest_consumption_enabled": false,
+    "runtime_production_consumption_enabled": false
+  }
+}

--- a/docs/migration/V3_1_BASELINE_SEMANTIC_EXPECTATIONS.md
+++ b/docs/migration/V3_1_BASELINE_SEMANTIC_EXPECTATIONS.md
@@ -1,0 +1,55 @@
+# V3.1 Baseline Semantic Expectations
+
+Phase 21 enriches planner baseline snapshots with deterministic semantic expectation metadata where available.
+Semantic expectations are not production approval and do not authorize routing.
+
+## Recommendation
+
+- Recommendation: `OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING`
+- Production default routing authorized: `false`
+- Runtime production consumption enabled: `false`
+- Runtime manifest consumption enabled: `false`
+
+## Summary
+
+- Baseline records evaluated: `5`
+- Expectations available: `0`
+- Partial: `5`
+- Blocked: `0`
+- Production affected: `0`
+- Deterministic: `true`
+
+## Unavailable Semantic Fields
+
+| Field | Count |
+| --- | ---: |
+| `fixture_trace_fields` | `5` |
+| `manifest_trace_fields` | `5` |
+
+## Blocker Reasons
+
+| Reason | Count |
+| --- | ---: |
+
+## Expectation Records
+
+| Record | Baseline | Fixture Set | Status | Unavailable Fields |
+| --- | --- | --- | --- | --- |
+| `v3_1_baseline_semantic_expectation_14a1c0229a013775` | `v3_1_snapshot_472bcd4c1169053b` | `` | `semantic_expectations_partial` | `manifest_trace_fields, fixture_trace_fields` |
+| `v3_1_baseline_semantic_expectation_472de0e542c59be5` | `v3_1_snapshot_42674d7f460ed71c` | `` | `semantic_expectations_partial` | `manifest_trace_fields, fixture_trace_fields` |
+| `v3_1_baseline_semantic_expectation_90cd585c36aa4b63` | `v3_1_snapshot_372c946743469ec5` | `` | `semantic_expectations_partial` | `manifest_trace_fields, fixture_trace_fields` |
+| `v3_1_baseline_semantic_expectation_0a0981c3a1ce33a4` | `v3_1_snapshot_7fed448d66ec5b1b` | `` | `semantic_expectations_partial` | `manifest_trace_fields, fixture_trace_fields` |
+| `v3_1_baseline_semantic_expectation_b7d18ec156adbee8` | `v3_1_snapshot_4d312622ce8de408` | `` | `semantic_expectations_partial` | `manifest_trace_fields, fixture_trace_fields` |
+
+## Phase 21 Boundaries
+
+- semantic expectations are test-only governance metadata
+- semantic expectations are not production approval
+- semantic expectations do not authorize production routing
+- missing semantic fields remain visible
+- runtime manifest consumption remains disabled
+- legacy planner ownership remains intact
+
+## Conclusion
+
+Baseline semantic expectations are available for governance review, while production routing remains unchanged.


### PR DESCRIPTION
Adds deterministic baseline semantic expectation enrichment so controlled consumption semantic parity can compare against richer planner baseline metadata without enabling production routing.