### PR TITLE
v3.1: backfill baseline trace expectations

### DIFF
--- a/backend/app/planner_adapters/v3_1/__init__.py
+++ b/backend/app/planner_adapters/v3_1/__init__.py
@@ -24,6 +24,10 @@ from .baseline_semantic_expectations import (
     BASELINE_SEMANTIC_EXPECTATION_STATUSES,
     build_baseline_semantic_expectations,
 )
+from .baseline_trace_expectation_backfill import (
+    BASELINE_TRACE_EXPECTATION_BACKFILL_STATUSES,
+    build_baseline_trace_expectation_backfill,
+)
 from .review_policy_evaluation import (
     REVIEW_POLICY_OUTCOMES,
     V31ReviewPolicyEvaluation,
@@ -105,6 +109,7 @@ __all__ = [
     "DRIFT_CLASSIFICATIONS",
     "BASELINE_READINESS_CLASSIFICATIONS",
     "BASELINE_SEMANTIC_EXPECTATION_STATUSES",
+    "BASELINE_TRACE_EXPECTATION_BACKFILL_STATUSES",
     "FIXTURE_WORKFLOW_STATES",
     "FIXTURE_SET_LIFECYCLE_STATES",
     "REVIEW_POLICY_OUTCOMES",
@@ -137,6 +142,7 @@ __all__ = [
     "build_sample_review_policy_inputs",
     "build_sample_dual_run_inputs",
     "build_baseline_semantic_expectations",
+    "build_baseline_trace_expectation_backfill",
     "build_default_trusted_repository_probes",
     "build_fixture_set_readiness_gate",
     "evaluate_fixture_source_admission_policy",

--- a/backend/app/planner_adapters/v3_1/baseline_trace_expectation_backfill.py
+++ b/backend/app/planner_adapters/v3_1/baseline_trace_expectation_backfill.py
@@ -1,0 +1,343 @@
+"""Baseline trace expectation backfill for v3.1 governance.
+
+Trace expectation backfill uses deterministic governance artifacts to enrich
+baseline semantic expectation records with manifest and fixture trace fields.
+It does not invent semantics and cannot authorize production routing.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from copy import deepcopy
+from typing import Any
+
+from .approval_manifest_serialization import NON_PRODUCTION_AUTHORIZATION_STATE
+from .trusted_shadow_consumption import deterministic_hash
+
+
+BASELINE_TRACE_EXPECTATION_BACKFILL_STATUSES = (
+    "trace_expectations_backfilled",
+    "trace_expectations_partial",
+    "blocked_missing_baseline_expectation",
+    "blocked_missing_trace_source",
+    "blocked_trace_conflict",
+    "blocked_invalid_authorization_state",
+)
+STABLE_BASELINE_TRACE_BACKFILL_TOKEN = "v3_1_phase_22_baseline_trace_expectation_backfill_token"
+
+
+def build_baseline_trace_expectation_backfill(
+    *,
+    baseline_semantic_expectations: dict[str, Any] | list[dict[str, Any]],
+    controlled_consumption_parity_snapshot: dict[str, Any] | list[dict[str, Any]],
+    controlled_consumption_output_validation: dict[str, Any] | list[dict[str, Any]],
+    admission_aware_manifest_serialization: dict[str, Any] | list[dict[str, Any]],
+    run_id: str = "v3_1_phase_22_baseline_trace_expectation_backfill",
+) -> dict[str, Any]:
+    """Backfill deterministic trace expectations into baseline expectation records."""
+
+    expectations = _expectation_records(baseline_semantic_expectations)
+    parity_records = _parity_records(controlled_consumption_parity_snapshot)
+    validation_records = _validation_records(controlled_consumption_output_validation)
+    serialized_manifests = _serialized_manifests(admission_aware_manifest_serialization)
+    trace_sources = _trace_sources(
+        parity_records=parity_records,
+        validation_records=validation_records,
+        serialized_manifests=serialized_manifests,
+    )
+    backfill_records = [
+        _backfill_record(expectation=record, trace_source=trace_sources.get(str(record.get("baseline_id") or "")))
+        for record in sorted(expectations, key=_expectation_sort_key)
+    ]
+    if not backfill_records:
+        backfill_records = [_missing_expectation_record()]
+
+    counts = Counter(record["trace_backfill_status"] for record in backfill_records)
+    remaining_unavailable = Counter(field for record in backfill_records for field in record["remaining_unavailable_fields"])
+    blocker_reasons = Counter(reason for record in backfill_records for reason in record["blockers"])
+    trace_conflicts = Counter(conflict for record in backfill_records for conflict in record["trace_conflicts"])
+    expectation_hash = baseline_semantic_expectations.get("deterministic_hash") if isinstance(baseline_semantic_expectations, dict) else None
+    parity_hash = controlled_consumption_parity_snapshot.get("deterministic_hash") if isinstance(controlled_consumption_parity_snapshot, dict) else None
+    validation_hash = controlled_consumption_output_validation.get("deterministic_hash") if isinstance(controlled_consumption_output_validation, dict) else None
+    manifest_hash = admission_aware_manifest_serialization.get("deterministic_hash") if isinstance(admission_aware_manifest_serialization, dict) else None
+    envelope = {
+        "schema_version": "v3_1.baseline_trace_expectation_backfill.1",
+        "run": {
+            "run_id": run_id,
+            "baseline_expectation_record_count": len(expectations),
+            "trace_source_count": len(trace_sources),
+            "baseline_semantic_expectations_hash": expectation_hash,
+            "controlled_consumption_parity_snapshot_hash": parity_hash,
+            "controlled_consumption_output_validation_hash": validation_hash,
+            "admission_aware_manifest_serialization_hash": manifest_hash,
+        },
+        "summary": {
+            "baseline_expectation_records_evaluated": len(backfill_records),
+            "backfilled_count": counts["trace_expectations_backfilled"],
+            "partial_count": counts["trace_expectations_partial"],
+            "blocked_count": (
+                counts["blocked_missing_baseline_expectation"]
+                + counts["blocked_missing_trace_source"]
+                + counts["blocked_trace_conflict"]
+                + counts["blocked_invalid_authorization_state"]
+            ),
+            "production_affected_count": 0,
+            "production_output_affected": False,
+            "production_behavior_changed": False,
+            "production_default_routing_authorized": False,
+            "runtime_manifest_consumption_enabled": False,
+            "runtime_production_consumption_enabled": False,
+            "deterministic": True,
+        },
+        "trace_backfill_status_counts": {
+            status: counts[status]
+            for status in BASELINE_TRACE_EXPECTATION_BACKFILL_STATUSES
+        },
+        "remaining_unavailable_field_counts": dict(sorted(remaining_unavailable.items())),
+        "trace_conflict_counts": dict(sorted(trace_conflicts.items())),
+        "blocker_reason_counts": dict(sorted(blocker_reasons.items())),
+        "baseline_trace_backfill_records": backfill_records,
+        "safety_confirmations": {
+            "backfilled_expectations_authorize_production_routing": False,
+            "backfilled_expectations_are_production_approval": False,
+            "runtime_manifest_consumption_enabled": False,
+            "runtime_production_consumption_enabled": False,
+            "legacy_planner_ownership_preserved": True,
+            "production_output_affected": False,
+            "production_behavior_changed": False,
+            "production_planner_routing_changed": False,
+            "trusted_data_default_truth": False,
+        },
+        "metadata": {
+            "source": "v3_1_baseline_trace_expectation_backfill",
+            "observational_only": True,
+            "controlled_test_only": True,
+            "production_consumer": False,
+            "production_behavior_changed": False,
+            "planner_remap_performed": False,
+            "production_default_routing_authorized": False,
+            "stable_generation_token": STABLE_BASELINE_TRACE_BACKFILL_TOKEN,
+            "deterministic_serializer": "json_sort_keys_sha256",
+        },
+    }
+    envelope["deterministic_hash"] = deterministic_hash(envelope)
+    return envelope
+
+
+def _expectation_records(value: dict[str, Any] | list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if isinstance(value, list):
+        return [deepcopy(row) for row in value]
+    return [deepcopy(row) for row in value.get("baseline_semantic_expectation_records", [])]
+
+
+def _parity_records(value: dict[str, Any] | list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if isinstance(value, list):
+        return [deepcopy(row) for row in value]
+    return [deepcopy(row) for row in value.get("parity_records", [])]
+
+
+def _validation_records(value: dict[str, Any] | list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if isinstance(value, list):
+        return [deepcopy(row) for row in value]
+    return [deepcopy(row) for row in value.get("validation_records", [])]
+
+
+def _serialized_manifests(value: dict[str, Any] | list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if isinstance(value, list):
+        return [deepcopy(row) for row in value]
+    return [deepcopy(row) for row in value.get("serialized_manifests", [])]
+
+
+def _trace_sources(
+    *,
+    parity_records: list[dict[str, Any]],
+    validation_records: list[dict[str, Any]],
+    serialized_manifests: list[dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    validations_by_key = {_trace_key(record): record for record in validation_records if _trace_key(record)}
+    manifests_by_key = {_trace_key(record): record for record in serialized_manifests if _trace_key(record)}
+    sources: dict[str, dict[str, Any]] = {}
+    for parity in sorted(parity_records, key=_parity_sort_key):
+        if parity.get("parity_status") != "parity_confirmed" or not parity.get("baseline_id"):
+            continue
+        source = _source_from_parity(
+            parity=parity,
+            validation=validations_by_key.get(_trace_key(parity)),
+            manifest=manifests_by_key.get(_trace_key(parity)),
+        )
+        sources[str(parity["baseline_id"])] = source
+    return sources
+
+
+def _source_from_parity(
+    *,
+    parity: dict[str, Any],
+    validation: dict[str, Any] | None,
+    manifest: dict[str, Any] | None,
+) -> dict[str, Any]:
+    manifest_id = parity.get("manifest_id")
+    fixture_set_id = parity.get("fixture_set_id")
+    conflicts: list[str] = []
+    authorization_states = []
+    if validation is not None:
+        validation_auth = (validation.get("traceability_summary") or {}).get("authorization_state")
+        authorization_states.append(validation_auth)
+        if validation.get("manifest_id") != manifest_id:
+            conflicts.append("validation_manifest_id")
+        if validation.get("fixture_set_id") != fixture_set_id:
+            conflicts.append("validation_fixture_set_id")
+    if manifest is not None:
+        manifest_auth = (manifest.get("authorization_status") or {}).get("authorization_state")
+        authorization_states.append(manifest_auth)
+        if manifest.get("manifest_id") != manifest_id:
+            conflicts.append("serialized_manifest_id")
+        if manifest.get("fixture_set_id") != fixture_set_id:
+            conflicts.append("serialized_fixture_set_id")
+    return {
+        "manifest_id": manifest_id,
+        "fixture_set_id": fixture_set_id,
+        "validation_present": validation is not None,
+        "serialized_manifest_present": manifest is not None,
+        "authorization_states": authorization_states,
+        "authorization_valid": bool(authorization_states) and all(state == NON_PRODUCTION_AUTHORIZATION_STATE for state in authorization_states),
+        "conflicts": conflicts,
+    }
+
+
+def _backfill_record(*, expectation: dict[str, Any], trace_source: dict[str, Any] | None) -> dict[str, Any]:
+    manifest_fields = deepcopy(expectation.get("expected_manifest_trace_fields") or {})
+    fixture_fields = deepcopy(expectation.get("expected_fixture_trace_fields") or {})
+    conflicts = _trace_conflicts(expectation=expectation, trace_source=trace_source)
+    if trace_source and not conflicts and trace_source.get("authorization_valid"):
+        manifest_fields.setdefault("manifest_id", trace_source.get("manifest_id"))
+        fixture_fields.setdefault("fixture_set_id", trace_source.get("fixture_set_id"))
+    remaining_unavailable = _remaining_unavailable(
+        original_unavailable=list(expectation.get("unavailable_semantic_fields") or []),
+        manifest_fields=manifest_fields,
+        fixture_fields=fixture_fields,
+    )
+    blockers = _blockers(expectation=expectation, trace_source=trace_source, conflicts=conflicts)
+    status = _status(blockers=blockers, remaining_unavailable=remaining_unavailable, trace_source=trace_source)
+    seed = {
+        "baseline_id": expectation.get("baseline_id"),
+        "manifest_id": manifest_fields.get("manifest_id"),
+        "fixture_set_id": fixture_fields.get("fixture_set_id"),
+        "status": status,
+        "token": STABLE_BASELINE_TRACE_BACKFILL_TOKEN,
+    }
+    return {
+        "baseline_trace_backfill_id": f"v3_1_baseline_trace_backfill_{deterministic_hash(seed)[:16]}",
+        "baseline_id": expectation.get("baseline_id"),
+        "fixture_set_id": fixture_fields.get("fixture_set_id"),
+        "manifest_id": manifest_fields.get("manifest_id"),
+        "original_semantic_expectation_status": expectation.get("semantic_expectation_status"),
+        "backfilled_manifest_trace_fields": manifest_fields,
+        "backfilled_fixture_trace_fields": fixture_fields,
+        "remaining_unavailable_fields": remaining_unavailable,
+        "trace_backfill_status": status,
+        "trace_conflicts": conflicts,
+        "blockers": blockers,
+        "backfilled_expectations_authorize_production_routing": False,
+        "production_output_affected": False,
+        "metadata": {
+            "observational_only": True,
+            "controlled_test_only": True,
+            "production_consumer": False,
+            "planner_remap_performed": False,
+        },
+    }
+
+
+def _missing_expectation_record() -> dict[str, Any]:
+    seed = {"missing_baseline_expectation": True, "token": STABLE_BASELINE_TRACE_BACKFILL_TOKEN}
+    return {
+        "baseline_trace_backfill_id": f"v3_1_baseline_trace_backfill_{deterministic_hash(seed)[:16]}",
+        "baseline_id": None,
+        "fixture_set_id": None,
+        "manifest_id": None,
+        "original_semantic_expectation_status": None,
+        "backfilled_manifest_trace_fields": {},
+        "backfilled_fixture_trace_fields": {},
+        "remaining_unavailable_fields": [],
+        "trace_backfill_status": "blocked_missing_baseline_expectation",
+        "trace_conflicts": [],
+        "blockers": ["blocked_missing_baseline_expectation"],
+        "backfilled_expectations_authorize_production_routing": False,
+        "production_output_affected": False,
+        "metadata": {
+            "observational_only": True,
+            "controlled_test_only": True,
+            "production_consumer": False,
+            "planner_remap_performed": False,
+        },
+    }
+
+
+def _trace_conflicts(*, expectation: dict[str, Any], trace_source: dict[str, Any] | None) -> list[str]:
+    if not trace_source:
+        return []
+    conflicts = list(trace_source.get("conflicts") or [])
+    expected_manifest = (expectation.get("expected_manifest_trace_fields") or {}).get("manifest_id")
+    expected_fixture = (expectation.get("expected_fixture_trace_fields") or {}).get("fixture_set_id")
+    if expected_manifest and expected_manifest != trace_source.get("manifest_id"):
+        conflicts.append("baseline_manifest_id")
+    if expected_fixture and expected_fixture != trace_source.get("fixture_set_id"):
+        conflicts.append("baseline_fixture_set_id")
+    return sorted(set(conflicts))
+
+
+def _remaining_unavailable(*, original_unavailable: list[str], manifest_fields: dict[str, Any], fixture_fields: dict[str, Any]) -> list[str]:
+    remaining: list[str] = []
+    for field in original_unavailable:
+        if field == "manifest_trace_fields" and manifest_fields.get("manifest_id"):
+            continue
+        if field == "fixture_trace_fields" and fixture_fields.get("fixture_set_id"):
+            continue
+        remaining.append(field)
+    return remaining
+
+
+def _blockers(*, expectation: dict[str, Any], trace_source: dict[str, Any] | None, conflicts: list[str]) -> list[str]:
+    blockers: list[str] = []
+    if not expectation.get("baseline_id"):
+        blockers.append("blocked_missing_baseline_expectation")
+    if conflicts:
+        blockers.append("blocked_trace_conflict")
+    if trace_source and not trace_source.get("authorization_valid"):
+        blockers.append("blocked_invalid_authorization_state")
+    return blockers
+
+
+def _status(*, blockers: list[str], remaining_unavailable: list[str], trace_source: dict[str, Any] | None) -> str:
+    if blockers:
+        return blockers[0]
+    if not trace_source:
+        return "trace_expectations_partial"
+    if remaining_unavailable:
+        return "trace_expectations_partial"
+    return "trace_expectations_backfilled"
+
+
+def _trace_key(record: dict[str, Any] | None) -> tuple[str, str] | None:
+    if not record:
+        return None
+    manifest_id = record.get("manifest_id")
+    fixture_set_id = record.get("fixture_set_id")
+    if not manifest_id or not fixture_set_id:
+        return None
+    return (str(manifest_id), str(fixture_set_id))
+
+
+def _expectation_sort_key(record: dict[str, Any]) -> tuple[str, str]:
+    return (
+        str(record.get("baseline_id") or ""),
+        str(record.get("baseline_semantic_expectation_id") or ""),
+    )
+
+
+def _parity_sort_key(record: dict[str, Any]) -> tuple[str, str, str]:
+    return (
+        str(record.get("baseline_id") or ""),
+        str(record.get("fixture_set_id") or ""),
+        str(record.get("manifest_id") or ""),
+    )

--- a/backend/scripts/report_v3_1_baseline_trace_expectation_backfill.py
+++ b/backend/scripts/report_v3_1_baseline_trace_expectation_backfill.py
@@ -1,0 +1,186 @@
+"""Generate the v3.1 baseline trace expectation backfill report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.planner_adapters.v3_1.baseline_trace_expectation_backfill import build_baseline_trace_expectation_backfill  # noqa: E402
+
+
+DETERMINISTIC_GENERATED_AT = "2026-05-15T00:00:00+00:00"
+
+
+def build_v3_1_baseline_trace_expectation_backfill_report() -> dict[str, Any]:
+    repo_root = Path(__file__).resolve().parents[2]
+    expectations = _read_json(repo_root / "docs" / "generated" / "v3_1_baseline_semantic_expectations_report.json")[
+        "baseline_semantic_expectations"
+    ]
+    parity = _read_json(repo_root / "docs" / "generated" / "v3_1_controlled_consumption_parity_snapshot_report.json")[
+        "controlled_consumption_parity_snapshot"
+    ]
+    validation = _read_json(repo_root / "docs" / "generated" / "v3_1_controlled_consumption_output_validation_report.json")[
+        "controlled_consumption_output_validation"
+    ]
+    manifests = _read_json(repo_root / "docs" / "generated" / "v3_1_admission_aware_manifest_serialization_report.json")[
+        "admission_aware_manifest_serialization"
+    ]
+    backfill = build_baseline_trace_expectation_backfill(
+        baseline_semantic_expectations=expectations,
+        controlled_consumption_parity_snapshot=parity,
+        controlled_consumption_output_validation=validation,
+        admission_aware_manifest_serialization=manifests,
+    )
+    repeated = build_baseline_trace_expectation_backfill(
+        baseline_semantic_expectations=expectations,
+        controlled_consumption_parity_snapshot=parity,
+        controlled_consumption_output_validation=validation,
+        admission_aware_manifest_serialization=manifests,
+    )
+    report = {
+        "schema_version": "v3_1.baseline_trace_expectation_backfill_report.1",
+        "generated_at": DETERMINISTIC_GENERATED_AT,
+        "phase": "v3.1_phase_22_baseline_trace_expectation_backfill",
+        "recommendation": "OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING",
+        "production_default_routing_authorized": False,
+        "runtime_manifest_consumption_enabled": False,
+        "runtime_production_consumption_enabled": False,
+        "summary": {
+            **backfill["summary"],
+            "deterministic": backfill["deterministic_hash"] == repeated["deterministic_hash"],
+        },
+        "baseline_trace_expectation_backfill": backfill,
+        "deterministic_guarantees": {
+            "passed": backfill["deterministic_hash"] == repeated["deterministic_hash"],
+            "sample_hash": backfill["deterministic_hash"],
+            "repeated_hash": repeated["deterministic_hash"],
+            "timestamp_excluded_from_hash": True,
+            "json_sort_keys": True,
+        },
+        "phase_22_boundaries": [
+            "trace expectation backfill is test-only governance metadata",
+            "backfilled expectations are not production approval",
+            "backfilled expectations do not authorize production routing",
+            "trace fields are sourced only from deterministic governance artifacts",
+            "runtime manifest consumption remains disabled",
+            "legacy planner ownership remains intact",
+        ],
+        "metadata": {
+            "source": "v3_1_baseline_trace_expectation_backfill_report",
+            "observational_only": True,
+            "controlled_test_only": True,
+            "production_behavior_changed": False,
+            "production_default_routing_authorized": False,
+            "planner_remap_performed": False,
+        },
+    }
+    return _normalize_generated_at(report)
+
+
+def write_report(report: dict[str, Any], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_markdown(report: dict[str, Any], output_path: Path) -> None:
+    backfill = report["baseline_trace_expectation_backfill"]
+    summary = report["summary"]
+    lines = [
+        "# V3.1 Baseline Trace Expectation Backfill",
+        "",
+        "Phase 22 backfills deterministic manifest and fixture trace expectations from existing governance artifacts.",
+        "Backfilled expectations are not production approval and do not authorize routing.",
+        "",
+        "## Recommendation",
+        "",
+        f"- Recommendation: `{report['recommendation']}`",
+        f"- Production default routing authorized: `{str(report['production_default_routing_authorized']).lower()}`",
+        f"- Runtime production consumption enabled: `{str(report['runtime_production_consumption_enabled']).lower()}`",
+        f"- Runtime manifest consumption enabled: `{str(report['runtime_manifest_consumption_enabled']).lower()}`",
+        "",
+        "## Summary",
+        "",
+        f"- Baseline expectation records evaluated: `{summary['baseline_expectation_records_evaluated']}`",
+        f"- Backfilled: `{summary['backfilled_count']}`",
+        f"- Partial: `{summary['partial_count']}`",
+        f"- Blocked: `{summary['blocked_count']}`",
+        f"- Production affected: `{summary['production_affected_count']}`",
+        f"- Deterministic: `{str(summary['deterministic']).lower()}`",
+        "",
+        "## Remaining Unavailable Fields",
+        "",
+        "| Field | Count |",
+        "| --- | ---: |",
+    ]
+    for field, count in backfill["remaining_unavailable_field_counts"].items():
+        lines.append(f"| `{field}` | `{count}` |")
+    lines.extend(["", "## Trace Conflicts", "", "| Conflict | Count |", "| --- | ---: |"])
+    for conflict, count in backfill["trace_conflict_counts"].items():
+        lines.append(f"| `{conflict}` | `{count}` |")
+    lines.extend(["", "## Blocker Reasons", "", "| Reason | Count |", "| --- | ---: |"])
+    for reason, count in backfill["blocker_reason_counts"].items():
+        lines.append(f"| `{reason}` | `{count}` |")
+    lines.extend(
+        [
+            "",
+            "## Backfill Records",
+            "",
+            "| Record | Baseline | Manifest | Fixture Set | Status |",
+            "| --- | --- | --- | --- | --- |",
+        ]
+    )
+    for row in backfill["baseline_trace_backfill_records"]:
+        lines.append(
+            f"| `{row['baseline_trace_backfill_id']}` | `{row['baseline_id'] or ''}` | `{row['manifest_id'] or ''}` | `{row['fixture_set_id'] or ''}` | `{row['trace_backfill_status']}` |"
+        )
+    lines.extend(["", "## Phase 22 Boundaries", ""])
+    lines.extend(f"- {item}" for item in report["phase_22_boundaries"])
+    lines.extend(
+        [
+            "",
+            "## Conclusion",
+            "",
+            "Baseline trace expectation backfill is available for governance review, while production routing remains unchanged.",
+        ]
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _normalize_generated_at(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: DETERMINISTIC_GENERATED_AT if key == "generated_at" else _normalize_generated_at(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_normalize_generated_at(item) for item in value]
+    return deepcopy(value)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", default="docs/generated/v3_1_baseline_trace_expectation_backfill_report.json")
+    parser.add_argument("--markdown-output", default="docs/migration/V3_1_BASELINE_TRACE_EXPECTATION_BACKFILL.md")
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[2]
+    report = build_v3_1_baseline_trace_expectation_backfill_report()
+    write_report(report, repo_root / args.output)
+    write_markdown(report, repo_root / args.markdown_output)
+    print(json.dumps(report["summary"], indent=2, sort_keys=True))
+    print(report["recommendation"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_v3_1_baseline_trace_expectation_backfill.py
+++ b/backend/tests/test_v3_1_baseline_trace_expectation_backfill.py
@@ -1,0 +1,207 @@
+from app.planner_adapters.v3_1.baseline_trace_expectation_backfill import build_baseline_trace_expectation_backfill
+from scripts.report_v3_1_baseline_trace_expectation_backfill import build_v3_1_baseline_trace_expectation_backfill_report
+
+
+def test_manifest_and_fixture_traces_backfill_when_sources_exist():
+    result = build_baseline_trace_expectation_backfill(
+        baseline_semantic_expectations=_expectations([_expectation()]),
+        controlled_consumption_parity_snapshot=_parity([_parity_record()]),
+        controlled_consumption_output_validation=_validation([_validation_record()]),
+        admission_aware_manifest_serialization=_serialization([_manifest_record()]),
+    )
+
+    record = result["baseline_trace_backfill_records"][0]
+    assert record["trace_backfill_status"] == "trace_expectations_backfilled"
+    assert record["manifest_id"] == "manifest_a"
+    assert record["fixture_set_id"] == "set_a"
+    assert record["remaining_unavailable_fields"] == []
+
+
+def test_missing_trace_source_remains_partial():
+    result = build_baseline_trace_expectation_backfill(
+        baseline_semantic_expectations=_expectations([_expectation()]),
+        controlled_consumption_parity_snapshot=_parity([]),
+        controlled_consumption_output_validation=_validation([]),
+        admission_aware_manifest_serialization=_serialization([]),
+    )
+
+    record = result["baseline_trace_backfill_records"][0]
+    assert record["trace_backfill_status"] == "trace_expectations_partial"
+    assert record["remaining_unavailable_fields"] == ["manifest_trace_fields", "fixture_trace_fields"]
+
+
+def test_missing_baseline_expectation_blocks():
+    result = build_baseline_trace_expectation_backfill(
+        baseline_semantic_expectations=_expectations([]),
+        controlled_consumption_parity_snapshot=_parity([]),
+        controlled_consumption_output_validation=_validation([]),
+        admission_aware_manifest_serialization=_serialization([]),
+    )
+
+    assert result["baseline_trace_backfill_records"][0]["trace_backfill_status"] == "blocked_missing_baseline_expectation"
+
+
+def test_conflicting_trace_sources_block():
+    result = build_baseline_trace_expectation_backfill(
+        baseline_semantic_expectations=_expectations([_expectation(expected_manifest_fields={"manifest_id": "different_manifest"})]),
+        controlled_consumption_parity_snapshot=_parity([_parity_record()]),
+        controlled_consumption_output_validation=_validation([_validation_record()]),
+        admission_aware_manifest_serialization=_serialization([_manifest_record()]),
+    )
+
+    record = result["baseline_trace_backfill_records"][0]
+    assert record["trace_backfill_status"] == "blocked_trace_conflict"
+    assert record["trace_conflicts"] == ["baseline_manifest_id"]
+
+
+def test_invalid_authorization_state_blocks():
+    result = build_baseline_trace_expectation_backfill(
+        baseline_semantic_expectations=_expectations([_expectation()]),
+        controlled_consumption_parity_snapshot=_parity([_parity_record()]),
+        controlled_consumption_output_validation=_validation([_validation_record(authorization_state="production_authoritative")]),
+        admission_aware_manifest_serialization=_serialization([_manifest_record()]),
+    )
+
+    assert result["baseline_trace_backfill_records"][0]["trace_backfill_status"] == "blocked_invalid_authorization_state"
+
+
+def test_deterministic_ordering():
+    expectations = [_expectation("baseline_b"), _expectation("baseline_a")]
+    parity = [_parity_record("baseline_b", "manifest_b", "set_b"), _parity_record("baseline_a", "manifest_a", "set_a")]
+    validations = [_validation_record("manifest_b", "set_b"), _validation_record("manifest_a", "set_a")]
+    manifests = [_manifest_record("manifest_b", "set_b"), _manifest_record("manifest_a", "set_a")]
+    first = build_baseline_trace_expectation_backfill(
+        baseline_semantic_expectations=_expectations(expectations),
+        controlled_consumption_parity_snapshot=_parity(parity),
+        controlled_consumption_output_validation=_validation(validations),
+        admission_aware_manifest_serialization=_serialization(manifests),
+    )
+    second = build_baseline_trace_expectation_backfill(
+        baseline_semantic_expectations=_expectations(list(reversed(expectations))),
+        controlled_consumption_parity_snapshot=_parity(list(reversed(parity))),
+        controlled_consumption_output_validation=_validation(list(reversed(validations))),
+        admission_aware_manifest_serialization=_serialization(list(reversed(manifests))),
+    )
+
+    assert first["deterministic_hash"] == second["deterministic_hash"]
+    assert [row["baseline_id"] for row in first["baseline_trace_backfill_records"]] == ["baseline_a", "baseline_b"]
+
+
+def test_stable_report_generation():
+    first = build_v3_1_baseline_trace_expectation_backfill_report()
+    second = build_v3_1_baseline_trace_expectation_backfill_report()
+
+    assert first["deterministic_guarantees"]["passed"] is True
+    assert first["baseline_trace_expectation_backfill"]["deterministic_hash"] == second["baseline_trace_expectation_backfill"]["deterministic_hash"]
+    assert first["summary"] == second["summary"]
+
+
+def test_no_production_routing_enablement():
+    result = build_baseline_trace_expectation_backfill(
+        baseline_semantic_expectations=_expectations([_expectation()]),
+        controlled_consumption_parity_snapshot=_parity([_parity_record()]),
+        controlled_consumption_output_validation=_validation([_validation_record()]),
+        admission_aware_manifest_serialization=_serialization([_manifest_record()]),
+    )
+    record = result["baseline_trace_backfill_records"][0]
+
+    assert result["safety_confirmations"]["backfilled_expectations_authorize_production_routing"] is False
+    assert result["safety_confirmations"]["backfilled_expectations_are_production_approval"] is False
+    assert result["summary"]["runtime_manifest_consumption_enabled"] is False
+    assert record["backfilled_expectations_authorize_production_routing"] is False
+
+
+def _expectations(records):
+    return {
+        "schema_version": "v3_1.baseline_semantic_expectations.1",
+        "deterministic_hash": "expectation-hash",
+        "baseline_semantic_expectation_records": records,
+    }
+
+
+def _expectation(baseline_id="baseline_a", expected_manifest_fields=None, expected_fixture_fields=None):
+    return {
+        "baseline_semantic_expectation_id": f"expectation_{baseline_id}",
+        "baseline_id": baseline_id,
+        "fixture_set_id": (expected_fixture_fields or {}).get("fixture_set_id"),
+        "expected_identity_fields": {"snapshot_id": baseline_id, "stable_key": baseline_id},
+        "expected_manifest_trace_fields": expected_manifest_fields or {},
+        "expected_fixture_trace_fields": expected_fixture_fields or {},
+        "semantic_expectations": {},
+        "unavailable_semantic_fields": ["manifest_trace_fields", "fixture_trace_fields"],
+        "semantic_expectation_status": "semantic_expectations_partial",
+        "blockers": [],
+        "semantic_expectations_authorize_production_routing": False,
+        "production_output_affected": False,
+    }
+
+
+def _parity(records):
+    return {
+        "schema_version": "v3_1.controlled_consumption_parity_snapshot.1",
+        "deterministic_hash": "parity-hash",
+        "parity_records": records,
+    }
+
+
+def _parity_record(baseline_id="baseline_a", manifest_id="manifest_a", fixture_set_id="set_a"):
+    return {
+        "parity_record_id": f"parity_{baseline_id}",
+        "baseline_id": baseline_id,
+        "manifest_id": manifest_id,
+        "fixture_set_id": fixture_set_id,
+        "parity_status": "parity_confirmed",
+        "blockers": [],
+        "parity_authorizes_production_routing": False,
+        "production_output_affected": False,
+    }
+
+
+def _validation(records):
+    return {
+        "schema_version": "v3_1.controlled_consumption_output_validation.1",
+        "deterministic_hash": "validation-hash",
+        "validation_records": records,
+    }
+
+
+def _validation_record(manifest_id="manifest_a", fixture_set_id="set_a", authorization_state="non_production_authoritative"):
+    return {
+        "validation_record_id": f"validation_{manifest_id}_{fixture_set_id}",
+        "manifest_id": manifest_id,
+        "fixture_set_id": fixture_set_id,
+        "validation_status": "valid_controlled_test_output",
+        "traceability_summary": {
+            "manifest_trace_present": bool(manifest_id),
+            "fixture_set_trace_present": bool(fixture_set_id),
+            "authorization_state": authorization_state,
+            "runtime_consumption_enabled": False,
+            "not_production_consumption": True,
+        },
+        "validation_authorizes_production_routing": False,
+        "production_output_affected": False,
+    }
+
+
+def _serialization(records):
+    return {
+        "schema_version": "v3_1.admission_aware_manifest_serialization.1",
+        "deterministic_hash": "serialization-hash",
+        "serialized_manifests": records,
+    }
+
+
+def _manifest_record(manifest_id="manifest_a", fixture_set_id="set_a", authorization_state="non_production_authoritative"):
+    return {
+        "manifest_id": manifest_id,
+        "fixture_set_id": fixture_set_id,
+        "serialization_status": "serialized_manifest",
+        "authorization_status": {
+            "authorization_state": authorization_state,
+            "manifest_authorizes_production_routing": False,
+            "manifest_is_production_approved": False,
+            "manifest_is_production_authoritative": False,
+        },
+        "non_production_authoritative": True,
+        "production_output_affected": False,
+    }

--- a/docs/generated/v3_1_baseline_trace_expectation_backfill_report.json
+++ b/docs/generated/v3_1_baseline_trace_expectation_backfill_report.json
@@ -1,0 +1,230 @@
+{
+  "baseline_trace_expectation_backfill": {
+    "baseline_trace_backfill_records": [
+      {
+        "backfilled_expectations_authorize_production_routing": false,
+        "backfilled_fixture_trace_fields": {},
+        "backfilled_manifest_trace_fields": {},
+        "baseline_id": "v3_1_snapshot_372c946743469ec5",
+        "baseline_trace_backfill_id": "v3_1_baseline_trace_backfill_6ce426b2b1644e8e",
+        "blockers": [],
+        "fixture_set_id": null,
+        "manifest_id": null,
+        "metadata": {
+          "controlled_test_only": true,
+          "observational_only": true,
+          "planner_remap_performed": false,
+          "production_consumer": false
+        },
+        "original_semantic_expectation_status": "semantic_expectations_partial",
+        "production_output_affected": false,
+        "remaining_unavailable_fields": [
+          "manifest_trace_fields",
+          "fixture_trace_fields"
+        ],
+        "trace_backfill_status": "trace_expectations_partial",
+        "trace_conflicts": []
+      },
+      {
+        "backfilled_expectations_authorize_production_routing": false,
+        "backfilled_fixture_trace_fields": {},
+        "backfilled_manifest_trace_fields": {},
+        "baseline_id": "v3_1_snapshot_42674d7f460ed71c",
+        "baseline_trace_backfill_id": "v3_1_baseline_trace_backfill_a3262364e64d3665",
+        "blockers": [],
+        "fixture_set_id": null,
+        "manifest_id": null,
+        "metadata": {
+          "controlled_test_only": true,
+          "observational_only": true,
+          "planner_remap_performed": false,
+          "production_consumer": false
+        },
+        "original_semantic_expectation_status": "semantic_expectations_partial",
+        "production_output_affected": false,
+        "remaining_unavailable_fields": [
+          "manifest_trace_fields",
+          "fixture_trace_fields"
+        ],
+        "trace_backfill_status": "trace_expectations_partial",
+        "trace_conflicts": []
+      },
+      {
+        "backfilled_expectations_authorize_production_routing": false,
+        "backfilled_fixture_trace_fields": {
+          "fixture_set_id": "v3_1_fixture_set_6d3b668a84cfbb69"
+        },
+        "backfilled_manifest_trace_fields": {
+          "manifest_id": "v3_1_admission_manifest_198a3e2110f9e5e4"
+        },
+        "baseline_id": "v3_1_snapshot_472bcd4c1169053b",
+        "baseline_trace_backfill_id": "v3_1_baseline_trace_backfill_0649c3b0041786f6",
+        "blockers": [],
+        "fixture_set_id": "v3_1_fixture_set_6d3b668a84cfbb69",
+        "manifest_id": "v3_1_admission_manifest_198a3e2110f9e5e4",
+        "metadata": {
+          "controlled_test_only": true,
+          "observational_only": true,
+          "planner_remap_performed": false,
+          "production_consumer": false
+        },
+        "original_semantic_expectation_status": "semantic_expectations_partial",
+        "production_output_affected": false,
+        "remaining_unavailable_fields": [],
+        "trace_backfill_status": "trace_expectations_backfilled",
+        "trace_conflicts": []
+      },
+      {
+        "backfilled_expectations_authorize_production_routing": false,
+        "backfilled_fixture_trace_fields": {},
+        "backfilled_manifest_trace_fields": {},
+        "baseline_id": "v3_1_snapshot_4d312622ce8de408",
+        "baseline_trace_backfill_id": "v3_1_baseline_trace_backfill_229de2756705b110",
+        "blockers": [],
+        "fixture_set_id": null,
+        "manifest_id": null,
+        "metadata": {
+          "controlled_test_only": true,
+          "observational_only": true,
+          "planner_remap_performed": false,
+          "production_consumer": false
+        },
+        "original_semantic_expectation_status": "semantic_expectations_partial",
+        "production_output_affected": false,
+        "remaining_unavailable_fields": [
+          "manifest_trace_fields",
+          "fixture_trace_fields"
+        ],
+        "trace_backfill_status": "trace_expectations_partial",
+        "trace_conflicts": []
+      },
+      {
+        "backfilled_expectations_authorize_production_routing": false,
+        "backfilled_fixture_trace_fields": {},
+        "backfilled_manifest_trace_fields": {},
+        "baseline_id": "v3_1_snapshot_7fed448d66ec5b1b",
+        "baseline_trace_backfill_id": "v3_1_baseline_trace_backfill_8651606742e0c061",
+        "blockers": [],
+        "fixture_set_id": null,
+        "manifest_id": null,
+        "metadata": {
+          "controlled_test_only": true,
+          "observational_only": true,
+          "planner_remap_performed": false,
+          "production_consumer": false
+        },
+        "original_semantic_expectation_status": "semantic_expectations_partial",
+        "production_output_affected": false,
+        "remaining_unavailable_fields": [
+          "manifest_trace_fields",
+          "fixture_trace_fields"
+        ],
+        "trace_backfill_status": "trace_expectations_partial",
+        "trace_conflicts": []
+      }
+    ],
+    "blocker_reason_counts": {},
+    "deterministic_hash": "8acd948034de16ce8c4ec52154b7e9d928509c1fdd9b3b0dd50fbd46cb434d6c",
+    "metadata": {
+      "controlled_test_only": true,
+      "deterministic_serializer": "json_sort_keys_sha256",
+      "observational_only": true,
+      "planner_remap_performed": false,
+      "production_behavior_changed": false,
+      "production_consumer": false,
+      "production_default_routing_authorized": false,
+      "source": "v3_1_baseline_trace_expectation_backfill",
+      "stable_generation_token": "v3_1_phase_22_baseline_trace_expectation_backfill_token"
+    },
+    "remaining_unavailable_field_counts": {
+      "fixture_trace_fields": 4,
+      "manifest_trace_fields": 4
+    },
+    "run": {
+      "admission_aware_manifest_serialization_hash": "8fa65134e7e0bf7f839c2ad01b22b26b7fc59c26787f23b7c13331fc5654ecda",
+      "baseline_expectation_record_count": 5,
+      "baseline_semantic_expectations_hash": "676a8712111518f9db713b3bf1d2f3ce6ab0fbf485bc1e7dc5127ac263bcb60d",
+      "controlled_consumption_output_validation_hash": "3364892148b06185a66ca86a64243a32ab54324995ed8752be795bed78300677",
+      "controlled_consumption_parity_snapshot_hash": "5e5744d7474cc3e8ca26e1163178c65744e46a07f01674bc4b11acbec486b20c",
+      "run_id": "v3_1_phase_22_baseline_trace_expectation_backfill",
+      "trace_source_count": 1
+    },
+    "safety_confirmations": {
+      "backfilled_expectations_are_production_approval": false,
+      "backfilled_expectations_authorize_production_routing": false,
+      "legacy_planner_ownership_preserved": true,
+      "production_behavior_changed": false,
+      "production_output_affected": false,
+      "production_planner_routing_changed": false,
+      "runtime_manifest_consumption_enabled": false,
+      "runtime_production_consumption_enabled": false,
+      "trusted_data_default_truth": false
+    },
+    "schema_version": "v3_1.baseline_trace_expectation_backfill.1",
+    "summary": {
+      "backfilled_count": 1,
+      "baseline_expectation_records_evaluated": 5,
+      "blocked_count": 0,
+      "deterministic": true,
+      "partial_count": 4,
+      "production_affected_count": 0,
+      "production_behavior_changed": false,
+      "production_default_routing_authorized": false,
+      "production_output_affected": false,
+      "runtime_manifest_consumption_enabled": false,
+      "runtime_production_consumption_enabled": false
+    },
+    "trace_backfill_status_counts": {
+      "blocked_invalid_authorization_state": 0,
+      "blocked_missing_baseline_expectation": 0,
+      "blocked_missing_trace_source": 0,
+      "blocked_trace_conflict": 0,
+      "trace_expectations_backfilled": 1,
+      "trace_expectations_partial": 4
+    },
+    "trace_conflict_counts": {}
+  },
+  "deterministic_guarantees": {
+    "json_sort_keys": true,
+    "passed": true,
+    "repeated_hash": "8acd948034de16ce8c4ec52154b7e9d928509c1fdd9b3b0dd50fbd46cb434d6c",
+    "sample_hash": "8acd948034de16ce8c4ec52154b7e9d928509c1fdd9b3b0dd50fbd46cb434d6c",
+    "timestamp_excluded_from_hash": true
+  },
+  "generated_at": "2026-05-15T00:00:00+00:00",
+  "metadata": {
+    "controlled_test_only": true,
+    "observational_only": true,
+    "planner_remap_performed": false,
+    "production_behavior_changed": false,
+    "production_default_routing_authorized": false,
+    "source": "v3_1_baseline_trace_expectation_backfill_report"
+  },
+  "phase": "v3.1_phase_22_baseline_trace_expectation_backfill",
+  "phase_22_boundaries": [
+    "trace expectation backfill is test-only governance metadata",
+    "backfilled expectations are not production approval",
+    "backfilled expectations do not authorize production routing",
+    "trace fields are sourced only from deterministic governance artifacts",
+    "runtime manifest consumption remains disabled",
+    "legacy planner ownership remains intact"
+  ],
+  "production_default_routing_authorized": false,
+  "recommendation": "OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING",
+  "runtime_manifest_consumption_enabled": false,
+  "runtime_production_consumption_enabled": false,
+  "schema_version": "v3_1.baseline_trace_expectation_backfill_report.1",
+  "summary": {
+    "backfilled_count": 1,
+    "baseline_expectation_records_evaluated": 5,
+    "blocked_count": 0,
+    "deterministic": true,
+    "partial_count": 4,
+    "production_affected_count": 0,
+    "production_behavior_changed": false,
+    "production_default_routing_authorized": false,
+    "production_output_affected": false,
+    "runtime_manifest_consumption_enabled": false,
+    "runtime_production_consumption_enabled": false
+  }
+}

--- a/docs/migration/V3_1_BASELINE_TRACE_EXPECTATION_BACKFILL.md
+++ b/docs/migration/V3_1_BASELINE_TRACE_EXPECTATION_BACKFILL.md
@@ -1,0 +1,60 @@
+# V3.1 Baseline Trace Expectation Backfill
+
+Phase 22 backfills deterministic manifest and fixture trace expectations from existing governance artifacts.
+Backfilled expectations are not production approval and do not authorize routing.
+
+## Recommendation
+
+- Recommendation: `OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING`
+- Production default routing authorized: `false`
+- Runtime production consumption enabled: `false`
+- Runtime manifest consumption enabled: `false`
+
+## Summary
+
+- Baseline expectation records evaluated: `5`
+- Backfilled: `1`
+- Partial: `4`
+- Blocked: `0`
+- Production affected: `0`
+- Deterministic: `true`
+
+## Remaining Unavailable Fields
+
+| Field | Count |
+| --- | ---: |
+| `fixture_trace_fields` | `4` |
+| `manifest_trace_fields` | `4` |
+
+## Trace Conflicts
+
+| Conflict | Count |
+| --- | ---: |
+
+## Blocker Reasons
+
+| Reason | Count |
+| --- | ---: |
+
+## Backfill Records
+
+| Record | Baseline | Manifest | Fixture Set | Status |
+| --- | --- | --- | --- | --- |
+| `v3_1_baseline_trace_backfill_6ce426b2b1644e8e` | `v3_1_snapshot_372c946743469ec5` | `` | `` | `trace_expectations_partial` |
+| `v3_1_baseline_trace_backfill_a3262364e64d3665` | `v3_1_snapshot_42674d7f460ed71c` | `` | `` | `trace_expectations_partial` |
+| `v3_1_baseline_trace_backfill_0649c3b0041786f6` | `v3_1_snapshot_472bcd4c1169053b` | `v3_1_admission_manifest_198a3e2110f9e5e4` | `v3_1_fixture_set_6d3b668a84cfbb69` | `trace_expectations_backfilled` |
+| `v3_1_baseline_trace_backfill_229de2756705b110` | `v3_1_snapshot_4d312622ce8de408` | `` | `` | `trace_expectations_partial` |
+| `v3_1_baseline_trace_backfill_8651606742e0c061` | `v3_1_snapshot_7fed448d66ec5b1b` | `` | `` | `trace_expectations_partial` |
+
+## Phase 22 Boundaries
+
+- trace expectation backfill is test-only governance metadata
+- backfilled expectations are not production approval
+- backfilled expectations do not authorize production routing
+- trace fields are sourced only from deterministic governance artifacts
+- runtime manifest consumption remains disabled
+- legacy planner ownership remains intact
+
+## Conclusion
+
+Baseline trace expectation backfill is available for governance review, while production routing remains unchanged.


### PR DESCRIPTION
Adds deterministic baseline trace expectation backfill from existing governance artifacts so semantic parity can use safe manifest and fixture traces without enabling production routing.