### PR TITLE
v3.1: refresh semantic parity with trace backfill

### DIFF
--- a/backend/app/planner_adapters/v3_1/__init__.py
+++ b/backend/app/planner_adapters/v3_1/__init__.py
@@ -28,6 +28,10 @@ from .baseline_trace_expectation_backfill import (
     BASELINE_TRACE_EXPECTATION_BACKFILL_STATUSES,
     build_baseline_trace_expectation_backfill,
 )
+from .trace_backfilled_semantic_parity import (
+    TRACE_BACKFILLED_SEMANTIC_PARITY_STATUSES,
+    build_trace_backfilled_semantic_parity,
+)
 from .review_policy_evaluation import (
     REVIEW_POLICY_OUTCOMES,
     V31ReviewPolicyEvaluation,
@@ -110,6 +114,7 @@ __all__ = [
     "BASELINE_READINESS_CLASSIFICATIONS",
     "BASELINE_SEMANTIC_EXPECTATION_STATUSES",
     "BASELINE_TRACE_EXPECTATION_BACKFILL_STATUSES",
+    "TRACE_BACKFILLED_SEMANTIC_PARITY_STATUSES",
     "FIXTURE_WORKFLOW_STATES",
     "FIXTURE_SET_LIFECYCLE_STATES",
     "REVIEW_POLICY_OUTCOMES",
@@ -143,6 +148,7 @@ __all__ = [
     "build_sample_dual_run_inputs",
     "build_baseline_semantic_expectations",
     "build_baseline_trace_expectation_backfill",
+    "build_trace_backfilled_semantic_parity",
     "build_default_trusted_repository_probes",
     "build_fixture_set_readiness_gate",
     "evaluate_fixture_source_admission_policy",

--- a/backend/app/planner_adapters/v3_1/trace_backfilled_semantic_parity.py
+++ b/backend/app/planner_adapters/v3_1/trace_backfilled_semantic_parity.py
@@ -1,0 +1,312 @@
+"""Trace-backfilled semantic parity refresh for v3.1 governance.
+
+This layer refreshes controlled-consumption semantic parity using deterministic
+baseline trace backfill records. It only confirms parity when trace-backed
+expectations match validated controlled output evidence.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from copy import deepcopy
+from typing import Any
+
+from .approval_manifest_serialization import NON_PRODUCTION_AUTHORIZATION_STATE
+from .trusted_shadow_consumption import deterministic_hash
+
+
+TRACE_BACKFILLED_SEMANTIC_PARITY_STATUSES = (
+    "semantic_parity_confirmed",
+    "semantic_parity_partial",
+    "blocked_missing_semantic_parity_record",
+    "blocked_missing_backfilled_expectation",
+    "blocked_trace_conflict",
+    "blocked_invalid_authorization_state",
+    "blocked_missing_controlled_output",
+)
+STABLE_TRACE_BACKFILLED_SEMANTIC_PARITY_TOKEN = "v3_1_phase_23_trace_backfilled_semantic_parity_token"
+
+
+def build_trace_backfilled_semantic_parity(
+    *,
+    controlled_consumption_semantic_parity: dict[str, Any] | list[dict[str, Any]],
+    baseline_trace_expectation_backfill: dict[str, Any] | list[dict[str, Any]],
+    controlled_consumption_output_validation: dict[str, Any] | list[dict[str, Any]],
+    run_id: str = "v3_1_phase_23_trace_backfilled_semantic_parity",
+) -> dict[str, Any]:
+    """Refresh semantic parity using backfilled trace expectations."""
+
+    semantic_records = _semantic_records(controlled_consumption_semantic_parity)
+    backfill_records = _backfill_records(baseline_trace_expectation_backfill)
+    validation_records = _validation_records(controlled_consumption_output_validation)
+    backfill_by_baseline = {
+        str(record.get("baseline_id")): record
+        for record in backfill_records
+        if record.get("baseline_id")
+    }
+    validation_by_key = {_trace_key(record): record for record in validation_records if _trace_key(record)}
+    refreshed_records = [
+        _refresh_record(
+            semantic_record=record,
+            backfill_record=backfill_by_baseline.get(str(record.get("baseline_id") or "")),
+            validation_record=validation_by_key.get(_trace_key(record)),
+        )
+        for record in sorted(semantic_records, key=_semantic_sort_key)
+    ]
+    if not refreshed_records:
+        refreshed_records = [_missing_semantic_parity_record()]
+
+    counts = Counter(record["final_semantic_parity_status"] for record in refreshed_records)
+    blocker_reasons = Counter(reason for record in refreshed_records for reason in record["blockers"])
+    remaining_unavailable = Counter(field for record in refreshed_records for field in record["remaining_unavailable_fields"])
+    mismatches = Counter(field for record in refreshed_records for field in record["mismatched_fields"])
+    semantic_hash = controlled_consumption_semantic_parity.get("deterministic_hash") if isinstance(controlled_consumption_semantic_parity, dict) else None
+    backfill_hash = baseline_trace_expectation_backfill.get("deterministic_hash") if isinstance(baseline_trace_expectation_backfill, dict) else None
+    validation_hash = controlled_consumption_output_validation.get("deterministic_hash") if isinstance(controlled_consumption_output_validation, dict) else None
+    envelope = {
+        "schema_version": "v3_1.trace_backfilled_semantic_parity.1",
+        "run": {
+            "run_id": run_id,
+            "semantic_parity_record_count": len(semantic_records),
+            "trace_backfill_record_count": len(backfill_records),
+            "validated_output_record_count": len(validation_records),
+            "controlled_consumption_semantic_parity_hash": semantic_hash,
+            "baseline_trace_expectation_backfill_hash": backfill_hash,
+            "controlled_consumption_output_validation_hash": validation_hash,
+        },
+        "summary": {
+            "records_evaluated": len(refreshed_records),
+            "semantic_parity_confirmed_count": counts["semantic_parity_confirmed"],
+            "semantic_parity_partial_count": counts["semantic_parity_partial"],
+            "blocked_count": len(refreshed_records) - counts["semantic_parity_confirmed"] - counts["semantic_parity_partial"],
+            "promoted_from_partial_count": sum(1 for record in refreshed_records if record["promoted_from_partial"] is True),
+            "production_affected_count": 0,
+            "production_output_affected": False,
+            "production_behavior_changed": False,
+            "production_default_routing_authorized": False,
+            "runtime_manifest_consumption_enabled": False,
+            "runtime_production_consumption_enabled": False,
+            "deterministic": True,
+        },
+        "trace_backfilled_semantic_parity_status_counts": {
+            status: counts[status]
+            for status in TRACE_BACKFILLED_SEMANTIC_PARITY_STATUSES
+        },
+        "remaining_unavailable_field_counts": dict(sorted(remaining_unavailable.items())),
+        "mismatched_field_counts": dict(sorted(mismatches.items())),
+        "blocker_reason_counts": dict(sorted(blocker_reasons.items())),
+        "trace_backfilled_semantic_parity_records": refreshed_records,
+        "safety_confirmations": {
+            "semantic_parity_authorizes_production_routing": False,
+            "semantic_parity_is_production_approval": False,
+            "runtime_manifest_consumption_enabled": False,
+            "runtime_production_consumption_enabled": False,
+            "legacy_planner_ownership_preserved": True,
+            "production_output_affected": False,
+            "production_behavior_changed": False,
+            "production_planner_routing_changed": False,
+            "trusted_data_default_truth": False,
+        },
+        "metadata": {
+            "source": "v3_1_trace_backfilled_semantic_parity",
+            "observational_only": True,
+            "controlled_test_only": True,
+            "production_consumer": False,
+            "production_behavior_changed": False,
+            "planner_remap_performed": False,
+            "production_default_routing_authorized": False,
+            "stable_generation_token": STABLE_TRACE_BACKFILLED_SEMANTIC_PARITY_TOKEN,
+            "deterministic_serializer": "json_sort_keys_sha256",
+        },
+    }
+    envelope["deterministic_hash"] = deterministic_hash(envelope)
+    return envelope
+
+
+def _semantic_records(value: dict[str, Any] | list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if isinstance(value, list):
+        return [deepcopy(row) for row in value]
+    return [deepcopy(row) for row in value.get("semantic_parity_records", [])]
+
+
+def _backfill_records(value: dict[str, Any] | list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if isinstance(value, list):
+        return [deepcopy(row) for row in value]
+    return [deepcopy(row) for row in value.get("baseline_trace_backfill_records", [])]
+
+
+def _validation_records(value: dict[str, Any] | list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if isinstance(value, list):
+        return [deepcopy(row) for row in value]
+    return [deepcopy(row) for row in value.get("validation_records", [])]
+
+
+def _refresh_record(
+    *,
+    semantic_record: dict[str, Any],
+    backfill_record: dict[str, Any] | None,
+    validation_record: dict[str, Any] | None,
+) -> dict[str, Any]:
+    compared_fields, mismatched_fields = _compare_trace_fields(
+        backfill_record=backfill_record,
+        validation_record=validation_record,
+    )
+    blockers = _blockers(
+        semantic_record=semantic_record,
+        backfill_record=backfill_record,
+        validation_record=validation_record,
+        mismatched_fields=mismatched_fields,
+    )
+    if backfill_record is not None:
+        remaining_unavailable = list(backfill_record.get("remaining_unavailable_fields") or [])
+    else:
+        remaining_unavailable = list(semantic_record.get("unavailable_fields") or [])
+    status = _status(
+        blockers=blockers,
+        backfill_record=backfill_record,
+        remaining_unavailable=remaining_unavailable,
+        original_status=semantic_record.get("semantic_parity_status"),
+    )
+    seed = {
+        "semantic_parity_record_id": semantic_record.get("semantic_parity_record_id"),
+        "baseline_id": semantic_record.get("baseline_id"),
+        "manifest_id": semantic_record.get("manifest_id"),
+        "fixture_set_id": semantic_record.get("fixture_set_id"),
+        "status": status,
+        "token": STABLE_TRACE_BACKFILLED_SEMANTIC_PARITY_TOKEN,
+    }
+    original_status = semantic_record.get("semantic_parity_status")
+    return {
+        "trace_backfilled_semantic_parity_id": f"v3_1_trace_backfilled_semantic_parity_{deterministic_hash(seed)[:16]}",
+        "manifest_id": semantic_record.get("manifest_id"),
+        "fixture_set_id": semantic_record.get("fixture_set_id"),
+        "baseline_id": semantic_record.get("baseline_id"),
+        "original_semantic_parity_status": original_status,
+        "backfill_status": (backfill_record or {}).get("trace_backfill_status"),
+        "final_semantic_parity_status": status,
+        "compared_trace_fields": compared_fields,
+        "remaining_unavailable_fields": remaining_unavailable,
+        "mismatched_fields": mismatched_fields,
+        "blockers": blockers,
+        "promoted_from_partial": original_status == "semantic_parity_partial" and status == "semantic_parity_confirmed",
+        "semantic_parity_authorizes_production_routing": False,
+        "production_output_affected": False,
+        "metadata": {
+            "observational_only": True,
+            "controlled_test_only": True,
+            "production_consumer": False,
+            "planner_remap_performed": False,
+        },
+    }
+
+
+def _missing_semantic_parity_record() -> dict[str, Any]:
+    seed = {"missing_semantic_parity": True, "token": STABLE_TRACE_BACKFILLED_SEMANTIC_PARITY_TOKEN}
+    return {
+        "trace_backfilled_semantic_parity_id": f"v3_1_trace_backfilled_semantic_parity_{deterministic_hash(seed)[:16]}",
+        "manifest_id": None,
+        "fixture_set_id": None,
+        "baseline_id": None,
+        "original_semantic_parity_status": None,
+        "backfill_status": None,
+        "final_semantic_parity_status": "blocked_missing_semantic_parity_record",
+        "compared_trace_fields": [],
+        "remaining_unavailable_fields": [],
+        "mismatched_fields": [],
+        "blockers": ["blocked_missing_semantic_parity_record"],
+        "promoted_from_partial": False,
+        "semantic_parity_authorizes_production_routing": False,
+        "production_output_affected": False,
+        "metadata": {
+            "observational_only": True,
+            "controlled_test_only": True,
+            "production_consumer": False,
+            "planner_remap_performed": False,
+        },
+    }
+
+
+def _compare_trace_fields(
+    *,
+    backfill_record: dict[str, Any] | None,
+    validation_record: dict[str, Any] | None,
+) -> tuple[list[dict[str, Any]], list[str]]:
+    if not backfill_record or not validation_record:
+        return [], []
+    compared: list[dict[str, Any]] = []
+    mismatched: list[str] = []
+    checks = (
+        ("manifest_id", (backfill_record.get("backfilled_manifest_trace_fields") or {}).get("manifest_id"), validation_record.get("manifest_id")),
+        ("fixture_set_id", (backfill_record.get("backfilled_fixture_trace_fields") or {}).get("fixture_set_id"), validation_record.get("fixture_set_id")),
+    )
+    for field, expected, actual in checks:
+        if expected is None:
+            continue
+        matches = expected == actual
+        compared.append({"field": field, "expected": expected, "actual": actual, "matches": matches})
+        if not matches:
+            mismatched.append(field)
+    return compared, mismatched
+
+
+def _blockers(
+    *,
+    semantic_record: dict[str, Any],
+    backfill_record: dict[str, Any] | None,
+    validation_record: dict[str, Any] | None,
+    mismatched_fields: list[str],
+) -> list[str]:
+    blockers: list[str] = []
+    if not semantic_record.get("semantic_parity_record_id"):
+        blockers.append("blocked_missing_semantic_parity_record")
+    if backfill_record is None:
+        blockers.append("blocked_missing_backfilled_expectation")
+    if validation_record is None:
+        blockers.append("blocked_missing_controlled_output")
+    if (backfill_record or {}).get("trace_conflicts"):
+        blockers.append("blocked_trace_conflict")
+    if mismatched_fields:
+        blockers.append("blocked_trace_conflict")
+    if _authorization_state(validation_record) != NON_PRODUCTION_AUTHORIZATION_STATE:
+        blockers.append("blocked_invalid_authorization_state")
+    return sorted(set(blockers), key=blockers.index)
+
+
+def _status(
+    *,
+    blockers: list[str],
+    backfill_record: dict[str, Any] | None,
+    remaining_unavailable: list[str],
+    original_status: str | None,
+) -> str:
+    if blockers:
+        return blockers[0]
+    if original_status == "semantic_parity_confirmed":
+        return "semantic_parity_confirmed"
+    if (backfill_record or {}).get("trace_backfill_status") == "trace_expectations_backfilled" and not remaining_unavailable:
+        return "semantic_parity_confirmed"
+    return "semantic_parity_partial"
+
+
+def _authorization_state(record: dict[str, Any] | None) -> str | None:
+    if not record:
+        return None
+    return (record.get("traceability_summary") or {}).get("authorization_state")
+
+
+def _trace_key(record: dict[str, Any] | None) -> tuple[str, str] | None:
+    if not record:
+        return None
+    manifest_id = record.get("manifest_id")
+    fixture_set_id = record.get("fixture_set_id")
+    if not manifest_id or not fixture_set_id:
+        return None
+    return (str(manifest_id), str(fixture_set_id))
+
+
+def _semantic_sort_key(record: dict[str, Any]) -> tuple[str, str, str]:
+    return (
+        str(record.get("fixture_set_id") or ""),
+        str(record.get("manifest_id") or ""),
+        str(record.get("baseline_id") or ""),
+    )

--- a/backend/scripts/report_v3_1_trace_backfilled_semantic_parity.py
+++ b/backend/scripts/report_v3_1_trace_backfilled_semantic_parity.py
@@ -1,0 +1,182 @@
+"""Generate the v3.1 trace-backfilled semantic parity report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.planner_adapters.v3_1.trace_backfilled_semantic_parity import build_trace_backfilled_semantic_parity  # noqa: E402
+
+
+DETERMINISTIC_GENERATED_AT = "2026-05-15T00:00:00+00:00"
+
+
+def build_v3_1_trace_backfilled_semantic_parity_report() -> dict[str, Any]:
+    repo_root = Path(__file__).resolve().parents[2]
+    semantic = _read_json(repo_root / "docs" / "generated" / "v3_1_controlled_consumption_semantic_parity_report.json")[
+        "controlled_consumption_semantic_parity"
+    ]
+    backfill = _read_json(repo_root / "docs" / "generated" / "v3_1_baseline_trace_expectation_backfill_report.json")[
+        "baseline_trace_expectation_backfill"
+    ]
+    validation = _read_json(repo_root / "docs" / "generated" / "v3_1_controlled_consumption_output_validation_report.json")[
+        "controlled_consumption_output_validation"
+    ]
+    refreshed = build_trace_backfilled_semantic_parity(
+        controlled_consumption_semantic_parity=semantic,
+        baseline_trace_expectation_backfill=backfill,
+        controlled_consumption_output_validation=validation,
+    )
+    repeated = build_trace_backfilled_semantic_parity(
+        controlled_consumption_semantic_parity=semantic,
+        baseline_trace_expectation_backfill=backfill,
+        controlled_consumption_output_validation=validation,
+    )
+    report = {
+        "schema_version": "v3_1.trace_backfilled_semantic_parity_report.1",
+        "generated_at": DETERMINISTIC_GENERATED_AT,
+        "phase": "v3.1_phase_23_trace_backfilled_semantic_parity_refresh",
+        "recommendation": "OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING",
+        "production_default_routing_authorized": False,
+        "runtime_manifest_consumption_enabled": False,
+        "runtime_production_consumption_enabled": False,
+        "summary": {
+            **refreshed["summary"],
+            "deterministic": refreshed["deterministic_hash"] == repeated["deterministic_hash"],
+        },
+        "trace_backfilled_semantic_parity": refreshed,
+        "deterministic_guarantees": {
+            "passed": refreshed["deterministic_hash"] == repeated["deterministic_hash"],
+            "sample_hash": refreshed["deterministic_hash"],
+            "repeated_hash": repeated["deterministic_hash"],
+            "timestamp_excluded_from_hash": True,
+            "json_sort_keys": True,
+        },
+        "phase_23_boundaries": [
+            "trace-backfilled semantic parity is test-only governance metadata",
+            "confirmed semantic parity is not production approval",
+            "confirmed semantic parity does not authorize production routing",
+            "trace expectations must match deterministic controlled output evidence",
+            "runtime manifest consumption remains disabled",
+            "legacy planner ownership remains intact",
+        ],
+        "metadata": {
+            "source": "v3_1_trace_backfilled_semantic_parity_report",
+            "observational_only": True,
+            "controlled_test_only": True,
+            "production_behavior_changed": False,
+            "production_default_routing_authorized": False,
+            "planner_remap_performed": False,
+        },
+    }
+    return _normalize_generated_at(report)
+
+
+def write_report(report: dict[str, Any], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_markdown(report: dict[str, Any], output_path: Path) -> None:
+    refreshed = report["trace_backfilled_semantic_parity"]
+    summary = report["summary"]
+    lines = [
+        "# V3.1 Trace-Backfilled Semantic Parity",
+        "",
+        "Phase 23 refreshes controlled-consumption semantic parity using deterministic trace backfill evidence.",
+        "Confirmed semantic parity is not production approval and does not authorize routing.",
+        "",
+        "## Recommendation",
+        "",
+        f"- Recommendation: `{report['recommendation']}`",
+        f"- Production default routing authorized: `{str(report['production_default_routing_authorized']).lower()}`",
+        f"- Runtime production consumption enabled: `{str(report['runtime_production_consumption_enabled']).lower()}`",
+        f"- Runtime manifest consumption enabled: `{str(report['runtime_manifest_consumption_enabled']).lower()}`",
+        "",
+        "## Summary",
+        "",
+        f"- Records evaluated: `{summary['records_evaluated']}`",
+        f"- Confirmed: `{summary['semantic_parity_confirmed_count']}`",
+        f"- Partial: `{summary['semantic_parity_partial_count']}`",
+        f"- Blocked: `{summary['blocked_count']}`",
+        f"- Promoted from partial: `{summary['promoted_from_partial_count']}`",
+        f"- Production affected: `{summary['production_affected_count']}`",
+        f"- Deterministic: `{str(summary['deterministic']).lower()}`",
+        "",
+        "## Remaining Unavailable Fields",
+        "",
+        "| Field | Count |",
+        "| --- | ---: |",
+    ]
+    for field, count in refreshed["remaining_unavailable_field_counts"].items():
+        lines.append(f"| `{field}` | `{count}` |")
+    lines.extend(["", "## Mismatch Summary", "", "| Field | Count |", "| --- | ---: |"])
+    for field, count in refreshed["mismatched_field_counts"].items():
+        lines.append(f"| `{field}` | `{count}` |")
+    lines.extend(["", "## Blocker Reasons", "", "| Reason | Count |", "| --- | ---: |"])
+    for reason, count in refreshed["blocker_reason_counts"].items():
+        lines.append(f"| `{reason}` | `{count}` |")
+    lines.extend(
+        [
+            "",
+            "## Refreshed Records",
+            "",
+            "| Record | Manifest | Fixture Set | Baseline | Original | Backfill | Final |",
+            "| --- | --- | --- | --- | --- | --- | --- |",
+        ]
+    )
+    for row in refreshed["trace_backfilled_semantic_parity_records"]:
+        lines.append(
+            f"| `{row['trace_backfilled_semantic_parity_id']}` | `{row['manifest_id'] or ''}` | `{row['fixture_set_id'] or ''}` | `{row['baseline_id'] or ''}` | `{row['original_semantic_parity_status'] or ''}` | `{row['backfill_status'] or ''}` | `{row['final_semantic_parity_status']}` |"
+        )
+    lines.extend(["", "## Phase 23 Boundaries", ""])
+    lines.extend(f"- {item}" for item in report["phase_23_boundaries"])
+    lines.extend(
+        [
+            "",
+            "## Conclusion",
+            "",
+            "Trace-backfilled semantic parity is available for governance review, while production routing remains unchanged.",
+        ]
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _normalize_generated_at(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: DETERMINISTIC_GENERATED_AT if key == "generated_at" else _normalize_generated_at(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_normalize_generated_at(item) for item in value]
+    return deepcopy(value)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", default="docs/generated/v3_1_trace_backfilled_semantic_parity_report.json")
+    parser.add_argument("--markdown-output", default="docs/migration/V3_1_TRACE_BACKFILLED_SEMANTIC_PARITY.md")
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[2]
+    report = build_v3_1_trace_backfilled_semantic_parity_report()
+    write_report(report, repo_root / args.output)
+    write_markdown(report, repo_root / args.markdown_output)
+    print(json.dumps(report["summary"], indent=2, sort_keys=True))
+    print(report["recommendation"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_v3_1_trace_backfilled_semantic_parity.py
+++ b/backend/tests/test_v3_1_trace_backfilled_semantic_parity.py
@@ -1,0 +1,184 @@
+from app.planner_adapters.v3_1.trace_backfilled_semantic_parity import build_trace_backfilled_semantic_parity
+from scripts.report_v3_1_trace_backfilled_semantic_parity import build_v3_1_trace_backfilled_semantic_parity_report
+
+
+def test_matching_backfilled_traces_promote_partial_to_confirmed():
+    result = build_trace_backfilled_semantic_parity(
+        controlled_consumption_semantic_parity=_semantic([_semantic_record()]),
+        baseline_trace_expectation_backfill=_backfill([_backfill_record()]),
+        controlled_consumption_output_validation=_validation([_validation_record()]),
+    )
+
+    record = result["trace_backfilled_semantic_parity_records"][0]
+    assert record["final_semantic_parity_status"] == "semantic_parity_confirmed"
+    assert record["promoted_from_partial"] is True
+
+
+def test_unavailable_trace_expectations_remain_partial():
+    result = build_trace_backfilled_semantic_parity(
+        controlled_consumption_semantic_parity=_semantic([_semantic_record()]),
+        baseline_trace_expectation_backfill=_backfill([_backfill_record(status="trace_expectations_partial", remaining=["manifest_trace_fields"])]),
+        controlled_consumption_output_validation=_validation([_validation_record()]),
+    )
+
+    record = result["trace_backfilled_semantic_parity_records"][0]
+    assert record["final_semantic_parity_status"] == "semantic_parity_partial"
+    assert record["remaining_unavailable_fields"] == ["manifest_trace_fields"]
+
+
+def test_trace_mismatch_blocks():
+    result = build_trace_backfilled_semantic_parity(
+        controlled_consumption_semantic_parity=_semantic([_semantic_record()]),
+        baseline_trace_expectation_backfill=_backfill([_backfill_record(manifest_id="different_manifest")]),
+        controlled_consumption_output_validation=_validation([_validation_record()]),
+    )
+
+    record = result["trace_backfilled_semantic_parity_records"][0]
+    assert record["final_semantic_parity_status"] == "blocked_trace_conflict"
+    assert record["mismatched_fields"] == ["manifest_id"]
+
+
+def test_missing_backfill_record_blocks():
+    result = build_trace_backfilled_semantic_parity(
+        controlled_consumption_semantic_parity=_semantic([_semantic_record()]),
+        baseline_trace_expectation_backfill=_backfill([]),
+        controlled_consumption_output_validation=_validation([_validation_record()]),
+    )
+
+    assert result["trace_backfilled_semantic_parity_records"][0]["final_semantic_parity_status"] == "blocked_missing_backfilled_expectation"
+
+
+def test_missing_controlled_output_blocks():
+    result = build_trace_backfilled_semantic_parity(
+        controlled_consumption_semantic_parity=_semantic([_semantic_record()]),
+        baseline_trace_expectation_backfill=_backfill([_backfill_record()]),
+        controlled_consumption_output_validation=_validation([]),
+    )
+
+    assert result["trace_backfilled_semantic_parity_records"][0]["final_semantic_parity_status"] == "blocked_missing_controlled_output"
+
+
+def test_invalid_authorization_state_blocks():
+    result = build_trace_backfilled_semantic_parity(
+        controlled_consumption_semantic_parity=_semantic([_semantic_record()]),
+        baseline_trace_expectation_backfill=_backfill([_backfill_record()]),
+        controlled_consumption_output_validation=_validation([_validation_record(authorization_state="production_authoritative")]),
+    )
+
+    assert result["trace_backfilled_semantic_parity_records"][0]["final_semantic_parity_status"] == "blocked_invalid_authorization_state"
+
+
+def test_deterministic_ordering():
+    first = build_trace_backfilled_semantic_parity(
+        controlled_consumption_semantic_parity=_semantic([_semantic_record("baseline_b", "manifest_b", "set_b"), _semantic_record("baseline_a", "manifest_a", "set_a")]),
+        baseline_trace_expectation_backfill=_backfill([_backfill_record("baseline_b", "manifest_b", "set_b"), _backfill_record("baseline_a", "manifest_a", "set_a")]),
+        controlled_consumption_output_validation=_validation([_validation_record("manifest_b", "set_b"), _validation_record("manifest_a", "set_a")]),
+    )
+    second = build_trace_backfilled_semantic_parity(
+        controlled_consumption_semantic_parity=_semantic([_semantic_record("baseline_a", "manifest_a", "set_a"), _semantic_record("baseline_b", "manifest_b", "set_b")]),
+        baseline_trace_expectation_backfill=_backfill([_backfill_record("baseline_a", "manifest_a", "set_a"), _backfill_record("baseline_b", "manifest_b", "set_b")]),
+        controlled_consumption_output_validation=_validation([_validation_record("manifest_a", "set_a"), _validation_record("manifest_b", "set_b")]),
+    )
+
+    assert first["deterministic_hash"] == second["deterministic_hash"]
+    assert [row["baseline_id"] for row in first["trace_backfilled_semantic_parity_records"]] == ["baseline_a", "baseline_b"]
+
+
+def test_stable_report_generation():
+    first = build_v3_1_trace_backfilled_semantic_parity_report()
+    second = build_v3_1_trace_backfilled_semantic_parity_report()
+
+    assert first["deterministic_guarantees"]["passed"] is True
+    assert first["trace_backfilled_semantic_parity"]["deterministic_hash"] == second["trace_backfilled_semantic_parity"]["deterministic_hash"]
+    assert first["summary"] == second["summary"]
+
+
+def test_no_production_routing_enablement():
+    result = build_trace_backfilled_semantic_parity(
+        controlled_consumption_semantic_parity=_semantic([_semantic_record()]),
+        baseline_trace_expectation_backfill=_backfill([_backfill_record()]),
+        controlled_consumption_output_validation=_validation([_validation_record()]),
+    )
+    record = result["trace_backfilled_semantic_parity_records"][0]
+
+    assert result["safety_confirmations"]["semantic_parity_authorizes_production_routing"] is False
+    assert result["safety_confirmations"]["semantic_parity_is_production_approval"] is False
+    assert result["summary"]["runtime_manifest_consumption_enabled"] is False
+    assert record["semantic_parity_authorizes_production_routing"] is False
+
+
+def _semantic(records):
+    return {
+        "schema_version": "v3_1.controlled_consumption_semantic_parity.1",
+        "deterministic_hash": "semantic-hash",
+        "semantic_parity_records": records,
+    }
+
+
+def _semantic_record(baseline_id="baseline_a", manifest_id="manifest_a", fixture_set_id="set_a"):
+    return {
+        "semantic_parity_record_id": f"semantic_{baseline_id}",
+        "manifest_id": manifest_id,
+        "fixture_set_id": fixture_set_id,
+        "baseline_id": baseline_id,
+        "structural_parity_status": "parity_confirmed",
+        "semantic_parity_status": "semantic_parity_partial",
+        "compared_fields": [],
+        "unavailable_fields": ["baseline_semantics"],
+        "mismatched_fields": [],
+        "blockers": [],
+        "semantic_parity_authorizes_production_routing": False,
+        "production_output_affected": False,
+    }
+
+
+def _backfill(records):
+    return {
+        "schema_version": "v3_1.baseline_trace_expectation_backfill.1",
+        "deterministic_hash": "backfill-hash",
+        "baseline_trace_backfill_records": records,
+    }
+
+
+def _backfill_record(baseline_id="baseline_a", manifest_id="manifest_a", fixture_set_id="set_a", status="trace_expectations_backfilled", remaining=None):
+    return {
+        "baseline_trace_backfill_id": f"backfill_{baseline_id}",
+        "baseline_id": baseline_id,
+        "manifest_id": manifest_id,
+        "fixture_set_id": fixture_set_id,
+        "original_semantic_expectation_status": "semantic_expectations_partial",
+        "backfilled_manifest_trace_fields": {"manifest_id": manifest_id} if manifest_id else {},
+        "backfilled_fixture_trace_fields": {"fixture_set_id": fixture_set_id} if fixture_set_id else {},
+        "remaining_unavailable_fields": remaining or [],
+        "trace_backfill_status": status,
+        "trace_conflicts": [],
+        "blockers": [],
+        "backfilled_expectations_authorize_production_routing": False,
+        "production_output_affected": False,
+    }
+
+
+def _validation(records):
+    return {
+        "schema_version": "v3_1.controlled_consumption_output_validation.1",
+        "deterministic_hash": "validation-hash",
+        "validation_records": records,
+    }
+
+
+def _validation_record(manifest_id="manifest_a", fixture_set_id="set_a", authorization_state="non_production_authoritative"):
+    return {
+        "validation_record_id": f"validation_{manifest_id}_{fixture_set_id}",
+        "manifest_id": manifest_id,
+        "fixture_set_id": fixture_set_id,
+        "validation_status": "valid_controlled_test_output",
+        "traceability_summary": {
+            "manifest_trace_present": bool(manifest_id),
+            "fixture_set_trace_present": bool(fixture_set_id),
+            "authorization_state": authorization_state,
+            "runtime_consumption_enabled": False,
+            "not_production_consumption": True,
+        },
+        "validation_authorizes_production_routing": False,
+        "production_output_affected": False,
+    }

--- a/docs/generated/v3_1_trace_backfilled_semantic_parity_report.json
+++ b/docs/generated/v3_1_trace_backfilled_semantic_parity_report.json
@@ -1,0 +1,144 @@
+{
+  "deterministic_guarantees": {
+    "json_sort_keys": true,
+    "passed": true,
+    "repeated_hash": "1d50646772e3803ae099d697d8a2454b708376454813bbbf286dac3dfdbcf0d7",
+    "sample_hash": "1d50646772e3803ae099d697d8a2454b708376454813bbbf286dac3dfdbcf0d7",
+    "timestamp_excluded_from_hash": true
+  },
+  "generated_at": "2026-05-15T00:00:00+00:00",
+  "metadata": {
+    "controlled_test_only": true,
+    "observational_only": true,
+    "planner_remap_performed": false,
+    "production_behavior_changed": false,
+    "production_default_routing_authorized": false,
+    "source": "v3_1_trace_backfilled_semantic_parity_report"
+  },
+  "phase": "v3.1_phase_23_trace_backfilled_semantic_parity_refresh",
+  "phase_23_boundaries": [
+    "trace-backfilled semantic parity is test-only governance metadata",
+    "confirmed semantic parity is not production approval",
+    "confirmed semantic parity does not authorize production routing",
+    "trace expectations must match deterministic controlled output evidence",
+    "runtime manifest consumption remains disabled",
+    "legacy planner ownership remains intact"
+  ],
+  "production_default_routing_authorized": false,
+  "recommendation": "OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING",
+  "runtime_manifest_consumption_enabled": false,
+  "runtime_production_consumption_enabled": false,
+  "schema_version": "v3_1.trace_backfilled_semantic_parity_report.1",
+  "summary": {
+    "blocked_count": 0,
+    "deterministic": true,
+    "production_affected_count": 0,
+    "production_behavior_changed": false,
+    "production_default_routing_authorized": false,
+    "production_output_affected": false,
+    "promoted_from_partial_count": 1,
+    "records_evaluated": 1,
+    "runtime_manifest_consumption_enabled": false,
+    "runtime_production_consumption_enabled": false,
+    "semantic_parity_confirmed_count": 1,
+    "semantic_parity_partial_count": 0
+  },
+  "trace_backfilled_semantic_parity": {
+    "blocker_reason_counts": {},
+    "deterministic_hash": "1d50646772e3803ae099d697d8a2454b708376454813bbbf286dac3dfdbcf0d7",
+    "metadata": {
+      "controlled_test_only": true,
+      "deterministic_serializer": "json_sort_keys_sha256",
+      "observational_only": true,
+      "planner_remap_performed": false,
+      "production_behavior_changed": false,
+      "production_consumer": false,
+      "production_default_routing_authorized": false,
+      "source": "v3_1_trace_backfilled_semantic_parity",
+      "stable_generation_token": "v3_1_phase_23_trace_backfilled_semantic_parity_token"
+    },
+    "mismatched_field_counts": {},
+    "remaining_unavailable_field_counts": {},
+    "run": {
+      "baseline_trace_expectation_backfill_hash": "8acd948034de16ce8c4ec52154b7e9d928509c1fdd9b3b0dd50fbd46cb434d6c",
+      "controlled_consumption_output_validation_hash": "3364892148b06185a66ca86a64243a32ab54324995ed8752be795bed78300677",
+      "controlled_consumption_semantic_parity_hash": "47279660e764a52abdd3e61f0e157f89af79d8b3d74d124dcd329535b83beb22",
+      "run_id": "v3_1_phase_23_trace_backfilled_semantic_parity",
+      "semantic_parity_record_count": 1,
+      "trace_backfill_record_count": 5,
+      "validated_output_record_count": 1
+    },
+    "safety_confirmations": {
+      "legacy_planner_ownership_preserved": true,
+      "production_behavior_changed": false,
+      "production_output_affected": false,
+      "production_planner_routing_changed": false,
+      "runtime_manifest_consumption_enabled": false,
+      "runtime_production_consumption_enabled": false,
+      "semantic_parity_authorizes_production_routing": false,
+      "semantic_parity_is_production_approval": false,
+      "trusted_data_default_truth": false
+    },
+    "schema_version": "v3_1.trace_backfilled_semantic_parity.1",
+    "summary": {
+      "blocked_count": 0,
+      "deterministic": true,
+      "production_affected_count": 0,
+      "production_behavior_changed": false,
+      "production_default_routing_authorized": false,
+      "production_output_affected": false,
+      "promoted_from_partial_count": 1,
+      "records_evaluated": 1,
+      "runtime_manifest_consumption_enabled": false,
+      "runtime_production_consumption_enabled": false,
+      "semantic_parity_confirmed_count": 1,
+      "semantic_parity_partial_count": 0
+    },
+    "trace_backfilled_semantic_parity_records": [
+      {
+        "backfill_status": "trace_expectations_backfilled",
+        "baseline_id": "v3_1_snapshot_472bcd4c1169053b",
+        "blockers": [],
+        "compared_trace_fields": [
+          {
+            "actual": "v3_1_admission_manifest_198a3e2110f9e5e4",
+            "expected": "v3_1_admission_manifest_198a3e2110f9e5e4",
+            "field": "manifest_id",
+            "matches": true
+          },
+          {
+            "actual": "v3_1_fixture_set_6d3b668a84cfbb69",
+            "expected": "v3_1_fixture_set_6d3b668a84cfbb69",
+            "field": "fixture_set_id",
+            "matches": true
+          }
+        ],
+        "final_semantic_parity_status": "semantic_parity_confirmed",
+        "fixture_set_id": "v3_1_fixture_set_6d3b668a84cfbb69",
+        "manifest_id": "v3_1_admission_manifest_198a3e2110f9e5e4",
+        "metadata": {
+          "controlled_test_only": true,
+          "observational_only": true,
+          "planner_remap_performed": false,
+          "production_consumer": false
+        },
+        "mismatched_fields": [],
+        "original_semantic_parity_status": "semantic_parity_partial",
+        "production_output_affected": false,
+        "promoted_from_partial": true,
+        "remaining_unavailable_fields": [],
+        "semantic_parity_authorizes_production_routing": false,
+        "trace_backfilled_semantic_parity_id": "v3_1_trace_backfilled_semantic_parity_08ac4b6263ae4975"
+      }
+    ],
+    "trace_backfilled_semantic_parity_status_counts": {
+      "blocked_invalid_authorization_state": 0,
+      "blocked_missing_backfilled_expectation": 0,
+      "blocked_missing_controlled_output": 0,
+      "blocked_missing_semantic_parity_record": 0,
+      "blocked_trace_conflict": 0,
+      "semantic_parity_confirmed": 1,
+      "semantic_parity_partial": 0
+    }
+  }
+}

--- a/docs/migration/V3_1_TRACE_BACKFILLED_SEMANTIC_PARITY.md
+++ b/docs/migration/V3_1_TRACE_BACKFILLED_SEMANTIC_PARITY.md
@@ -1,0 +1,55 @@
+# V3.1 Trace-Backfilled Semantic Parity
+
+Phase 23 refreshes controlled-consumption semantic parity using deterministic trace backfill evidence.
+Confirmed semantic parity is not production approval and does not authorize routing.
+
+## Recommendation
+
+- Recommendation: `OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING`
+- Production default routing authorized: `false`
+- Runtime production consumption enabled: `false`
+- Runtime manifest consumption enabled: `false`
+
+## Summary
+
+- Records evaluated: `1`
+- Confirmed: `1`
+- Partial: `0`
+- Blocked: `0`
+- Promoted from partial: `1`
+- Production affected: `0`
+- Deterministic: `true`
+
+## Remaining Unavailable Fields
+
+| Field | Count |
+| --- | ---: |
+
+## Mismatch Summary
+
+| Field | Count |
+| --- | ---: |
+
+## Blocker Reasons
+
+| Reason | Count |
+| --- | ---: |
+
+## Refreshed Records
+
+| Record | Manifest | Fixture Set | Baseline | Original | Backfill | Final |
+| --- | --- | --- | --- | --- | --- | --- |
+| `v3_1_trace_backfilled_semantic_parity_08ac4b6263ae4975` | `v3_1_admission_manifest_198a3e2110f9e5e4` | `v3_1_fixture_set_6d3b668a84cfbb69` | `v3_1_snapshot_472bcd4c1169053b` | `semantic_parity_partial` | `trace_expectations_backfilled` | `semantic_parity_confirmed` |
+
+## Phase 23 Boundaries
+
+- trace-backfilled semantic parity is test-only governance metadata
+- confirmed semantic parity is not production approval
+- confirmed semantic parity does not authorize production routing
+- trace expectations must match deterministic controlled output evidence
+- runtime manifest consumption remains disabled
+- legacy planner ownership remains intact
+
+## Conclusion
+
+Trace-backfilled semantic parity is available for governance review, while production routing remains unchanged.


### PR DESCRIPTION
Adds deterministic trace-backfilled semantic parity refresh so controlled consumption parity can be confirmed when backfilled baseline trace expectations match validated controlled output evidence.