### PR TITLE
v3.1: add limited experimental runtime guard contract

### DIFF
--- a/backend/app/planner_adapters/v3_1/__init__.py
+++ b/backend/app/planner_adapters/v3_1/__init__.py
@@ -36,6 +36,10 @@ from .controlled_consumption_promotion_readiness import (
     CONTROLLED_CONSUMPTION_PROMOTION_READINESS_STATUSES,
     build_controlled_consumption_promotion_readiness,
 )
+from .limited_experimental_runtime_guards import (
+    LIMITED_EXPERIMENTAL_RUNTIME_GUARD_STATUSES,
+    build_limited_experimental_runtime_guards,
+)
 from .review_policy_evaluation import (
     REVIEW_POLICY_OUTCOMES,
     V31ReviewPolicyEvaluation,
@@ -120,6 +124,7 @@ __all__ = [
     "BASELINE_TRACE_EXPECTATION_BACKFILL_STATUSES",
     "TRACE_BACKFILLED_SEMANTIC_PARITY_STATUSES",
     "CONTROLLED_CONSUMPTION_PROMOTION_READINESS_STATUSES",
+    "LIMITED_EXPERIMENTAL_RUNTIME_GUARD_STATUSES",
     "FIXTURE_WORKFLOW_STATES",
     "FIXTURE_SET_LIFECYCLE_STATES",
     "REVIEW_POLICY_OUTCOMES",
@@ -155,6 +160,7 @@ __all__ = [
     "build_baseline_trace_expectation_backfill",
     "build_trace_backfilled_semantic_parity",
     "build_controlled_consumption_promotion_readiness",
+    "build_limited_experimental_runtime_guards",
     "build_default_trusted_repository_probes",
     "build_fixture_set_readiness_gate",
     "evaluate_fixture_source_admission_policy",

--- a/backend/app/planner_adapters/v3_1/limited_experimental_runtime_guards.py
+++ b/backend/app/planner_adapters/v3_1/limited_experimental_runtime_guards.py
@@ -1,0 +1,347 @@
+"""Limited experimental runtime guard contract for v3.1 governance.
+
+This module defines the guardrail contract for a future limited experimental
+runtime path. It does not enable runtime manifest consumption or production
+routing.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from copy import deepcopy
+from typing import Any
+
+from .approval_manifest_serialization import NON_PRODUCTION_AUTHORIZATION_STATE
+from .trusted_shadow_consumption import deterministic_hash
+
+
+LIMITED_EXPERIMENTAL_RUNTIME_GUARD_STATUSES = (
+    "guard_contract_ready",
+    "blocked_missing_promotion_readiness",
+    "blocked_invalid_manifest_eligibility",
+    "blocked_invalid_authorization_state",
+    "blocked_runtime_consumption_enabled",
+    "blocked_production_routing_authorized",
+    "blocked_missing_non_production_manifest",
+)
+STABLE_LIMITED_RUNTIME_GUARD_TOKEN = "v3_1_phase_25_limited_experimental_runtime_guards_token"
+
+
+def build_limited_experimental_runtime_guards(
+    *,
+    controlled_consumption_promotion_readiness: dict[str, Any] | list[dict[str, Any]],
+    manifest_consumption_eligibility: dict[str, Any] | list[dict[str, Any]],
+    admission_aware_manifest_serialization: dict[str, Any] | list[dict[str, Any]],
+    production_non_consumption_assumptions: dict[str, Any] | None = None,
+    run_id: str = "v3_1_phase_25_limited_experimental_runtime_guards",
+) -> dict[str, Any]:
+    """Build deterministic limited experimental runtime guard records."""
+
+    readiness_records = _readiness_records(controlled_consumption_promotion_readiness)
+    eligibility_records = _eligibility_records(manifest_consumption_eligibility)
+    manifests = _serialized_manifests(admission_aware_manifest_serialization)
+    assumptions = production_non_consumption_assumptions or {}
+    runtime_enabled = _runtime_enabled(
+        controlled_consumption_promotion_readiness,
+        manifest_consumption_eligibility,
+        admission_aware_manifest_serialization,
+        assumptions,
+    )
+    production_routing_authorized = _production_routing_authorized(
+        controlled_consumption_promotion_readiness,
+        manifest_consumption_eligibility,
+        admission_aware_manifest_serialization,
+        assumptions,
+    )
+    eligibility_by_key = {_trace_key(record): record for record in eligibility_records if _trace_key(record)}
+    manifests_by_key = {_trace_key(record): record for record in manifests if _trace_key(record)}
+    guard_records = [
+        _guard_record(
+            readiness=record,
+            eligibility=eligibility_by_key.get(_trace_key(record)),
+            manifest=manifests_by_key.get(_trace_key(record)),
+            runtime_enabled=runtime_enabled,
+            production_routing_authorized=production_routing_authorized,
+        )
+        for record in sorted(readiness_records, key=_record_sort_key)
+    ]
+    if not guard_records:
+        guard_records = [_missing_readiness_record(runtime_enabled=runtime_enabled, production_routing_authorized=production_routing_authorized)]
+
+    counts = Counter(record["guard_contract_status"] for record in guard_records)
+    blocker_reasons = Counter(reason for record in guard_records for reason in record["blockers"])
+    envelope = {
+        "schema_version": "v3_1.limited_experimental_runtime_guards.1",
+        "run": {
+            "run_id": run_id,
+            "promotion_readiness_record_count": len(readiness_records),
+            "manifest_eligibility_record_count": len(eligibility_records),
+            "serialized_manifest_count": len(manifests),
+            "controlled_consumption_promotion_readiness_hash": _source_hash(controlled_consumption_promotion_readiness),
+            "manifest_consumption_eligibility_hash": _source_hash(manifest_consumption_eligibility),
+            "admission_aware_manifest_serialization_hash": _source_hash(admission_aware_manifest_serialization),
+        },
+        "summary": {
+            "records_evaluated": len(guard_records),
+            "guard_contract_ready_count": counts["guard_contract_ready"],
+            "blocked_count": len(guard_records) - counts["guard_contract_ready"],
+            "production_affected_count": 0,
+            "production_output_affected": False,
+            "production_behavior_changed": False,
+            "production_default_routing_authorized": False,
+            "runtime_manifest_consumption_enabled": False,
+            "runtime_production_consumption_enabled": False,
+            "deterministic": True,
+        },
+        "guard_contract_status_counts": {
+            status: counts[status]
+            for status in LIMITED_EXPERIMENTAL_RUNTIME_GUARD_STATUSES
+        },
+        "blocker_reason_counts": dict(sorted(blocker_reasons.items())),
+        "required_guard_conditions": {
+            "promotion_readiness_required": "ready_for_limited_experimental_runtime_consideration",
+            "manifest_eligibility_required": "eligible_for_controlled_test_consumption",
+            "authorization_state_required": NON_PRODUCTION_AUTHORIZATION_STATE,
+            "runtime_manifest_consumption_enabled_required": False,
+            "production_routing_authorized_required": False,
+            "serialized_manifest_must_be_non_production_authoritative": True,
+        },
+        "limited_experimental_runtime_guard_records": guard_records,
+        "safety_confirmations": {
+            "guard_readiness_enables_runtime_behavior": False,
+            "guard_readiness_authorizes_production_routing": False,
+            "guard_readiness_is_production_approval": False,
+            "runtime_manifest_consumption_enabled": False,
+            "runtime_production_consumption_enabled": False,
+            "legacy_planner_ownership_preserved": True,
+            "production_output_affected": False,
+            "production_behavior_changed": False,
+            "production_planner_routing_changed": False,
+            "trusted_data_default_truth": False,
+        },
+        "metadata": {
+            "source": "v3_1_limited_experimental_runtime_guards",
+            "observational_only": True,
+            "guard_contract_only": True,
+            "controlled_test_only": True,
+            "runtime_behavior_enabled": False,
+            "production_consumer": False,
+            "production_behavior_changed": False,
+            "planner_remap_performed": False,
+            "production_default_routing_authorized": False,
+            "stable_generation_token": STABLE_LIMITED_RUNTIME_GUARD_TOKEN,
+            "deterministic_serializer": "json_sort_keys_sha256",
+        },
+    }
+    envelope["deterministic_hash"] = deterministic_hash(envelope)
+    return envelope
+
+
+def _readiness_records(value: dict[str, Any] | list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if isinstance(value, list):
+        return [deepcopy(row) for row in value]
+    return [deepcopy(row) for row in value.get("promotion_readiness_records", [])]
+
+
+def _eligibility_records(value: dict[str, Any] | list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if isinstance(value, list):
+        return [deepcopy(row) for row in value]
+    return [deepcopy(row) for row in value.get("eligibility_records", [])]
+
+
+def _serialized_manifests(value: dict[str, Any] | list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if isinstance(value, list):
+        return [deepcopy(row) for row in value]
+    return [deepcopy(row) for row in value.get("serialized_manifests", [])]
+
+
+def _guard_record(
+    *,
+    readiness: dict[str, Any],
+    eligibility: dict[str, Any] | None,
+    manifest: dict[str, Any] | None,
+    runtime_enabled: bool,
+    production_routing_authorized: bool,
+) -> dict[str, Any]:
+    blockers = _blockers(
+        readiness=readiness,
+        eligibility=eligibility,
+        manifest=manifest,
+        runtime_enabled=runtime_enabled,
+        production_routing_authorized=production_routing_authorized,
+    )
+    status = blockers[0] if blockers else "guard_contract_ready"
+    authorization_state = _authorization_state(readiness=readiness, eligibility=eligibility, manifest=manifest)
+    seed = {
+        "manifest_id": readiness.get("manifest_id"),
+        "fixture_set_id": readiness.get("fixture_set_id"),
+        "status": status,
+        "token": STABLE_LIMITED_RUNTIME_GUARD_TOKEN,
+    }
+    return {
+        "runtime_guard_contract_id": f"v3_1_limited_runtime_guard_{deterministic_hash(seed)[:16]}",
+        "manifest_id": readiness.get("manifest_id"),
+        "fixture_set_id": readiness.get("fixture_set_id"),
+        "promotion_readiness_status": readiness.get("promotion_readiness_status"),
+        "eligibility_status": (eligibility or {}).get("eligibility_status"),
+        "authorization_state": authorization_state,
+        "runtime_consumption_enabled": runtime_enabled,
+        "production_routing_authorized": production_routing_authorized,
+        "guard_contract_status": status,
+        "blockers": blockers,
+        "guard_readiness_enables_runtime_behavior": False,
+        "guard_readiness_authorizes_production_routing": False,
+        "production_output_affected": False,
+        "metadata": {
+            "observational_only": True,
+            "guard_contract_only": True,
+            "runtime_behavior_enabled": False,
+            "production_consumer": False,
+            "planner_remap_performed": False,
+        },
+    }
+
+
+def _missing_readiness_record(*, runtime_enabled: bool, production_routing_authorized: bool) -> dict[str, Any]:
+    seed = {"missing_readiness": True, "runtime_enabled": runtime_enabled, "production_routing_authorized": production_routing_authorized, "token": STABLE_LIMITED_RUNTIME_GUARD_TOKEN}
+    blockers = ["blocked_missing_promotion_readiness"]
+    if runtime_enabled:
+        blockers.append("blocked_runtime_consumption_enabled")
+    if production_routing_authorized:
+        blockers.append("blocked_production_routing_authorized")
+    return {
+        "runtime_guard_contract_id": f"v3_1_limited_runtime_guard_{deterministic_hash(seed)[:16]}",
+        "manifest_id": None,
+        "fixture_set_id": None,
+        "promotion_readiness_status": None,
+        "eligibility_status": None,
+        "authorization_state": None,
+        "runtime_consumption_enabled": runtime_enabled,
+        "production_routing_authorized": production_routing_authorized,
+        "guard_contract_status": "blocked_missing_promotion_readiness",
+        "blockers": blockers,
+        "guard_readiness_enables_runtime_behavior": False,
+        "guard_readiness_authorizes_production_routing": False,
+        "production_output_affected": False,
+        "metadata": {
+            "observational_only": True,
+            "guard_contract_only": True,
+            "runtime_behavior_enabled": False,
+            "production_consumer": False,
+            "planner_remap_performed": False,
+        },
+    }
+
+
+def _blockers(
+    *,
+    readiness: dict[str, Any],
+    eligibility: dict[str, Any] | None,
+    manifest: dict[str, Any] | None,
+    runtime_enabled: bool,
+    production_routing_authorized: bool,
+) -> list[str]:
+    blockers: list[str] = []
+    if readiness.get("promotion_readiness_status") != "ready_for_limited_experimental_runtime_consideration":
+        blockers.append("blocked_missing_promotion_readiness")
+    if eligibility is None or eligibility.get("eligibility_status") != "eligible_for_controlled_test_consumption":
+        blockers.append("blocked_invalid_manifest_eligibility")
+    if _authorization_state(readiness=readiness, eligibility=eligibility, manifest=manifest) != NON_PRODUCTION_AUTHORIZATION_STATE:
+        blockers.append("blocked_invalid_authorization_state")
+    if runtime_enabled:
+        blockers.append("blocked_runtime_consumption_enabled")
+    if production_routing_authorized:
+        blockers.append("blocked_production_routing_authorized")
+    if not _manifest_is_non_production_authoritative(manifest):
+        blockers.append("blocked_missing_non_production_manifest")
+    return sorted(set(blockers), key=blockers.index)
+
+
+def _authorization_state(
+    *,
+    readiness: dict[str, Any],
+    eligibility: dict[str, Any] | None,
+    manifest: dict[str, Any] | None,
+) -> str | None:
+    states = [
+        (eligibility or {}).get("authorization_state"),
+        ((manifest or {}).get("authorization_status") or {}).get("authorization_state"),
+    ]
+    for state in states:
+        if state:
+            return state
+    if readiness.get("promotion_readiness_status") == "ready_for_limited_experimental_runtime_consideration":
+        return NON_PRODUCTION_AUTHORIZATION_STATE
+    return None
+
+
+def _manifest_is_non_production_authoritative(manifest: dict[str, Any] | None) -> bool:
+    if not manifest:
+        return False
+    authorization = manifest.get("authorization_status") or {}
+    return (
+        manifest.get("non_production_authoritative") is True
+        and authorization.get("authorization_state") == NON_PRODUCTION_AUTHORIZATION_STATE
+        and authorization.get("manifest_authorizes_production_routing") is False
+        and authorization.get("manifest_is_production_authoritative") is False
+        and authorization.get("manifest_is_production_approved") is False
+    )
+
+
+def _runtime_enabled(*values: Any) -> bool:
+    for value in values:
+        if not isinstance(value, dict):
+            continue
+        summary = value.get("summary") or {}
+        safety = value.get("safety_confirmations") or {}
+        if (
+            value.get("runtime_manifest_consumption_enabled")
+            or value.get("runtime_production_consumption_enabled")
+            or summary.get("runtime_manifest_consumption_enabled")
+            or summary.get("runtime_production_consumption_enabled")
+            or summary.get("manifest_runtime_consumption_enabled")
+            or safety.get("runtime_manifest_consumption_enabled")
+            or safety.get("runtime_production_consumption_enabled")
+        ):
+            return True
+    return False
+
+
+def _production_routing_authorized(*values: Any) -> bool:
+    for value in values:
+        if not isinstance(value, dict):
+            continue
+        summary = value.get("summary") or {}
+        safety = value.get("safety_confirmations") or {}
+        if (
+            value.get("production_default_routing_authorized")
+            or summary.get("production_default_routing_authorized")
+            or summary.get("production_routing_authorized")
+            or safety.get("production_planner_routing_changed")
+            or safety.get("guard_readiness_authorizes_production_routing")
+        ):
+            return True
+    return False
+
+
+def _trace_key(record: dict[str, Any] | None) -> tuple[str, str] | None:
+    if not record:
+        return None
+    manifest_id = record.get("manifest_id")
+    fixture_set_id = record.get("fixture_set_id")
+    if not manifest_id or not fixture_set_id:
+        return None
+    return (str(manifest_id), str(fixture_set_id))
+
+
+def _record_sort_key(record: dict[str, Any]) -> tuple[str, str]:
+    return (
+        str(record.get("fixture_set_id") or ""),
+        str(record.get("manifest_id") or ""),
+    )
+
+
+def _source_hash(value: dict[str, Any] | list[dict[str, Any]]) -> str | None:
+    if isinstance(value, dict):
+        return value.get("deterministic_hash")
+    return None

--- a/backend/scripts/report_v3_1_limited_experimental_runtime_guards.py
+++ b/backend/scripts/report_v3_1_limited_experimental_runtime_guards.py
@@ -1,0 +1,185 @@
+"""Generate the v3.1 limited experimental runtime guard contract report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.planner_adapters.v3_1.limited_experimental_runtime_guards import build_limited_experimental_runtime_guards  # noqa: E402
+
+
+DETERMINISTIC_GENERATED_AT = "2026-05-15T00:00:00+00:00"
+
+
+def build_v3_1_limited_experimental_runtime_guards_report() -> dict[str, Any]:
+    repo_root = Path(__file__).resolve().parents[2]
+    readiness = _read_json(repo_root / "docs" / "generated" / "v3_1_controlled_consumption_promotion_readiness_report.json")[
+        "controlled_consumption_promotion_readiness"
+    ]
+    eligibility = _read_json(repo_root / "docs" / "generated" / "v3_1_manifest_consumption_eligibility_report.json")[
+        "manifest_consumption_eligibility"
+    ]
+    manifests = _read_json(repo_root / "docs" / "generated" / "v3_1_admission_aware_manifest_serialization_report.json")[
+        "admission_aware_manifest_serialization"
+    ]
+    assumptions = {
+        "runtime_manifest_consumption_enabled": False,
+        "runtime_production_consumption_enabled": False,
+        "production_default_routing_authorized": False,
+        "production_routing_authorized": False,
+    }
+    guards = build_limited_experimental_runtime_guards(
+        controlled_consumption_promotion_readiness=readiness,
+        manifest_consumption_eligibility=eligibility,
+        admission_aware_manifest_serialization=manifests,
+        production_non_consumption_assumptions=assumptions,
+    )
+    repeated = build_limited_experimental_runtime_guards(
+        controlled_consumption_promotion_readiness=readiness,
+        manifest_consumption_eligibility=eligibility,
+        admission_aware_manifest_serialization=manifests,
+        production_non_consumption_assumptions=assumptions,
+    )
+    report = {
+        "schema_version": "v3_1.limited_experimental_runtime_guards_report.1",
+        "generated_at": DETERMINISTIC_GENERATED_AT,
+        "phase": "v3.1_phase_25_limited_experimental_runtime_guard_design",
+        "recommendation": "OBSERVATIONAL_ONLY_DO_NOT_ENABLE_RUNTIME_MANIFEST_CONSUMPTION",
+        "production_default_routing_authorized": False,
+        "runtime_manifest_consumption_enabled": False,
+        "runtime_production_consumption_enabled": False,
+        "summary": {
+            **guards["summary"],
+            "deterministic": guards["deterministic_hash"] == repeated["deterministic_hash"],
+        },
+        "limited_experimental_runtime_guards": guards,
+        "deterministic_guarantees": {
+            "passed": guards["deterministic_hash"] == repeated["deterministic_hash"],
+            "sample_hash": guards["deterministic_hash"],
+            "repeated_hash": repeated["deterministic_hash"],
+            "timestamp_excluded_from_hash": True,
+            "json_sort_keys": True,
+        },
+        "phase_25_boundaries": [
+            "runtime guard readiness is a design contract only",
+            "guard readiness does not enable runtime manifest consumption",
+            "guard readiness does not authorize production routing",
+            "manifests remain non-production-authoritative",
+            "production planner routing remains unchanged",
+            "legacy planner ownership remains intact",
+        ],
+        "metadata": {
+            "source": "v3_1_limited_experimental_runtime_guards_report",
+            "observational_only": True,
+            "guard_contract_only": True,
+            "runtime_behavior_enabled": False,
+            "production_behavior_changed": False,
+            "production_default_routing_authorized": False,
+            "planner_remap_performed": False,
+        },
+    }
+    return _normalize_generated_at(report)
+
+
+def write_report(report: dict[str, Any], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_markdown(report: dict[str, Any], output_path: Path) -> None:
+    guards = report["limited_experimental_runtime_guards"]
+    summary = report["summary"]
+    conditions = guards["required_guard_conditions"]
+    lines = [
+        "# V3.1 Limited Experimental Runtime Guards",
+        "",
+        "Phase 25 defines a guardrail contract for future limited experimental runtime consideration.",
+        "This does not enable runtime manifest consumption and does not authorize production routing.",
+        "",
+        "## Recommendation",
+        "",
+        f"- Recommendation: `{report['recommendation']}`",
+        f"- Production default routing authorized: `{str(report['production_default_routing_authorized']).lower()}`",
+        f"- Runtime production consumption enabled: `{str(report['runtime_production_consumption_enabled']).lower()}`",
+        f"- Runtime manifest consumption enabled: `{str(report['runtime_manifest_consumption_enabled']).lower()}`",
+        "",
+        "## Summary",
+        "",
+        f"- Records evaluated: `{summary['records_evaluated']}`",
+        f"- Guard-contract ready: `{summary['guard_contract_ready_count']}`",
+        f"- Blocked: `{summary['blocked_count']}`",
+        f"- Production affected: `{summary['production_affected_count']}`",
+        f"- Deterministic: `{str(summary['deterministic']).lower()}`",
+        "",
+        "## Required Guard Conditions",
+        "",
+    ]
+    for key, value in conditions.items():
+        lines.append(f"- {key}: `{value}`")
+    lines.extend(["", "## Blocker Reasons", "", "| Reason | Count |", "| --- | ---: |"])
+    for reason, count in guards["blocker_reason_counts"].items():
+        lines.append(f"| `{reason}` | `{count}` |")
+    lines.extend(
+        [
+            "",
+            "## Guard Records",
+            "",
+            "| Record | Manifest | Fixture Set | Guard Status |",
+            "| --- | --- | --- | --- |",
+        ]
+    )
+    for row in guards["limited_experimental_runtime_guard_records"]:
+        lines.append(
+            f"| `{row['runtime_guard_contract_id']}` | `{row['manifest_id'] or ''}` | `{row['fixture_set_id'] or ''}` | `{row['guard_contract_status']}` |"
+        )
+    lines.extend(["", "## Phase 25 Boundaries", ""])
+    lines.extend(f"- {item}" for item in report["phase_25_boundaries"])
+    lines.extend(
+        [
+            "",
+            "## Conclusion",
+            "",
+            "Limited experimental runtime guards are defined for governance review, while runtime consumption and production routing remain disabled.",
+        ]
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _normalize_generated_at(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: DETERMINISTIC_GENERATED_AT if key == "generated_at" else _normalize_generated_at(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_normalize_generated_at(item) for item in value]
+    return deepcopy(value)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", default="docs/generated/v3_1_limited_experimental_runtime_guards_report.json")
+    parser.add_argument("--markdown-output", default="docs/migration/V3_1_LIMITED_EXPERIMENTAL_RUNTIME_GUARDS.md")
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[2]
+    report = build_v3_1_limited_experimental_runtime_guards_report()
+    write_report(report, repo_root / args.output)
+    write_markdown(report, repo_root / args.markdown_output)
+    print(json.dumps(report["summary"], indent=2, sort_keys=True))
+    print(report["recommendation"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_v3_1_limited_experimental_runtime_guards.py
+++ b/backend/tests/test_v3_1_limited_experimental_runtime_guards.py
@@ -1,0 +1,151 @@
+from app.planner_adapters.v3_1.limited_experimental_runtime_guards import build_limited_experimental_runtime_guards
+from scripts.report_v3_1_limited_experimental_runtime_guards import build_v3_1_limited_experimental_runtime_guards_report
+
+
+def test_valid_promotion_readiness_evidence_produces_guard_contract_ready():
+    result = _build()
+
+    record = result["limited_experimental_runtime_guard_records"][0]
+    assert record["guard_contract_status"] == "guard_contract_ready"
+    assert result["summary"]["guard_contract_ready_count"] == 1
+
+
+def test_missing_promotion_readiness_blocks():
+    result = _build(readiness=[])
+
+    assert result["limited_experimental_runtime_guard_records"][0]["guard_contract_status"] == "blocked_missing_promotion_readiness"
+
+
+def test_invalid_eligibility_blocks():
+    result = _build(eligibility=[_eligibility_record(status="blocked_missing_hash")])
+
+    assert result["limited_experimental_runtime_guard_records"][0]["guard_contract_status"] == "blocked_invalid_manifest_eligibility"
+
+
+def test_invalid_authorization_state_blocks():
+    result = _build(eligibility=[_eligibility_record(authorization_state="production_authoritative")])
+
+    assert result["limited_experimental_runtime_guard_records"][0]["guard_contract_status"] == "blocked_invalid_authorization_state"
+
+
+def test_runtime_consumption_enabled_blocks():
+    result = _build(assumptions={"runtime_manifest_consumption_enabled": True})
+
+    assert result["limited_experimental_runtime_guard_records"][0]["guard_contract_status"] == "blocked_runtime_consumption_enabled"
+
+
+def test_production_routing_authorized_blocks():
+    result = _build(assumptions={"production_default_routing_authorized": True})
+
+    assert result["limited_experimental_runtime_guard_records"][0]["guard_contract_status"] == "blocked_production_routing_authorized"
+
+
+def test_missing_non_production_manifest_blocks():
+    result = _build(manifests=[])
+
+    assert result["limited_experimental_runtime_guard_records"][0]["guard_contract_status"] == "blocked_missing_non_production_manifest"
+
+
+def test_deterministic_ordering():
+    first = _build(
+        readiness=[_readiness_record("manifest_b", "set_b"), _readiness_record("manifest_a", "set_a")],
+        eligibility=[_eligibility_record("manifest_b", "set_b"), _eligibility_record("manifest_a", "set_a")],
+        manifests=[_manifest_record("manifest_b", "set_b"), _manifest_record("manifest_a", "set_a")],
+    )
+    second = _build(
+        readiness=[_readiness_record("manifest_a", "set_a"), _readiness_record("manifest_b", "set_b")],
+        eligibility=[_eligibility_record("manifest_a", "set_a"), _eligibility_record("manifest_b", "set_b")],
+        manifests=[_manifest_record("manifest_a", "set_a"), _manifest_record("manifest_b", "set_b")],
+    )
+
+    assert first["deterministic_hash"] == second["deterministic_hash"]
+    assert [row["manifest_id"] for row in first["limited_experimental_runtime_guard_records"]] == ["manifest_a", "manifest_b"]
+
+
+def test_stable_report_generation():
+    first = build_v3_1_limited_experimental_runtime_guards_report()
+    second = build_v3_1_limited_experimental_runtime_guards_report()
+
+    assert first["deterministic_guarantees"]["passed"] is True
+    assert first["limited_experimental_runtime_guards"]["deterministic_hash"] == second["limited_experimental_runtime_guards"]["deterministic_hash"]
+    assert first["summary"] == second["summary"]
+
+
+def test_no_production_routing_enablement():
+    result = _build()
+    record = result["limited_experimental_runtime_guard_records"][0]
+
+    assert result["safety_confirmations"]["guard_readiness_enables_runtime_behavior"] is False
+    assert result["safety_confirmations"]["guard_readiness_authorizes_production_routing"] is False
+    assert result["safety_confirmations"]["guard_readiness_is_production_approval"] is False
+    assert record["guard_readiness_enables_runtime_behavior"] is False
+
+
+def _build(readiness=None, eligibility=None, manifests=None, assumptions=None):
+    return build_limited_experimental_runtime_guards(
+        controlled_consumption_promotion_readiness=_payload("promotion_readiness_records", [_readiness_record()] if readiness is None else readiness),
+        manifest_consumption_eligibility=_payload("eligibility_records", [_eligibility_record()] if eligibility is None else eligibility),
+        admission_aware_manifest_serialization=_payload("serialized_manifests", [_manifest_record()] if manifests is None else manifests),
+        production_non_consumption_assumptions=assumptions
+        or {
+            "runtime_manifest_consumption_enabled": False,
+            "runtime_production_consumption_enabled": False,
+            "production_default_routing_authorized": False,
+        },
+    )
+
+
+def _payload(key, records):
+    return {
+        "schema_version": f"v3_1.test.{key}.1",
+        "deterministic_hash": f"{key}-hash",
+        "summary": {
+            "runtime_manifest_consumption_enabled": False,
+            "runtime_production_consumption_enabled": False,
+            "production_default_routing_authorized": False,
+        },
+        "safety_confirmations": {
+            "runtime_manifest_consumption_enabled": False,
+            "runtime_production_consumption_enabled": False,
+            "production_planner_routing_changed": False,
+        },
+        key: records,
+    }
+
+
+def _readiness_record(manifest_id="manifest_a", fixture_set_id="set_a", status="ready_for_limited_experimental_runtime_consideration"):
+    return {
+        "manifest_id": manifest_id,
+        "fixture_set_id": fixture_set_id,
+        "promotion_readiness_status": status,
+        "eligibility_status": "eligible_for_controlled_test_consumption",
+        "promotion_readiness_authorizes_production_routing": False,
+        "production_output_affected": False,
+    }
+
+
+def _eligibility_record(manifest_id="manifest_a", fixture_set_id="set_a", status="eligible_for_controlled_test_consumption", authorization_state="non_production_authoritative"):
+    return {
+        "manifest_id": manifest_id,
+        "fixture_set_id": fixture_set_id,
+        "eligibility_status": status,
+        "authorization_state": authorization_state,
+        "eligibility_authorizes_production_routing": False,
+        "production_output_affected": False,
+    }
+
+
+def _manifest_record(manifest_id="manifest_a", fixture_set_id="set_a", authorization_state="non_production_authoritative"):
+    return {
+        "manifest_id": manifest_id,
+        "fixture_set_id": fixture_set_id,
+        "serialization_status": "serialized_manifest",
+        "authorization_status": {
+            "authorization_state": authorization_state,
+            "manifest_authorizes_production_routing": False,
+            "manifest_is_production_approved": False,
+            "manifest_is_production_authoritative": False,
+        },
+        "non_production_authoritative": True,
+        "production_output_affected": False,
+    }

--- a/docs/generated/v3_1_limited_experimental_runtime_guards_report.json
+++ b/docs/generated/v3_1_limited_experimental_runtime_guards_report.json
@@ -1,0 +1,137 @@
+{
+  "deterministic_guarantees": {
+    "json_sort_keys": true,
+    "passed": true,
+    "repeated_hash": "5545f8146c04f2869bcfe3c76cf1040e08e51ef73d3669d7b415acd22d1ee4e2",
+    "sample_hash": "5545f8146c04f2869bcfe3c76cf1040e08e51ef73d3669d7b415acd22d1ee4e2",
+    "timestamp_excluded_from_hash": true
+  },
+  "generated_at": "2026-05-15T00:00:00+00:00",
+  "limited_experimental_runtime_guards": {
+    "blocker_reason_counts": {},
+    "deterministic_hash": "5545f8146c04f2869bcfe3c76cf1040e08e51ef73d3669d7b415acd22d1ee4e2",
+    "guard_contract_status_counts": {
+      "blocked_invalid_authorization_state": 0,
+      "blocked_invalid_manifest_eligibility": 0,
+      "blocked_missing_non_production_manifest": 0,
+      "blocked_missing_promotion_readiness": 0,
+      "blocked_production_routing_authorized": 0,
+      "blocked_runtime_consumption_enabled": 0,
+      "guard_contract_ready": 1
+    },
+    "limited_experimental_runtime_guard_records": [
+      {
+        "authorization_state": "non_production_authoritative",
+        "blockers": [],
+        "eligibility_status": "eligible_for_controlled_test_consumption",
+        "fixture_set_id": "v3_1_fixture_set_6d3b668a84cfbb69",
+        "guard_contract_status": "guard_contract_ready",
+        "guard_readiness_authorizes_production_routing": false,
+        "guard_readiness_enables_runtime_behavior": false,
+        "manifest_id": "v3_1_admission_manifest_198a3e2110f9e5e4",
+        "metadata": {
+          "guard_contract_only": true,
+          "observational_only": true,
+          "planner_remap_performed": false,
+          "production_consumer": false,
+          "runtime_behavior_enabled": false
+        },
+        "production_output_affected": false,
+        "production_routing_authorized": false,
+        "promotion_readiness_status": "ready_for_limited_experimental_runtime_consideration",
+        "runtime_consumption_enabled": false,
+        "runtime_guard_contract_id": "v3_1_limited_runtime_guard_44d3e56c7546418d"
+      }
+    ],
+    "metadata": {
+      "controlled_test_only": true,
+      "deterministic_serializer": "json_sort_keys_sha256",
+      "guard_contract_only": true,
+      "observational_only": true,
+      "planner_remap_performed": false,
+      "production_behavior_changed": false,
+      "production_consumer": false,
+      "production_default_routing_authorized": false,
+      "runtime_behavior_enabled": false,
+      "source": "v3_1_limited_experimental_runtime_guards",
+      "stable_generation_token": "v3_1_phase_25_limited_experimental_runtime_guards_token"
+    },
+    "required_guard_conditions": {
+      "authorization_state_required": "non_production_authoritative",
+      "manifest_eligibility_required": "eligible_for_controlled_test_consumption",
+      "production_routing_authorized_required": false,
+      "promotion_readiness_required": "ready_for_limited_experimental_runtime_consideration",
+      "runtime_manifest_consumption_enabled_required": false,
+      "serialized_manifest_must_be_non_production_authoritative": true
+    },
+    "run": {
+      "admission_aware_manifest_serialization_hash": "8fa65134e7e0bf7f839c2ad01b22b26b7fc59c26787f23b7c13331fc5654ecda",
+      "controlled_consumption_promotion_readiness_hash": "65e0814411b9053c2fd50da6c80fbaf960280beee4ddaee2c6a978c32ae6516c",
+      "manifest_consumption_eligibility_hash": "e5776401439dbe2ac5feef32f9c0ae924d7769f691ea3e90fcb1774f39fcbbf4",
+      "manifest_eligibility_record_count": 1,
+      "promotion_readiness_record_count": 1,
+      "run_id": "v3_1_phase_25_limited_experimental_runtime_guards",
+      "serialized_manifest_count": 1
+    },
+    "safety_confirmations": {
+      "guard_readiness_authorizes_production_routing": false,
+      "guard_readiness_enables_runtime_behavior": false,
+      "guard_readiness_is_production_approval": false,
+      "legacy_planner_ownership_preserved": true,
+      "production_behavior_changed": false,
+      "production_output_affected": false,
+      "production_planner_routing_changed": false,
+      "runtime_manifest_consumption_enabled": false,
+      "runtime_production_consumption_enabled": false,
+      "trusted_data_default_truth": false
+    },
+    "schema_version": "v3_1.limited_experimental_runtime_guards.1",
+    "summary": {
+      "blocked_count": 0,
+      "deterministic": true,
+      "guard_contract_ready_count": 1,
+      "production_affected_count": 0,
+      "production_behavior_changed": false,
+      "production_default_routing_authorized": false,
+      "production_output_affected": false,
+      "records_evaluated": 1,
+      "runtime_manifest_consumption_enabled": false,
+      "runtime_production_consumption_enabled": false
+    }
+  },
+  "metadata": {
+    "guard_contract_only": true,
+    "observational_only": true,
+    "planner_remap_performed": false,
+    "production_behavior_changed": false,
+    "production_default_routing_authorized": false,
+    "runtime_behavior_enabled": false,
+    "source": "v3_1_limited_experimental_runtime_guards_report"
+  },
+  "phase": "v3.1_phase_25_limited_experimental_runtime_guard_design",
+  "phase_25_boundaries": [
+    "runtime guard readiness is a design contract only",
+    "guard readiness does not enable runtime manifest consumption",
+    "guard readiness does not authorize production routing",
+    "manifests remain non-production-authoritative",
+    "production planner routing remains unchanged",
+    "legacy planner ownership remains intact"
+  ],
+  "production_default_routing_authorized": false,
+  "recommendation": "OBSERVATIONAL_ONLY_DO_NOT_ENABLE_RUNTIME_MANIFEST_CONSUMPTION",
+  "runtime_manifest_consumption_enabled": false,
+  "runtime_production_consumption_enabled": false,
+  "schema_version": "v3_1.limited_experimental_runtime_guards_report.1",
+  "summary": {
+    "blocked_count": 0,
+    "deterministic": true,
+    "guard_contract_ready_count": 1,
+    "production_affected_count": 0,
+    "production_behavior_changed": false,
+    "production_default_routing_authorized": false,
+    "production_output_affected": false,
+    "records_evaluated": 1,
+    "runtime_manifest_consumption_enabled": false,
+    "runtime_production_consumption_enabled": false
+  }
+}

--- a/docs/migration/V3_1_LIMITED_EXPERIMENTAL_RUNTIME_GUARDS.md
+++ b/docs/migration/V3_1_LIMITED_EXPERIMENTAL_RUNTIME_GUARDS.md
@@ -1,0 +1,52 @@
+# V3.1 Limited Experimental Runtime Guards
+
+Phase 25 defines a guardrail contract for future limited experimental runtime consideration.
+This does not enable runtime manifest consumption and does not authorize production routing.
+
+## Recommendation
+
+- Recommendation: `OBSERVATIONAL_ONLY_DO_NOT_ENABLE_RUNTIME_MANIFEST_CONSUMPTION`
+- Production default routing authorized: `false`
+- Runtime production consumption enabled: `false`
+- Runtime manifest consumption enabled: `false`
+
+## Summary
+
+- Records evaluated: `1`
+- Guard-contract ready: `1`
+- Blocked: `0`
+- Production affected: `0`
+- Deterministic: `true`
+
+## Required Guard Conditions
+
+- promotion_readiness_required: `ready_for_limited_experimental_runtime_consideration`
+- manifest_eligibility_required: `eligible_for_controlled_test_consumption`
+- authorization_state_required: `non_production_authoritative`
+- runtime_manifest_consumption_enabled_required: `False`
+- production_routing_authorized_required: `False`
+- serialized_manifest_must_be_non_production_authoritative: `True`
+
+## Blocker Reasons
+
+| Reason | Count |
+| --- | ---: |
+
+## Guard Records
+
+| Record | Manifest | Fixture Set | Guard Status |
+| --- | --- | --- | --- |
+| `v3_1_limited_runtime_guard_44d3e56c7546418d` | `v3_1_admission_manifest_198a3e2110f9e5e4` | `v3_1_fixture_set_6d3b668a84cfbb69` | `guard_contract_ready` |
+
+## Phase 25 Boundaries
+
+- runtime guard readiness is a design contract only
+- guard readiness does not enable runtime manifest consumption
+- guard readiness does not authorize production routing
+- manifests remain non-production-authoritative
+- production planner routing remains unchanged
+- legacy planner ownership remains intact
+
+## Conclusion
+
+Limited experimental runtime guards are defined for governance review, while runtime consumption and production routing remain disabled.


### PR DESCRIPTION
Adds deterministic guard contract reporting for future limited experimental runtime consideration while preserving disabled runtime consumption and production routing isolation.