### PR TITLE
v3.2: implement runtime isolation contracts

### DIFF
--- a/backend/app/planner_adapters/v3_2/__init__.py
+++ b/backend/app/planner_adapters/v3_2/__init__.py
@@ -13,6 +13,21 @@ from .experimental_runtime_entrypoint_contracts import (
     classify_runtime_entrypoint_state,
     evaluate_runtime_entrypoint_contract,
 )
+from .runtime_isolation_contracts import (
+    MANIFEST_CONSUMPTION_CROSSOVER_BLOCKED,
+    PLANNER_OWNERSHIP_CROSSOVER_BLOCKED,
+    PRODUCTION_ROUTING_CROSSOVER_BLOCKED,
+    ROLLBACK_CONTAINMENT_REQUIRED,
+    RUNTIME_ISOLATION_BLOCKED,
+    RUNTIME_ISOLATION_CONTRACT_STATUSES,
+    RUNTIME_ISOLATION_SATISFIED,
+    RUNTIME_MUTATION_BLOCKED,
+    SIDE_EFFECT_BOUNDARY_BLOCKED,
+    build_runtime_isolation_contract,
+    classify_runtime_isolation_state,
+    evaluate_runtime_isolation_contract,
+    summarize_runtime_isolation_contract,
+)
 
 __all__ = [
     "EXPERIMENTAL_RUNTIME_BLOCKED",
@@ -23,7 +38,20 @@ __all__ = [
     "RUNTIME_DISABLED_BY_POLICY",
     "RUNTIME_ENTRYPOINT_CONTRACT_STATUSES",
     "RUNTIME_ROLLBACK_REQUIRED",
+    "MANIFEST_CONSUMPTION_CROSSOVER_BLOCKED",
+    "PLANNER_OWNERSHIP_CROSSOVER_BLOCKED",
+    "PRODUCTION_ROUTING_CROSSOVER_BLOCKED",
+    "ROLLBACK_CONTAINMENT_REQUIRED",
+    "RUNTIME_ISOLATION_BLOCKED",
+    "RUNTIME_ISOLATION_CONTRACT_STATUSES",
+    "RUNTIME_ISOLATION_SATISFIED",
+    "RUNTIME_MUTATION_BLOCKED",
+    "SIDE_EFFECT_BOUNDARY_BLOCKED",
     "build_runtime_entrypoint_contract",
+    "build_runtime_isolation_contract",
     "classify_runtime_entrypoint_state",
+    "classify_runtime_isolation_state",
     "evaluate_runtime_entrypoint_contract",
+    "evaluate_runtime_isolation_contract",
+    "summarize_runtime_isolation_contract",
 ]

--- a/backend/app/planner_adapters/v3_2/runtime_isolation_contracts.py
+++ b/backend/app/planner_adapters/v3_2/runtime_isolation_contracts.py
@@ -1,0 +1,372 @@
+"""Runtime isolation contracts for v3.2 limited experimental runtime governance.
+
+This module layers isolation governance on top of v3.2 Phase 1 entrypoint
+contracts. It is pure and deterministic, and it does not enable runtime
+manifest consumption or production routing.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from copy import deepcopy
+from typing import Any
+
+from app.planner_adapters.v3_1.approval_manifest_serialization import NON_PRODUCTION_AUTHORIZATION_STATE
+from app.planner_adapters.v3_1.trusted_shadow_consumption import deterministic_hash
+from app.planner_adapters.v3_2.experimental_runtime_entrypoint_contracts import (
+    EXPERIMENTAL_RUNTIME_ELIGIBLE,
+    PRODUCTION_RUNTIME_PROHIBITED,
+)
+
+
+RUNTIME_ISOLATION_SATISFIED = "runtime_isolation_satisfied"
+RUNTIME_ISOLATION_BLOCKED = "runtime_isolation_blocked"
+PRODUCTION_ROUTING_CROSSOVER_BLOCKED = "production_routing_crossover_blocked"
+MANIFEST_CONSUMPTION_CROSSOVER_BLOCKED = "manifest_consumption_crossover_blocked"
+PLANNER_OWNERSHIP_CROSSOVER_BLOCKED = "planner_ownership_crossover_blocked"
+RUNTIME_MUTATION_BLOCKED = "runtime_mutation_blocked"
+SIDE_EFFECT_BOUNDARY_BLOCKED = "side_effect_boundary_blocked"
+ROLLBACK_CONTAINMENT_REQUIRED = "rollback_containment_required"
+
+RUNTIME_ISOLATION_CONTRACT_STATUSES = (
+    RUNTIME_ISOLATION_SATISFIED,
+    RUNTIME_ISOLATION_BLOCKED,
+    PRODUCTION_ROUTING_CROSSOVER_BLOCKED,
+    MANIFEST_CONSUMPTION_CROSSOVER_BLOCKED,
+    PLANNER_OWNERSHIP_CROSSOVER_BLOCKED,
+    RUNTIME_MUTATION_BLOCKED,
+    SIDE_EFFECT_BOUNDARY_BLOCKED,
+    ROLLBACK_CONTAINMENT_REQUIRED,
+)
+STABLE_RUNTIME_ISOLATION_CONTRACT_TOKEN = "v3_2_phase_2_runtime_isolation_contracts_token"
+
+
+def build_runtime_isolation_contract(
+    runtime_isolation_requests: dict[str, Any] | list[dict[str, Any]],
+    *,
+    experimental_runtime_entrypoint_contracts: dict[str, Any] | list[dict[str, Any]],
+    run_id: str = "v3_2_phase_2_runtime_isolation_contracts",
+) -> dict[str, Any]:
+    """Build deterministic runtime isolation contracts from explicit inputs."""
+
+    requests = _isolation_requests(runtime_isolation_requests)
+    entrypoints = _entrypoint_records(experimental_runtime_entrypoint_contracts)
+    entrypoint_by_key = {_trace_key(record): record for record in entrypoints if _trace_key(record)}
+    contracts = [
+        evaluate_runtime_isolation_contract(
+            request,
+            entrypoint_contract=entrypoint_by_key.get(_trace_key(request)),
+        )
+        for request in sorted(requests, key=_record_sort_key)
+    ]
+    if not contracts:
+        contracts = [evaluate_runtime_isolation_contract({}, entrypoint_contract=None)]
+    return summarize_runtime_isolation_contract(
+        contracts,
+        run_id=run_id,
+        runtime_isolation_requests_hash=_source_hash(runtime_isolation_requests),
+        experimental_runtime_entrypoint_contracts_hash=_source_hash(experimental_runtime_entrypoint_contracts),
+        request_count=len(requests),
+        entrypoint_count=len(entrypoints),
+    )
+
+
+def evaluate_runtime_isolation_contract(
+    runtime_isolation_request: dict[str, Any],
+    *,
+    entrypoint_contract: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Evaluate one isolation request against a Phase 1 entrypoint contract."""
+
+    request = deepcopy(runtime_isolation_request)
+    entrypoint = deepcopy(entrypoint_contract) if entrypoint_contract else None
+    blockers = _blockers(request, entrypoint)
+    status = classify_runtime_isolation_state(request, blockers=blockers)
+    manifest_id = request.get("manifest_id") or (entrypoint or {}).get("manifest_id")
+    fixture_set_id = request.get("fixture_set_id") or (entrypoint or {}).get("fixture_set_id")
+    seed = {
+        "manifest_id": manifest_id,
+        "fixture_set_id": fixture_set_id,
+        "status": status,
+        "token": STABLE_RUNTIME_ISOLATION_CONTRACT_TOKEN,
+    }
+    return {
+        "runtime_isolation_contract_id": f"v3_2_runtime_isolation_contract_{deterministic_hash(seed)[:16]}",
+        "manifest_id": manifest_id,
+        "fixture_set_id": fixture_set_id,
+        "entrypoint_contract_status": (entrypoint or {}).get("runtime_entrypoint_status"),
+        "entrypoint_authorization_state": (entrypoint or {}).get("runtime_authorization_state"),
+        "entrypoint_production_runtime_classification": (entrypoint or {}).get("production_runtime_classification", PRODUCTION_RUNTIME_PROHIBITED),
+        "runtime_isolation_boundary_state": request.get("runtime_isolation_boundary_state"),
+        "production_routing_separation_state": request.get("production_routing_separation_state"),
+        "manifest_consumption_separation_state": request.get("manifest_consumption_separation_state"),
+        "planner_ownership_separation_state": request.get("planner_ownership_separation_state"),
+        "runtime_mutation_prohibition_state": request.get("runtime_mutation_prohibition_state"),
+        "experimental_only_execution_scope": request.get("experimental_only_execution_scope"),
+        "runtime_side_effect_prohibition_state": request.get("runtime_side_effect_prohibition_state"),
+        "rollback_containment_state": request.get("rollback_containment_state"),
+        "isolation_blocker_state": "blocked" if blockers else "unblocked_for_contract_only",
+        "isolation_trace_classification": _trace_classification(status),
+        "runtime_isolation_status": status,
+        "blockers": blockers,
+        "runtime_manifest_consumption_enabled": False,
+        "runtime_production_consumption_enabled": False,
+        "production_routing_authorized": False,
+        "production_runtime_classification": PRODUCTION_RUNTIME_PROHIBITED,
+        "isolation_contract_authorizes_runtime_consumption": False,
+        "isolation_contract_authorizes_production_routing": False,
+        "production_output_affected": False,
+        "metadata": {
+            "governance_only": True,
+            "runtime_isolation_contract_only": True,
+            "runtime_behavior_enabled": False,
+            "production_runtime_prohibited": True,
+            "production_consumer": False,
+            "planner_remap_performed": False,
+            "silent_runtime_activation_allowed": False,
+            "fallback_isolation_allowed": False,
+            "implicit_manifest_consumption_allowed": False,
+        },
+    }
+
+
+def classify_runtime_isolation_state(
+    runtime_isolation_request: dict[str, Any],
+    *,
+    blockers: list[str] | None = None,
+) -> str:
+    """Classify isolation state with explicit non-boolean categories."""
+
+    blocker_set = set(blockers if blockers is not None else _blockers(runtime_isolation_request or {}, None))
+    if "production_routing_crossover" in blocker_set or "production_routing_authorized" in blocker_set:
+        return PRODUCTION_ROUTING_CROSSOVER_BLOCKED
+    if "manifest_consumption_crossover" in blocker_set or "implicit_manifest_consumption" in blocker_set:
+        return MANIFEST_CONSUMPTION_CROSSOVER_BLOCKED
+    if "planner_ownership_crossover" in blocker_set:
+        return PLANNER_OWNERSHIP_CROSSOVER_BLOCKED
+    if "runtime_mutation_requested" in blocker_set:
+        return RUNTIME_MUTATION_BLOCKED
+    if "side_effect_boundary_failed" in blocker_set:
+        return SIDE_EFFECT_BOUNDARY_BLOCKED
+    if "rollback_containment_missing" in blocker_set or "rollback_containment_required" in blocker_set:
+        return ROLLBACK_CONTAINMENT_REQUIRED
+    if blocker_set:
+        return RUNTIME_ISOLATION_BLOCKED
+    return RUNTIME_ISOLATION_SATISFIED
+
+
+def summarize_runtime_isolation_contract(
+    runtime_isolation_contracts: list[dict[str, Any]],
+    *,
+    run_id: str = "v3_2_phase_2_runtime_isolation_contracts",
+    runtime_isolation_requests_hash: str | None = None,
+    experimental_runtime_entrypoint_contracts_hash: str | None = None,
+    request_count: int | None = None,
+    entrypoint_count: int | None = None,
+) -> dict[str, Any]:
+    """Return a deterministic summary envelope for isolation contracts."""
+
+    contracts = [deepcopy(record) for record in sorted(runtime_isolation_contracts, key=_record_sort_key)]
+    counts = Counter(record["runtime_isolation_status"] for record in contracts)
+    blocker_counts = Counter(blocker for record in contracts for blocker in record["blockers"])
+    boundary_counts = Counter(record.get("runtime_isolation_boundary_state") or "missing" for record in contracts)
+    routing_counts = Counter(record.get("production_routing_separation_state") or "missing" for record in contracts)
+    manifest_counts = Counter(record.get("manifest_consumption_separation_state") or "missing" for record in contracts)
+    planner_counts = Counter(record.get("planner_ownership_separation_state") or "missing" for record in contracts)
+    mutation_counts = Counter(record.get("runtime_mutation_prohibition_state") or "missing" for record in contracts)
+    side_effect_counts = Counter(record.get("runtime_side_effect_prohibition_state") or "missing" for record in contracts)
+    rollback_counts = Counter(record.get("rollback_containment_state") or "missing" for record in contracts)
+    envelope = {
+        "schema_version": "v3_2.runtime_isolation_contracts.1",
+        "run": {
+            "run_id": run_id,
+            "runtime_isolation_request_count": len(contracts) if request_count is None else request_count,
+            "entrypoint_contract_count": entrypoint_count,
+            "runtime_isolation_requests_hash": runtime_isolation_requests_hash,
+            "experimental_runtime_entrypoint_contracts_hash": experimental_runtime_entrypoint_contracts_hash,
+        },
+        "summary": {
+            "records_evaluated": len(contracts),
+            "runtime_isolation_satisfied_count": counts[RUNTIME_ISOLATION_SATISFIED],
+            "runtime_isolation_blocked_count": len(contracts) - counts[RUNTIME_ISOLATION_SATISFIED],
+            "production_routing_crossover_blocked_count": counts[PRODUCTION_ROUTING_CROSSOVER_BLOCKED],
+            "manifest_consumption_crossover_blocked_count": counts[MANIFEST_CONSUMPTION_CROSSOVER_BLOCKED],
+            "planner_ownership_crossover_blocked_count": counts[PLANNER_OWNERSHIP_CROSSOVER_BLOCKED],
+            "runtime_mutation_blocked_count": counts[RUNTIME_MUTATION_BLOCKED],
+            "side_effect_boundary_blocked_count": counts[SIDE_EFFECT_BOUNDARY_BLOCKED],
+            "rollback_containment_required_count": counts[ROLLBACK_CONTAINMENT_REQUIRED],
+            "runtime_manifest_consumption_enabled": False,
+            "runtime_production_consumption_enabled": False,
+            "production_routing_authorized": False,
+            "production_default_routing_authorized": False,
+            "production_output_affected": False,
+            "production_behavior_changed": False,
+            "deterministic": True,
+        },
+        "runtime_isolation_status_counts": {
+            status: counts[status]
+            for status in RUNTIME_ISOLATION_CONTRACT_STATUSES
+        },
+        "isolation_state_distribution": dict(sorted(boundary_counts.items())),
+        "production_routing_crossover_distribution": dict(sorted(routing_counts.items())),
+        "manifest_consumption_crossover_distribution": dict(sorted(manifest_counts.items())),
+        "planner_ownership_crossover_distribution": dict(sorted(planner_counts.items())),
+        "runtime_mutation_blocker_distribution": dict(sorted(mutation_counts.items())),
+        "side_effect_blocker_distribution": dict(sorted(side_effect_counts.items())),
+        "rollback_containment_distribution": dict(sorted(rollback_counts.items())),
+        "blocker_distribution": dict(sorted(blocker_counts.items())),
+        "phase_1_entrypoint_compatibility": {
+            "entrypoint_contract_records": entrypoint_count,
+            "requires_experimental_runtime_eligible": True,
+            "runtime_manifest_consumption_enabled": False,
+            "production_routing_authorized": False,
+            "production_runtime_prohibited": True,
+            "explicit_opt_in_preserved": True,
+            "runtime_disabled_states_remain_visible": True,
+            "rollback_required_states_remain_visible": True,
+        },
+        "runtime_disabled_path_verification": {
+            "runtime_manifest_consumption_enabled": False,
+            "runtime_production_consumption_enabled": False,
+            "production_runtime_prohibited": True,
+            "production_routing_authorized": False,
+            "silent_runtime_activation_allowed": False,
+            "implicit_manifest_consumption_allowed": False,
+            "fallback_isolation_allowed": False,
+        },
+        "runtime_isolation_contracts": contracts,
+        "safety_confirmations": {
+            "isolation_contract_enables_runtime_manifest_consumption": False,
+            "isolation_contract_authorizes_production_routing": False,
+            "isolation_contract_mutates_planner_ownership": False,
+            "production_runtime_routing_prohibited": True,
+            "runtime_manifest_consumption_enabled": False,
+            "runtime_production_consumption_enabled": False,
+            "legacy_planner_ownership_preserved": True,
+            "production_output_affected": False,
+            "production_behavior_changed": False,
+            "production_planner_routing_changed": False,
+            "trusted_data_default_truth": False,
+        },
+        "metadata": {
+            "source": "v3_2_runtime_isolation_contracts",
+            "governance_only": True,
+            "runtime_isolation_contract_only": True,
+            "runtime_behavior_enabled": False,
+            "production_runtime_prohibited": True,
+            "production_consumer": False,
+            "production_behavior_changed": False,
+            "planner_remap_performed": False,
+            "stable_generation_token": STABLE_RUNTIME_ISOLATION_CONTRACT_TOKEN,
+            "deterministic_serializer": "json_sort_keys_sha256",
+        },
+    }
+    envelope["deterministic_hash"] = deterministic_hash(envelope)
+    return envelope
+
+
+def _blockers(request: dict[str, Any], entrypoint: dict[str, Any] | None) -> list[str]:
+    blockers: list[str] = []
+    if entrypoint is None:
+        blockers.append("missing_phase_1_entrypoint_authorization_context")
+    else:
+        if entrypoint.get("runtime_entrypoint_status") != EXPERIMENTAL_RUNTIME_ELIGIBLE:
+            blockers.append("phase_1_entrypoint_not_eligible")
+        if entrypoint.get("runtime_manifest_consumption_enabled") is True:
+            blockers.append("runtime_manifest_consumption_enabled")
+        if entrypoint.get("production_routing_authorized") is True:
+            blockers.append("production_routing_authorized")
+        if entrypoint.get("production_runtime_classification") != PRODUCTION_RUNTIME_PROHIBITED:
+            blockers.append("production_runtime_not_prohibited")
+        if entrypoint.get("explicit_experimental_runtime_opt_in") is not True:
+            blockers.append("explicit_experimental_opt_in_missing")
+        if entrypoint.get("runtime_authorization_state") != NON_PRODUCTION_AUTHORIZATION_STATE:
+            blockers.append("runtime_authorization_invalid")
+    if not request:
+        blockers.append("missing_isolation_inputs")
+        return blockers
+    if request.get("runtime_isolation_boundary_state") != "isolation_boundary_satisfied":
+        blockers.append("isolation_boundary_missing")
+    if request.get("production_routing_separation_state") != "production_routing_separated" or request.get("production_routing_crossover") is True:
+        blockers.append("production_routing_crossover")
+    if _manifest_consumption_blocked(request):
+        blockers.append("manifest_consumption_crossover")
+    if request.get("planner_ownership_separation_state") != "planner_ownership_separated" or request.get("planner_ownership_mutation_requested") is True:
+        blockers.append("planner_ownership_crossover")
+    if request.get("runtime_mutation_prohibition_state") != "runtime_mutation_prohibited" or request.get("runtime_mutation_requested") is True:
+        blockers.append("runtime_mutation_requested")
+    if _side_effect_blocked(request):
+        blockers.append("side_effect_boundary_failed")
+    if request.get("rollback_containment_state") != "rollback_contained":
+        blockers.append("rollback_containment_missing")
+    if request.get("experimental_only_execution_scope") != "experimental_only":
+        blockers.append("experimental_only_scope_missing")
+    return sorted(set(blockers), key=blockers.index)
+
+
+def _manifest_consumption_blocked(request: dict[str, Any]) -> bool:
+    if request.get("manifest_consumption_separation_state") != "manifest_consumption_separated":
+        return True
+    if request.get("manifest_consumption_crossover") is True:
+        return not (
+            request.get("manifest_consumption_scope") == "experimental_only"
+            and request.get("manifest_authorization_state") == NON_PRODUCTION_AUTHORIZATION_STATE
+            and request.get("implicit_manifest_consumption") is False
+        )
+    return request.get("implicit_manifest_consumption") is True
+
+
+def _side_effect_blocked(request: dict[str, Any]) -> bool:
+    if request.get("runtime_side_effect_prohibition_state") == "side_effects_prohibited":
+        return False
+    return not (
+        request.get("runtime_side_effect_prohibition_state") == "side_effects_isolated_reversible_non_production"
+        and request.get("side_effects_isolated") is True
+        and request.get("side_effects_reversible") is True
+        and request.get("side_effects_non_production") is True
+    )
+
+
+def _isolation_requests(value: dict[str, Any] | list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if isinstance(value, list):
+        return [deepcopy(record) for record in value]
+    return [deepcopy(record) for record in value.get("runtime_isolation_requests", [])]
+
+
+def _entrypoint_records(value: dict[str, Any] | list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if isinstance(value, list):
+        return [deepcopy(record) for record in value]
+    return [deepcopy(record) for record in value.get("runtime_entrypoint_contracts", [])]
+
+
+def _trace_key(record: dict[str, Any] | None) -> tuple[str, str] | None:
+    if not record:
+        return None
+    manifest_id = record.get("manifest_id")
+    fixture_set_id = record.get("fixture_set_id")
+    if not manifest_id or not fixture_set_id:
+        return None
+    return (str(manifest_id), str(fixture_set_id))
+
+
+def _record_sort_key(record: dict[str, Any]) -> tuple[str, str]:
+    return (
+        str(record.get("fixture_set_id") or ""),
+        str(record.get("manifest_id") or ""),
+    )
+
+
+def _trace_classification(status: str) -> str:
+    if status == RUNTIME_ISOLATION_SATISFIED:
+        return "runtime_isolation_trace_satisfied"
+    if status == ROLLBACK_CONTAINMENT_REQUIRED:
+        return "runtime_isolation_trace_rollback_required"
+    if status == PRODUCTION_ROUTING_CROSSOVER_BLOCKED:
+        return "runtime_isolation_trace_production_crossover_blocked"
+    return "runtime_isolation_trace_blocked"
+
+
+def _source_hash(value: dict[str, Any] | list[dict[str, Any]]) -> str | None:
+    if isinstance(value, dict):
+        return value.get("deterministic_hash")
+    return None

--- a/backend/scripts/report_v3_2_runtime_isolation_contracts.py
+++ b/backend/scripts/report_v3_2_runtime_isolation_contracts.py
@@ -1,0 +1,228 @@
+"""Generate the v3.2 runtime isolation contract report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.planner_adapters.v3_1.approval_manifest_serialization import NON_PRODUCTION_AUTHORIZATION_STATE  # noqa: E402
+from app.planner_adapters.v3_1.trusted_shadow_consumption import deterministic_hash  # noqa: E402
+from app.planner_adapters.v3_2.runtime_isolation_contracts import build_runtime_isolation_contract  # noqa: E402
+
+
+DETERMINISTIC_GENERATED_AT = "2026-05-15T00:00:00+00:00"
+
+
+def build_v3_2_runtime_isolation_contracts_report() -> dict[str, Any]:
+    repo_root = Path(__file__).resolve().parents[2]
+    entrypoint = _read_json(repo_root / "docs" / "generated" / "v3_2_experimental_runtime_entrypoint_contracts_report.json")[
+        "experimental_runtime_entrypoint_contracts"
+    ]
+    isolation_requests = _isolation_requests_from_entrypoint(entrypoint)
+    request_payload = {"runtime_isolation_requests": isolation_requests, "deterministic_hash": deterministic_hash(isolation_requests)}
+    isolation = build_runtime_isolation_contract(
+        request_payload,
+        experimental_runtime_entrypoint_contracts=entrypoint,
+    )
+    repeated = build_runtime_isolation_contract(
+        request_payload,
+        experimental_runtime_entrypoint_contracts=entrypoint,
+    )
+    report = {
+        "schema_version": "v3_2.runtime_isolation_contracts_report.1",
+        "generated_at": DETERMINISTIC_GENERATED_AT,
+        "phase": "v3.2_phase_2_runtime_isolation_contracts",
+        "recommendation": "RUNTIME_ISOLATION_CONTRACT_READY_FOR_FUTURE_EXPERIMENTAL_RUNTIME_DESIGN_ONLY",
+        "runtime_manifest_consumption_enabled": False,
+        "runtime_production_consumption_enabled": False,
+        "production_runtime_prohibited": True,
+        "production_routing_authorized": False,
+        "production_default_routing_authorized": False,
+        "summary": {
+            **isolation["summary"],
+            "deterministic": isolation["deterministic_hash"] == repeated["deterministic_hash"],
+        },
+        "runtime_isolation_contracts": isolation,
+        "isolation_state_distributions": isolation["isolation_state_distribution"],
+        "production_routing_crossover_distributions": isolation["production_routing_crossover_distribution"],
+        "manifest_consumption_crossover_distributions": isolation["manifest_consumption_crossover_distribution"],
+        "planner_ownership_crossover_distributions": isolation["planner_ownership_crossover_distribution"],
+        "runtime_mutation_blocker_distributions": isolation["runtime_mutation_blocker_distribution"],
+        "side_effect_blocker_distributions": isolation["side_effect_blocker_distribution"],
+        "rollback_containment_distributions": isolation["rollback_containment_distribution"],
+        "phase_1_entrypoint_compatibility_summary": isolation["phase_1_entrypoint_compatibility"],
+        "runtime_disabled_path_verification": isolation["runtime_disabled_path_verification"],
+        "production_prohibited_verification": {
+            "production_runtime_prohibited": True,
+            "production_routing_authorized": False,
+            "production_default_routing_authorized": False,
+        },
+        "deterministic_guarantees": {
+            "passed": isolation["deterministic_hash"] == repeated["deterministic_hash"],
+            "sample_hash": isolation["deterministic_hash"],
+            "repeated_hash": repeated["deterministic_hash"],
+            "timestamp_excluded_from_hash": True,
+            "json_sort_keys": True,
+        },
+        "phase_2_boundaries": [
+            "runtime isolation contracts are governance only",
+            "runtime manifest consumption remains disabled by default",
+            "production runtime routing remains prohibited",
+            "manifest consumption cannot become implicit runtime behavior",
+            "planner ownership mutation remains blocked",
+            "side effects must be prohibited or isolated, reversible, and non-production",
+        ],
+        "future_phase_foundation": [
+            "future phases may evaluate initialization only after isolation contracts remain satisfied",
+            "future phases must preserve entrypoint authorization and explicit opt-in",
+            "future phases must continue to block production routing and planner ownership crossover",
+        ],
+        "metadata": {
+            "source": "v3_2_runtime_isolation_contracts_report",
+            "governance_only": True,
+            "runtime_isolation_contract_only": True,
+            "runtime_behavior_enabled": False,
+            "production_runtime_prohibited": True,
+            "production_behavior_changed": False,
+            "production_default_routing_authorized": False,
+            "planner_remap_performed": False,
+        },
+    }
+    return _normalize_generated_at(report)
+
+
+def write_report(report: dict[str, Any], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_markdown(report: dict[str, Any], output_path: Path) -> None:
+    isolation = report["runtime_isolation_contracts"]
+    summary = report["summary"]
+    lines = [
+        "# V3.2 Runtime Isolation Contracts",
+        "",
+        "Phase 2 defines isolation rules that must hold before future limited experimental runtime initialization can be considered.",
+        "This does not enable runtime manifest consumption or production routing.",
+        "",
+        "## Phase 1 Compatibility",
+        "",
+        "Phase 2 builds on Phase 1 by requiring an eligible entrypoint contract, explicit opt-in, non-production authorization, disabled runtime consumption, and prohibited production runtime classification.",
+        "",
+        "## Separation Requirements",
+        "",
+        "Production routing must remain separated so experimental runtime evidence cannot cross into planner output ownership.",
+        "Manifest consumption cannot become implicit runtime behavior; any future consumption must stay explicit, experimental-only, and non-production-authoritative.",
+        "Planner ownership cannot be silently mutated because production planner ownership remains legacy-controlled.",
+        "",
+        "## Side Effects And Rollback",
+        "",
+        "Runtime side effects are blocked unless explicitly isolated, reversible, and non-production. Rollback containment must remain visible before later runtime-adjacent phases.",
+        "",
+        "## Summary",
+        "",
+        f"- Records evaluated: `{summary['records_evaluated']}`",
+        f"- Isolation satisfied: `{summary['runtime_isolation_satisfied_count']}`",
+        f"- Isolation blocked: `{summary['runtime_isolation_blocked_count']}`",
+        f"- Runtime manifest consumption enabled: `{str(summary['runtime_manifest_consumption_enabled']).lower()}`",
+        f"- Production routing authorized: `{str(summary['production_routing_authorized']).lower()}`",
+        f"- Deterministic: `{str(summary['deterministic']).lower()}`",
+        "",
+        "## Blocker Distribution",
+        "",
+        "| Blocker | Count |",
+        "| --- | ---: |",
+    ]
+    for blocker, count in isolation["blocker_distribution"].items():
+        lines.append(f"| `{blocker}` | `{count}` |")
+    lines.extend(
+        [
+            "",
+            "## Isolation Records",
+            "",
+            "| Contract | Manifest | Fixture Set | Status | Isolation | Routing | Manifest Consumption |",
+            "| --- | --- | --- | --- | --- | --- | --- |",
+        ]
+    )
+    for row in isolation["runtime_isolation_contracts"]:
+        lines.append(
+            f"| `{row['runtime_isolation_contract_id']}` | `{row['manifest_id'] or ''}` | `{row['fixture_set_id'] or ''}` | `{row['runtime_isolation_status']}` | `{row['runtime_isolation_boundary_state'] or ''}` | `{row['production_routing_separation_state'] or ''}` | `{row['manifest_consumption_separation_state'] or ''}` |"
+        )
+    lines.extend(["", "## Future Phases", ""])
+    lines.extend(f"- {item}" for item in report["future_phase_foundation"])
+    lines.extend(["", "## Boundaries", ""])
+    lines.extend(f"- {item}" for item in report["phase_2_boundaries"])
+    lines.extend(
+        [
+            "",
+            "## Conclusion",
+            "",
+            "Runtime isolation contracts are satisfied for governance review only. Production runtime routing remains prohibited and default runtime manifest consumption remains disabled.",
+        ]
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _isolation_requests_from_entrypoint(entrypoint: dict[str, Any]) -> list[dict[str, Any]]:
+    return [
+        {
+            "manifest_id": record.get("manifest_id"),
+            "fixture_set_id": record.get("fixture_set_id"),
+            "runtime_isolation_boundary_state": "isolation_boundary_satisfied",
+            "production_routing_separation_state": "production_routing_separated",
+            "manifest_consumption_separation_state": "manifest_consumption_separated",
+            "manifest_consumption_scope": "experimental_only",
+            "manifest_authorization_state": NON_PRODUCTION_AUTHORIZATION_STATE,
+            "implicit_manifest_consumption": False,
+            "planner_ownership_separation_state": "planner_ownership_separated",
+            "runtime_mutation_prohibition_state": "runtime_mutation_prohibited",
+            "experimental_only_execution_scope": "experimental_only",
+            "runtime_side_effect_prohibition_state": "side_effects_prohibited",
+            "rollback_containment_state": "rollback_contained",
+            "production_routing_crossover": False,
+            "manifest_consumption_crossover": False,
+            "planner_ownership_mutation_requested": False,
+            "runtime_mutation_requested": False,
+        }
+        for record in entrypoint.get("runtime_entrypoint_contracts", [])
+    ]
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _normalize_generated_at(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: DETERMINISTIC_GENERATED_AT if key == "generated_at" else _normalize_generated_at(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_normalize_generated_at(item) for item in value]
+    return deepcopy(value)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", default="docs/generated/v3_2_runtime_isolation_contracts_report.json")
+    parser.add_argument("--markdown-output", default="docs/migration/V3_2_RUNTIME_ISOLATION_CONTRACTS.md")
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[2]
+    report = build_v3_2_runtime_isolation_contracts_report()
+    write_report(report, repo_root / args.output)
+    write_markdown(report, repo_root / args.markdown_output)
+    print(json.dumps(report["summary"], indent=2, sort_keys=True))
+    print(report["recommendation"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_v3_2_runtime_isolation_contracts.py
+++ b/backend/tests/test_v3_2_runtime_isolation_contracts.py
@@ -1,0 +1,203 @@
+from app.planner_adapters.v3_2.runtime_isolation_contracts import (
+    MANIFEST_CONSUMPTION_CROSSOVER_BLOCKED,
+    PLANNER_OWNERSHIP_CROSSOVER_BLOCKED,
+    PRODUCTION_ROUTING_CROSSOVER_BLOCKED,
+    ROLLBACK_CONTAINMENT_REQUIRED,
+    RUNTIME_ISOLATION_SATISFIED,
+    RUNTIME_MUTATION_BLOCKED,
+    SIDE_EFFECT_BOUNDARY_BLOCKED,
+    build_runtime_isolation_contract,
+    classify_runtime_isolation_state,
+    evaluate_runtime_isolation_contract,
+)
+from scripts.report_v3_2_runtime_isolation_contracts import build_v3_2_runtime_isolation_contracts_report
+
+
+def test_deterministic_ordering():
+    first = _build([_request("manifest_b", "set_b"), _request("manifest_a", "set_a")], [_entrypoint("manifest_b", "set_b"), _entrypoint("manifest_a", "set_a")])
+    second = _build([_request("manifest_a", "set_a"), _request("manifest_b", "set_b")], [_entrypoint("manifest_a", "set_a"), _entrypoint("manifest_b", "set_b")])
+
+    assert first["deterministic_hash"] == second["deterministic_hash"]
+    assert [row["manifest_id"] for row in first["runtime_isolation_contracts"]] == ["manifest_a", "manifest_b"]
+
+
+def test_deterministic_hashes_and_repeat_run_stability():
+    first = _build()
+    second = _build()
+
+    assert first["deterministic_hash"] == second["deterministic_hash"]
+    assert first["summary"]["deterministic"] is True
+
+
+def test_phase_1_entrypoint_compatibility():
+    result = _build()
+
+    record = result["runtime_isolation_contracts"][0]
+    assert record["entrypoint_contract_status"] == "experimental_runtime_eligible"
+    assert result["phase_1_entrypoint_compatibility"]["production_runtime_prohibited"] is True
+
+
+def test_production_routing_crossover_blocking():
+    result = _build([_request(production_routing_crossover=True)])
+
+    assert result["runtime_isolation_contracts"][0]["runtime_isolation_status"] == PRODUCTION_ROUTING_CROSSOVER_BLOCKED
+
+
+def test_manifest_consumption_crossover_blocking():
+    result = _build([_request(manifest_consumption_crossover=True, manifest_consumption_scope="production")])
+
+    assert result["runtime_isolation_contracts"][0]["runtime_isolation_status"] == MANIFEST_CONSUMPTION_CROSSOVER_BLOCKED
+
+
+def test_planner_ownership_crossover_blocking():
+    result = _build([_request(planner_ownership_mutation_requested=True)])
+
+    assert result["runtime_isolation_contracts"][0]["runtime_isolation_status"] == PLANNER_OWNERSHIP_CROSSOVER_BLOCKED
+
+
+def test_runtime_mutation_blocking():
+    result = _build([_request(runtime_mutation_requested=True)])
+
+    assert result["runtime_isolation_contracts"][0]["runtime_isolation_status"] == RUNTIME_MUTATION_BLOCKED
+
+
+def test_side_effect_boundary_blocking():
+    result = _build([_request(runtime_side_effect_prohibition_state="side_effects_external")])
+
+    assert result["runtime_isolation_contracts"][0]["runtime_isolation_status"] == SIDE_EFFECT_BOUNDARY_BLOCKED
+
+
+def test_rollback_containment_required_behavior():
+    result = _build([_request(rollback_containment_state="rollback_not_contained")])
+
+    assert result["runtime_isolation_contracts"][0]["runtime_isolation_status"] == ROLLBACK_CONTAINMENT_REQUIRED
+
+
+def test_missing_isolation_inputs_fail_visibly():
+    result = _build([])
+
+    record = result["runtime_isolation_contracts"][0]
+    assert record["runtime_isolation_status"] != RUNTIME_ISOLATION_SATISFIED
+    assert "missing_isolation_inputs" in record["blockers"]
+
+
+def test_missing_phase_1_authorization_context_fails_visibly():
+    record = evaluate_runtime_isolation_contract(_request(), entrypoint_contract=None)
+
+    assert "missing_phase_1_entrypoint_authorization_context" in record["blockers"]
+
+
+def test_blocker_accumulation_behavior():
+    result = _build([_request(production_routing_crossover=True, planner_ownership_mutation_requested=True, runtime_mutation_requested=True)])
+
+    blockers = result["runtime_isolation_contracts"][0]["blockers"]
+    assert "production_routing_crossover" in blockers
+    assert "planner_ownership_crossover" in blockers
+    assert "runtime_mutation_requested" in blockers
+
+
+def test_no_silent_runtime_activation():
+    result = _build()
+    record = result["runtime_isolation_contracts"][0]
+
+    assert record["metadata"]["silent_runtime_activation_allowed"] is False
+    assert record["metadata"]["fallback_isolation_allowed"] is False
+    assert record["isolation_contract_authorizes_runtime_consumption"] is False
+
+
+def test_no_implicit_manifest_consumption():
+    result = _build()
+    record = result["runtime_isolation_contracts"][0]
+
+    assert record["metadata"]["implicit_manifest_consumption_allowed"] is False
+    assert result["runtime_disabled_path_verification"]["implicit_manifest_consumption_allowed"] is False
+
+
+def test_no_production_routing_changes_and_runtime_remains_prohibited():
+    result = _build()
+
+    assert result["safety_confirmations"]["isolation_contract_authorizes_production_routing"] is False
+    assert result["safety_confirmations"]["production_runtime_routing_prohibited"] is True
+    assert result["summary"]["production_behavior_changed"] is False
+
+
+def test_production_runtime_remains_prohibited():
+    result = _build()
+
+    assert result["runtime_isolation_contracts"][0]["production_runtime_classification"] == "production_runtime_prohibited"
+    assert result["runtime_disabled_path_verification"]["production_runtime_prohibited"] is True
+
+
+def test_classify_runtime_isolation_state_is_explicit():
+    assert classify_runtime_isolation_state(_request(), blockers=[]) == RUNTIME_ISOLATION_SATISFIED
+    assert classify_runtime_isolation_state(_request(), blockers=["manifest_consumption_crossover"]) == MANIFEST_CONSUMPTION_CROSSOVER_BLOCKED
+
+
+def test_stable_report_generation():
+    first = build_v3_2_runtime_isolation_contracts_report()
+    second = build_v3_2_runtime_isolation_contracts_report()
+
+    assert first["deterministic_guarantees"]["passed"] is True
+    assert first["runtime_isolation_contracts"]["deterministic_hash"] == second["runtime_isolation_contracts"]["deterministic_hash"]
+    assert first["summary"] == second["summary"]
+
+
+def _build(requests=None, entrypoints=None):
+    return build_runtime_isolation_contract(
+        {"runtime_isolation_requests": [_request()] if requests is None else requests, "deterministic_hash": "isolation-requests-hash"},
+        experimental_runtime_entrypoint_contracts={"runtime_entrypoint_contracts": [_entrypoint()] if entrypoints is None else entrypoints, "deterministic_hash": "entrypoint-hash"},
+    )
+
+
+def _request(
+    manifest_id="manifest_a",
+    fixture_set_id="set_a",
+    runtime_isolation_boundary_state="isolation_boundary_satisfied",
+    production_routing_separation_state="production_routing_separated",
+    manifest_consumption_separation_state="manifest_consumption_separated",
+    manifest_consumption_scope="experimental_only",
+    manifest_authorization_state="non_production_authoritative",
+    implicit_manifest_consumption=False,
+    planner_ownership_separation_state="planner_ownership_separated",
+    runtime_mutation_prohibition_state="runtime_mutation_prohibited",
+    experimental_only_execution_scope="experimental_only",
+    runtime_side_effect_prohibition_state="side_effects_prohibited",
+    rollback_containment_state="rollback_contained",
+    production_routing_crossover=False,
+    manifest_consumption_crossover=False,
+    planner_ownership_mutation_requested=False,
+    runtime_mutation_requested=False,
+):
+    return {
+        "manifest_id": manifest_id,
+        "fixture_set_id": fixture_set_id,
+        "runtime_isolation_boundary_state": runtime_isolation_boundary_state,
+        "production_routing_separation_state": production_routing_separation_state,
+        "manifest_consumption_separation_state": manifest_consumption_separation_state,
+        "manifest_consumption_scope": manifest_consumption_scope,
+        "manifest_authorization_state": manifest_authorization_state,
+        "implicit_manifest_consumption": implicit_manifest_consumption,
+        "planner_ownership_separation_state": planner_ownership_separation_state,
+        "runtime_mutation_prohibition_state": runtime_mutation_prohibition_state,
+        "experimental_only_execution_scope": experimental_only_execution_scope,
+        "runtime_side_effect_prohibition_state": runtime_side_effect_prohibition_state,
+        "rollback_containment_state": rollback_containment_state,
+        "production_routing_crossover": production_routing_crossover,
+        "manifest_consumption_crossover": manifest_consumption_crossover,
+        "planner_ownership_mutation_requested": planner_ownership_mutation_requested,
+        "runtime_mutation_requested": runtime_mutation_requested,
+    }
+
+
+def _entrypoint(manifest_id="manifest_a", fixture_set_id="set_a", status="experimental_runtime_eligible"):
+    return {
+        "manifest_id": manifest_id,
+        "fixture_set_id": fixture_set_id,
+        "runtime_entrypoint_status": status,
+        "runtime_authorization_state": "non_production_authoritative",
+        "runtime_manifest_consumption_enabled": False,
+        "runtime_production_consumption_enabled": False,
+        "production_routing_authorized": False,
+        "production_runtime_classification": "production_runtime_prohibited",
+        "explicit_experimental_runtime_opt_in": True,
+    }

--- a/docs/generated/v3_2_runtime_isolation_contracts_report.json
+++ b/docs/generated/v3_2_runtime_isolation_contracts_report.json
@@ -1,0 +1,249 @@
+{
+  "deterministic_guarantees": {
+    "json_sort_keys": true,
+    "passed": true,
+    "repeated_hash": "e1fbca6e37f791c227797d7d67b8676f12f6f63cfd4b2ab751bb6cf307d62df9",
+    "sample_hash": "e1fbca6e37f791c227797d7d67b8676f12f6f63cfd4b2ab751bb6cf307d62df9",
+    "timestamp_excluded_from_hash": true
+  },
+  "future_phase_foundation": [
+    "future phases may evaluate initialization only after isolation contracts remain satisfied",
+    "future phases must preserve entrypoint authorization and explicit opt-in",
+    "future phases must continue to block production routing and planner ownership crossover"
+  ],
+  "generated_at": "2026-05-15T00:00:00+00:00",
+  "isolation_state_distributions": {
+    "isolation_boundary_satisfied": 1
+  },
+  "manifest_consumption_crossover_distributions": {
+    "manifest_consumption_separated": 1
+  },
+  "metadata": {
+    "governance_only": true,
+    "planner_remap_performed": false,
+    "production_behavior_changed": false,
+    "production_default_routing_authorized": false,
+    "production_runtime_prohibited": true,
+    "runtime_behavior_enabled": false,
+    "runtime_isolation_contract_only": true,
+    "source": "v3_2_runtime_isolation_contracts_report"
+  },
+  "phase": "v3.2_phase_2_runtime_isolation_contracts",
+  "phase_1_entrypoint_compatibility_summary": {
+    "entrypoint_contract_records": 1,
+    "explicit_opt_in_preserved": true,
+    "production_routing_authorized": false,
+    "production_runtime_prohibited": true,
+    "requires_experimental_runtime_eligible": true,
+    "rollback_required_states_remain_visible": true,
+    "runtime_disabled_states_remain_visible": true,
+    "runtime_manifest_consumption_enabled": false
+  },
+  "phase_2_boundaries": [
+    "runtime isolation contracts are governance only",
+    "runtime manifest consumption remains disabled by default",
+    "production runtime routing remains prohibited",
+    "manifest consumption cannot become implicit runtime behavior",
+    "planner ownership mutation remains blocked",
+    "side effects must be prohibited or isolated, reversible, and non-production"
+  ],
+  "planner_ownership_crossover_distributions": {
+    "planner_ownership_separated": 1
+  },
+  "production_default_routing_authorized": false,
+  "production_prohibited_verification": {
+    "production_default_routing_authorized": false,
+    "production_routing_authorized": false,
+    "production_runtime_prohibited": true
+  },
+  "production_routing_authorized": false,
+  "production_routing_crossover_distributions": {
+    "production_routing_separated": 1
+  },
+  "production_runtime_prohibited": true,
+  "recommendation": "RUNTIME_ISOLATION_CONTRACT_READY_FOR_FUTURE_EXPERIMENTAL_RUNTIME_DESIGN_ONLY",
+  "rollback_containment_distributions": {
+    "rollback_contained": 1
+  },
+  "runtime_disabled_path_verification": {
+    "fallback_isolation_allowed": false,
+    "implicit_manifest_consumption_allowed": false,
+    "production_routing_authorized": false,
+    "production_runtime_prohibited": true,
+    "runtime_manifest_consumption_enabled": false,
+    "runtime_production_consumption_enabled": false,
+    "silent_runtime_activation_allowed": false
+  },
+  "runtime_isolation_contracts": {
+    "blocker_distribution": {},
+    "deterministic_hash": "e1fbca6e37f791c227797d7d67b8676f12f6f63cfd4b2ab751bb6cf307d62df9",
+    "isolation_state_distribution": {
+      "isolation_boundary_satisfied": 1
+    },
+    "manifest_consumption_crossover_distribution": {
+      "manifest_consumption_separated": 1
+    },
+    "metadata": {
+      "deterministic_serializer": "json_sort_keys_sha256",
+      "governance_only": true,
+      "planner_remap_performed": false,
+      "production_behavior_changed": false,
+      "production_consumer": false,
+      "production_runtime_prohibited": true,
+      "runtime_behavior_enabled": false,
+      "runtime_isolation_contract_only": true,
+      "source": "v3_2_runtime_isolation_contracts",
+      "stable_generation_token": "v3_2_phase_2_runtime_isolation_contracts_token"
+    },
+    "phase_1_entrypoint_compatibility": {
+      "entrypoint_contract_records": 1,
+      "explicit_opt_in_preserved": true,
+      "production_routing_authorized": false,
+      "production_runtime_prohibited": true,
+      "requires_experimental_runtime_eligible": true,
+      "rollback_required_states_remain_visible": true,
+      "runtime_disabled_states_remain_visible": true,
+      "runtime_manifest_consumption_enabled": false
+    },
+    "planner_ownership_crossover_distribution": {
+      "planner_ownership_separated": 1
+    },
+    "production_routing_crossover_distribution": {
+      "production_routing_separated": 1
+    },
+    "rollback_containment_distribution": {
+      "rollback_contained": 1
+    },
+    "run": {
+      "entrypoint_contract_count": 1,
+      "experimental_runtime_entrypoint_contracts_hash": "fb9ed486aedd12c343b9a0acd443eabb4a067c969d865e4296a748e3bb330b0a",
+      "run_id": "v3_2_phase_2_runtime_isolation_contracts",
+      "runtime_isolation_request_count": 1,
+      "runtime_isolation_requests_hash": "1993f00f2950c193fd3fa1c5403edfb038bdf1f9a86eecbee7f7fd40b73fc7b2"
+    },
+    "runtime_disabled_path_verification": {
+      "fallback_isolation_allowed": false,
+      "implicit_manifest_consumption_allowed": false,
+      "production_routing_authorized": false,
+      "production_runtime_prohibited": true,
+      "runtime_manifest_consumption_enabled": false,
+      "runtime_production_consumption_enabled": false,
+      "silent_runtime_activation_allowed": false
+    },
+    "runtime_isolation_contracts": [
+      {
+        "blockers": [],
+        "entrypoint_authorization_state": "non_production_authoritative",
+        "entrypoint_contract_status": "experimental_runtime_eligible",
+        "entrypoint_production_runtime_classification": "production_runtime_prohibited",
+        "experimental_only_execution_scope": "experimental_only",
+        "fixture_set_id": "v3_1_fixture_set_6d3b668a84cfbb69",
+        "isolation_blocker_state": "unblocked_for_contract_only",
+        "isolation_contract_authorizes_production_routing": false,
+        "isolation_contract_authorizes_runtime_consumption": false,
+        "isolation_trace_classification": "runtime_isolation_trace_satisfied",
+        "manifest_consumption_separation_state": "manifest_consumption_separated",
+        "manifest_id": "v3_1_admission_manifest_198a3e2110f9e5e4",
+        "metadata": {
+          "fallback_isolation_allowed": false,
+          "governance_only": true,
+          "implicit_manifest_consumption_allowed": false,
+          "planner_remap_performed": false,
+          "production_consumer": false,
+          "production_runtime_prohibited": true,
+          "runtime_behavior_enabled": false,
+          "runtime_isolation_contract_only": true,
+          "silent_runtime_activation_allowed": false
+        },
+        "planner_ownership_separation_state": "planner_ownership_separated",
+        "production_output_affected": false,
+        "production_routing_authorized": false,
+        "production_routing_separation_state": "production_routing_separated",
+        "production_runtime_classification": "production_runtime_prohibited",
+        "rollback_containment_state": "rollback_contained",
+        "runtime_isolation_boundary_state": "isolation_boundary_satisfied",
+        "runtime_isolation_contract_id": "v3_2_runtime_isolation_contract_6e7b1a690ef20ad5",
+        "runtime_isolation_status": "runtime_isolation_satisfied",
+        "runtime_manifest_consumption_enabled": false,
+        "runtime_mutation_prohibition_state": "runtime_mutation_prohibited",
+        "runtime_production_consumption_enabled": false,
+        "runtime_side_effect_prohibition_state": "side_effects_prohibited"
+      }
+    ],
+    "runtime_isolation_status_counts": {
+      "manifest_consumption_crossover_blocked": 0,
+      "planner_ownership_crossover_blocked": 0,
+      "production_routing_crossover_blocked": 0,
+      "rollback_containment_required": 0,
+      "runtime_isolation_blocked": 0,
+      "runtime_isolation_satisfied": 1,
+      "runtime_mutation_blocked": 0,
+      "side_effect_boundary_blocked": 0
+    },
+    "runtime_mutation_blocker_distribution": {
+      "runtime_mutation_prohibited": 1
+    },
+    "safety_confirmations": {
+      "isolation_contract_authorizes_production_routing": false,
+      "isolation_contract_enables_runtime_manifest_consumption": false,
+      "isolation_contract_mutates_planner_ownership": false,
+      "legacy_planner_ownership_preserved": true,
+      "production_behavior_changed": false,
+      "production_output_affected": false,
+      "production_planner_routing_changed": false,
+      "production_runtime_routing_prohibited": true,
+      "runtime_manifest_consumption_enabled": false,
+      "runtime_production_consumption_enabled": false,
+      "trusted_data_default_truth": false
+    },
+    "schema_version": "v3_2.runtime_isolation_contracts.1",
+    "side_effect_blocker_distribution": {
+      "side_effects_prohibited": 1
+    },
+    "summary": {
+      "deterministic": true,
+      "manifest_consumption_crossover_blocked_count": 0,
+      "planner_ownership_crossover_blocked_count": 0,
+      "production_behavior_changed": false,
+      "production_default_routing_authorized": false,
+      "production_output_affected": false,
+      "production_routing_authorized": false,
+      "production_routing_crossover_blocked_count": 0,
+      "records_evaluated": 1,
+      "rollback_containment_required_count": 0,
+      "runtime_isolation_blocked_count": 0,
+      "runtime_isolation_satisfied_count": 1,
+      "runtime_manifest_consumption_enabled": false,
+      "runtime_mutation_blocked_count": 0,
+      "runtime_production_consumption_enabled": false,
+      "side_effect_boundary_blocked_count": 0
+    }
+  },
+  "runtime_manifest_consumption_enabled": false,
+  "runtime_mutation_blocker_distributions": {
+    "runtime_mutation_prohibited": 1
+  },
+  "runtime_production_consumption_enabled": false,
+  "schema_version": "v3_2.runtime_isolation_contracts_report.1",
+  "side_effect_blocker_distributions": {
+    "side_effects_prohibited": 1
+  },
+  "summary": {
+    "deterministic": true,
+    "manifest_consumption_crossover_blocked_count": 0,
+    "planner_ownership_crossover_blocked_count": 0,
+    "production_behavior_changed": false,
+    "production_default_routing_authorized": false,
+    "production_output_affected": false,
+    "production_routing_authorized": false,
+    "production_routing_crossover_blocked_count": 0,
+    "records_evaluated": 1,
+    "rollback_containment_required_count": 0,
+    "runtime_isolation_blocked_count": 0,
+    "runtime_isolation_satisfied_count": 1,
+    "runtime_manifest_consumption_enabled": false,
+    "runtime_mutation_blocked_count": 0,
+    "runtime_production_consumption_enabled": false,
+    "side_effect_boundary_blocked_count": 0
+  }
+}

--- a/docs/migration/V3_2_RUNTIME_ISOLATION_CONTRACTS.md
+++ b/docs/migration/V3_2_RUNTIME_ISOLATION_CONTRACTS.md
@@ -1,0 +1,57 @@
+# V3.2 Runtime Isolation Contracts
+
+Phase 2 defines isolation rules that must hold before future limited experimental runtime initialization can be considered.
+This does not enable runtime manifest consumption or production routing.
+
+## Phase 1 Compatibility
+
+Phase 2 builds on Phase 1 by requiring an eligible entrypoint contract, explicit opt-in, non-production authorization, disabled runtime consumption, and prohibited production runtime classification.
+
+## Separation Requirements
+
+Production routing must remain separated so experimental runtime evidence cannot cross into planner output ownership.
+Manifest consumption cannot become implicit runtime behavior; any future consumption must stay explicit, experimental-only, and non-production-authoritative.
+Planner ownership cannot be silently mutated because production planner ownership remains legacy-controlled.
+
+## Side Effects And Rollback
+
+Runtime side effects are blocked unless explicitly isolated, reversible, and non-production. Rollback containment must remain visible before later runtime-adjacent phases.
+
+## Summary
+
+- Records evaluated: `1`
+- Isolation satisfied: `1`
+- Isolation blocked: `0`
+- Runtime manifest consumption enabled: `false`
+- Production routing authorized: `false`
+- Deterministic: `true`
+
+## Blocker Distribution
+
+| Blocker | Count |
+| --- | ---: |
+
+## Isolation Records
+
+| Contract | Manifest | Fixture Set | Status | Isolation | Routing | Manifest Consumption |
+| --- | --- | --- | --- | --- | --- | --- |
+| `v3_2_runtime_isolation_contract_6e7b1a690ef20ad5` | `v3_1_admission_manifest_198a3e2110f9e5e4` | `v3_1_fixture_set_6d3b668a84cfbb69` | `runtime_isolation_satisfied` | `isolation_boundary_satisfied` | `production_routing_separated` | `manifest_consumption_separated` |
+
+## Future Phases
+
+- future phases may evaluate initialization only after isolation contracts remain satisfied
+- future phases must preserve entrypoint authorization and explicit opt-in
+- future phases must continue to block production routing and planner ownership crossover
+
+## Boundaries
+
+- runtime isolation contracts are governance only
+- runtime manifest consumption remains disabled by default
+- production runtime routing remains prohibited
+- manifest consumption cannot become implicit runtime behavior
+- planner ownership mutation remains blocked
+- side effects must be prohibited or isolated, reversible, and non-production
+
+## Conclusion
+
+Runtime isolation contracts are satisfied for governance review only. Production runtime routing remains prohibited and default runtime manifest consumption remains disabled.


### PR DESCRIPTION
Add deterministic runtime isolation governance contracts for v3.2 limited experimental runtime architecture, preserving production routing separation, manifest consumption prohibition, planner ownership safety, side-effect blocking, rollback containment, and Phase 1 entrypoint compatibility.