### PR TITLE
v3.1: add experimental runtime readiness closeout

### DIFF
--- a/backend/app/planner_adapters/v3_1/__init__.py
+++ b/backend/app/planner_adapters/v3_1/__init__.py
@@ -48,6 +48,10 @@ from .dry_run_result_stability import (
     DRY_RUN_RESULT_STABILITY_STATUSES,
     audit_dry_run_result_stability,
 )
+from .experimental_runtime_readiness_closeout import (
+    EXPERIMENTAL_RUNTIME_READINESS_CLOSEOUT_STATUSES,
+    build_experimental_runtime_readiness_closeout,
+)
 from .review_policy_evaluation import (
     REVIEW_POLICY_OUTCOMES,
     V31ReviewPolicyEvaluation,
@@ -135,6 +139,7 @@ __all__ = [
     "LIMITED_EXPERIMENTAL_RUNTIME_GUARD_STATUSES",
     "LIMITED_EXPERIMENTAL_RUNTIME_DRY_RUN_STATUSES",
     "DRY_RUN_RESULT_STABILITY_STATUSES",
+    "EXPERIMENTAL_RUNTIME_READINESS_CLOSEOUT_STATUSES",
     "FIXTURE_WORKFLOW_STATES",
     "FIXTURE_SET_LIFECYCLE_STATES",
     "REVIEW_POLICY_OUTCOMES",
@@ -173,6 +178,7 @@ __all__ = [
     "build_limited_experimental_runtime_guards",
     "build_limited_experimental_runtime_dry_run",
     "audit_dry_run_result_stability",
+    "build_experimental_runtime_readiness_closeout",
     "build_default_trusted_repository_probes",
     "build_fixture_set_readiness_gate",
     "evaluate_fixture_source_admission_policy",

--- a/backend/app/planner_adapters/v3_1/experimental_runtime_readiness_closeout.py
+++ b/backend/app/planner_adapters/v3_1/experimental_runtime_readiness_closeout.py
@@ -1,0 +1,321 @@
+"""Experimental runtime readiness closeout audit for v3.1 governance.
+
+The closeout summarizes the controlled-consumption evidence chain for future
+limited experimental runtime consideration. It is reporting-only and does not
+enable runtime manifest consumption or production routing.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from copy import deepcopy
+from typing import Any
+
+from .trusted_shadow_consumption import deterministic_hash
+
+
+EXPERIMENTAL_RUNTIME_READINESS_CLOSEOUT_STATUSES = (
+    "ready_for_future_limited_experimental_runtime_phase",
+    "blocked_missing_manifest_eligibility",
+    "blocked_missing_controlled_consumption",
+    "blocked_missing_output_validation",
+    "blocked_missing_structural_parity",
+    "blocked_missing_semantic_parity",
+    "blocked_missing_promotion_readiness",
+    "blocked_missing_runtime_guard",
+    "blocked_missing_dry_run",
+    "blocked_missing_dry_run_stability",
+    "blocked_runtime_consumption_enabled",
+    "blocked_production_routing_authorized",
+)
+STABLE_EXPERIMENTAL_RUNTIME_READINESS_CLOSEOUT_TOKEN = "v3_1_phase_28_experimental_runtime_readiness_closeout_token"
+
+
+def build_experimental_runtime_readiness_closeout(
+    *,
+    manifest_consumption_eligibility: dict[str, Any] | list[dict[str, Any]],
+    controlled_test_consumption: dict[str, Any] | list[dict[str, Any]],
+    controlled_consumption_output_validation: dict[str, Any] | list[dict[str, Any]],
+    controlled_consumption_parity_snapshot: dict[str, Any] | list[dict[str, Any]],
+    trace_backfilled_semantic_parity: dict[str, Any] | list[dict[str, Any]],
+    controlled_consumption_promotion_readiness: dict[str, Any] | list[dict[str, Any]],
+    limited_experimental_runtime_guards: dict[str, Any] | list[dict[str, Any]],
+    limited_experimental_runtime_dry_run: dict[str, Any] | list[dict[str, Any]],
+    dry_run_result_stability: dict[str, Any] | list[dict[str, Any]],
+    run_id: str = "v3_1_phase_28_experimental_runtime_readiness_closeout",
+) -> dict[str, Any]:
+    """Build deterministic closeout readiness records from governance evidence."""
+
+    eligibility = _records(manifest_consumption_eligibility, "eligibility_records")
+    consumption = _records(controlled_test_consumption, "controlled_consumption_records")
+    validation = _records(controlled_consumption_output_validation, "validation_records")
+    structural = _records(controlled_consumption_parity_snapshot, "parity_records")
+    semantic = _records(trace_backfilled_semantic_parity, "trace_backfilled_semantic_parity_records")
+    promotion = _records(controlled_consumption_promotion_readiness, "promotion_readiness_records")
+    guards = _records(limited_experimental_runtime_guards, "limited_experimental_runtime_guard_records")
+    dry_runs = _records(limited_experimental_runtime_dry_run, "limited_experimental_runtime_dry_run_records")
+    stability = _records(dry_run_result_stability, "dry_run_result_stability_records")
+    runtime_enabled = _runtime_enabled(
+        manifest_consumption_eligibility,
+        controlled_test_consumption,
+        controlled_consumption_output_validation,
+        controlled_consumption_parity_snapshot,
+        trace_backfilled_semantic_parity,
+        controlled_consumption_promotion_readiness,
+        limited_experimental_runtime_guards,
+        limited_experimental_runtime_dry_run,
+        dry_run_result_stability,
+    )
+    production_routing_authorized = _production_routing_authorized(
+        manifest_consumption_eligibility,
+        controlled_test_consumption,
+        controlled_consumption_output_validation,
+        controlled_consumption_parity_snapshot,
+        trace_backfilled_semantic_parity,
+        controlled_consumption_promotion_readiness,
+        limited_experimental_runtime_guards,
+        limited_experimental_runtime_dry_run,
+        dry_run_result_stability,
+    )
+    layer_maps = {
+        "eligibility": _by_key(eligibility),
+        "consumption": _by_key(consumption),
+        "validation": _by_key(validation),
+        "structural": _by_key(structural),
+        "semantic": _by_key(semantic),
+        "promotion": _by_key(promotion),
+        "guard": _by_key(guards),
+        "dry_run": _by_key(dry_runs),
+        "stability": _by_key(stability),
+    }
+    keys = sorted(
+        {
+            key
+            for mapping in layer_maps.values()
+            for key in mapping
+        },
+        key=lambda item: (item[1], item[0]),
+    )
+    if not keys:
+        keys = [(None, None)]
+    closeout_records = [
+        _closeout_record(
+            key=key,
+            layers=layer_maps,
+            runtime_enabled=runtime_enabled,
+            production_routing_authorized=production_routing_authorized,
+        )
+        for key in keys
+    ]
+    counts = Counter(record["closeout_readiness_status"] for record in closeout_records)
+    blockers = Counter(reason for record in closeout_records for reason in record["blockers"])
+    envelope = {
+        "schema_version": "v3_1.experimental_runtime_readiness_closeout.1",
+        "run": {
+            "run_id": run_id,
+            "manifest_eligibility_hash": _source_hash(manifest_consumption_eligibility),
+            "controlled_test_consumption_hash": _source_hash(controlled_test_consumption),
+            "controlled_consumption_output_validation_hash": _source_hash(controlled_consumption_output_validation),
+            "controlled_consumption_parity_snapshot_hash": _source_hash(controlled_consumption_parity_snapshot),
+            "trace_backfilled_semantic_parity_hash": _source_hash(trace_backfilled_semantic_parity),
+            "controlled_consumption_promotion_readiness_hash": _source_hash(controlled_consumption_promotion_readiness),
+            "limited_experimental_runtime_guards_hash": _source_hash(limited_experimental_runtime_guards),
+            "limited_experimental_runtime_dry_run_hash": _source_hash(limited_experimental_runtime_dry_run),
+            "dry_run_result_stability_hash": _source_hash(dry_run_result_stability),
+        },
+        "summary": {
+            "records_evaluated": len(closeout_records),
+            "ready_count": counts["ready_for_future_limited_experimental_runtime_phase"],
+            "blocked_count": len(closeout_records) - counts["ready_for_future_limited_experimental_runtime_phase"],
+            "runtime_manifest_consumption_enabled": False,
+            "runtime_production_consumption_enabled": False,
+            "production_routing_authorized": False,
+            "production_default_routing_authorized": False,
+            "production_affected_count": 0,
+            "production_output_affected": False,
+            "production_behavior_changed": False,
+            "deterministic": True,
+        },
+        "closeout_status_counts": {
+            status: counts[status]
+            for status in EXPERIMENTAL_RUNTIME_READINESS_CLOSEOUT_STATUSES
+        },
+        "unresolved_blocker_counts": dict(sorted(blockers.items())),
+        "evidence_chain_summary": {
+            "manifest_eligibility_records": len(eligibility),
+            "controlled_consumption_records": len(consumption),
+            "output_validation_records": len(validation),
+            "structural_parity_records": len(structural),
+            "semantic_parity_records": len(semantic),
+            "promotion_readiness_records": len(promotion),
+            "runtime_guard_records": len(guards),
+            "dry_run_records": len(dry_runs),
+            "dry_run_stability_records": len(stability),
+            "runtime_manifest_consumption_enabled": runtime_enabled,
+            "production_routing_authorized": production_routing_authorized,
+        },
+        "closeout_records": closeout_records,
+        "safety_confirmations": {
+            "closeout_authorizes_runtime_manifest_consumption": False,
+            "closeout_authorizes_production_routing": False,
+            "closeout_is_production_approval": False,
+            "runtime_manifest_consumption_enabled": False,
+            "runtime_production_consumption_enabled": False,
+            "legacy_planner_ownership_preserved": True,
+            "production_output_affected": False,
+            "production_behavior_changed": False,
+            "production_planner_routing_changed": False,
+            "trusted_data_default_truth": False,
+        },
+        "metadata": {
+            "source": "v3_1_experimental_runtime_readiness_closeout",
+            "observational_only": True,
+            "audit_reporting_only": True,
+            "runtime_behavior_enabled": False,
+            "production_consumer": False,
+            "production_behavior_changed": False,
+            "planner_remap_performed": False,
+            "production_default_routing_authorized": False,
+            "stable_generation_token": STABLE_EXPERIMENTAL_RUNTIME_READINESS_CLOSEOUT_TOKEN,
+            "deterministic_serializer": "json_sort_keys_sha256",
+        },
+    }
+    envelope["deterministic_hash"] = deterministic_hash(envelope)
+    return envelope
+
+
+def _closeout_record(
+    *,
+    key: tuple[str | None, str | None],
+    layers: dict[str, dict[tuple[str | None, str | None], dict[str, Any]]],
+    runtime_enabled: bool,
+    production_routing_authorized: bool,
+) -> dict[str, Any]:
+    manifest_id, fixture_set_id = key
+    evidence = {
+        "manifest_eligibility": (layers["eligibility"].get(key) or {}).get("eligibility_status"),
+        "controlled_consumption": (layers["consumption"].get(key) or {}).get("controlled_consumption_status"),
+        "output_validation": (layers["validation"].get(key) or {}).get("validation_status"),
+        "structural_parity": (layers["structural"].get(key) or {}).get("parity_status"),
+        "semantic_parity": (layers["semantic"].get(key) or {}).get("final_semantic_parity_status"),
+        "promotion_readiness": (layers["promotion"].get(key) or {}).get("promotion_readiness_status"),
+        "runtime_guard": (layers["guard"].get(key) or {}).get("guard_contract_status"),
+        "runtime_dry_run": (layers["dry_run"].get(key) or {}).get("dry_run_status"),
+        "dry_run_stability": (layers["stability"].get(key) or {}).get("stability_status"),
+    }
+    blockers = _blockers(evidence, runtime_enabled=runtime_enabled, production_routing_authorized=production_routing_authorized)
+    status = blockers[0] if blockers else "ready_for_future_limited_experimental_runtime_phase"
+    seed = {
+        "manifest_id": manifest_id,
+        "fixture_set_id": fixture_set_id,
+        "status": status,
+        "token": STABLE_EXPERIMENTAL_RUNTIME_READINESS_CLOSEOUT_TOKEN,
+    }
+    return {
+        "experimental_runtime_readiness_closeout_id": f"v3_1_experimental_runtime_closeout_{deterministic_hash(seed)[:16]}",
+        "manifest_id": manifest_id,
+        "fixture_set_id": fixture_set_id,
+        "evidence_chain_statuses": evidence,
+        "closeout_readiness_status": status,
+        "blockers": blockers,
+        "closeout_readiness_authorizes_runtime_routing": False,
+        "closeout_readiness_authorizes_production_routing": False,
+        "production_output_affected": False,
+        "metadata": {
+            "observational_only": True,
+            "audit_reporting_only": True,
+            "runtime_behavior_enabled": False,
+            "production_consumer": False,
+            "planner_remap_performed": False,
+            "closeout_readiness_does_not_authorize_runtime_or_production_routing": True,
+        },
+    }
+
+
+def _blockers(evidence: dict[str, Any], *, runtime_enabled: bool, production_routing_authorized: bool) -> list[str]:
+    blockers: list[str] = []
+    if evidence["manifest_eligibility"] != "eligible_for_controlled_test_consumption":
+        blockers.append("blocked_missing_manifest_eligibility")
+    if evidence["controlled_consumption"] != "consumed_in_controlled_test":
+        blockers.append("blocked_missing_controlled_consumption")
+    if evidence["output_validation"] != "valid_controlled_test_output":
+        blockers.append("blocked_missing_output_validation")
+    if evidence["structural_parity"] != "parity_confirmed":
+        blockers.append("blocked_missing_structural_parity")
+    if evidence["semantic_parity"] != "semantic_parity_confirmed":
+        blockers.append("blocked_missing_semantic_parity")
+    if evidence["promotion_readiness"] != "ready_for_limited_experimental_runtime_consideration":
+        blockers.append("blocked_missing_promotion_readiness")
+    if evidence["runtime_guard"] != "guard_contract_ready":
+        blockers.append("blocked_missing_runtime_guard")
+    if evidence["runtime_dry_run"] != "dry_run_ready":
+        blockers.append("blocked_missing_dry_run")
+    if evidence["dry_run_stability"] != "dry_run_stable":
+        blockers.append("blocked_missing_dry_run_stability")
+    if runtime_enabled:
+        blockers.append("blocked_runtime_consumption_enabled")
+    if production_routing_authorized:
+        blockers.append("blocked_production_routing_authorized")
+    return blockers
+
+
+def _records(value: dict[str, Any] | list[dict[str, Any]], key: str) -> list[dict[str, Any]]:
+    if isinstance(value, list):
+        return [deepcopy(record) for record in value]
+    return [deepcopy(record) for record in value.get(key, [])]
+
+
+def _by_key(records: list[dict[str, Any]]) -> dict[tuple[str | None, str | None], dict[str, Any]]:
+    return {
+        _trace_key(record): record
+        for record in records
+        if _trace_key(record) != (None, None)
+    }
+
+
+def _trace_key(record: dict[str, Any]) -> tuple[str | None, str | None]:
+    manifest_id = record.get("manifest_id")
+    fixture_set_id = record.get("fixture_set_id")
+    return (str(manifest_id) if manifest_id is not None else None, str(fixture_set_id) if fixture_set_id is not None else None)
+
+
+def _runtime_enabled(*values: Any) -> bool:
+    for value in values:
+        if not isinstance(value, dict):
+            continue
+        summary = value.get("summary") or {}
+        safety = value.get("safety_confirmations") or {}
+        if (
+            value.get("runtime_manifest_consumption_enabled")
+            or value.get("runtime_production_consumption_enabled")
+            or summary.get("runtime_manifest_consumption_enabled")
+            or summary.get("runtime_production_consumption_enabled")
+            or summary.get("manifest_runtime_consumption_enabled")
+            or safety.get("runtime_manifest_consumption_enabled")
+            or safety.get("runtime_production_consumption_enabled")
+        ):
+            return True
+    return False
+
+
+def _production_routing_authorized(*values: Any) -> bool:
+    for value in values:
+        if not isinstance(value, dict):
+            continue
+        summary = value.get("summary") or {}
+        safety = value.get("safety_confirmations") or {}
+        if (
+            value.get("production_default_routing_authorized")
+            or value.get("production_routing_authorized")
+            or summary.get("production_default_routing_authorized")
+            or summary.get("production_routing_authorized")
+            or safety.get("production_planner_routing_changed")
+        ):
+            return True
+    return False
+
+
+def _source_hash(value: dict[str, Any] | list[dict[str, Any]]) -> str | None:
+    if isinstance(value, dict):
+        return value.get("deterministic_hash")
+    return None

--- a/backend/scripts/report_v3_1_experimental_runtime_readiness_closeout.py
+++ b/backend/scripts/report_v3_1_experimental_runtime_readiness_closeout.py
@@ -1,0 +1,210 @@
+"""Generate the v3.1 experimental runtime readiness closeout report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.planner_adapters.v3_1.experimental_runtime_readiness_closeout import build_experimental_runtime_readiness_closeout  # noqa: E402
+
+
+DETERMINISTIC_GENERATED_AT = "2026-05-15T00:00:00+00:00"
+
+
+def build_v3_1_experimental_runtime_readiness_closeout_report() -> dict[str, Any]:
+    repo_root = Path(__file__).resolve().parents[2]
+    eligibility = _read_json(repo_root / "docs" / "generated" / "v3_1_manifest_consumption_eligibility_report.json")[
+        "manifest_consumption_eligibility"
+    ]
+    consumption = _read_json(repo_root / "docs" / "generated" / "v3_1_controlled_test_consumption_report.json")[
+        "controlled_test_consumption"
+    ]
+    validation = _read_json(repo_root / "docs" / "generated" / "v3_1_controlled_consumption_output_validation_report.json")[
+        "controlled_consumption_output_validation"
+    ]
+    structural = _read_json(repo_root / "docs" / "generated" / "v3_1_controlled_consumption_parity_snapshot_report.json")[
+        "controlled_consumption_parity_snapshot"
+    ]
+    semantic = _read_json(repo_root / "docs" / "generated" / "v3_1_trace_backfilled_semantic_parity_report.json")[
+        "trace_backfilled_semantic_parity"
+    ]
+    promotion = _read_json(repo_root / "docs" / "generated" / "v3_1_controlled_consumption_promotion_readiness_report.json")[
+        "controlled_consumption_promotion_readiness"
+    ]
+    guards = _read_json(repo_root / "docs" / "generated" / "v3_1_limited_experimental_runtime_guards_report.json")[
+        "limited_experimental_runtime_guards"
+    ]
+    dry_run = _read_json(repo_root / "docs" / "generated" / "v3_1_limited_experimental_runtime_dry_run_report.json")[
+        "limited_experimental_runtime_dry_run"
+    ]
+    stability = _read_json(repo_root / "docs" / "generated" / "v3_1_dry_run_result_stability_report.json")[
+        "dry_run_result_stability"
+    ]
+    closeout = build_experimental_runtime_readiness_closeout(
+        manifest_consumption_eligibility=eligibility,
+        controlled_test_consumption=consumption,
+        controlled_consumption_output_validation=validation,
+        controlled_consumption_parity_snapshot=structural,
+        trace_backfilled_semantic_parity=semantic,
+        controlled_consumption_promotion_readiness=promotion,
+        limited_experimental_runtime_guards=guards,
+        limited_experimental_runtime_dry_run=dry_run,
+        dry_run_result_stability=stability,
+    )
+    repeated = build_experimental_runtime_readiness_closeout(
+        manifest_consumption_eligibility=eligibility,
+        controlled_test_consumption=consumption,
+        controlled_consumption_output_validation=validation,
+        controlled_consumption_parity_snapshot=structural,
+        trace_backfilled_semantic_parity=semantic,
+        controlled_consumption_promotion_readiness=promotion,
+        limited_experimental_runtime_guards=guards,
+        limited_experimental_runtime_dry_run=dry_run,
+        dry_run_result_stability=stability,
+    )
+    report = {
+        "schema_version": "v3_1.experimental_runtime_readiness_closeout_report.1",
+        "generated_at": DETERMINISTIC_GENERATED_AT,
+        "phase": "v3.1_phase_28_experimental_runtime_readiness_closeout_audit",
+        "recommendation": "READY_FOR_FUTURE_LIMITED_EXPERIMENTAL_RUNTIME_PHASE_REVIEW_ONLY",
+        "recommended_next_phase": "future limited experimental runtime planning, still gated and not production-authorized",
+        "runtime_manifest_consumption_enabled": False,
+        "runtime_production_consumption_enabled": False,
+        "production_routing_authorized": False,
+        "production_default_routing_authorized": False,
+        "summary": {
+            **closeout["summary"],
+            "deterministic": closeout["deterministic_hash"] == repeated["deterministic_hash"],
+        },
+        "experimental_runtime_readiness_closeout": closeout,
+        "deterministic_guarantees": {
+            "passed": closeout["deterministic_hash"] == repeated["deterministic_hash"],
+            "sample_hash": closeout["deterministic_hash"],
+            "repeated_hash": repeated["deterministic_hash"],
+            "timestamp_excluded_from_hash": True,
+            "json_sort_keys": True,
+        },
+        "phase_28_boundaries": [
+            "closeout is audit/reporting only",
+            "closeout does not enable runtime manifest consumption",
+            "closeout does not authorize production routing",
+            "manifests remain non-production-authoritative",
+            "production planner routing remains unchanged",
+            "legacy planner ownership remains intact",
+        ],
+        "metadata": {
+            "source": "v3_1_experimental_runtime_readiness_closeout_report",
+            "observational_only": True,
+            "audit_reporting_only": True,
+            "runtime_behavior_enabled": False,
+            "production_behavior_changed": False,
+            "production_default_routing_authorized": False,
+            "planner_remap_performed": False,
+        },
+    }
+    return _normalize_generated_at(report)
+
+
+def write_report(report: dict[str, Any], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_markdown(report: dict[str, Any], output_path: Path) -> None:
+    closeout = report["experimental_runtime_readiness_closeout"]
+    summary = report["summary"]
+    evidence = closeout["evidence_chain_summary"]
+    lines = [
+        "# V3.1 Experimental Runtime Readiness Closeout",
+        "",
+        "Phase 28 summarizes the v3.1 controlled-consumption evidence chain for future limited experimental runtime consideration.",
+        "Closeout readiness is not runtime approval and does not authorize production routing.",
+        "",
+        "## Recommendation",
+        "",
+        f"- Recommendation: `{report['recommendation']}`",
+        f"- Recommended next phase: {report['recommended_next_phase']}",
+        f"- Runtime manifest consumption enabled: `{str(report['runtime_manifest_consumption_enabled']).lower()}`",
+        f"- Production routing authorized: `{str(report['production_routing_authorized']).lower()}`",
+        "",
+        "## Summary",
+        "",
+        f"- Records evaluated: `{summary['records_evaluated']}`",
+        f"- Ready: `{summary['ready_count']}`",
+        f"- Blocked: `{summary['blocked_count']}`",
+        f"- Runtime manifest consumption enabled: `{str(summary['runtime_manifest_consumption_enabled']).lower()}`",
+        f"- Production routing authorized: `{str(summary['production_routing_authorized']).lower()}`",
+        f"- Deterministic: `{str(summary['deterministic']).lower()}`",
+        "",
+        "## Evidence Chain Summary",
+        "",
+    ]
+    for key, value in evidence.items():
+        lines.append(f"- {key}: `{value}`")
+    lines.extend(["", "## Unresolved Blockers", "", "| Blocker | Count |", "| --- | ---: |"])
+    for reason, count in closeout["unresolved_blocker_counts"].items():
+        lines.append(f"| `{reason}` | `{count}` |")
+    lines.extend(
+        [
+            "",
+            "## Closeout Records",
+            "",
+            "| Record | Manifest | Fixture Set | Closeout Status |",
+            "| --- | --- | --- | --- |",
+        ]
+    )
+    for row in closeout["closeout_records"]:
+        lines.append(
+            f"| `{row['experimental_runtime_readiness_closeout_id']}` | `{row['manifest_id'] or ''}` | `{row['fixture_set_id'] or ''}` | `{row['closeout_readiness_status']}` |"
+        )
+    lines.extend(["", "## Phase 28 Boundaries", ""])
+    lines.extend(f"- {item}" for item in report["phase_28_boundaries"])
+    lines.extend(
+        [
+            "",
+            "## Conclusion",
+            "",
+            "The controlled-consumption evidence chain is summarized for governance review only. Runtime consumption and production routing remain disabled.",
+        ]
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _normalize_generated_at(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: DETERMINISTIC_GENERATED_AT if key == "generated_at" else _normalize_generated_at(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_normalize_generated_at(item) for item in value]
+    return deepcopy(value)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", default="docs/generated/v3_1_experimental_runtime_readiness_closeout_report.json")
+    parser.add_argument("--markdown-output", default="docs/migration/V3_1_EXPERIMENTAL_RUNTIME_READINESS_CLOSEOUT.md")
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[2]
+    report = build_v3_1_experimental_runtime_readiness_closeout_report()
+    write_report(report, repo_root / args.output)
+    write_markdown(report, repo_root / args.markdown_output)
+    print(json.dumps(report["summary"], indent=2, sort_keys=True))
+    print(report["recommendation"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_v3_1_experimental_runtime_readiness_closeout.py
+++ b/backend/tests/test_v3_1_experimental_runtime_readiness_closeout.py
@@ -1,0 +1,208 @@
+from app.planner_adapters.v3_1.experimental_runtime_readiness_closeout import build_experimental_runtime_readiness_closeout
+from scripts.report_v3_1_experimental_runtime_readiness_closeout import build_v3_1_experimental_runtime_readiness_closeout_report
+
+
+def test_complete_evidence_chain_produces_ready():
+    result = _build()
+
+    record = result["closeout_records"][0]
+    assert record["closeout_readiness_status"] == "ready_for_future_limited_experimental_runtime_phase"
+    assert result["summary"]["ready_count"] == 1
+
+
+def test_missing_manifest_eligibility_blocks():
+    result = _build(eligibility=[])
+
+    assert result["closeout_records"][0]["closeout_readiness_status"] == "blocked_missing_manifest_eligibility"
+
+
+def test_missing_controlled_consumption_blocks():
+    result = _build(consumption=[])
+
+    assert result["closeout_records"][0]["closeout_readiness_status"] == "blocked_missing_controlled_consumption"
+
+
+def test_missing_output_validation_blocks():
+    result = _build(validation=[])
+
+    assert result["closeout_records"][0]["closeout_readiness_status"] == "blocked_missing_output_validation"
+
+
+def test_missing_structural_parity_blocks():
+    result = _build(structural=[])
+
+    assert result["closeout_records"][0]["closeout_readiness_status"] == "blocked_missing_structural_parity"
+
+
+def test_missing_semantic_parity_blocks():
+    result = _build(semantic=[])
+
+    assert result["closeout_records"][0]["closeout_readiness_status"] == "blocked_missing_semantic_parity"
+
+
+def test_missing_promotion_readiness_blocks():
+    result = _build(promotion=[])
+
+    assert result["closeout_records"][0]["closeout_readiness_status"] == "blocked_missing_promotion_readiness"
+
+
+def test_missing_runtime_guard_blocks():
+    result = _build(guard=[])
+
+    assert result["closeout_records"][0]["closeout_readiness_status"] == "blocked_missing_runtime_guard"
+
+
+def test_missing_dry_run_blocks():
+    result = _build(dry_run=[])
+
+    assert result["closeout_records"][0]["closeout_readiness_status"] == "blocked_missing_dry_run"
+
+
+def test_missing_dry_run_stability_blocks():
+    result = _build(stability=[])
+
+    assert result["closeout_records"][0]["closeout_readiness_status"] == "blocked_missing_dry_run_stability"
+
+
+def test_runtime_consumption_enabled_blocks():
+    eligibility = _payload("eligibility_records", [_eligibility_record()])
+    eligibility["summary"]["runtime_manifest_consumption_enabled"] = True
+    result = _build(eligibility_payload=eligibility)
+
+    assert "blocked_runtime_consumption_enabled" in result["closeout_records"][0]["blockers"]
+
+
+def test_production_routing_authorized_blocks():
+    eligibility = _payload("eligibility_records", [_eligibility_record()])
+    eligibility["summary"]["production_routing_authorized"] = True
+    result = _build(eligibility_payload=eligibility)
+
+    assert "blocked_production_routing_authorized" in result["closeout_records"][0]["blockers"]
+
+
+def test_deterministic_ordering():
+    first = _build(
+        eligibility=[_eligibility_record("manifest_b", "set_b"), _eligibility_record("manifest_a", "set_a")],
+        consumption=[_consumption_record("manifest_b", "set_b"), _consumption_record("manifest_a", "set_a")],
+        validation=[_validation_record("manifest_b", "set_b"), _validation_record("manifest_a", "set_a")],
+        structural=[_structural_record("manifest_b", "set_b"), _structural_record("manifest_a", "set_a")],
+        semantic=[_semantic_record("manifest_b", "set_b"), _semantic_record("manifest_a", "set_a")],
+        promotion=[_promotion_record("manifest_b", "set_b"), _promotion_record("manifest_a", "set_a")],
+        guard=[_guard_record("manifest_b", "set_b"), _guard_record("manifest_a", "set_a")],
+        dry_run=[_dry_run_record("manifest_b", "set_b"), _dry_run_record("manifest_a", "set_a")],
+        stability=[_stability_record("manifest_b", "set_b"), _stability_record("manifest_a", "set_a")],
+    )
+    second = _build(
+        eligibility=[_eligibility_record("manifest_a", "set_a"), _eligibility_record("manifest_b", "set_b")],
+        consumption=[_consumption_record("manifest_a", "set_a"), _consumption_record("manifest_b", "set_b")],
+        validation=[_validation_record("manifest_a", "set_a"), _validation_record("manifest_b", "set_b")],
+        structural=[_structural_record("manifest_a", "set_a"), _structural_record("manifest_b", "set_b")],
+        semantic=[_semantic_record("manifest_a", "set_a"), _semantic_record("manifest_b", "set_b")],
+        promotion=[_promotion_record("manifest_a", "set_a"), _promotion_record("manifest_b", "set_b")],
+        guard=[_guard_record("manifest_a", "set_a"), _guard_record("manifest_b", "set_b")],
+        dry_run=[_dry_run_record("manifest_a", "set_a"), _dry_run_record("manifest_b", "set_b")],
+        stability=[_stability_record("manifest_a", "set_a"), _stability_record("manifest_b", "set_b")],
+    )
+
+    assert first["deterministic_hash"] == second["deterministic_hash"]
+    assert [row["manifest_id"] for row in first["closeout_records"]] == ["manifest_a", "manifest_b"]
+
+
+def test_stable_report_generation():
+    first = build_v3_1_experimental_runtime_readiness_closeout_report()
+    second = build_v3_1_experimental_runtime_readiness_closeout_report()
+
+    assert first["deterministic_guarantees"]["passed"] is True
+    assert first["experimental_runtime_readiness_closeout"]["deterministic_hash"] == second["experimental_runtime_readiness_closeout"]["deterministic_hash"]
+    assert first["summary"] == second["summary"]
+
+
+def test_no_production_routing_enablement():
+    result = _build()
+    record = result["closeout_records"][0]
+
+    assert result["safety_confirmations"]["closeout_authorizes_runtime_manifest_consumption"] is False
+    assert result["safety_confirmations"]["closeout_authorizes_production_routing"] is False
+    assert result["safety_confirmations"]["closeout_is_production_approval"] is False
+    assert record["closeout_readiness_authorizes_runtime_routing"] is False
+
+
+def _build(
+    *,
+    eligibility=None,
+    consumption=None,
+    validation=None,
+    structural=None,
+    semantic=None,
+    promotion=None,
+    guard=None,
+    dry_run=None,
+    stability=None,
+    eligibility_payload=None,
+):
+    return build_experimental_runtime_readiness_closeout(
+        manifest_consumption_eligibility=eligibility_payload or _payload("eligibility_records", [_eligibility_record()] if eligibility is None else eligibility),
+        controlled_test_consumption=_payload("controlled_consumption_records", [_consumption_record()] if consumption is None else consumption),
+        controlled_consumption_output_validation=_payload("validation_records", [_validation_record()] if validation is None else validation),
+        controlled_consumption_parity_snapshot=_payload("parity_records", [_structural_record()] if structural is None else structural),
+        trace_backfilled_semantic_parity=_payload("trace_backfilled_semantic_parity_records", [_semantic_record()] if semantic is None else semantic),
+        controlled_consumption_promotion_readiness=_payload("promotion_readiness_records", [_promotion_record()] if promotion is None else promotion),
+        limited_experimental_runtime_guards=_payload("limited_experimental_runtime_guard_records", [_guard_record()] if guard is None else guard),
+        limited_experimental_runtime_dry_run=_payload("limited_experimental_runtime_dry_run_records", [_dry_run_record()] if dry_run is None else dry_run),
+        dry_run_result_stability=_payload("dry_run_result_stability_records", [_stability_record()] if stability is None else stability),
+    )
+
+
+def _payload(key, records):
+    return {
+        "schema_version": f"v3_1.test.{key}.1",
+        "deterministic_hash": f"{key}-hash",
+        "summary": {
+            "runtime_manifest_consumption_enabled": False,
+            "runtime_production_consumption_enabled": False,
+            "production_default_routing_authorized": False,
+            "production_routing_authorized": False,
+        },
+        "safety_confirmations": {
+            "runtime_manifest_consumption_enabled": False,
+            "runtime_production_consumption_enabled": False,
+            "production_planner_routing_changed": False,
+        },
+        key: records,
+    }
+
+
+def _eligibility_record(manifest_id="manifest_a", fixture_set_id="set_a"):
+    return {"manifest_id": manifest_id, "fixture_set_id": fixture_set_id, "eligibility_status": "eligible_for_controlled_test_consumption"}
+
+
+def _consumption_record(manifest_id="manifest_a", fixture_set_id="set_a"):
+    return {"manifest_id": manifest_id, "fixture_set_id": fixture_set_id, "controlled_consumption_status": "consumed_in_controlled_test"}
+
+
+def _validation_record(manifest_id="manifest_a", fixture_set_id="set_a"):
+    return {"manifest_id": manifest_id, "fixture_set_id": fixture_set_id, "validation_status": "valid_controlled_test_output"}
+
+
+def _structural_record(manifest_id="manifest_a", fixture_set_id="set_a"):
+    return {"manifest_id": manifest_id, "fixture_set_id": fixture_set_id, "parity_status": "parity_confirmed"}
+
+
+def _semantic_record(manifest_id="manifest_a", fixture_set_id="set_a"):
+    return {"manifest_id": manifest_id, "fixture_set_id": fixture_set_id, "final_semantic_parity_status": "semantic_parity_confirmed"}
+
+
+def _promotion_record(manifest_id="manifest_a", fixture_set_id="set_a"):
+    return {"manifest_id": manifest_id, "fixture_set_id": fixture_set_id, "promotion_readiness_status": "ready_for_limited_experimental_runtime_consideration"}
+
+
+def _guard_record(manifest_id="manifest_a", fixture_set_id="set_a"):
+    return {"manifest_id": manifest_id, "fixture_set_id": fixture_set_id, "guard_contract_status": "guard_contract_ready"}
+
+
+def _dry_run_record(manifest_id="manifest_a", fixture_set_id="set_a"):
+    return {"manifest_id": manifest_id, "fixture_set_id": fixture_set_id, "dry_run_status": "dry_run_ready"}
+
+
+def _stability_record(manifest_id="manifest_a", fixture_set_id="set_a"):
+    return {"manifest_id": manifest_id, "fixture_set_id": fixture_set_id, "stability_status": "dry_run_stable"}

--- a/docs/generated/v3_1_experimental_runtime_readiness_closeout_report.json
+++ b/docs/generated/v3_1_experimental_runtime_readiness_closeout_report.json
@@ -1,0 +1,160 @@
+{
+  "deterministic_guarantees": {
+    "json_sort_keys": true,
+    "passed": true,
+    "repeated_hash": "5446aed43fd538a0f54bd182c96f8d4428aeec7135d72881a17d6ac91f2f7cb7",
+    "sample_hash": "5446aed43fd538a0f54bd182c96f8d4428aeec7135d72881a17d6ac91f2f7cb7",
+    "timestamp_excluded_from_hash": true
+  },
+  "experimental_runtime_readiness_closeout": {
+    "closeout_records": [
+      {
+        "blockers": [],
+        "closeout_readiness_authorizes_production_routing": false,
+        "closeout_readiness_authorizes_runtime_routing": false,
+        "closeout_readiness_status": "ready_for_future_limited_experimental_runtime_phase",
+        "evidence_chain_statuses": {
+          "controlled_consumption": "consumed_in_controlled_test",
+          "dry_run_stability": "dry_run_stable",
+          "manifest_eligibility": "eligible_for_controlled_test_consumption",
+          "output_validation": "valid_controlled_test_output",
+          "promotion_readiness": "ready_for_limited_experimental_runtime_consideration",
+          "runtime_dry_run": "dry_run_ready",
+          "runtime_guard": "guard_contract_ready",
+          "semantic_parity": "semantic_parity_confirmed",
+          "structural_parity": "parity_confirmed"
+        },
+        "experimental_runtime_readiness_closeout_id": "v3_1_experimental_runtime_closeout_083a4072bdd59bed",
+        "fixture_set_id": "v3_1_fixture_set_6d3b668a84cfbb69",
+        "manifest_id": "v3_1_admission_manifest_198a3e2110f9e5e4",
+        "metadata": {
+          "audit_reporting_only": true,
+          "closeout_readiness_does_not_authorize_runtime_or_production_routing": true,
+          "observational_only": true,
+          "planner_remap_performed": false,
+          "production_consumer": false,
+          "runtime_behavior_enabled": false
+        },
+        "production_output_affected": false
+      }
+    ],
+    "closeout_status_counts": {
+      "blocked_missing_controlled_consumption": 0,
+      "blocked_missing_dry_run": 0,
+      "blocked_missing_dry_run_stability": 0,
+      "blocked_missing_manifest_eligibility": 0,
+      "blocked_missing_output_validation": 0,
+      "blocked_missing_promotion_readiness": 0,
+      "blocked_missing_runtime_guard": 0,
+      "blocked_missing_semantic_parity": 0,
+      "blocked_missing_structural_parity": 0,
+      "blocked_production_routing_authorized": 0,
+      "blocked_runtime_consumption_enabled": 0,
+      "ready_for_future_limited_experimental_runtime_phase": 1
+    },
+    "deterministic_hash": "5446aed43fd538a0f54bd182c96f8d4428aeec7135d72881a17d6ac91f2f7cb7",
+    "evidence_chain_summary": {
+      "controlled_consumption_records": 1,
+      "dry_run_records": 1,
+      "dry_run_stability_records": 1,
+      "manifest_eligibility_records": 1,
+      "output_validation_records": 1,
+      "production_routing_authorized": false,
+      "promotion_readiness_records": 1,
+      "runtime_guard_records": 1,
+      "runtime_manifest_consumption_enabled": false,
+      "semantic_parity_records": 1,
+      "structural_parity_records": 1
+    },
+    "metadata": {
+      "audit_reporting_only": true,
+      "deterministic_serializer": "json_sort_keys_sha256",
+      "observational_only": true,
+      "planner_remap_performed": false,
+      "production_behavior_changed": false,
+      "production_consumer": false,
+      "production_default_routing_authorized": false,
+      "runtime_behavior_enabled": false,
+      "source": "v3_1_experimental_runtime_readiness_closeout",
+      "stable_generation_token": "v3_1_phase_28_experimental_runtime_readiness_closeout_token"
+    },
+    "run": {
+      "controlled_consumption_output_validation_hash": "3364892148b06185a66ca86a64243a32ab54324995ed8752be795bed78300677",
+      "controlled_consumption_parity_snapshot_hash": "5e5744d7474cc3e8ca26e1163178c65744e46a07f01674bc4b11acbec486b20c",
+      "controlled_consumption_promotion_readiness_hash": "65e0814411b9053c2fd50da6c80fbaf960280beee4ddaee2c6a978c32ae6516c",
+      "controlled_test_consumption_hash": "f08b0dd2a540a8f4da38a059b3c0def3d029747cb1416201946a1795e6d30c04",
+      "dry_run_result_stability_hash": "60bb71a5baf620bf079153e799392f65031a738508e61b2cfcadbce4cf61bc95",
+      "limited_experimental_runtime_dry_run_hash": "94e78981dd86e29bee96a286817cee5df86ccbf92cbe45fc03963518487f0950",
+      "limited_experimental_runtime_guards_hash": "5545f8146c04f2869bcfe3c76cf1040e08e51ef73d3669d7b415acd22d1ee4e2",
+      "manifest_eligibility_hash": "e5776401439dbe2ac5feef32f9c0ae924d7769f691ea3e90fcb1774f39fcbbf4",
+      "run_id": "v3_1_phase_28_experimental_runtime_readiness_closeout",
+      "trace_backfilled_semantic_parity_hash": "1d50646772e3803ae099d697d8a2454b708376454813bbbf286dac3dfdbcf0d7"
+    },
+    "safety_confirmations": {
+      "closeout_authorizes_production_routing": false,
+      "closeout_authorizes_runtime_manifest_consumption": false,
+      "closeout_is_production_approval": false,
+      "legacy_planner_ownership_preserved": true,
+      "production_behavior_changed": false,
+      "production_output_affected": false,
+      "production_planner_routing_changed": false,
+      "runtime_manifest_consumption_enabled": false,
+      "runtime_production_consumption_enabled": false,
+      "trusted_data_default_truth": false
+    },
+    "schema_version": "v3_1.experimental_runtime_readiness_closeout.1",
+    "summary": {
+      "blocked_count": 0,
+      "deterministic": true,
+      "production_affected_count": 0,
+      "production_behavior_changed": false,
+      "production_default_routing_authorized": false,
+      "production_output_affected": false,
+      "production_routing_authorized": false,
+      "ready_count": 1,
+      "records_evaluated": 1,
+      "runtime_manifest_consumption_enabled": false,
+      "runtime_production_consumption_enabled": false
+    },
+    "unresolved_blocker_counts": {}
+  },
+  "generated_at": "2026-05-15T00:00:00+00:00",
+  "metadata": {
+    "audit_reporting_only": true,
+    "observational_only": true,
+    "planner_remap_performed": false,
+    "production_behavior_changed": false,
+    "production_default_routing_authorized": false,
+    "runtime_behavior_enabled": false,
+    "source": "v3_1_experimental_runtime_readiness_closeout_report"
+  },
+  "phase": "v3.1_phase_28_experimental_runtime_readiness_closeout_audit",
+  "phase_28_boundaries": [
+    "closeout is audit/reporting only",
+    "closeout does not enable runtime manifest consumption",
+    "closeout does not authorize production routing",
+    "manifests remain non-production-authoritative",
+    "production planner routing remains unchanged",
+    "legacy planner ownership remains intact"
+  ],
+  "production_default_routing_authorized": false,
+  "production_routing_authorized": false,
+  "recommendation": "READY_FOR_FUTURE_LIMITED_EXPERIMENTAL_RUNTIME_PHASE_REVIEW_ONLY",
+  "recommended_next_phase": "future limited experimental runtime planning, still gated and not production-authorized",
+  "runtime_manifest_consumption_enabled": false,
+  "runtime_production_consumption_enabled": false,
+  "schema_version": "v3_1.experimental_runtime_readiness_closeout_report.1",
+  "summary": {
+    "blocked_count": 0,
+    "deterministic": true,
+    "production_affected_count": 0,
+    "production_behavior_changed": false,
+    "production_default_routing_authorized": false,
+    "production_output_affected": false,
+    "production_routing_authorized": false,
+    "ready_count": 1,
+    "records_evaluated": 1,
+    "runtime_manifest_consumption_enabled": false,
+    "runtime_production_consumption_enabled": false
+  }
+}

--- a/docs/migration/V3_1_EXPERIMENTAL_RUNTIME_READINESS_CLOSEOUT.md
+++ b/docs/migration/V3_1_EXPERIMENTAL_RUNTIME_READINESS_CLOSEOUT.md
@@ -1,0 +1,58 @@
+# V3.1 Experimental Runtime Readiness Closeout
+
+Phase 28 summarizes the v3.1 controlled-consumption evidence chain for future limited experimental runtime consideration.
+Closeout readiness is not runtime approval and does not authorize production routing.
+
+## Recommendation
+
+- Recommendation: `READY_FOR_FUTURE_LIMITED_EXPERIMENTAL_RUNTIME_PHASE_REVIEW_ONLY`
+- Recommended next phase: future limited experimental runtime planning, still gated and not production-authorized
+- Runtime manifest consumption enabled: `false`
+- Production routing authorized: `false`
+
+## Summary
+
+- Records evaluated: `1`
+- Ready: `1`
+- Blocked: `0`
+- Runtime manifest consumption enabled: `false`
+- Production routing authorized: `false`
+- Deterministic: `true`
+
+## Evidence Chain Summary
+
+- manifest_eligibility_records: `1`
+- controlled_consumption_records: `1`
+- output_validation_records: `1`
+- structural_parity_records: `1`
+- semantic_parity_records: `1`
+- promotion_readiness_records: `1`
+- runtime_guard_records: `1`
+- dry_run_records: `1`
+- dry_run_stability_records: `1`
+- runtime_manifest_consumption_enabled: `False`
+- production_routing_authorized: `False`
+
+## Unresolved Blockers
+
+| Blocker | Count |
+| --- | ---: |
+
+## Closeout Records
+
+| Record | Manifest | Fixture Set | Closeout Status |
+| --- | --- | --- | --- |
+| `v3_1_experimental_runtime_closeout_083a4072bdd59bed` | `v3_1_admission_manifest_198a3e2110f9e5e4` | `v3_1_fixture_set_6d3b668a84cfbb69` | `ready_for_future_limited_experimental_runtime_phase` |
+
+## Phase 28 Boundaries
+
+- closeout is audit/reporting only
+- closeout does not enable runtime manifest consumption
+- closeout does not authorize production routing
+- manifests remain non-production-authoritative
+- production planner routing remains unchanged
+- legacy planner ownership remains intact
+
+## Conclusion
+
+The controlled-consumption evidence chain is summarized for governance review only. Runtime consumption and production routing remain disabled.


### PR DESCRIPTION
Adds deterministic closeout auditing for the v3.1 controlled-consumption evidence chain while preserving disabled runtime consumption and production routing isolation.