### PR TITLE
v3.1: add controlled consumption promotion readiness

### DIFF
--- a/backend/app/planner_adapters/v3_1/__init__.py
+++ b/backend/app/planner_adapters/v3_1/__init__.py
@@ -32,6 +32,10 @@ from .trace_backfilled_semantic_parity import (
     TRACE_BACKFILLED_SEMANTIC_PARITY_STATUSES,
     build_trace_backfilled_semantic_parity,
 )
+from .controlled_consumption_promotion_readiness import (
+    CONTROLLED_CONSUMPTION_PROMOTION_READINESS_STATUSES,
+    build_controlled_consumption_promotion_readiness,
+)
 from .review_policy_evaluation import (
     REVIEW_POLICY_OUTCOMES,
     V31ReviewPolicyEvaluation,
@@ -115,6 +119,7 @@ __all__ = [
     "BASELINE_SEMANTIC_EXPECTATION_STATUSES",
     "BASELINE_TRACE_EXPECTATION_BACKFILL_STATUSES",
     "TRACE_BACKFILLED_SEMANTIC_PARITY_STATUSES",
+    "CONTROLLED_CONSUMPTION_PROMOTION_READINESS_STATUSES",
     "FIXTURE_WORKFLOW_STATES",
     "FIXTURE_SET_LIFECYCLE_STATES",
     "REVIEW_POLICY_OUTCOMES",
@@ -149,6 +154,7 @@ __all__ = [
     "build_baseline_semantic_expectations",
     "build_baseline_trace_expectation_backfill",
     "build_trace_backfilled_semantic_parity",
+    "build_controlled_consumption_promotion_readiness",
     "build_default_trusted_repository_probes",
     "build_fixture_set_readiness_gate",
     "evaluate_fixture_source_admission_policy",

--- a/backend/app/planner_adapters/v3_1/controlled_consumption_promotion_readiness.py
+++ b/backend/app/planner_adapters/v3_1/controlled_consumption_promotion_readiness.py
@@ -1,0 +1,327 @@
+"""Controlled consumption promotion readiness gate for v3.1 governance.
+
+Promotion readiness is limited to future experimental runtime consideration.
+It does not enable production routing, runtime manifest consumption, or
+production-authoritative manifests.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from copy import deepcopy
+from typing import Any
+
+from .approval_manifest_serialization import NON_PRODUCTION_AUTHORIZATION_STATE
+from .trusted_shadow_consumption import deterministic_hash
+
+
+CONTROLLED_CONSUMPTION_PROMOTION_READINESS_STATUSES = (
+    "ready_for_limited_experimental_runtime_consideration",
+    "blocked_missing_controlled_consumption",
+    "blocked_invalid_output_validation",
+    "blocked_missing_structural_parity",
+    "blocked_missing_semantic_parity",
+    "blocked_invalid_manifest_eligibility",
+    "blocked_invalid_authorization_state",
+    "blocked_runtime_consumption_enabled",
+)
+STABLE_PROMOTION_READINESS_TOKEN = "v3_1_phase_24_controlled_consumption_promotion_readiness_token"
+
+
+def build_controlled_consumption_promotion_readiness(
+    *,
+    controlled_test_consumption: dict[str, Any] | list[dict[str, Any]],
+    controlled_consumption_output_validation: dict[str, Any] | list[dict[str, Any]],
+    controlled_consumption_parity_snapshot: dict[str, Any] | list[dict[str, Any]],
+    trace_backfilled_semantic_parity: dict[str, Any] | list[dict[str, Any]],
+    manifest_consumption_eligibility: dict[str, Any] | list[dict[str, Any]],
+    run_id: str = "v3_1_phase_24_controlled_consumption_promotion_readiness",
+) -> dict[str, Any]:
+    """Build deterministic promotion readiness records from the evidence chain."""
+
+    consumption_records = _consumption_records(controlled_test_consumption)
+    validation_records = _validation_records(controlled_consumption_output_validation)
+    parity_records = _parity_records(controlled_consumption_parity_snapshot)
+    semantic_records = _semantic_records(trace_backfilled_semantic_parity)
+    eligibility_records = _eligibility_records(manifest_consumption_eligibility)
+    runtime_enabled = any(
+        (
+            _runtime_enabled(controlled_test_consumption),
+            _runtime_enabled(controlled_consumption_output_validation),
+            _runtime_enabled(controlled_consumption_parity_snapshot),
+            _runtime_enabled(trace_backfilled_semantic_parity),
+            _runtime_enabled(manifest_consumption_eligibility),
+        )
+    )
+    validation_by_key = {_trace_key(record): record for record in validation_records if _trace_key(record)}
+    parity_by_key = {_trace_key(record): record for record in parity_records if _trace_key(record)}
+    semantic_by_key = {_trace_key(record): record for record in semantic_records if _trace_key(record)}
+    eligibility_by_key = {_trace_key(record): record for record in eligibility_records if _trace_key(record)}
+    readiness_records = [
+        _readiness_record(
+            consumption=record,
+            validation=validation_by_key.get(_trace_key(record)),
+            structural_parity=parity_by_key.get(_trace_key(record)),
+            semantic_parity=semantic_by_key.get(_trace_key(record)),
+            eligibility=eligibility_by_key.get(_trace_key(record)),
+            runtime_enabled=runtime_enabled,
+        )
+        for record in sorted(consumption_records, key=_record_sort_key)
+    ]
+    if not readiness_records:
+        readiness_records = [_missing_consumption_record(runtime_enabled=runtime_enabled)]
+
+    counts = Counter(record["promotion_readiness_status"] for record in readiness_records)
+    blocker_reasons = Counter(reason for record in readiness_records for reason in record["blockers"])
+    envelope = {
+        "schema_version": "v3_1.controlled_consumption_promotion_readiness.1",
+        "run": {
+            "run_id": run_id,
+            "controlled_consumption_record_count": len(consumption_records),
+            "validation_record_count": len(validation_records),
+            "structural_parity_record_count": len(parity_records),
+            "semantic_parity_record_count": len(semantic_records),
+            "eligibility_record_count": len(eligibility_records),
+            "controlled_test_consumption_hash": _source_hash(controlled_test_consumption),
+            "controlled_consumption_output_validation_hash": _source_hash(controlled_consumption_output_validation),
+            "controlled_consumption_parity_snapshot_hash": _source_hash(controlled_consumption_parity_snapshot),
+            "trace_backfilled_semantic_parity_hash": _source_hash(trace_backfilled_semantic_parity),
+            "manifest_consumption_eligibility_hash": _source_hash(manifest_consumption_eligibility),
+        },
+        "summary": {
+            "records_evaluated": len(readiness_records),
+            "ready_count": counts["ready_for_limited_experimental_runtime_consideration"],
+            "blocked_count": len(readiness_records) - counts["ready_for_limited_experimental_runtime_consideration"],
+            "production_affected_count": 0,
+            "production_output_affected": False,
+            "production_behavior_changed": False,
+            "production_default_routing_authorized": False,
+            "runtime_manifest_consumption_enabled": False,
+            "runtime_production_consumption_enabled": False,
+            "deterministic": True,
+        },
+        "promotion_readiness_status_counts": {
+            status: counts[status]
+            for status in CONTROLLED_CONSUMPTION_PROMOTION_READINESS_STATUSES
+        },
+        "blocker_reason_counts": dict(sorted(blocker_reasons.items())),
+        "evidence_chain_summary": {
+            "controlled_consumption_records": len(consumption_records),
+            "validated_output_records": len(validation_records),
+            "structural_parity_records": len(parity_records),
+            "semantic_parity_records": len(semantic_records),
+            "manifest_eligibility_records": len(eligibility_records),
+            "runtime_consumption_enabled": runtime_enabled,
+            "production_routing_authorized": False,
+        },
+        "promotion_readiness_records": readiness_records,
+        "safety_confirmations": {
+            "promotion_readiness_authorizes_production_routing": False,
+            "promotion_readiness_is_production_approval": False,
+            "promotion_readiness_enables_runtime_consumption": False,
+            "runtime_manifest_consumption_enabled": False,
+            "runtime_production_consumption_enabled": False,
+            "legacy_planner_ownership_preserved": True,
+            "production_output_affected": False,
+            "production_behavior_changed": False,
+            "production_planner_routing_changed": False,
+            "trusted_data_default_truth": False,
+        },
+        "metadata": {
+            "source": "v3_1_controlled_consumption_promotion_readiness",
+            "observational_only": True,
+            "controlled_test_only": True,
+            "future_limited_experimental_consideration_only": True,
+            "production_consumer": False,
+            "production_behavior_changed": False,
+            "planner_remap_performed": False,
+            "production_default_routing_authorized": False,
+            "stable_generation_token": STABLE_PROMOTION_READINESS_TOKEN,
+            "deterministic_serializer": "json_sort_keys_sha256",
+        },
+    }
+    envelope["deterministic_hash"] = deterministic_hash(envelope)
+    return envelope
+
+
+def _consumption_records(value: dict[str, Any] | list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if isinstance(value, list):
+        return [deepcopy(row) for row in value]
+    return [deepcopy(row) for row in value.get("controlled_consumption_records", [])]
+
+
+def _validation_records(value: dict[str, Any] | list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if isinstance(value, list):
+        return [deepcopy(row) for row in value]
+    return [deepcopy(row) for row in value.get("validation_records", [])]
+
+
+def _parity_records(value: dict[str, Any] | list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if isinstance(value, list):
+        return [deepcopy(row) for row in value]
+    return [deepcopy(row) for row in value.get("parity_records", [])]
+
+
+def _semantic_records(value: dict[str, Any] | list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if isinstance(value, list):
+        return [deepcopy(row) for row in value]
+    return [deepcopy(row) for row in value.get("trace_backfilled_semantic_parity_records", [])]
+
+
+def _eligibility_records(value: dict[str, Any] | list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if isinstance(value, list):
+        return [deepcopy(row) for row in value]
+    return [deepcopy(row) for row in value.get("eligibility_records", [])]
+
+
+def _readiness_record(
+    *,
+    consumption: dict[str, Any],
+    validation: dict[str, Any] | None,
+    structural_parity: dict[str, Any] | None,
+    semantic_parity: dict[str, Any] | None,
+    eligibility: dict[str, Any] | None,
+    runtime_enabled: bool,
+) -> dict[str, Any]:
+    blockers = _blockers(
+        consumption=consumption,
+        validation=validation,
+        structural_parity=structural_parity,
+        semantic_parity=semantic_parity,
+        eligibility=eligibility,
+        runtime_enabled=runtime_enabled,
+    )
+    status = blockers[0] if blockers else "ready_for_limited_experimental_runtime_consideration"
+    seed = {
+        "manifest_id": consumption.get("manifest_id"),
+        "fixture_set_id": consumption.get("fixture_set_id"),
+        "status": status,
+        "token": STABLE_PROMOTION_READINESS_TOKEN,
+    }
+    return {
+        "promotion_readiness_id": f"v3_1_promotion_readiness_{deterministic_hash(seed)[:16]}",
+        "manifest_id": consumption.get("manifest_id"),
+        "fixture_set_id": consumption.get("fixture_set_id"),
+        "controlled_consumption_status": consumption.get("controlled_consumption_status"),
+        "validation_status": (validation or {}).get("validation_status"),
+        "structural_parity_status": (structural_parity or {}).get("parity_status"),
+        "semantic_parity_status": (semantic_parity or {}).get("final_semantic_parity_status"),
+        "eligibility_status": (eligibility or {}).get("eligibility_status"),
+        "promotion_readiness_status": status,
+        "blockers": blockers,
+        "promotion_readiness_authorizes_production_routing": False,
+        "production_output_affected": False,
+        "metadata": {
+            "observational_only": True,
+            "controlled_test_only": True,
+            "future_limited_experimental_consideration_only": True,
+            "production_consumer": False,
+            "planner_remap_performed": False,
+        },
+    }
+
+
+def _missing_consumption_record(*, runtime_enabled: bool) -> dict[str, Any]:
+    seed = {"missing_consumption": True, "runtime_enabled": runtime_enabled, "token": STABLE_PROMOTION_READINESS_TOKEN}
+    blockers = ["blocked_missing_controlled_consumption"]
+    if runtime_enabled:
+        blockers.append("blocked_runtime_consumption_enabled")
+    return {
+        "promotion_readiness_id": f"v3_1_promotion_readiness_{deterministic_hash(seed)[:16]}",
+        "manifest_id": None,
+        "fixture_set_id": None,
+        "controlled_consumption_status": None,
+        "validation_status": None,
+        "structural_parity_status": None,
+        "semantic_parity_status": None,
+        "eligibility_status": None,
+        "promotion_readiness_status": "blocked_missing_controlled_consumption",
+        "blockers": blockers,
+        "promotion_readiness_authorizes_production_routing": False,
+        "production_output_affected": False,
+        "metadata": {
+            "observational_only": True,
+            "controlled_test_only": True,
+            "future_limited_experimental_consideration_only": True,
+            "production_consumer": False,
+            "planner_remap_performed": False,
+        },
+    }
+
+
+def _blockers(
+    *,
+    consumption: dict[str, Any],
+    validation: dict[str, Any] | None,
+    structural_parity: dict[str, Any] | None,
+    semantic_parity: dict[str, Any] | None,
+    eligibility: dict[str, Any] | None,
+    runtime_enabled: bool,
+) -> list[str]:
+    blockers: list[str] = []
+    if consumption.get("controlled_consumption_status") != "consumed_in_controlled_test":
+        blockers.append("blocked_missing_controlled_consumption")
+    if validation is None or validation.get("validation_status") != "valid_controlled_test_output":
+        blockers.append("blocked_invalid_output_validation")
+    if structural_parity is None or structural_parity.get("parity_status") != "parity_confirmed":
+        blockers.append("blocked_missing_structural_parity")
+    if semantic_parity is None or semantic_parity.get("final_semantic_parity_status") != "semantic_parity_confirmed":
+        blockers.append("blocked_missing_semantic_parity")
+    if eligibility is None or eligibility.get("eligibility_status") != "eligible_for_controlled_test_consumption":
+        blockers.append("blocked_invalid_manifest_eligibility")
+    if _authorization_invalid(consumption=consumption, validation=validation, eligibility=eligibility):
+        blockers.append("blocked_invalid_authorization_state")
+    if runtime_enabled:
+        blockers.append("blocked_runtime_consumption_enabled")
+    return sorted(set(blockers), key=blockers.index)
+
+
+def _authorization_invalid(
+    *,
+    consumption: dict[str, Any],
+    validation: dict[str, Any] | None,
+    eligibility: dict[str, Any] | None,
+) -> bool:
+    states = [
+        consumption.get("authorization_state"),
+        (validation or {}).get("traceability_summary", {}).get("authorization_state"),
+        (eligibility or {}).get("authorization_state"),
+    ]
+    return any(state != NON_PRODUCTION_AUTHORIZATION_STATE for state in states if state is not None) or not states[0]
+
+
+def _runtime_enabled(value: dict[str, Any] | list[dict[str, Any]]) -> bool:
+    if not isinstance(value, dict):
+        return False
+    summary = value.get("summary") or {}
+    safety = value.get("safety_confirmations") or {}
+    return bool(
+        summary.get("runtime_manifest_consumption_enabled")
+        or summary.get("runtime_production_consumption_enabled")
+        or summary.get("manifest_runtime_consumption_enabled")
+        or safety.get("runtime_manifest_consumption_enabled")
+        or safety.get("runtime_production_consumption_enabled")
+    )
+
+
+def _trace_key(record: dict[str, Any] | None) -> tuple[str, str] | None:
+    if not record:
+        return None
+    manifest_id = record.get("manifest_id")
+    fixture_set_id = record.get("fixture_set_id")
+    if not manifest_id or not fixture_set_id:
+        return None
+    return (str(manifest_id), str(fixture_set_id))
+
+
+def _record_sort_key(record: dict[str, Any]) -> tuple[str, str]:
+    return (
+        str(record.get("fixture_set_id") or ""),
+        str(record.get("manifest_id") or ""),
+    )
+
+
+def _source_hash(value: dict[str, Any] | list[dict[str, Any]]) -> str | None:
+    if isinstance(value, dict):
+        return value.get("deterministic_hash")
+    return None

--- a/backend/scripts/report_v3_1_controlled_consumption_promotion_readiness.py
+++ b/backend/scripts/report_v3_1_controlled_consumption_promotion_readiness.py
@@ -1,0 +1,195 @@
+"""Generate the v3.1 controlled consumption promotion readiness report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.planner_adapters.v3_1.controlled_consumption_promotion_readiness import build_controlled_consumption_promotion_readiness  # noqa: E402
+
+
+DETERMINISTIC_GENERATED_AT = "2026-05-15T00:00:00+00:00"
+
+
+def build_v3_1_controlled_consumption_promotion_readiness_report() -> dict[str, Any]:
+    repo_root = Path(__file__).resolve().parents[2]
+    consumption = _read_json(repo_root / "docs" / "generated" / "v3_1_controlled_test_consumption_report.json")[
+        "controlled_test_consumption"
+    ]
+    validation = _read_json(repo_root / "docs" / "generated" / "v3_1_controlled_consumption_output_validation_report.json")[
+        "controlled_consumption_output_validation"
+    ]
+    structural = _read_json(repo_root / "docs" / "generated" / "v3_1_controlled_consumption_parity_snapshot_report.json")[
+        "controlled_consumption_parity_snapshot"
+    ]
+    semantic = _read_json(repo_root / "docs" / "generated" / "v3_1_trace_backfilled_semantic_parity_report.json")[
+        "trace_backfilled_semantic_parity"
+    ]
+    eligibility = _read_json(repo_root / "docs" / "generated" / "v3_1_manifest_consumption_eligibility_report.json")[
+        "manifest_consumption_eligibility"
+    ]
+    readiness = build_controlled_consumption_promotion_readiness(
+        controlled_test_consumption=consumption,
+        controlled_consumption_output_validation=validation,
+        controlled_consumption_parity_snapshot=structural,
+        trace_backfilled_semantic_parity=semantic,
+        manifest_consumption_eligibility=eligibility,
+    )
+    repeated = build_controlled_consumption_promotion_readiness(
+        controlled_test_consumption=consumption,
+        controlled_consumption_output_validation=validation,
+        controlled_consumption_parity_snapshot=structural,
+        trace_backfilled_semantic_parity=semantic,
+        manifest_consumption_eligibility=eligibility,
+    )
+    report = {
+        "schema_version": "v3_1.controlled_consumption_promotion_readiness_report.1",
+        "generated_at": DETERMINISTIC_GENERATED_AT,
+        "phase": "v3.1_phase_24_controlled_consumption_promotion_readiness_gate",
+        "recommendation": "OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING",
+        "production_default_routing_authorized": False,
+        "runtime_manifest_consumption_enabled": False,
+        "runtime_production_consumption_enabled": False,
+        "summary": {
+            **readiness["summary"],
+            "deterministic": readiness["deterministic_hash"] == repeated["deterministic_hash"],
+        },
+        "controlled_consumption_promotion_readiness": readiness,
+        "deterministic_guarantees": {
+            "passed": readiness["deterministic_hash"] == repeated["deterministic_hash"],
+            "sample_hash": readiness["deterministic_hash"],
+            "repeated_hash": repeated["deterministic_hash"],
+            "timestamp_excluded_from_hash": True,
+            "json_sort_keys": True,
+        },
+        "phase_24_boundaries": [
+            "promotion readiness is for future limited experimental runtime consideration only",
+            "promotion readiness is not production approval",
+            "promotion readiness does not authorize production routing",
+            "runtime manifest consumption remains disabled",
+            "manifests remain non-production-authoritative",
+            "legacy planner ownership remains intact",
+        ],
+        "metadata": {
+            "source": "v3_1_controlled_consumption_promotion_readiness_report",
+            "observational_only": True,
+            "controlled_test_only": True,
+            "future_limited_experimental_consideration_only": True,
+            "production_behavior_changed": False,
+            "production_default_routing_authorized": False,
+            "planner_remap_performed": False,
+        },
+    }
+    return _normalize_generated_at(report)
+
+
+def write_report(report: dict[str, Any], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_markdown(report: dict[str, Any], output_path: Path) -> None:
+    readiness = report["controlled_consumption_promotion_readiness"]
+    summary = report["summary"]
+    evidence = readiness["evidence_chain_summary"]
+    lines = [
+        "# V3.1 Controlled Consumption Promotion Readiness",
+        "",
+        "Phase 24 gates the controlled-consumption evidence chain for future limited experimental runtime consideration.",
+        "Promotion readiness is not production approval and does not authorize routing.",
+        "",
+        "## Recommendation",
+        "",
+        f"- Recommendation: `{report['recommendation']}`",
+        f"- Production default routing authorized: `{str(report['production_default_routing_authorized']).lower()}`",
+        f"- Runtime production consumption enabled: `{str(report['runtime_production_consumption_enabled']).lower()}`",
+        f"- Runtime manifest consumption enabled: `{str(report['runtime_manifest_consumption_enabled']).lower()}`",
+        "",
+        "## Summary",
+        "",
+        f"- Records evaluated: `{summary['records_evaluated']}`",
+        f"- Ready: `{summary['ready_count']}`",
+        f"- Blocked: `{summary['blocked_count']}`",
+        f"- Production affected: `{summary['production_affected_count']}`",
+        f"- Deterministic: `{str(summary['deterministic']).lower()}`",
+        "",
+        "## Evidence Chain",
+        "",
+        f"- Controlled consumption records: `{evidence['controlled_consumption_records']}`",
+        f"- Validated output records: `{evidence['validated_output_records']}`",
+        f"- Structural parity records: `{evidence['structural_parity_records']}`",
+        f"- Semantic parity records: `{evidence['semantic_parity_records']}`",
+        f"- Manifest eligibility records: `{evidence['manifest_eligibility_records']}`",
+        f"- Runtime consumption enabled: `{str(evidence['runtime_consumption_enabled']).lower()}`",
+        "",
+        "## Blocker Reasons",
+        "",
+        "| Reason | Count |",
+        "| --- | ---: |",
+    ]
+    for reason, count in readiness["blocker_reason_counts"].items():
+        lines.append(f"| `{reason}` | `{count}` |")
+    lines.extend(
+        [
+            "",
+            "## Readiness Records",
+            "",
+            "| Record | Manifest | Fixture Set | Readiness |",
+            "| --- | --- | --- | --- |",
+        ]
+    )
+    for row in readiness["promotion_readiness_records"]:
+        lines.append(
+            f"| `{row['promotion_readiness_id']}` | `{row['manifest_id'] or ''}` | `{row['fixture_set_id'] or ''}` | `{row['promotion_readiness_status']}` |"
+        )
+    lines.extend(["", "## Phase 24 Boundaries", ""])
+    lines.extend(f"- {item}" for item in report["phase_24_boundaries"])
+    lines.extend(
+        [
+            "",
+            "## Conclusion",
+            "",
+            "Controlled consumption promotion readiness is available for governance review, while production routing remains unchanged.",
+        ]
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _normalize_generated_at(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: DETERMINISTIC_GENERATED_AT if key == "generated_at" else _normalize_generated_at(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_normalize_generated_at(item) for item in value]
+    return deepcopy(value)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", default="docs/generated/v3_1_controlled_consumption_promotion_readiness_report.json")
+    parser.add_argument("--markdown-output", default="docs/migration/V3_1_CONTROLLED_CONSUMPTION_PROMOTION_READINESS.md")
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[2]
+    report = build_v3_1_controlled_consumption_promotion_readiness_report()
+    write_report(report, repo_root / args.output)
+    write_markdown(report, repo_root / args.markdown_output)
+    print(json.dumps(report["summary"], indent=2, sort_keys=True))
+    print(report["recommendation"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_v3_1_controlled_consumption_promotion_readiness.py
+++ b/backend/tests/test_v3_1_controlled_consumption_promotion_readiness.py
@@ -1,0 +1,185 @@
+from app.planner_adapters.v3_1.controlled_consumption_promotion_readiness import build_controlled_consumption_promotion_readiness
+from scripts.report_v3_1_controlled_consumption_promotion_readiness import build_v3_1_controlled_consumption_promotion_readiness_report
+
+
+def test_fully_valid_evidence_chain_becomes_ready():
+    result = _build()
+
+    record = result["promotion_readiness_records"][0]
+    assert record["promotion_readiness_status"] == "ready_for_limited_experimental_runtime_consideration"
+    assert result["summary"]["ready_count"] == 1
+
+
+def test_missing_controlled_consumption_blocks():
+    result = _build(consumption=[])
+
+    assert result["promotion_readiness_records"][0]["promotion_readiness_status"] == "blocked_missing_controlled_consumption"
+
+
+def test_invalid_output_validation_blocks():
+    result = _build(validation=[_validation_record(status="blocked_invalid_consumption_status")])
+
+    assert result["promotion_readiness_records"][0]["promotion_readiness_status"] == "blocked_invalid_output_validation"
+
+
+def test_missing_structural_parity_blocks():
+    result = _build(structural=[])
+
+    assert result["promotion_readiness_records"][0]["promotion_readiness_status"] == "blocked_missing_structural_parity"
+
+
+def test_missing_semantic_parity_blocks():
+    result = _build(semantic=[])
+
+    assert result["promotion_readiness_records"][0]["promotion_readiness_status"] == "blocked_missing_semantic_parity"
+
+
+def test_invalid_eligibility_blocks():
+    result = _build(eligibility=[_eligibility_record(status="blocked_missing_hash")])
+
+    assert result["promotion_readiness_records"][0]["promotion_readiness_status"] == "blocked_invalid_manifest_eligibility"
+
+
+def test_invalid_authorization_state_blocks():
+    result = _build(consumption=[_consumption_record(authorization_state="production_authoritative")])
+
+    assert result["promotion_readiness_records"][0]["promotion_readiness_status"] == "blocked_invalid_authorization_state"
+
+
+def test_runtime_consumption_enabled_blocks():
+    payload = _payload("controlled_consumption_records", [_consumption_record()])
+    payload["summary"]["runtime_manifest_consumption_enabled"] = True
+    result = build_controlled_consumption_promotion_readiness(
+        controlled_test_consumption=payload,
+        controlled_consumption_output_validation=_payload("validation_records", [_validation_record()]),
+        controlled_consumption_parity_snapshot=_payload("parity_records", [_structural_record()]),
+        trace_backfilled_semantic_parity=_payload("trace_backfilled_semantic_parity_records", [_semantic_record()]),
+        manifest_consumption_eligibility=_payload("eligibility_records", [_eligibility_record()]),
+    )
+
+    assert result["promotion_readiness_records"][0]["promotion_readiness_status"] == "blocked_runtime_consumption_enabled"
+
+
+def test_deterministic_ordering():
+    first = _build(
+        consumption=[_consumption_record("manifest_b", "set_b"), _consumption_record("manifest_a", "set_a")],
+        validation=[_validation_record("manifest_b", "set_b"), _validation_record("manifest_a", "set_a")],
+        structural=[_structural_record("manifest_b", "set_b"), _structural_record("manifest_a", "set_a")],
+        semantic=[_semantic_record("manifest_b", "set_b"), _semantic_record("manifest_a", "set_a")],
+        eligibility=[_eligibility_record("manifest_b", "set_b"), _eligibility_record("manifest_a", "set_a")],
+    )
+    second = _build(
+        consumption=[_consumption_record("manifest_a", "set_a"), _consumption_record("manifest_b", "set_b")],
+        validation=[_validation_record("manifest_a", "set_a"), _validation_record("manifest_b", "set_b")],
+        structural=[_structural_record("manifest_a", "set_a"), _structural_record("manifest_b", "set_b")],
+        semantic=[_semantic_record("manifest_a", "set_a"), _semantic_record("manifest_b", "set_b")],
+        eligibility=[_eligibility_record("manifest_a", "set_a"), _eligibility_record("manifest_b", "set_b")],
+    )
+
+    assert first["deterministic_hash"] == second["deterministic_hash"]
+    assert [row["manifest_id"] for row in first["promotion_readiness_records"]] == ["manifest_a", "manifest_b"]
+
+
+def test_stable_report_generation():
+    first = build_v3_1_controlled_consumption_promotion_readiness_report()
+    second = build_v3_1_controlled_consumption_promotion_readiness_report()
+
+    assert first["deterministic_guarantees"]["passed"] is True
+    assert first["controlled_consumption_promotion_readiness"]["deterministic_hash"] == second["controlled_consumption_promotion_readiness"]["deterministic_hash"]
+    assert first["summary"] == second["summary"]
+
+
+def test_no_production_routing_enablement():
+    result = _build()
+    record = result["promotion_readiness_records"][0]
+
+    assert result["safety_confirmations"]["promotion_readiness_authorizes_production_routing"] is False
+    assert result["safety_confirmations"]["promotion_readiness_is_production_approval"] is False
+    assert result["safety_confirmations"]["promotion_readiness_enables_runtime_consumption"] is False
+    assert record["promotion_readiness_authorizes_production_routing"] is False
+
+
+def _build(consumption=None, validation=None, structural=None, semantic=None, eligibility=None):
+    return build_controlled_consumption_promotion_readiness(
+        controlled_test_consumption=_payload("controlled_consumption_records", [_consumption_record()] if consumption is None else consumption),
+        controlled_consumption_output_validation=_payload("validation_records", [_validation_record()] if validation is None else validation),
+        controlled_consumption_parity_snapshot=_payload("parity_records", [_structural_record()] if structural is None else structural),
+        trace_backfilled_semantic_parity=_payload("trace_backfilled_semantic_parity_records", [_semantic_record()] if semantic is None else semantic),
+        manifest_consumption_eligibility=_payload("eligibility_records", [_eligibility_record()] if eligibility is None else eligibility),
+    )
+
+
+def _payload(key, records):
+    return {
+        "schema_version": f"v3_1.test.{key}.1",
+        "deterministic_hash": f"{key}-hash",
+        "summary": {
+            "runtime_manifest_consumption_enabled": False,
+            "runtime_production_consumption_enabled": False,
+            "manifest_runtime_consumption_enabled": False,
+        },
+        "safety_confirmations": {
+            "runtime_manifest_consumption_enabled": False,
+            "runtime_production_consumption_enabled": False,
+        },
+        key: records,
+    }
+
+
+def _consumption_record(manifest_id="manifest_a", fixture_set_id="set_a", authorization_state="non_production_authoritative"):
+    return {
+        "manifest_id": manifest_id,
+        "fixture_set_id": fixture_set_id,
+        "controlled_consumption_status": "consumed_in_controlled_test",
+        "eligibility_status": "eligible_for_controlled_test_consumption",
+        "authorization_state": authorization_state,
+        "controlled_consumption_authorizes_production_routing": False,
+        "not_production_consumption": True,
+        "production_output_affected": False,
+    }
+
+
+def _validation_record(manifest_id="manifest_a", fixture_set_id="set_a", status="valid_controlled_test_output", authorization_state="non_production_authoritative"):
+    return {
+        "manifest_id": manifest_id,
+        "fixture_set_id": fixture_set_id,
+        "validation_status": status,
+        "traceability_summary": {
+            "authorization_state": authorization_state,
+            "manifest_trace_present": bool(manifest_id),
+            "fixture_set_trace_present": bool(fixture_set_id),
+        },
+        "validation_authorizes_production_routing": False,
+        "production_output_affected": False,
+    }
+
+
+def _structural_record(manifest_id="manifest_a", fixture_set_id="set_a"):
+    return {
+        "manifest_id": manifest_id,
+        "fixture_set_id": fixture_set_id,
+        "parity_status": "parity_confirmed",
+        "parity_authorizes_production_routing": False,
+        "production_output_affected": False,
+    }
+
+
+def _semantic_record(manifest_id="manifest_a", fixture_set_id="set_a"):
+    return {
+        "manifest_id": manifest_id,
+        "fixture_set_id": fixture_set_id,
+        "final_semantic_parity_status": "semantic_parity_confirmed",
+        "semantic_parity_authorizes_production_routing": False,
+        "production_output_affected": False,
+    }
+
+
+def _eligibility_record(manifest_id="manifest_a", fixture_set_id="set_a", status="eligible_for_controlled_test_consumption", authorization_state="non_production_authoritative"):
+    return {
+        "manifest_id": manifest_id,
+        "fixture_set_id": fixture_set_id,
+        "eligibility_status": status,
+        "authorization_state": authorization_state,
+        "eligibility_authorizes_production_routing": False,
+        "production_output_affected": False,
+    }

--- a/docs/generated/v3_1_controlled_consumption_promotion_readiness_report.json
+++ b/docs/generated/v3_1_controlled_consumption_promotion_readiness_report.json
@@ -1,0 +1,141 @@
+{
+  "controlled_consumption_promotion_readiness": {
+    "blocker_reason_counts": {},
+    "deterministic_hash": "65e0814411b9053c2fd50da6c80fbaf960280beee4ddaee2c6a978c32ae6516c",
+    "evidence_chain_summary": {
+      "controlled_consumption_records": 1,
+      "manifest_eligibility_records": 1,
+      "production_routing_authorized": false,
+      "runtime_consumption_enabled": false,
+      "semantic_parity_records": 1,
+      "structural_parity_records": 1,
+      "validated_output_records": 1
+    },
+    "metadata": {
+      "controlled_test_only": true,
+      "deterministic_serializer": "json_sort_keys_sha256",
+      "future_limited_experimental_consideration_only": true,
+      "observational_only": true,
+      "planner_remap_performed": false,
+      "production_behavior_changed": false,
+      "production_consumer": false,
+      "production_default_routing_authorized": false,
+      "source": "v3_1_controlled_consumption_promotion_readiness",
+      "stable_generation_token": "v3_1_phase_24_controlled_consumption_promotion_readiness_token"
+    },
+    "promotion_readiness_records": [
+      {
+        "blockers": [],
+        "controlled_consumption_status": "consumed_in_controlled_test",
+        "eligibility_status": "eligible_for_controlled_test_consumption",
+        "fixture_set_id": "v3_1_fixture_set_6d3b668a84cfbb69",
+        "manifest_id": "v3_1_admission_manifest_198a3e2110f9e5e4",
+        "metadata": {
+          "controlled_test_only": true,
+          "future_limited_experimental_consideration_only": true,
+          "observational_only": true,
+          "planner_remap_performed": false,
+          "production_consumer": false
+        },
+        "production_output_affected": false,
+        "promotion_readiness_authorizes_production_routing": false,
+        "promotion_readiness_id": "v3_1_promotion_readiness_88ebdd1667b59f37",
+        "promotion_readiness_status": "ready_for_limited_experimental_runtime_consideration",
+        "semantic_parity_status": "semantic_parity_confirmed",
+        "structural_parity_status": "parity_confirmed",
+        "validation_status": "valid_controlled_test_output"
+      }
+    ],
+    "promotion_readiness_status_counts": {
+      "blocked_invalid_authorization_state": 0,
+      "blocked_invalid_manifest_eligibility": 0,
+      "blocked_invalid_output_validation": 0,
+      "blocked_missing_controlled_consumption": 0,
+      "blocked_missing_semantic_parity": 0,
+      "blocked_missing_structural_parity": 0,
+      "blocked_runtime_consumption_enabled": 0,
+      "ready_for_limited_experimental_runtime_consideration": 1
+    },
+    "run": {
+      "controlled_consumption_output_validation_hash": "3364892148b06185a66ca86a64243a32ab54324995ed8752be795bed78300677",
+      "controlled_consumption_parity_snapshot_hash": "5e5744d7474cc3e8ca26e1163178c65744e46a07f01674bc4b11acbec486b20c",
+      "controlled_consumption_record_count": 1,
+      "controlled_test_consumption_hash": "f08b0dd2a540a8f4da38a059b3c0def3d029747cb1416201946a1795e6d30c04",
+      "eligibility_record_count": 1,
+      "manifest_consumption_eligibility_hash": "e5776401439dbe2ac5feef32f9c0ae924d7769f691ea3e90fcb1774f39fcbbf4",
+      "run_id": "v3_1_phase_24_controlled_consumption_promotion_readiness",
+      "semantic_parity_record_count": 1,
+      "structural_parity_record_count": 1,
+      "trace_backfilled_semantic_parity_hash": "1d50646772e3803ae099d697d8a2454b708376454813bbbf286dac3dfdbcf0d7",
+      "validation_record_count": 1
+    },
+    "safety_confirmations": {
+      "legacy_planner_ownership_preserved": true,
+      "production_behavior_changed": false,
+      "production_output_affected": false,
+      "production_planner_routing_changed": false,
+      "promotion_readiness_authorizes_production_routing": false,
+      "promotion_readiness_enables_runtime_consumption": false,
+      "promotion_readiness_is_production_approval": false,
+      "runtime_manifest_consumption_enabled": false,
+      "runtime_production_consumption_enabled": false,
+      "trusted_data_default_truth": false
+    },
+    "schema_version": "v3_1.controlled_consumption_promotion_readiness.1",
+    "summary": {
+      "blocked_count": 0,
+      "deterministic": true,
+      "production_affected_count": 0,
+      "production_behavior_changed": false,
+      "production_default_routing_authorized": false,
+      "production_output_affected": false,
+      "ready_count": 1,
+      "records_evaluated": 1,
+      "runtime_manifest_consumption_enabled": false,
+      "runtime_production_consumption_enabled": false
+    }
+  },
+  "deterministic_guarantees": {
+    "json_sort_keys": true,
+    "passed": true,
+    "repeated_hash": "65e0814411b9053c2fd50da6c80fbaf960280beee4ddaee2c6a978c32ae6516c",
+    "sample_hash": "65e0814411b9053c2fd50da6c80fbaf960280beee4ddaee2c6a978c32ae6516c",
+    "timestamp_excluded_from_hash": true
+  },
+  "generated_at": "2026-05-15T00:00:00+00:00",
+  "metadata": {
+    "controlled_test_only": true,
+    "future_limited_experimental_consideration_only": true,
+    "observational_only": true,
+    "planner_remap_performed": false,
+    "production_behavior_changed": false,
+    "production_default_routing_authorized": false,
+    "source": "v3_1_controlled_consumption_promotion_readiness_report"
+  },
+  "phase": "v3.1_phase_24_controlled_consumption_promotion_readiness_gate",
+  "phase_24_boundaries": [
+    "promotion readiness is for future limited experimental runtime consideration only",
+    "promotion readiness is not production approval",
+    "promotion readiness does not authorize production routing",
+    "runtime manifest consumption remains disabled",
+    "manifests remain non-production-authoritative",
+    "legacy planner ownership remains intact"
+  ],
+  "production_default_routing_authorized": false,
+  "recommendation": "OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING",
+  "runtime_manifest_consumption_enabled": false,
+  "runtime_production_consumption_enabled": false,
+  "schema_version": "v3_1.controlled_consumption_promotion_readiness_report.1",
+  "summary": {
+    "blocked_count": 0,
+    "deterministic": true,
+    "production_affected_count": 0,
+    "production_behavior_changed": false,
+    "production_default_routing_authorized": false,
+    "production_output_affected": false,
+    "ready_count": 1,
+    "records_evaluated": 1,
+    "runtime_manifest_consumption_enabled": false,
+    "runtime_production_consumption_enabled": false
+  }
+}

--- a/docs/migration/V3_1_CONTROLLED_CONSUMPTION_PROMOTION_READINESS.md
+++ b/docs/migration/V3_1_CONTROLLED_CONSUMPTION_PROMOTION_READINESS.md
@@ -1,0 +1,52 @@
+# V3.1 Controlled Consumption Promotion Readiness
+
+Phase 24 gates the controlled-consumption evidence chain for future limited experimental runtime consideration.
+Promotion readiness is not production approval and does not authorize routing.
+
+## Recommendation
+
+- Recommendation: `OBSERVATIONAL_ONLY_DO_NOT_ENABLE_PRODUCTION_DEFAULT_ROUTING`
+- Production default routing authorized: `false`
+- Runtime production consumption enabled: `false`
+- Runtime manifest consumption enabled: `false`
+
+## Summary
+
+- Records evaluated: `1`
+- Ready: `1`
+- Blocked: `0`
+- Production affected: `0`
+- Deterministic: `true`
+
+## Evidence Chain
+
+- Controlled consumption records: `1`
+- Validated output records: `1`
+- Structural parity records: `1`
+- Semantic parity records: `1`
+- Manifest eligibility records: `1`
+- Runtime consumption enabled: `false`
+
+## Blocker Reasons
+
+| Reason | Count |
+| --- | ---: |
+
+## Readiness Records
+
+| Record | Manifest | Fixture Set | Readiness |
+| --- | --- | --- | --- |
+| `v3_1_promotion_readiness_88ebdd1667b59f37` | `v3_1_admission_manifest_198a3e2110f9e5e4` | `v3_1_fixture_set_6d3b668a84cfbb69` | `ready_for_limited_experimental_runtime_consideration` |
+
+## Phase 24 Boundaries
+
+- promotion readiness is for future limited experimental runtime consideration only
+- promotion readiness is not production approval
+- promotion readiness does not authorize production routing
+- runtime manifest consumption remains disabled
+- manifests remain non-production-authoritative
+- legacy planner ownership remains intact
+
+## Conclusion
+
+Controlled consumption promotion readiness is available for governance review, while production routing remains unchanged.


### PR DESCRIPTION
Adds deterministic promotion readiness gating for the controlled-consumption evidence chain while preserving production routing isolation and non-production manifest authorization.