### PR TITLE
v3.1: add limited experimental runtime dry run

### DIFF
--- a/backend/app/planner_adapters/v3_1/__init__.py
+++ b/backend/app/planner_adapters/v3_1/__init__.py
@@ -40,6 +40,10 @@ from .limited_experimental_runtime_guards import (
     LIMITED_EXPERIMENTAL_RUNTIME_GUARD_STATUSES,
     build_limited_experimental_runtime_guards,
 )
+from .limited_experimental_runtime_dry_run import (
+    LIMITED_EXPERIMENTAL_RUNTIME_DRY_RUN_STATUSES,
+    build_limited_experimental_runtime_dry_run,
+)
 from .review_policy_evaluation import (
     REVIEW_POLICY_OUTCOMES,
     V31ReviewPolicyEvaluation,
@@ -125,6 +129,7 @@ __all__ = [
     "TRACE_BACKFILLED_SEMANTIC_PARITY_STATUSES",
     "CONTROLLED_CONSUMPTION_PROMOTION_READINESS_STATUSES",
     "LIMITED_EXPERIMENTAL_RUNTIME_GUARD_STATUSES",
+    "LIMITED_EXPERIMENTAL_RUNTIME_DRY_RUN_STATUSES",
     "FIXTURE_WORKFLOW_STATES",
     "FIXTURE_SET_LIFECYCLE_STATES",
     "REVIEW_POLICY_OUTCOMES",
@@ -161,6 +166,7 @@ __all__ = [
     "build_trace_backfilled_semantic_parity",
     "build_controlled_consumption_promotion_readiness",
     "build_limited_experimental_runtime_guards",
+    "build_limited_experimental_runtime_dry_run",
     "build_default_trusted_repository_probes",
     "build_fixture_set_readiness_gate",
     "evaluate_fixture_source_admission_policy",

--- a/backend/app/planner_adapters/v3_1/limited_experimental_runtime_dry_run.py
+++ b/backend/app/planner_adapters/v3_1/limited_experimental_runtime_dry_run.py
@@ -1,0 +1,414 @@
+"""Limited experimental runtime dry-run adapter for v3.1 governance.
+
+The adapter exercises the guarded manifest evidence chain in dry-run mode only.
+It is pure, non-mutating, and does not enable runtime manifest consumption or
+production routing.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from copy import deepcopy
+from typing import Any
+
+from .approval_manifest_serialization import NON_PRODUCTION_AUTHORIZATION_STATE
+from .trusted_shadow_consumption import deterministic_hash
+
+
+LIMITED_EXPERIMENTAL_RUNTIME_DRY_RUN_STATUSES = (
+    "dry_run_ready",
+    "blocked_missing_guard_contract",
+    "blocked_invalid_guard_status",
+    "blocked_missing_promotion_readiness",
+    "blocked_invalid_authorization_state",
+    "blocked_runtime_consumption_enabled",
+    "blocked_production_routing_authorized",
+    "blocked_missing_manifest",
+    "blocked_missing_validated_evidence",
+)
+STABLE_LIMITED_RUNTIME_DRY_RUN_TOKEN = "v3_1_phase_26_limited_experimental_runtime_dry_run_token"
+
+
+def build_limited_experimental_runtime_dry_run(
+    *,
+    limited_experimental_runtime_guards: dict[str, Any] | list[dict[str, Any]],
+    controlled_consumption_promotion_readiness: dict[str, Any] | list[dict[str, Any]],
+    admission_aware_manifest_serialization: dict[str, Any] | list[dict[str, Any]],
+    controlled_consumption_output_validation: dict[str, Any] | list[dict[str, Any]],
+    controlled_consumption_parity_snapshot: dict[str, Any] | list[dict[str, Any]],
+    trace_backfilled_semantic_parity: dict[str, Any] | list[dict[str, Any]],
+    run_id: str = "v3_1_phase_26_limited_experimental_runtime_dry_run",
+) -> dict[str, Any]:
+    """Build deterministic dry-run records from guarded non-production evidence."""
+
+    guard_records = _guard_records(limited_experimental_runtime_guards)
+    readiness_records = _readiness_records(controlled_consumption_promotion_readiness)
+    manifests = _serialized_manifests(admission_aware_manifest_serialization)
+    validations = _validation_records(controlled_consumption_output_validation)
+    structural_parity = _structural_parity_records(controlled_consumption_parity_snapshot)
+    semantic_parity = _semantic_parity_records(trace_backfilled_semantic_parity)
+    runtime_enabled = _runtime_enabled(
+        limited_experimental_runtime_guards,
+        controlled_consumption_promotion_readiness,
+        admission_aware_manifest_serialization,
+        controlled_consumption_output_validation,
+        controlled_consumption_parity_snapshot,
+        trace_backfilled_semantic_parity,
+    )
+    production_routing_authorized = _production_routing_authorized(
+        limited_experimental_runtime_guards,
+        controlled_consumption_promotion_readiness,
+        admission_aware_manifest_serialization,
+        controlled_consumption_output_validation,
+        controlled_consumption_parity_snapshot,
+        trace_backfilled_semantic_parity,
+    )
+    readiness_by_key = {_trace_key(record): record for record in readiness_records if _trace_key(record)}
+    manifests_by_key = {_trace_key(record): record for record in manifests if _trace_key(record)}
+    validations_by_key = {_trace_key(record): record for record in validations if _trace_key(record)}
+    structural_by_key = {_trace_key(record): record for record in structural_parity if _trace_key(record)}
+    semantic_by_key = {_trace_key(record): record for record in semantic_parity if _trace_key(record)}
+    dry_run_records = [
+        _dry_run_record(
+            guard=record,
+            readiness=readiness_by_key.get(_trace_key(record)),
+            manifest=manifests_by_key.get(_trace_key(record)),
+            validation=validations_by_key.get(_trace_key(record)),
+            structural_parity=structural_by_key.get(_trace_key(record)),
+            semantic_parity=semantic_by_key.get(_trace_key(record)),
+            runtime_enabled=runtime_enabled,
+            production_routing_authorized=production_routing_authorized,
+        )
+        for record in sorted(guard_records, key=_record_sort_key)
+    ]
+    if not dry_run_records:
+        dry_run_records = [_missing_guard_record(runtime_enabled=runtime_enabled, production_routing_authorized=production_routing_authorized)]
+
+    counts = Counter(record["dry_run_status"] for record in dry_run_records)
+    blocker_reasons = Counter(reason for record in dry_run_records for reason in record["blockers"])
+    envelope = {
+        "schema_version": "v3_1.limited_experimental_runtime_dry_run.1",
+        "run": {
+            "run_id": run_id,
+            "guard_record_count": len(guard_records),
+            "promotion_readiness_record_count": len(readiness_records),
+            "serialized_manifest_count": len(manifests),
+            "validation_record_count": len(validations),
+            "structural_parity_record_count": len(structural_parity),
+            "semantic_parity_record_count": len(semantic_parity),
+            "limited_experimental_runtime_guards_hash": _source_hash(limited_experimental_runtime_guards),
+            "controlled_consumption_promotion_readiness_hash": _source_hash(controlled_consumption_promotion_readiness),
+            "admission_aware_manifest_serialization_hash": _source_hash(admission_aware_manifest_serialization),
+            "controlled_consumption_output_validation_hash": _source_hash(controlled_consumption_output_validation),
+            "controlled_consumption_parity_snapshot_hash": _source_hash(controlled_consumption_parity_snapshot),
+            "trace_backfilled_semantic_parity_hash": _source_hash(trace_backfilled_semantic_parity),
+        },
+        "summary": {
+            "records_evaluated": len(dry_run_records),
+            "dry_run_ready_count": counts["dry_run_ready"],
+            "blocked_count": len(dry_run_records) - counts["dry_run_ready"],
+            "runtime_manifest_consumption_enabled": False,
+            "runtime_production_consumption_enabled": False,
+            "production_routing_authorized": False,
+            "production_default_routing_authorized": False,
+            "production_affected_count": 0,
+            "production_output_affected": False,
+            "production_behavior_changed": False,
+            "deterministic": True,
+        },
+        "dry_run_status_counts": {
+            status: counts[status]
+            for status in LIMITED_EXPERIMENTAL_RUNTIME_DRY_RUN_STATUSES
+        },
+        "blocker_reason_counts": dict(sorted(blocker_reasons.items())),
+        "evidence_summary": {
+            "guard_records": len(guard_records),
+            "promotion_readiness_records": len(readiness_records),
+            "serialized_manifests": len(manifests),
+            "validation_records": len(validations),
+            "structural_parity_records": len(structural_parity),
+            "semantic_parity_records": len(semantic_parity),
+            "runtime_manifest_consumption_enabled": runtime_enabled,
+            "production_routing_authorized": production_routing_authorized,
+            "dry_run_mutates_runtime_state": False,
+        },
+        "limited_experimental_runtime_dry_run_records": dry_run_records,
+        "safety_confirmations": {
+            "dry_run_enables_runtime_routing": False,
+            "dry_run_authorizes_production_routing": False,
+            "dry_run_is_production_approval": False,
+            "dry_run_mutates_runtime_state": False,
+            "runtime_manifest_consumption_enabled": False,
+            "runtime_production_consumption_enabled": False,
+            "legacy_planner_ownership_preserved": True,
+            "production_output_affected": False,
+            "production_behavior_changed": False,
+            "production_planner_routing_changed": False,
+            "trusted_data_default_truth": False,
+        },
+        "metadata": {
+            "source": "v3_1_limited_experimental_runtime_dry_run",
+            "observational_only": True,
+            "dry_run_only": True,
+            "non_mutating": True,
+            "runtime_behavior_enabled": False,
+            "production_consumer": False,
+            "production_behavior_changed": False,
+            "planner_remap_performed": False,
+            "production_default_routing_authorized": False,
+            "stable_generation_token": STABLE_LIMITED_RUNTIME_DRY_RUN_TOKEN,
+            "deterministic_serializer": "json_sort_keys_sha256",
+        },
+    }
+    envelope["deterministic_hash"] = deterministic_hash(envelope)
+    return envelope
+
+
+def _guard_records(value: dict[str, Any] | list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if isinstance(value, list):
+        return [deepcopy(row) for row in value]
+    return [deepcopy(row) for row in value.get("limited_experimental_runtime_guard_records", [])]
+
+
+def _readiness_records(value: dict[str, Any] | list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if isinstance(value, list):
+        return [deepcopy(row) for row in value]
+    return [deepcopy(row) for row in value.get("promotion_readiness_records", [])]
+
+
+def _serialized_manifests(value: dict[str, Any] | list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if isinstance(value, list):
+        return [deepcopy(row) for row in value]
+    return [deepcopy(row) for row in value.get("serialized_manifests", [])]
+
+
+def _validation_records(value: dict[str, Any] | list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if isinstance(value, list):
+        return [deepcopy(row) for row in value]
+    return [deepcopy(row) for row in value.get("validation_records", [])]
+
+
+def _structural_parity_records(value: dict[str, Any] | list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if isinstance(value, list):
+        return [deepcopy(row) for row in value]
+    return [deepcopy(row) for row in value.get("parity_records", [])]
+
+
+def _semantic_parity_records(value: dict[str, Any] | list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if isinstance(value, list):
+        return [deepcopy(row) for row in value]
+    return [deepcopy(row) for row in value.get("trace_backfilled_semantic_parity_records", [])]
+
+
+def _dry_run_record(
+    *,
+    guard: dict[str, Any],
+    readiness: dict[str, Any] | None,
+    manifest: dict[str, Any] | None,
+    validation: dict[str, Any] | None,
+    structural_parity: dict[str, Any] | None,
+    semantic_parity: dict[str, Any] | None,
+    runtime_enabled: bool,
+    production_routing_authorized: bool,
+) -> dict[str, Any]:
+    blockers = _blockers(
+        guard=guard,
+        readiness=readiness,
+        manifest=manifest,
+        validation=validation,
+        structural_parity=structural_parity,
+        semantic_parity=semantic_parity,
+        runtime_enabled=runtime_enabled,
+        production_routing_authorized=production_routing_authorized,
+    )
+    status = blockers[0] if blockers else "dry_run_ready"
+    authorization_state = _authorization_state(guard=guard, manifest=manifest)
+    seed = {
+        "manifest_id": guard.get("manifest_id"),
+        "fixture_set_id": guard.get("fixture_set_id"),
+        "status": status,
+        "token": STABLE_LIMITED_RUNTIME_DRY_RUN_TOKEN,
+    }
+    return {
+        "limited_runtime_dry_run_id": f"v3_1_limited_runtime_dry_run_{deterministic_hash(seed)[:16]}",
+        "manifest_id": guard.get("manifest_id"),
+        "fixture_set_id": guard.get("fixture_set_id"),
+        "guard_status": guard.get("guard_contract_status"),
+        "promotion_readiness_status": (readiness or {}).get("promotion_readiness_status"),
+        "authorization_state": authorization_state,
+        "dry_run_status": status,
+        "blockers": blockers,
+        "evidence_summary": {
+            "manifest_present": manifest is not None,
+            "validation_status": (validation or {}).get("validation_status"),
+            "structural_parity_status": (structural_parity or {}).get("parity_status"),
+            "semantic_parity_status": (semantic_parity or {}).get("final_semantic_parity_status"),
+            "runtime_consumption_enabled": runtime_enabled,
+            "production_routing_authorized": production_routing_authorized,
+            "dry_run_mutates_runtime_state": False,
+        },
+        "dry_run_enables_runtime_routing": False,
+        "dry_run_authorizes_production_routing": False,
+        "production_output_affected": False,
+        "metadata": {
+            "observational_only": True,
+            "dry_run_only": True,
+            "non_mutating": True,
+            "runtime_behavior_enabled": False,
+            "production_consumer": False,
+            "planner_remap_performed": False,
+        },
+    }
+
+
+def _missing_guard_record(*, runtime_enabled: bool, production_routing_authorized: bool) -> dict[str, Any]:
+    seed = {"missing_guard": True, "runtime_enabled": runtime_enabled, "production_routing_authorized": production_routing_authorized, "token": STABLE_LIMITED_RUNTIME_DRY_RUN_TOKEN}
+    blockers = ["blocked_missing_guard_contract"]
+    if runtime_enabled:
+        blockers.append("blocked_runtime_consumption_enabled")
+    if production_routing_authorized:
+        blockers.append("blocked_production_routing_authorized")
+    return {
+        "limited_runtime_dry_run_id": f"v3_1_limited_runtime_dry_run_{deterministic_hash(seed)[:16]}",
+        "manifest_id": None,
+        "fixture_set_id": None,
+        "guard_status": None,
+        "promotion_readiness_status": None,
+        "authorization_state": None,
+        "dry_run_status": "blocked_missing_guard_contract",
+        "blockers": blockers,
+        "evidence_summary": {
+            "manifest_present": False,
+            "validation_status": None,
+            "structural_parity_status": None,
+            "semantic_parity_status": None,
+            "runtime_consumption_enabled": runtime_enabled,
+            "production_routing_authorized": production_routing_authorized,
+            "dry_run_mutates_runtime_state": False,
+        },
+        "dry_run_enables_runtime_routing": False,
+        "dry_run_authorizes_production_routing": False,
+        "production_output_affected": False,
+        "metadata": {
+            "observational_only": True,
+            "dry_run_only": True,
+            "non_mutating": True,
+            "runtime_behavior_enabled": False,
+            "production_consumer": False,
+            "planner_remap_performed": False,
+        },
+    }
+
+
+def _blockers(
+    *,
+    guard: dict[str, Any],
+    readiness: dict[str, Any] | None,
+    manifest: dict[str, Any] | None,
+    validation: dict[str, Any] | None,
+    structural_parity: dict[str, Any] | None,
+    semantic_parity: dict[str, Any] | None,
+    runtime_enabled: bool,
+    production_routing_authorized: bool,
+) -> list[str]:
+    blockers: list[str] = []
+    if not guard:
+        blockers.append("blocked_missing_guard_contract")
+    if guard.get("guard_contract_status") != "guard_contract_ready":
+        blockers.append("blocked_invalid_guard_status")
+    if readiness is None or readiness.get("promotion_readiness_status") != "ready_for_limited_experimental_runtime_consideration":
+        blockers.append("blocked_missing_promotion_readiness")
+    if _authorization_state(guard=guard, manifest=manifest) != NON_PRODUCTION_AUTHORIZATION_STATE:
+        blockers.append("blocked_invalid_authorization_state")
+    if runtime_enabled:
+        blockers.append("blocked_runtime_consumption_enabled")
+    if production_routing_authorized:
+        blockers.append("blocked_production_routing_authorized")
+    if not _manifest_is_non_production_authoritative(manifest):
+        blockers.append("blocked_missing_manifest")
+    if (
+        validation is None
+        or validation.get("validation_status") != "valid_controlled_test_output"
+        or structural_parity is None
+        or structural_parity.get("parity_status") != "parity_confirmed"
+        or semantic_parity is None
+        or semantic_parity.get("final_semantic_parity_status") != "semantic_parity_confirmed"
+    ):
+        blockers.append("blocked_missing_validated_evidence")
+    return sorted(set(blockers), key=blockers.index)
+
+
+def _authorization_state(*, guard: dict[str, Any], manifest: dict[str, Any] | None) -> str | None:
+    return guard.get("authorization_state") or ((manifest or {}).get("authorization_status") or {}).get("authorization_state")
+
+
+def _manifest_is_non_production_authoritative(manifest: dict[str, Any] | None) -> bool:
+    if not manifest:
+        return False
+    authorization = manifest.get("authorization_status") or {}
+    return (
+        manifest.get("non_production_authoritative") is True
+        and authorization.get("authorization_state") == NON_PRODUCTION_AUTHORIZATION_STATE
+        and authorization.get("manifest_authorizes_production_routing") is False
+        and authorization.get("manifest_is_production_authoritative") is False
+        and authorization.get("manifest_is_production_approved") is False
+    )
+
+
+def _runtime_enabled(*values: Any) -> bool:
+    for value in values:
+        if not isinstance(value, dict):
+            continue
+        summary = value.get("summary") or {}
+        safety = value.get("safety_confirmations") or {}
+        if (
+            value.get("runtime_manifest_consumption_enabled")
+            or value.get("runtime_production_consumption_enabled")
+            or summary.get("runtime_manifest_consumption_enabled")
+            or summary.get("runtime_production_consumption_enabled")
+            or summary.get("manifest_runtime_consumption_enabled")
+            or safety.get("runtime_manifest_consumption_enabled")
+            or safety.get("runtime_production_consumption_enabled")
+        ):
+            return True
+    return False
+
+
+def _production_routing_authorized(*values: Any) -> bool:
+    for value in values:
+        if not isinstance(value, dict):
+            continue
+        summary = value.get("summary") or {}
+        safety = value.get("safety_confirmations") or {}
+        if (
+            value.get("production_default_routing_authorized")
+            or value.get("production_routing_authorized")
+            or summary.get("production_default_routing_authorized")
+            or summary.get("production_routing_authorized")
+            or safety.get("production_planner_routing_changed")
+        ):
+            return True
+    return False
+
+
+def _trace_key(record: dict[str, Any] | None) -> tuple[str, str] | None:
+    if not record:
+        return None
+    manifest_id = record.get("manifest_id")
+    fixture_set_id = record.get("fixture_set_id")
+    if not manifest_id or not fixture_set_id:
+        return None
+    return (str(manifest_id), str(fixture_set_id))
+
+
+def _record_sort_key(record: dict[str, Any]) -> tuple[str, str]:
+    return (
+        str(record.get("fixture_set_id") or ""),
+        str(record.get("manifest_id") or ""),
+    )
+
+
+def _source_hash(value: dict[str, Any] | list[dict[str, Any]]) -> str | None:
+    if isinstance(value, dict):
+        return value.get("deterministic_hash")
+    return None

--- a/backend/scripts/report_v3_1_limited_experimental_runtime_dry_run.py
+++ b/backend/scripts/report_v3_1_limited_experimental_runtime_dry_run.py
@@ -1,0 +1,194 @@
+"""Generate the v3.1 limited experimental runtime dry-run report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.planner_adapters.v3_1.limited_experimental_runtime_dry_run import build_limited_experimental_runtime_dry_run  # noqa: E402
+
+
+DETERMINISTIC_GENERATED_AT = "2026-05-15T00:00:00+00:00"
+
+
+def build_v3_1_limited_experimental_runtime_dry_run_report() -> dict[str, Any]:
+    repo_root = Path(__file__).resolve().parents[2]
+    guards = _read_json(repo_root / "docs" / "generated" / "v3_1_limited_experimental_runtime_guards_report.json")[
+        "limited_experimental_runtime_guards"
+    ]
+    readiness = _read_json(repo_root / "docs" / "generated" / "v3_1_controlled_consumption_promotion_readiness_report.json")[
+        "controlled_consumption_promotion_readiness"
+    ]
+    manifests = _read_json(repo_root / "docs" / "generated" / "v3_1_admission_aware_manifest_serialization_report.json")[
+        "admission_aware_manifest_serialization"
+    ]
+    validation = _read_json(repo_root / "docs" / "generated" / "v3_1_controlled_consumption_output_validation_report.json")[
+        "controlled_consumption_output_validation"
+    ]
+    structural = _read_json(repo_root / "docs" / "generated" / "v3_1_controlled_consumption_parity_snapshot_report.json")[
+        "controlled_consumption_parity_snapshot"
+    ]
+    semantic = _read_json(repo_root / "docs" / "generated" / "v3_1_trace_backfilled_semantic_parity_report.json")[
+        "trace_backfilled_semantic_parity"
+    ]
+    dry_run = build_limited_experimental_runtime_dry_run(
+        limited_experimental_runtime_guards=guards,
+        controlled_consumption_promotion_readiness=readiness,
+        admission_aware_manifest_serialization=manifests,
+        controlled_consumption_output_validation=validation,
+        controlled_consumption_parity_snapshot=structural,
+        trace_backfilled_semantic_parity=semantic,
+    )
+    repeated = build_limited_experimental_runtime_dry_run(
+        limited_experimental_runtime_guards=guards,
+        controlled_consumption_promotion_readiness=readiness,
+        admission_aware_manifest_serialization=manifests,
+        controlled_consumption_output_validation=validation,
+        controlled_consumption_parity_snapshot=structural,
+        trace_backfilled_semantic_parity=semantic,
+    )
+    report = {
+        "schema_version": "v3_1.limited_experimental_runtime_dry_run_report.1",
+        "generated_at": DETERMINISTIC_GENERATED_AT,
+        "phase": "v3.1_phase_26_limited_experimental_runtime_dry_run_adapter",
+        "recommendation": "OBSERVATIONAL_ONLY_DRY_RUN_DO_NOT_ENABLE_RUNTIME_MANIFEST_CONSUMPTION",
+        "runtime_manifest_consumption_enabled": False,
+        "runtime_production_consumption_enabled": False,
+        "production_routing_authorized": False,
+        "production_default_routing_authorized": False,
+        "summary": {
+            **dry_run["summary"],
+            "deterministic": dry_run["deterministic_hash"] == repeated["deterministic_hash"],
+        },
+        "limited_experimental_runtime_dry_run": dry_run,
+        "deterministic_guarantees": {
+            "passed": dry_run["deterministic_hash"] == repeated["deterministic_hash"],
+            "sample_hash": dry_run["deterministic_hash"],
+            "repeated_hash": repeated["deterministic_hash"],
+            "timestamp_excluded_from_hash": True,
+            "json_sort_keys": True,
+        },
+        "phase_26_boundaries": [
+            "dry-run is explicit and non-mutating",
+            "dry-run does not enable runtime manifest consumption",
+            "dry-run does not authorize production routing",
+            "manifests remain non-production-authoritative",
+            "production planner routing remains unchanged",
+            "legacy planner ownership remains intact",
+        ],
+        "metadata": {
+            "source": "v3_1_limited_experimental_runtime_dry_run_report",
+            "observational_only": True,
+            "dry_run_only": True,
+            "non_mutating": True,
+            "runtime_behavior_enabled": False,
+            "production_behavior_changed": False,
+            "production_default_routing_authorized": False,
+            "planner_remap_performed": False,
+        },
+    }
+    return _normalize_generated_at(report)
+
+
+def write_report(report: dict[str, Any], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_markdown(report: dict[str, Any], output_path: Path) -> None:
+    dry_run = report["limited_experimental_runtime_dry_run"]
+    summary = report["summary"]
+    evidence = dry_run["evidence_summary"]
+    lines = [
+        "# V3.1 Limited Experimental Runtime Dry Run",
+        "",
+        "Phase 26 exercises the guarded manifest path in dry-run mode only.",
+        "Dry-run is not production approval and does not enable runtime routing.",
+        "",
+        "## Recommendation",
+        "",
+        f"- Recommendation: `{report['recommendation']}`",
+        f"- Runtime manifest consumption enabled: `{str(report['runtime_manifest_consumption_enabled']).lower()}`",
+        f"- Production routing authorized: `{str(report['production_routing_authorized']).lower()}`",
+        "",
+        "## Summary",
+        "",
+        f"- Records evaluated: `{summary['records_evaluated']}`",
+        f"- Dry-run ready: `{summary['dry_run_ready_count']}`",
+        f"- Blocked: `{summary['blocked_count']}`",
+        f"- Runtime manifest consumption enabled: `{str(summary['runtime_manifest_consumption_enabled']).lower()}`",
+        f"- Production routing authorized: `{str(summary['production_routing_authorized']).lower()}`",
+        f"- Deterministic: `{str(summary['deterministic']).lower()}`",
+        "",
+        "## Evidence Summary",
+        "",
+    ]
+    for key, value in evidence.items():
+        lines.append(f"- {key}: `{value}`")
+    lines.extend(["", "## Blocker Reasons", "", "| Reason | Count |", "| --- | ---: |"])
+    for reason, count in dry_run["blocker_reason_counts"].items():
+        lines.append(f"| `{reason}` | `{count}` |")
+    lines.extend(
+        [
+            "",
+            "## Dry-Run Records",
+            "",
+            "| Record | Manifest | Fixture Set | Dry-Run Status |",
+            "| --- | --- | --- | --- |",
+        ]
+    )
+    for row in dry_run["limited_experimental_runtime_dry_run_records"]:
+        lines.append(
+            f"| `{row['limited_runtime_dry_run_id']}` | `{row['manifest_id'] or ''}` | `{row['fixture_set_id'] or ''}` | `{row['dry_run_status']}` |"
+        )
+    lines.extend(["", "## Phase 26 Boundaries", ""])
+    lines.extend(f"- {item}" for item in report["phase_26_boundaries"])
+    lines.extend(
+        [
+            "",
+            "## Conclusion",
+            "",
+            "Limited experimental runtime dry-run evidence is available for governance review, while runtime consumption and production routing remain disabled.",
+        ]
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _normalize_generated_at(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: DETERMINISTIC_GENERATED_AT if key == "generated_at" else _normalize_generated_at(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_normalize_generated_at(item) for item in value]
+    return deepcopy(value)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", default="docs/generated/v3_1_limited_experimental_runtime_dry_run_report.json")
+    parser.add_argument("--markdown-output", default="docs/migration/V3_1_LIMITED_EXPERIMENTAL_RUNTIME_DRY_RUN.md")
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[2]
+    report = build_v3_1_limited_experimental_runtime_dry_run_report()
+    write_report(report, repo_root / args.output)
+    write_markdown(report, repo_root / args.markdown_output)
+    print(json.dumps(report["summary"], indent=2, sort_keys=True))
+    print(report["recommendation"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_v3_1_limited_experimental_runtime_dry_run.py
+++ b/backend/tests/test_v3_1_limited_experimental_runtime_dry_run.py
@@ -1,0 +1,219 @@
+from app.planner_adapters.v3_1.limited_experimental_runtime_dry_run import build_limited_experimental_runtime_dry_run
+from scripts.report_v3_1_limited_experimental_runtime_dry_run import build_v3_1_limited_experimental_runtime_dry_run_report
+
+
+def test_valid_guard_readiness_manifest_evidence_produces_dry_run_ready():
+    result = _build()
+
+    record = result["limited_experimental_runtime_dry_run_records"][0]
+    assert record["dry_run_status"] == "dry_run_ready"
+    assert result["summary"]["dry_run_ready_count"] == 1
+
+
+def test_missing_guard_blocks():
+    result = _build(guards=[])
+
+    assert result["limited_experimental_runtime_dry_run_records"][0]["dry_run_status"] == "blocked_missing_guard_contract"
+
+
+def test_invalid_guard_status_blocks():
+    result = _build(guards=[_guard_record(status="blocked_missing_non_production_manifest")])
+
+    assert result["limited_experimental_runtime_dry_run_records"][0]["dry_run_status"] == "blocked_invalid_guard_status"
+
+
+def test_missing_promotion_readiness_blocks():
+    result = _build(readiness=[])
+
+    assert result["limited_experimental_runtime_dry_run_records"][0]["dry_run_status"] == "blocked_missing_promotion_readiness"
+
+
+def test_invalid_authorization_state_blocks():
+    result = _build(guards=[_guard_record(authorization_state="production_authoritative")])
+
+    assert result["limited_experimental_runtime_dry_run_records"][0]["dry_run_status"] == "blocked_invalid_authorization_state"
+
+
+def test_runtime_consumption_enabled_blocks():
+    guards = _payload("limited_experimental_runtime_guard_records", [_guard_record()])
+    guards["summary"]["runtime_manifest_consumption_enabled"] = True
+    result = build_limited_experimental_runtime_dry_run(
+        limited_experimental_runtime_guards=guards,
+        controlled_consumption_promotion_readiness=_payload("promotion_readiness_records", [_readiness_record()]),
+        admission_aware_manifest_serialization=_payload("serialized_manifests", [_manifest_record()]),
+        controlled_consumption_output_validation=_payload("validation_records", [_validation_record()]),
+        controlled_consumption_parity_snapshot=_payload("parity_records", [_structural_record()]),
+        trace_backfilled_semantic_parity=_payload("trace_backfilled_semantic_parity_records", [_semantic_record()]),
+    )
+
+    assert result["limited_experimental_runtime_dry_run_records"][0]["dry_run_status"] == "blocked_runtime_consumption_enabled"
+
+
+def test_production_routing_authorized_blocks():
+    guards = _payload("limited_experimental_runtime_guard_records", [_guard_record()])
+    guards["summary"]["production_default_routing_authorized"] = True
+    result = build_limited_experimental_runtime_dry_run(
+        limited_experimental_runtime_guards=guards,
+        controlled_consumption_promotion_readiness=_payload("promotion_readiness_records", [_readiness_record()]),
+        admission_aware_manifest_serialization=_payload("serialized_manifests", [_manifest_record()]),
+        controlled_consumption_output_validation=_payload("validation_records", [_validation_record()]),
+        controlled_consumption_parity_snapshot=_payload("parity_records", [_structural_record()]),
+        trace_backfilled_semantic_parity=_payload("trace_backfilled_semantic_parity_records", [_semantic_record()]),
+    )
+
+    assert result["limited_experimental_runtime_dry_run_records"][0]["dry_run_status"] == "blocked_production_routing_authorized"
+
+
+def test_missing_manifest_blocks():
+    result = _build(manifests=[])
+
+    assert result["limited_experimental_runtime_dry_run_records"][0]["dry_run_status"] == "blocked_missing_manifest"
+
+
+def test_missing_validated_evidence_blocks():
+    result = _build(validations=[])
+
+    assert result["limited_experimental_runtime_dry_run_records"][0]["dry_run_status"] == "blocked_missing_validated_evidence"
+
+
+def test_deterministic_ordering():
+    first = _build(
+        guards=[_guard_record("manifest_b", "set_b"), _guard_record("manifest_a", "set_a")],
+        readiness=[_readiness_record("manifest_b", "set_b"), _readiness_record("manifest_a", "set_a")],
+        manifests=[_manifest_record("manifest_b", "set_b"), _manifest_record("manifest_a", "set_a")],
+        validations=[_validation_record("manifest_b", "set_b"), _validation_record("manifest_a", "set_a")],
+        structural=[_structural_record("manifest_b", "set_b"), _structural_record("manifest_a", "set_a")],
+        semantic=[_semantic_record("manifest_b", "set_b"), _semantic_record("manifest_a", "set_a")],
+    )
+    second = _build(
+        guards=[_guard_record("manifest_a", "set_a"), _guard_record("manifest_b", "set_b")],
+        readiness=[_readiness_record("manifest_a", "set_a"), _readiness_record("manifest_b", "set_b")],
+        manifests=[_manifest_record("manifest_a", "set_a"), _manifest_record("manifest_b", "set_b")],
+        validations=[_validation_record("manifest_a", "set_a"), _validation_record("manifest_b", "set_b")],
+        structural=[_structural_record("manifest_a", "set_a"), _structural_record("manifest_b", "set_b")],
+        semantic=[_semantic_record("manifest_a", "set_a"), _semantic_record("manifest_b", "set_b")],
+    )
+
+    assert first["deterministic_hash"] == second["deterministic_hash"]
+    assert [row["manifest_id"] for row in first["limited_experimental_runtime_dry_run_records"]] == ["manifest_a", "manifest_b"]
+
+
+def test_stable_report_generation():
+    first = build_v3_1_limited_experimental_runtime_dry_run_report()
+    second = build_v3_1_limited_experimental_runtime_dry_run_report()
+
+    assert first["deterministic_guarantees"]["passed"] is True
+    assert first["limited_experimental_runtime_dry_run"]["deterministic_hash"] == second["limited_experimental_runtime_dry_run"]["deterministic_hash"]
+    assert first["summary"] == second["summary"]
+
+
+def test_no_production_routing_enablement():
+    result = _build()
+    record = result["limited_experimental_runtime_dry_run_records"][0]
+
+    assert result["safety_confirmations"]["dry_run_enables_runtime_routing"] is False
+    assert result["safety_confirmations"]["dry_run_authorizes_production_routing"] is False
+    assert result["safety_confirmations"]["dry_run_is_production_approval"] is False
+    assert record["dry_run_enables_runtime_routing"] is False
+
+
+def _build(guards=None, readiness=None, manifests=None, validations=None, structural=None, semantic=None):
+    return build_limited_experimental_runtime_dry_run(
+        limited_experimental_runtime_guards=_payload("limited_experimental_runtime_guard_records", [_guard_record()] if guards is None else guards),
+        controlled_consumption_promotion_readiness=_payload("promotion_readiness_records", [_readiness_record()] if readiness is None else readiness),
+        admission_aware_manifest_serialization=_payload("serialized_manifests", [_manifest_record()] if manifests is None else manifests),
+        controlled_consumption_output_validation=_payload("validation_records", [_validation_record()] if validations is None else validations),
+        controlled_consumption_parity_snapshot=_payload("parity_records", [_structural_record()] if structural is None else structural),
+        trace_backfilled_semantic_parity=_payload("trace_backfilled_semantic_parity_records", [_semantic_record()] if semantic is None else semantic),
+    )
+
+
+def _payload(key, records):
+    return {
+        "schema_version": f"v3_1.test.{key}.1",
+        "deterministic_hash": f"{key}-hash",
+        "summary": {
+            "runtime_manifest_consumption_enabled": False,
+            "runtime_production_consumption_enabled": False,
+            "production_default_routing_authorized": False,
+            "production_routing_authorized": False,
+        },
+        "safety_confirmations": {
+            "runtime_manifest_consumption_enabled": False,
+            "runtime_production_consumption_enabled": False,
+            "production_planner_routing_changed": False,
+        },
+        key: records,
+    }
+
+
+def _guard_record(manifest_id="manifest_a", fixture_set_id="set_a", status="guard_contract_ready", authorization_state="non_production_authoritative"):
+    return {
+        "manifest_id": manifest_id,
+        "fixture_set_id": fixture_set_id,
+        "guard_contract_status": status,
+        "promotion_readiness_status": "ready_for_limited_experimental_runtime_consideration",
+        "authorization_state": authorization_state,
+        "runtime_consumption_enabled": False,
+        "production_routing_authorized": False,
+        "guard_readiness_enables_runtime_behavior": False,
+        "guard_readiness_authorizes_production_routing": False,
+        "production_output_affected": False,
+    }
+
+
+def _readiness_record(manifest_id="manifest_a", fixture_set_id="set_a"):
+    return {
+        "manifest_id": manifest_id,
+        "fixture_set_id": fixture_set_id,
+        "promotion_readiness_status": "ready_for_limited_experimental_runtime_consideration",
+        "promotion_readiness_authorizes_production_routing": False,
+        "production_output_affected": False,
+    }
+
+
+def _manifest_record(manifest_id="manifest_a", fixture_set_id="set_a", authorization_state="non_production_authoritative"):
+    return {
+        "manifest_id": manifest_id,
+        "fixture_set_id": fixture_set_id,
+        "serialization_status": "serialized_manifest",
+        "authorization_status": {
+            "authorization_state": authorization_state,
+            "manifest_authorizes_production_routing": False,
+            "manifest_is_production_approved": False,
+            "manifest_is_production_authoritative": False,
+        },
+        "non_production_authoritative": True,
+        "production_output_affected": False,
+    }
+
+
+def _validation_record(manifest_id="manifest_a", fixture_set_id="set_a"):
+    return {
+        "manifest_id": manifest_id,
+        "fixture_set_id": fixture_set_id,
+        "validation_status": "valid_controlled_test_output",
+        "traceability_summary": {"authorization_state": "non_production_authoritative"},
+        "validation_authorizes_production_routing": False,
+        "production_output_affected": False,
+    }
+
+
+def _structural_record(manifest_id="manifest_a", fixture_set_id="set_a"):
+    return {
+        "manifest_id": manifest_id,
+        "fixture_set_id": fixture_set_id,
+        "parity_status": "parity_confirmed",
+        "parity_authorizes_production_routing": False,
+        "production_output_affected": False,
+    }
+
+
+def _semantic_record(manifest_id="manifest_a", fixture_set_id="set_a"):
+    return {
+        "manifest_id": manifest_id,
+        "fixture_set_id": fixture_set_id,
+        "final_semantic_parity_status": "semantic_parity_confirmed",
+        "semantic_parity_authorizes_production_routing": False,
+        "production_output_affected": False,
+    }

--- a/docs/generated/v3_1_limited_experimental_runtime_dry_run_report.json
+++ b/docs/generated/v3_1_limited_experimental_runtime_dry_run_report.json
@@ -1,0 +1,161 @@
+{
+  "deterministic_guarantees": {
+    "json_sort_keys": true,
+    "passed": true,
+    "repeated_hash": "94e78981dd86e29bee96a286817cee5df86ccbf92cbe45fc03963518487f0950",
+    "sample_hash": "94e78981dd86e29bee96a286817cee5df86ccbf92cbe45fc03963518487f0950",
+    "timestamp_excluded_from_hash": true
+  },
+  "generated_at": "2026-05-15T00:00:00+00:00",
+  "limited_experimental_runtime_dry_run": {
+    "blocker_reason_counts": {},
+    "deterministic_hash": "94e78981dd86e29bee96a286817cee5df86ccbf92cbe45fc03963518487f0950",
+    "dry_run_status_counts": {
+      "blocked_invalid_authorization_state": 0,
+      "blocked_invalid_guard_status": 0,
+      "blocked_missing_guard_contract": 0,
+      "blocked_missing_manifest": 0,
+      "blocked_missing_promotion_readiness": 0,
+      "blocked_missing_validated_evidence": 0,
+      "blocked_production_routing_authorized": 0,
+      "blocked_runtime_consumption_enabled": 0,
+      "dry_run_ready": 1
+    },
+    "evidence_summary": {
+      "dry_run_mutates_runtime_state": false,
+      "guard_records": 1,
+      "production_routing_authorized": false,
+      "promotion_readiness_records": 1,
+      "runtime_manifest_consumption_enabled": false,
+      "semantic_parity_records": 1,
+      "serialized_manifests": 1,
+      "structural_parity_records": 1,
+      "validation_records": 1
+    },
+    "limited_experimental_runtime_dry_run_records": [
+      {
+        "authorization_state": "non_production_authoritative",
+        "blockers": [],
+        "dry_run_authorizes_production_routing": false,
+        "dry_run_enables_runtime_routing": false,
+        "dry_run_status": "dry_run_ready",
+        "evidence_summary": {
+          "dry_run_mutates_runtime_state": false,
+          "manifest_present": true,
+          "production_routing_authorized": false,
+          "runtime_consumption_enabled": false,
+          "semantic_parity_status": "semantic_parity_confirmed",
+          "structural_parity_status": "parity_confirmed",
+          "validation_status": "valid_controlled_test_output"
+        },
+        "fixture_set_id": "v3_1_fixture_set_6d3b668a84cfbb69",
+        "guard_status": "guard_contract_ready",
+        "limited_runtime_dry_run_id": "v3_1_limited_runtime_dry_run_45df3b40e83dc4fd",
+        "manifest_id": "v3_1_admission_manifest_198a3e2110f9e5e4",
+        "metadata": {
+          "dry_run_only": true,
+          "non_mutating": true,
+          "observational_only": true,
+          "planner_remap_performed": false,
+          "production_consumer": false,
+          "runtime_behavior_enabled": false
+        },
+        "production_output_affected": false,
+        "promotion_readiness_status": "ready_for_limited_experimental_runtime_consideration"
+      }
+    ],
+    "metadata": {
+      "deterministic_serializer": "json_sort_keys_sha256",
+      "dry_run_only": true,
+      "non_mutating": true,
+      "observational_only": true,
+      "planner_remap_performed": false,
+      "production_behavior_changed": false,
+      "production_consumer": false,
+      "production_default_routing_authorized": false,
+      "runtime_behavior_enabled": false,
+      "source": "v3_1_limited_experimental_runtime_dry_run",
+      "stable_generation_token": "v3_1_phase_26_limited_experimental_runtime_dry_run_token"
+    },
+    "run": {
+      "admission_aware_manifest_serialization_hash": "8fa65134e7e0bf7f839c2ad01b22b26b7fc59c26787f23b7c13331fc5654ecda",
+      "controlled_consumption_output_validation_hash": "3364892148b06185a66ca86a64243a32ab54324995ed8752be795bed78300677",
+      "controlled_consumption_parity_snapshot_hash": "5e5744d7474cc3e8ca26e1163178c65744e46a07f01674bc4b11acbec486b20c",
+      "controlled_consumption_promotion_readiness_hash": "65e0814411b9053c2fd50da6c80fbaf960280beee4ddaee2c6a978c32ae6516c",
+      "guard_record_count": 1,
+      "limited_experimental_runtime_guards_hash": "5545f8146c04f2869bcfe3c76cf1040e08e51ef73d3669d7b415acd22d1ee4e2",
+      "promotion_readiness_record_count": 1,
+      "run_id": "v3_1_phase_26_limited_experimental_runtime_dry_run",
+      "semantic_parity_record_count": 1,
+      "serialized_manifest_count": 1,
+      "structural_parity_record_count": 1,
+      "trace_backfilled_semantic_parity_hash": "1d50646772e3803ae099d697d8a2454b708376454813bbbf286dac3dfdbcf0d7",
+      "validation_record_count": 1
+    },
+    "safety_confirmations": {
+      "dry_run_authorizes_production_routing": false,
+      "dry_run_enables_runtime_routing": false,
+      "dry_run_is_production_approval": false,
+      "dry_run_mutates_runtime_state": false,
+      "legacy_planner_ownership_preserved": true,
+      "production_behavior_changed": false,
+      "production_output_affected": false,
+      "production_planner_routing_changed": false,
+      "runtime_manifest_consumption_enabled": false,
+      "runtime_production_consumption_enabled": false,
+      "trusted_data_default_truth": false
+    },
+    "schema_version": "v3_1.limited_experimental_runtime_dry_run.1",
+    "summary": {
+      "blocked_count": 0,
+      "deterministic": true,
+      "dry_run_ready_count": 1,
+      "production_affected_count": 0,
+      "production_behavior_changed": false,
+      "production_default_routing_authorized": false,
+      "production_output_affected": false,
+      "production_routing_authorized": false,
+      "records_evaluated": 1,
+      "runtime_manifest_consumption_enabled": false,
+      "runtime_production_consumption_enabled": false
+    }
+  },
+  "metadata": {
+    "dry_run_only": true,
+    "non_mutating": true,
+    "observational_only": true,
+    "planner_remap_performed": false,
+    "production_behavior_changed": false,
+    "production_default_routing_authorized": false,
+    "runtime_behavior_enabled": false,
+    "source": "v3_1_limited_experimental_runtime_dry_run_report"
+  },
+  "phase": "v3.1_phase_26_limited_experimental_runtime_dry_run_adapter",
+  "phase_26_boundaries": [
+    "dry-run is explicit and non-mutating",
+    "dry-run does not enable runtime manifest consumption",
+    "dry-run does not authorize production routing",
+    "manifests remain non-production-authoritative",
+    "production planner routing remains unchanged",
+    "legacy planner ownership remains intact"
+  ],
+  "production_default_routing_authorized": false,
+  "production_routing_authorized": false,
+  "recommendation": "OBSERVATIONAL_ONLY_DRY_RUN_DO_NOT_ENABLE_RUNTIME_MANIFEST_CONSUMPTION",
+  "runtime_manifest_consumption_enabled": false,
+  "runtime_production_consumption_enabled": false,
+  "schema_version": "v3_1.limited_experimental_runtime_dry_run_report.1",
+  "summary": {
+    "blocked_count": 0,
+    "deterministic": true,
+    "dry_run_ready_count": 1,
+    "production_affected_count": 0,
+    "production_behavior_changed": false,
+    "production_default_routing_authorized": false,
+    "production_output_affected": false,
+    "production_routing_authorized": false,
+    "records_evaluated": 1,
+    "runtime_manifest_consumption_enabled": false,
+    "runtime_production_consumption_enabled": false
+  }
+}

--- a/docs/migration/V3_1_LIMITED_EXPERIMENTAL_RUNTIME_DRY_RUN.md
+++ b/docs/migration/V3_1_LIMITED_EXPERIMENTAL_RUNTIME_DRY_RUN.md
@@ -1,0 +1,55 @@
+# V3.1 Limited Experimental Runtime Dry Run
+
+Phase 26 exercises the guarded manifest path in dry-run mode only.
+Dry-run is not production approval and does not enable runtime routing.
+
+## Recommendation
+
+- Recommendation: `OBSERVATIONAL_ONLY_DRY_RUN_DO_NOT_ENABLE_RUNTIME_MANIFEST_CONSUMPTION`
+- Runtime manifest consumption enabled: `false`
+- Production routing authorized: `false`
+
+## Summary
+
+- Records evaluated: `1`
+- Dry-run ready: `1`
+- Blocked: `0`
+- Runtime manifest consumption enabled: `false`
+- Production routing authorized: `false`
+- Deterministic: `true`
+
+## Evidence Summary
+
+- guard_records: `1`
+- promotion_readiness_records: `1`
+- serialized_manifests: `1`
+- validation_records: `1`
+- structural_parity_records: `1`
+- semantic_parity_records: `1`
+- runtime_manifest_consumption_enabled: `False`
+- production_routing_authorized: `False`
+- dry_run_mutates_runtime_state: `False`
+
+## Blocker Reasons
+
+| Reason | Count |
+| --- | ---: |
+
+## Dry-Run Records
+
+| Record | Manifest | Fixture Set | Dry-Run Status |
+| --- | --- | --- | --- |
+| `v3_1_limited_runtime_dry_run_45df3b40e83dc4fd` | `v3_1_admission_manifest_198a3e2110f9e5e4` | `v3_1_fixture_set_6d3b668a84cfbb69` | `dry_run_ready` |
+
+## Phase 26 Boundaries
+
+- dry-run is explicit and non-mutating
+- dry-run does not enable runtime manifest consumption
+- dry-run does not authorize production routing
+- manifests remain non-production-authoritative
+- production planner routing remains unchanged
+- legacy planner ownership remains intact
+
+## Conclusion
+
+Limited experimental runtime dry-run evidence is available for governance review, while runtime consumption and production routing remain disabled.


### PR DESCRIPTION
Adds deterministic dry-run-only experimental runtime adapter for guarded non-production manifests while preserving disabled runtime consumption and production routing isolation.