### PR TITLE
v3.1: add dry-run result stability audit

### DIFF
--- a/backend/app/planner_adapters/v3_1/__init__.py
+++ b/backend/app/planner_adapters/v3_1/__init__.py
@@ -44,6 +44,10 @@ from .limited_experimental_runtime_dry_run import (
     LIMITED_EXPERIMENTAL_RUNTIME_DRY_RUN_STATUSES,
     build_limited_experimental_runtime_dry_run,
 )
+from .dry_run_result_stability import (
+    DRY_RUN_RESULT_STABILITY_STATUSES,
+    audit_dry_run_result_stability,
+)
 from .review_policy_evaluation import (
     REVIEW_POLICY_OUTCOMES,
     V31ReviewPolicyEvaluation,
@@ -130,6 +134,7 @@ __all__ = [
     "CONTROLLED_CONSUMPTION_PROMOTION_READINESS_STATUSES",
     "LIMITED_EXPERIMENTAL_RUNTIME_GUARD_STATUSES",
     "LIMITED_EXPERIMENTAL_RUNTIME_DRY_RUN_STATUSES",
+    "DRY_RUN_RESULT_STABILITY_STATUSES",
     "FIXTURE_WORKFLOW_STATES",
     "FIXTURE_SET_LIFECYCLE_STATES",
     "REVIEW_POLICY_OUTCOMES",
@@ -167,6 +172,7 @@ __all__ = [
     "build_controlled_consumption_promotion_readiness",
     "build_limited_experimental_runtime_guards",
     "build_limited_experimental_runtime_dry_run",
+    "audit_dry_run_result_stability",
     "build_default_trusted_repository_probes",
     "build_fixture_set_readiness_gate",
     "evaluate_fixture_source_admission_policy",

--- a/backend/app/planner_adapters/v3_1/dry_run_result_stability.py
+++ b/backend/app/planner_adapters/v3_1/dry_run_result_stability.py
@@ -1,0 +1,234 @@
+"""Dry-run result stability audit for v3.1 governance.
+
+The audit compares repeated limited experimental runtime dry-run snapshots and
+keeps the result observational only. It does not enable runtime consumption or
+production routing.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from copy import deepcopy
+from typing import Any
+
+from .trusted_shadow_consumption import deterministic_hash
+
+
+DRY_RUN_RESULT_STABILITY_STATUSES = (
+    "dry_run_stable",
+    "blocked_missing_dry_run_record",
+    "blocked_snapshot_count_insufficient",
+    "blocked_manifest_identity_drift",
+    "blocked_fixture_set_identity_drift",
+    "blocked_guard_status_drift",
+    "blocked_readiness_status_drift",
+    "blocked_authorization_state_drift",
+    "blocked_dry_run_status_drift",
+)
+STABLE_DRY_RUN_RESULT_STABILITY_TOKEN = "v3_1_phase_27_dry_run_result_stability_token"
+_DRIFT_FIELD_TO_BLOCKER = {
+    "manifest_id": "blocked_manifest_identity_drift",
+    "fixture_set_id": "blocked_fixture_set_identity_drift",
+    "guard_status": "blocked_guard_status_drift",
+    "promotion_readiness_status": "blocked_readiness_status_drift",
+    "authorization_state": "blocked_authorization_state_drift",
+    "dry_run_status": "blocked_dry_run_status_drift",
+}
+
+
+def audit_dry_run_result_stability(
+    dry_run_snapshots: list[dict[str, Any] | list[dict[str, Any]]],
+    *,
+    run_id: str = "v3_1_phase_27_dry_run_result_stability",
+) -> dict[str, Any]:
+    """Compare repeated dry-run snapshots and expose deterministic drift records."""
+
+    normalized_snapshots = [_dry_run_records(snapshot) for snapshot in dry_run_snapshots]
+    snapshot_count = len(normalized_snapshots)
+    keys = sorted(
+        {
+            key
+            for snapshot in normalized_snapshots
+            for record in snapshot
+            for key in [_comparison_key(record)]
+            if key is not None
+        },
+        key=lambda item: (item[0], item[1], item[2]),
+    )
+    if not keys:
+        keys = [(None, None, None)]
+
+    records = [
+        _stability_record(
+            key=key,
+            snapshots=normalized_snapshots,
+            snapshot_count=snapshot_count,
+        )
+        for key in keys
+    ]
+    counts = Counter(record["stability_status"] for record in records)
+    drift_reasons = Counter(reason for record in records for reason in record["blockers"])
+    envelope = {
+        "schema_version": "v3_1.dry_run_result_stability.1",
+        "run": {
+            "run_id": run_id,
+            "snapshot_count": snapshot_count,
+            "snapshot_record_counts": [len(snapshot) for snapshot in normalized_snapshots],
+            "snapshot_hashes": [_source_hash(snapshot) for snapshot in dry_run_snapshots],
+        },
+        "summary": {
+            "records_evaluated": len(records),
+            "stable_count": counts["dry_run_stable"],
+            "blocked_count": len(records) - counts["dry_run_stable"],
+            "runtime_manifest_consumption_enabled": False,
+            "runtime_production_consumption_enabled": False,
+            "production_routing_authorized": False,
+            "production_default_routing_authorized": False,
+            "production_affected_count": 0,
+            "production_output_affected": False,
+            "production_behavior_changed": False,
+            "deterministic": True,
+        },
+        "stability_status_counts": {
+            status: counts[status]
+            for status in DRY_RUN_RESULT_STABILITY_STATUSES
+        },
+        "drift_reason_counts": dict(sorted(drift_reasons.items())),
+        "compared_snapshot_summary": {
+            "compared_snapshot_count": snapshot_count,
+            "snapshot_count_sufficient": snapshot_count >= 2,
+            "records_per_snapshot": [len(snapshot) for snapshot in normalized_snapshots],
+            "runtime_manifest_consumption_enabled": False,
+            "production_routing_authorized": False,
+        },
+        "dry_run_result_stability_records": records,
+        "safety_confirmations": {
+            "stability_authorizes_production_routing": False,
+            "stability_enables_runtime_manifest_consumption": False,
+            "stability_is_production_approval": False,
+            "runtime_manifest_consumption_enabled": False,
+            "runtime_production_consumption_enabled": False,
+            "legacy_planner_ownership_preserved": True,
+            "production_output_affected": False,
+            "production_behavior_changed": False,
+            "production_planner_routing_changed": False,
+            "trusted_data_default_truth": False,
+        },
+        "metadata": {
+            "source": "v3_1_dry_run_result_stability",
+            "observational_only": True,
+            "dry_run_governance_only": True,
+            "runtime_behavior_enabled": False,
+            "production_consumer": False,
+            "production_behavior_changed": False,
+            "planner_remap_performed": False,
+            "production_default_routing_authorized": False,
+            "stable_generation_token": STABLE_DRY_RUN_RESULT_STABILITY_TOKEN,
+            "deterministic_serializer": "json_sort_keys_sha256",
+        },
+    }
+    envelope["deterministic_hash"] = deterministic_hash(envelope)
+    return envelope
+
+
+def _stability_record(
+    *,
+    key: tuple[str | None, str | None, str | None],
+    snapshots: list[list[dict[str, Any]]],
+    snapshot_count: int,
+) -> dict[str, Any]:
+    _, manifest_id, fixture_set_id = key
+    matches = [_find_record(snapshot, key) for snapshot in snapshots]
+    present = [record for record in matches if record is not None]
+    drift_fields = _drift_fields(present)
+    blockers: list[str] = []
+    if snapshot_count < 2:
+        blockers.append("blocked_snapshot_count_insufficient")
+    if not present or len(present) != snapshot_count:
+        blockers.append("blocked_missing_dry_run_record")
+    for field in drift_fields:
+        blockers.append(_DRIFT_FIELD_TO_BLOCKER[field])
+    blockers = sorted(set(blockers), key=blockers.index)
+    status = blockers[0] if blockers else "dry_run_stable"
+    seed = {
+        "manifest_id": manifest_id,
+        "fixture_set_id": fixture_set_id,
+        "status": status,
+        "token": STABLE_DRY_RUN_RESULT_STABILITY_TOKEN,
+    }
+    reference = present[0] if present else {}
+    return {
+        "dry_run_stability_id": f"v3_1_dry_run_stability_{deterministic_hash(seed)[:16]}",
+        "manifest_id": manifest_id or reference.get("manifest_id"),
+        "fixture_set_id": fixture_set_id or reference.get("fixture_set_id"),
+        "compared_snapshot_count": snapshot_count,
+        "stability_status": status,
+        "drift_fields": drift_fields,
+        "blockers": blockers,
+        "field_values": {
+            field: _stable_values(present, field)
+            for field in _DRIFT_FIELD_TO_BLOCKER
+        },
+        "stability_authorizes_production_routing": False,
+        "production_output_affected": False,
+        "metadata": {
+            "observational_only": True,
+            "dry_run_governance_only": True,
+            "runtime_behavior_enabled": False,
+            "production_consumer": False,
+            "planner_remap_performed": False,
+            "stability_does_not_authorize_production_routing": True,
+        },
+    }
+
+
+def _dry_run_records(value: dict[str, Any] | list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if isinstance(value, list):
+        return [deepcopy(record) for record in value]
+    return [
+        deepcopy(record)
+        for record in value.get("limited_experimental_runtime_dry_run_records", [])
+    ]
+
+
+def _comparison_key(record: dict[str, Any]) -> tuple[str, str, str] | None:
+    record_id = record.get("limited_runtime_dry_run_id")
+    manifest_id = record.get("manifest_id")
+    fixture_set_id = record.get("fixture_set_id")
+    if record_id is None and manifest_id is None and fixture_set_id is None:
+        return None
+    if record_id is not None:
+        return (str(record_id), "", "")
+    return (str(record_id or ""), str(manifest_id or ""), str(fixture_set_id or ""))
+
+
+def _find_record(snapshot: list[dict[str, Any]], key: tuple[str | None, str | None, str | None]) -> dict[str, Any] | None:
+    for record in snapshot:
+        if _comparison_key(record) == key:
+            return record
+    record_id, _, _ = key
+    if record_id:
+        for record in snapshot:
+            if str(record.get("limited_runtime_dry_run_id") or "") == record_id:
+                return record
+    return None
+
+
+def _drift_fields(records: list[dict[str, Any]]) -> list[str]:
+    drifted: list[str] = []
+    if len(records) < 2:
+        return drifted
+    for field in _DRIFT_FIELD_TO_BLOCKER:
+        if len({record.get(field) for record in records}) > 1:
+            drifted.append(field)
+    return drifted
+
+
+def _stable_values(records: list[dict[str, Any]], field: str) -> list[Any]:
+    return [record.get(field) for record in records]
+
+
+def _source_hash(value: dict[str, Any] | list[dict[str, Any]]) -> str | None:
+    if isinstance(value, dict):
+        return value.get("deterministic_hash")
+    return None

--- a/backend/scripts/report_v3_1_dry_run_result_stability.py
+++ b/backend/scripts/report_v3_1_dry_run_result_stability.py
@@ -1,0 +1,163 @@
+"""Generate the v3.1 dry-run result stability audit report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.planner_adapters.v3_1.dry_run_result_stability import audit_dry_run_result_stability  # noqa: E402
+from scripts.report_v3_1_limited_experimental_runtime_dry_run import build_v3_1_limited_experimental_runtime_dry_run_report  # noqa: E402
+
+
+DETERMINISTIC_GENERATED_AT = "2026-05-15T00:00:00+00:00"
+
+
+def build_v3_1_dry_run_result_stability_report() -> dict[str, Any]:
+    first_report = build_v3_1_limited_experimental_runtime_dry_run_report()
+    second_report = build_v3_1_limited_experimental_runtime_dry_run_report()
+    first_snapshot = first_report["limited_experimental_runtime_dry_run"]
+    second_snapshot = second_report["limited_experimental_runtime_dry_run"]
+    stability = audit_dry_run_result_stability([first_snapshot, second_snapshot])
+    report = {
+        "schema_version": "v3_1.dry_run_result_stability_report.1",
+        "generated_at": DETERMINISTIC_GENERATED_AT,
+        "phase": "v3.1_phase_27_dry_run_result_stability_audit",
+        "recommendation": "OBSERVATIONAL_ONLY_STABILITY_AUDIT_DO_NOT_ENABLE_RUNTIME_MANIFEST_CONSUMPTION",
+        "runtime_manifest_consumption_enabled": False,
+        "runtime_production_consumption_enabled": False,
+        "production_routing_authorized": False,
+        "production_default_routing_authorized": False,
+        "summary": stability["summary"],
+        "dry_run_result_stability": stability,
+        "deterministic_guarantees": {
+            "passed": first_snapshot["deterministic_hash"] == second_snapshot["deterministic_hash"],
+            "sample_hash": first_snapshot["deterministic_hash"],
+            "repeated_hash": second_snapshot["deterministic_hash"],
+            "stability_hash": stability["deterministic_hash"],
+            "timestamp_excluded_from_hash": True,
+            "json_sort_keys": True,
+        },
+        "phase_27_boundaries": [
+            "stability audit compares repeated dry-run snapshots only",
+            "stability audit does not enable runtime manifest consumption",
+            "stability audit does not authorize production routing",
+            "manifests remain non-production-authoritative",
+            "production planner routing remains unchanged",
+            "legacy planner ownership remains intact",
+        ],
+        "metadata": {
+            "source": "v3_1_dry_run_result_stability_report",
+            "observational_only": True,
+            "dry_run_governance_only": True,
+            "runtime_behavior_enabled": False,
+            "production_behavior_changed": False,
+            "production_default_routing_authorized": False,
+            "planner_remap_performed": False,
+        },
+    }
+    return _normalize_generated_at(report)
+
+
+def write_report(report: dict[str, Any], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_markdown(report: dict[str, Any], output_path: Path) -> None:
+    stability = report["dry_run_result_stability"]
+    summary = report["summary"]
+    compared = stability["compared_snapshot_summary"]
+    lines = [
+        "# V3.1 Dry-Run Result Stability",
+        "",
+        "Phase 27 verifies repeated limited experimental runtime dry-run results are deterministic.",
+        "Dry-run stability is not production approval and does not enable runtime routing.",
+        "",
+        "## Recommendation",
+        "",
+        f"- Recommendation: `{report['recommendation']}`",
+        f"- Runtime manifest consumption enabled: `{str(report['runtime_manifest_consumption_enabled']).lower()}`",
+        f"- Production routing authorized: `{str(report['production_routing_authorized']).lower()}`",
+        "",
+        "## Summary",
+        "",
+        f"- Records evaluated: `{summary['records_evaluated']}`",
+        f"- Stable: `{summary['stable_count']}`",
+        f"- Blocked: `{summary['blocked_count']}`",
+        f"- Runtime manifest consumption enabled: `{str(summary['runtime_manifest_consumption_enabled']).lower()}`",
+        f"- Production routing authorized: `{str(summary['production_routing_authorized']).lower()}`",
+        f"- Deterministic: `{str(summary['deterministic']).lower()}`",
+        "",
+        "## Compared Snapshot Summary",
+        "",
+        f"- Compared snapshot count: `{compared['compared_snapshot_count']}`",
+        f"- Snapshot count sufficient: `{str(compared['snapshot_count_sufficient']).lower()}`",
+        f"- Records per snapshot: `{compared['records_per_snapshot']}`",
+        "",
+        "## Drift Reasons",
+        "",
+        "| Reason | Count |",
+        "| --- | ---: |",
+    ]
+    for reason, count in stability["drift_reason_counts"].items():
+        lines.append(f"| `{reason}` | `{count}` |")
+    lines.extend(
+        [
+            "",
+            "## Stability Records",
+            "",
+            "| Record | Manifest | Fixture Set | Compared Snapshots | Stability Status | Drift Fields |",
+            "| --- | --- | --- | ---: | --- | --- |",
+        ]
+    )
+    for row in stability["dry_run_result_stability_records"]:
+        lines.append(
+            f"| `{row['dry_run_stability_id']}` | `{row['manifest_id'] or ''}` | `{row['fixture_set_id'] or ''}` | `{row['compared_snapshot_count']}` | `{row['stability_status']}` | `{', '.join(row['drift_fields'])}` |"
+        )
+    lines.extend(["", "## Phase 27 Boundaries", ""])
+    lines.extend(f"- {item}" for item in report["phase_27_boundaries"])
+    lines.extend(
+        [
+            "",
+            "## Conclusion",
+            "",
+            "Dry-run stability evidence is available for governance review, while runtime consumption and production routing remain disabled.",
+        ]
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _normalize_generated_at(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: DETERMINISTIC_GENERATED_AT if key == "generated_at" else _normalize_generated_at(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_normalize_generated_at(item) for item in value]
+    return deepcopy(value)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", default="docs/generated/v3_1_dry_run_result_stability_report.json")
+    parser.add_argument("--markdown-output", default="docs/migration/V3_1_DRY_RUN_RESULT_STABILITY.md")
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[2]
+    report = build_v3_1_dry_run_result_stability_report()
+    write_report(report, repo_root / args.output)
+    write_markdown(report, repo_root / args.markdown_output)
+    print(json.dumps(report["summary"], indent=2, sort_keys=True))
+    print(report["recommendation"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_v3_1_dry_run_result_stability.py
+++ b/backend/tests/test_v3_1_dry_run_result_stability.py
@@ -1,0 +1,129 @@
+from app.planner_adapters.v3_1.dry_run_result_stability import audit_dry_run_result_stability
+from scripts.report_v3_1_dry_run_result_stability import build_v3_1_dry_run_result_stability_report
+
+
+def test_repeated_identical_dry_run_snapshots_are_stable():
+    result = _audit([[_dry_run_record()], [_dry_run_record()]])
+
+    record = result["dry_run_result_stability_records"][0]
+    assert record["stability_status"] == "dry_run_stable"
+    assert record["compared_snapshot_count"] == 2
+    assert result["summary"]["stable_count"] == 1
+
+
+def test_insufficient_snapshots_block():
+    result = _audit([[_dry_run_record()]])
+
+    assert result["dry_run_result_stability_records"][0]["stability_status"] == "blocked_snapshot_count_insufficient"
+
+
+def test_missing_dry_run_record_blocks():
+    result = _audit([[_dry_run_record()], []])
+
+    record = result["dry_run_result_stability_records"][0]
+    assert record["stability_status"] == "blocked_missing_dry_run_record"
+    assert "blocked_missing_dry_run_record" in record["blockers"]
+
+
+def test_manifest_identity_drift_blocks():
+    first = _dry_run_record(record_id="dry_run_shared", manifest_id="manifest_a")
+    second = _dry_run_record(record_id="dry_run_shared", manifest_id="manifest_b")
+    result = audit_dry_run_result_stability([[first], [second]])
+
+    assert result["dry_run_result_stability_records"][0]["stability_status"] == "blocked_manifest_identity_drift"
+
+
+def test_fixture_set_identity_drift_blocks():
+    record = _dry_run_record(record_id="dry_run_shared", fixture_set_id="set_a")
+    drifted = _dry_run_record(record_id="dry_run_shared", fixture_set_id="set_b")
+    result = audit_dry_run_result_stability([[record], [drifted]])
+
+    assert result["dry_run_result_stability_records"][0]["stability_status"] == "blocked_fixture_set_identity_drift"
+
+
+def test_guard_status_drift_blocks():
+    result = _audit([[_dry_run_record()], [_dry_run_record(guard_status="blocked_invalid_manifest_eligibility")]])
+
+    assert result["dry_run_result_stability_records"][0]["stability_status"] == "blocked_guard_status_drift"
+
+
+def test_readiness_status_drift_blocks():
+    result = _audit([[_dry_run_record()], [_dry_run_record(promotion_readiness_status="blocked_missing_semantic_parity")]])
+
+    assert result["dry_run_result_stability_records"][0]["stability_status"] == "blocked_readiness_status_drift"
+
+
+def test_authorization_state_drift_blocks():
+    result = _audit([[_dry_run_record()], [_dry_run_record(authorization_state="production_authoritative")]])
+
+    assert result["dry_run_result_stability_records"][0]["stability_status"] == "blocked_authorization_state_drift"
+
+
+def test_dry_run_status_drift_blocks():
+    result = _audit([[_dry_run_record()], [_dry_run_record(dry_run_status="blocked_invalid_guard_status")]])
+
+    assert result["dry_run_result_stability_records"][0]["stability_status"] == "blocked_dry_run_status_drift"
+
+
+def test_deterministic_ordering():
+    first = _audit(
+        [
+            [_dry_run_record(manifest_id="manifest_b", fixture_set_id="set_b"), _dry_run_record(manifest_id="manifest_a", fixture_set_id="set_a")],
+            [_dry_run_record(manifest_id="manifest_b", fixture_set_id="set_b"), _dry_run_record(manifest_id="manifest_a", fixture_set_id="set_a")],
+        ]
+    )
+    second = _audit(
+        [
+            [_dry_run_record(manifest_id="manifest_a", fixture_set_id="set_a"), _dry_run_record(manifest_id="manifest_b", fixture_set_id="set_b")],
+            [_dry_run_record(manifest_id="manifest_a", fixture_set_id="set_a"), _dry_run_record(manifest_id="manifest_b", fixture_set_id="set_b")],
+        ]
+    )
+
+    assert first["deterministic_hash"] == second["deterministic_hash"]
+    assert [row["manifest_id"] for row in first["dry_run_result_stability_records"]] == ["manifest_a", "manifest_b"]
+
+
+def test_stable_report_generation():
+    first = build_v3_1_dry_run_result_stability_report()
+    second = build_v3_1_dry_run_result_stability_report()
+
+    assert first["deterministic_guarantees"]["passed"] is True
+    assert first["dry_run_result_stability"]["deterministic_hash"] == second["dry_run_result_stability"]["deterministic_hash"]
+    assert first["summary"] == second["summary"]
+
+
+def test_no_production_routing_enablement():
+    result = _audit([[_dry_run_record()], [_dry_run_record()]])
+
+    assert result["safety_confirmations"]["stability_authorizes_production_routing"] is False
+    assert result["safety_confirmations"]["stability_enables_runtime_manifest_consumption"] is False
+    assert result["safety_confirmations"]["stability_is_production_approval"] is False
+    assert result["summary"]["production_behavior_changed"] is False
+
+
+def _audit(snapshots):
+    return audit_dry_run_result_stability(snapshots)
+
+
+def _dry_run_record(
+    record_id=None,
+    manifest_id="manifest_a",
+    fixture_set_id="set_a",
+    guard_status="guard_contract_ready",
+    promotion_readiness_status="ready_for_limited_experimental_runtime_consideration",
+    authorization_state="non_production_authoritative",
+    dry_run_status="dry_run_ready",
+):
+    return {
+        "limited_runtime_dry_run_id": record_id or f"dry_run_{manifest_id}_{fixture_set_id}",
+        "manifest_id": manifest_id,
+        "fixture_set_id": fixture_set_id,
+        "guard_status": guard_status,
+        "promotion_readiness_status": promotion_readiness_status,
+        "authorization_state": authorization_state,
+        "dry_run_status": dry_run_status,
+        "blockers": [] if dry_run_status == "dry_run_ready" else [dry_run_status],
+        "dry_run_enables_runtime_routing": False,
+        "dry_run_authorizes_production_routing": False,
+        "production_output_affected": False,
+    }

--- a/docs/generated/v3_1_dry_run_result_stability_report.json
+++ b/docs/generated/v3_1_dry_run_result_stability_report.json
@@ -1,0 +1,170 @@
+{
+  "deterministic_guarantees": {
+    "json_sort_keys": true,
+    "passed": true,
+    "repeated_hash": "94e78981dd86e29bee96a286817cee5df86ccbf92cbe45fc03963518487f0950",
+    "sample_hash": "94e78981dd86e29bee96a286817cee5df86ccbf92cbe45fc03963518487f0950",
+    "stability_hash": "60bb71a5baf620bf079153e799392f65031a738508e61b2cfcadbce4cf61bc95",
+    "timestamp_excluded_from_hash": true
+  },
+  "dry_run_result_stability": {
+    "compared_snapshot_summary": {
+      "compared_snapshot_count": 2,
+      "production_routing_authorized": false,
+      "records_per_snapshot": [
+        1,
+        1
+      ],
+      "runtime_manifest_consumption_enabled": false,
+      "snapshot_count_sufficient": true
+    },
+    "deterministic_hash": "60bb71a5baf620bf079153e799392f65031a738508e61b2cfcadbce4cf61bc95",
+    "drift_reason_counts": {},
+    "dry_run_result_stability_records": [
+      {
+        "blockers": [],
+        "compared_snapshot_count": 2,
+        "drift_fields": [],
+        "dry_run_stability_id": "v3_1_dry_run_stability_3c9e01291be49ac1",
+        "field_values": {
+          "authorization_state": [
+            "non_production_authoritative",
+            "non_production_authoritative"
+          ],
+          "dry_run_status": [
+            "dry_run_ready",
+            "dry_run_ready"
+          ],
+          "fixture_set_id": [
+            "v3_1_fixture_set_6d3b668a84cfbb69",
+            "v3_1_fixture_set_6d3b668a84cfbb69"
+          ],
+          "guard_status": [
+            "guard_contract_ready",
+            "guard_contract_ready"
+          ],
+          "manifest_id": [
+            "v3_1_admission_manifest_198a3e2110f9e5e4",
+            "v3_1_admission_manifest_198a3e2110f9e5e4"
+          ],
+          "promotion_readiness_status": [
+            "ready_for_limited_experimental_runtime_consideration",
+            "ready_for_limited_experimental_runtime_consideration"
+          ]
+        },
+        "fixture_set_id": "v3_1_fixture_set_6d3b668a84cfbb69",
+        "manifest_id": "v3_1_admission_manifest_198a3e2110f9e5e4",
+        "metadata": {
+          "dry_run_governance_only": true,
+          "observational_only": true,
+          "planner_remap_performed": false,
+          "production_consumer": false,
+          "runtime_behavior_enabled": false,
+          "stability_does_not_authorize_production_routing": true
+        },
+        "production_output_affected": false,
+        "stability_authorizes_production_routing": false,
+        "stability_status": "dry_run_stable"
+      }
+    ],
+    "metadata": {
+      "deterministic_serializer": "json_sort_keys_sha256",
+      "dry_run_governance_only": true,
+      "observational_only": true,
+      "planner_remap_performed": false,
+      "production_behavior_changed": false,
+      "production_consumer": false,
+      "production_default_routing_authorized": false,
+      "runtime_behavior_enabled": false,
+      "source": "v3_1_dry_run_result_stability",
+      "stable_generation_token": "v3_1_phase_27_dry_run_result_stability_token"
+    },
+    "run": {
+      "run_id": "v3_1_phase_27_dry_run_result_stability",
+      "snapshot_count": 2,
+      "snapshot_hashes": [
+        "94e78981dd86e29bee96a286817cee5df86ccbf92cbe45fc03963518487f0950",
+        "94e78981dd86e29bee96a286817cee5df86ccbf92cbe45fc03963518487f0950"
+      ],
+      "snapshot_record_counts": [
+        1,
+        1
+      ]
+    },
+    "safety_confirmations": {
+      "legacy_planner_ownership_preserved": true,
+      "production_behavior_changed": false,
+      "production_output_affected": false,
+      "production_planner_routing_changed": false,
+      "runtime_manifest_consumption_enabled": false,
+      "runtime_production_consumption_enabled": false,
+      "stability_authorizes_production_routing": false,
+      "stability_enables_runtime_manifest_consumption": false,
+      "stability_is_production_approval": false,
+      "trusted_data_default_truth": false
+    },
+    "schema_version": "v3_1.dry_run_result_stability.1",
+    "stability_status_counts": {
+      "blocked_authorization_state_drift": 0,
+      "blocked_dry_run_status_drift": 0,
+      "blocked_fixture_set_identity_drift": 0,
+      "blocked_guard_status_drift": 0,
+      "blocked_manifest_identity_drift": 0,
+      "blocked_missing_dry_run_record": 0,
+      "blocked_readiness_status_drift": 0,
+      "blocked_snapshot_count_insufficient": 0,
+      "dry_run_stable": 1
+    },
+    "summary": {
+      "blocked_count": 0,
+      "deterministic": true,
+      "production_affected_count": 0,
+      "production_behavior_changed": false,
+      "production_default_routing_authorized": false,
+      "production_output_affected": false,
+      "production_routing_authorized": false,
+      "records_evaluated": 1,
+      "runtime_manifest_consumption_enabled": false,
+      "runtime_production_consumption_enabled": false,
+      "stable_count": 1
+    }
+  },
+  "generated_at": "2026-05-15T00:00:00+00:00",
+  "metadata": {
+    "dry_run_governance_only": true,
+    "observational_only": true,
+    "planner_remap_performed": false,
+    "production_behavior_changed": false,
+    "production_default_routing_authorized": false,
+    "runtime_behavior_enabled": false,
+    "source": "v3_1_dry_run_result_stability_report"
+  },
+  "phase": "v3.1_phase_27_dry_run_result_stability_audit",
+  "phase_27_boundaries": [
+    "stability audit compares repeated dry-run snapshots only",
+    "stability audit does not enable runtime manifest consumption",
+    "stability audit does not authorize production routing",
+    "manifests remain non-production-authoritative",
+    "production planner routing remains unchanged",
+    "legacy planner ownership remains intact"
+  ],
+  "production_default_routing_authorized": false,
+  "production_routing_authorized": false,
+  "recommendation": "OBSERVATIONAL_ONLY_STABILITY_AUDIT_DO_NOT_ENABLE_RUNTIME_MANIFEST_CONSUMPTION",
+  "runtime_manifest_consumption_enabled": false,
+  "runtime_production_consumption_enabled": false,
+  "schema_version": "v3_1.dry_run_result_stability_report.1",
+  "summary": {
+    "blocked_count": 0,
+    "deterministic": true,
+    "production_affected_count": 0,
+    "production_behavior_changed": false,
+    "production_default_routing_authorized": false,
+    "production_output_affected": false,
+    "production_routing_authorized": false,
+    "records_evaluated": 1,
+    "runtime_manifest_consumption_enabled": false,
+    "runtime_production_consumption_enabled": false,
+    "stable_count": 1
+  }
+}

--- a/docs/migration/V3_1_DRY_RUN_RESULT_STABILITY.md
+++ b/docs/migration/V3_1_DRY_RUN_RESULT_STABILITY.md
@@ -1,0 +1,49 @@
+# V3.1 Dry-Run Result Stability
+
+Phase 27 verifies repeated limited experimental runtime dry-run results are deterministic.
+Dry-run stability is not production approval and does not enable runtime routing.
+
+## Recommendation
+
+- Recommendation: `OBSERVATIONAL_ONLY_STABILITY_AUDIT_DO_NOT_ENABLE_RUNTIME_MANIFEST_CONSUMPTION`
+- Runtime manifest consumption enabled: `false`
+- Production routing authorized: `false`
+
+## Summary
+
+- Records evaluated: `1`
+- Stable: `1`
+- Blocked: `0`
+- Runtime manifest consumption enabled: `false`
+- Production routing authorized: `false`
+- Deterministic: `true`
+
+## Compared Snapshot Summary
+
+- Compared snapshot count: `2`
+- Snapshot count sufficient: `true`
+- Records per snapshot: `[1, 1]`
+
+## Drift Reasons
+
+| Reason | Count |
+| --- | ---: |
+
+## Stability Records
+
+| Record | Manifest | Fixture Set | Compared Snapshots | Stability Status | Drift Fields |
+| --- | --- | --- | ---: | --- | --- |
+| `v3_1_dry_run_stability_3c9e01291be49ac1` | `v3_1_admission_manifest_198a3e2110f9e5e4` | `v3_1_fixture_set_6d3b668a84cfbb69` | `2` | `dry_run_stable` | `` |
+
+## Phase 27 Boundaries
+
+- stability audit compares repeated dry-run snapshots only
+- stability audit does not enable runtime manifest consumption
+- stability audit does not authorize production routing
+- manifests remain non-production-authoritative
+- production planner routing remains unchanged
+- legacy planner ownership remains intact
+
+## Conclusion
+
+Dry-run stability evidence is available for governance review, while runtime consumption and production routing remain disabled.


### PR DESCRIPTION
Adds deterministic stability auditing for repeated limited experimental runtime dry-run results while preserving disabled runtime consumption and production routing isolation.