### PR TITLE
v3.5: add orchestration readiness evaluation contracts

### DIFF
--- a/backend/app/runtime_orchestration/__init__.py
+++ b/backend/app/runtime_orchestration/__init__.py
@@ -53,6 +53,37 @@ from .orchestration_visibility_models import (
     hash_orchestration_visibility,
     serialize_orchestration_visibility,
 )
+from .orchestration_readiness_evaluation import (
+    OrchestrationReadinessEvaluationInput,
+    default_orchestration_readiness_evaluation_input,
+    evaluate_orchestration_readiness,
+    export_orchestration_readiness_result,
+    hash_orchestration_readiness_input,
+    serialize_orchestration_readiness_result,
+)
+from .orchestration_readiness_report_models import (
+    OrchestrationReadinessBlocker,
+    OrchestrationReadinessResult,
+    export_readiness_result,
+    hash_readiness_result,
+    order_readiness_blockers,
+    serialize_readiness_result,
+)
+from .orchestration_readiness_status import (
+    BLOCKED_BY_AUTHORIZATION_FAILURE,
+    BLOCKED_BY_COMPATIBILITY_FAILURE,
+    BLOCKED_BY_ENVIRONMENT_FAILURE,
+    BLOCKED_BY_GOVERNANCE_DEPENDENCY,
+    BLOCKED_BY_REPLAY_LINEAGE_GAP,
+    BLOCKED_BY_ROLLBACK_LINEAGE_GAP,
+    MANUAL_REVIEW_REQUIRED,
+    PROHIBITED_ORCHESTRATION_REQUEST,
+    READINESS_STATUSES,
+    READY_FOR_FUTURE_ORCHESTRATION_PLANNING,
+    UNSUPPORTED_ORCHESTRATION_REQUEST,
+    classify_readiness_status,
+    export_readiness_statuses,
+)
 
 
 __all__ = [
@@ -101,4 +132,29 @@ __all__ = [
     "export_orchestration_visibility",
     "hash_orchestration_visibility",
     "serialize_orchestration_visibility",
+    "OrchestrationReadinessEvaluationInput",
+    "default_orchestration_readiness_evaluation_input",
+    "evaluate_orchestration_readiness",
+    "export_orchestration_readiness_result",
+    "hash_orchestration_readiness_input",
+    "serialize_orchestration_readiness_result",
+    "OrchestrationReadinessBlocker",
+    "OrchestrationReadinessResult",
+    "export_readiness_result",
+    "hash_readiness_result",
+    "order_readiness_blockers",
+    "serialize_readiness_result",
+    "BLOCKED_BY_AUTHORIZATION_FAILURE",
+    "BLOCKED_BY_COMPATIBILITY_FAILURE",
+    "BLOCKED_BY_ENVIRONMENT_FAILURE",
+    "BLOCKED_BY_GOVERNANCE_DEPENDENCY",
+    "BLOCKED_BY_REPLAY_LINEAGE_GAP",
+    "BLOCKED_BY_ROLLBACK_LINEAGE_GAP",
+    "MANUAL_REVIEW_REQUIRED",
+    "PROHIBITED_ORCHESTRATION_REQUEST",
+    "READINESS_STATUSES",
+    "READY_FOR_FUTURE_ORCHESTRATION_PLANNING",
+    "UNSUPPORTED_ORCHESTRATION_REQUEST",
+    "classify_readiness_status",
+    "export_readiness_statuses",
 ]

--- a/backend/app/runtime_orchestration/orchestration_readiness_evaluation.py
+++ b/backend/app/runtime_orchestration/orchestration_readiness_evaluation.py
@@ -1,0 +1,340 @@
+"""Planning-only orchestration readiness evaluation contracts for v3.5 Phase 2."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from app.runtime_intelligence.classification_hashing import deterministic_hash
+
+from .governance_consumption_contracts import GovernanceConsumptionContract, default_governance_consumption_contract
+from .orchestration_readiness_report_models import (
+    OrchestrationReadinessBlocker,
+    OrchestrationReadinessResult,
+    export_readiness_result,
+    serialize_readiness_result,
+)
+from .orchestration_readiness_status import (
+    BLOCKED_BY_AUTHORIZATION_FAILURE,
+    BLOCKED_BY_COMPATIBILITY_FAILURE,
+    BLOCKED_BY_ENVIRONMENT_FAILURE,
+    BLOCKED_BY_GOVERNANCE_DEPENDENCY,
+    BLOCKED_BY_REPLAY_LINEAGE_GAP,
+    BLOCKED_BY_ROLLBACK_LINEAGE_GAP,
+    MANUAL_REVIEW_REQUIRED,
+    PROHIBITED_ORCHESTRATION_REQUEST,
+    READY_FOR_FUTURE_ORCHESTRATION_PLANNING,
+    UNSUPPORTED_ORCHESTRATION_REQUEST,
+    classify_readiness_status,
+)
+
+
+@dataclass(frozen=True)
+class OrchestrationReadinessEvaluationInput:
+    contract: GovernanceConsumptionContract
+    required_governance_dependency_ids: tuple[str, ...]
+    required_replay_requirements: tuple[str, ...]
+    required_rollback_requirements: tuple[str, ...]
+    required_compatibility_requirements: tuple[str, ...]
+    expected_environment: str
+    allowed_orchestration_domains: tuple[str, ...]
+    prohibited_orchestration_domains: tuple[str, ...]
+    manual_review_required: bool = False
+    manual_review_reasons: tuple[str, ...] = ()
+
+
+def default_orchestration_readiness_evaluation_input() -> OrchestrationReadinessEvaluationInput:
+    contract = default_governance_consumption_contract()
+    return OrchestrationReadinessEvaluationInput(
+        contract=contract,
+        required_governance_dependency_ids=contract.governance_dependency_ids,
+        required_replay_requirements=("replay_lineage_id",),
+        required_rollback_requirements=("rollback_lineage_id",),
+        required_compatibility_requirements=contract.compatibility_requirements,
+        expected_environment="non_production",
+        allowed_orchestration_domains=contract.boundary_model.allowed_orchestration_domains,
+        prohibited_orchestration_domains=contract.boundary_model.prohibited_orchestration_domains,
+    )
+
+
+def evaluate_orchestration_readiness(
+    evaluation_input: OrchestrationReadinessEvaluationInput | None = None,
+) -> OrchestrationReadinessResult:
+    source = evaluation_input or default_orchestration_readiness_evaluation_input()
+    contract = source.contract
+    blockers: list[OrchestrationReadinessBlocker] = []
+    candidate_statuses: list[str] = []
+
+    missing_governance_dependencies = tuple(
+        sorted(set(source.required_governance_dependency_ids) - set(contract.governance_dependency_ids))
+    )
+    missing_replay_requirements = _missing_replay_requirements(source)
+    missing_rollback_requirements = _missing_rollback_requirements(source)
+    compatibility_failures = _compatibility_failures(source)
+    environment_failures = _environment_failures(source)
+    unsupported_states = tuple(sorted(set(contract.unsupported_orchestration_states)))
+    prohibited_domains = _prohibited_domains(source)
+    manual_review_reasons = tuple(sorted(set(source.manual_review_reasons))) if source.manual_review_required else ()
+
+    if not contract.orchestration_request_id or not contract.orchestration_scope_id:
+        _add_blocker(
+            blockers,
+            candidate_statuses,
+            BLOCKED_BY_GOVERNANCE_DEPENDENCY,
+            "orchestration_identity_missing",
+            "governance_dependency",
+            10,
+            "orchestration request identity and scope identity must be explicit",
+        )
+    for dependency_id in missing_governance_dependencies:
+        _add_blocker(
+            blockers,
+            candidate_statuses,
+            BLOCKED_BY_GOVERNANCE_DEPENDENCY,
+            f"missing_governance_dependency:{dependency_id}",
+            "governance_dependency",
+            20,
+            "required governance dependency is missing",
+        )
+    if contract.authorization_required and contract.authorization_state != "authorized_for_planning":
+        _add_blocker(
+            blockers,
+            candidate_statuses,
+            BLOCKED_BY_AUTHORIZATION_FAILURE,
+            "authorization_not_satisfied",
+            "authorization_failure",
+            30,
+            "non-production planning authorization must be explicit",
+        )
+    for requirement in missing_replay_requirements:
+        _add_blocker(
+            blockers,
+            candidate_statuses,
+            BLOCKED_BY_REPLAY_LINEAGE_GAP,
+            f"missing_replay_requirement:{requirement}",
+            "replay_lineage_gap",
+            40,
+            "required replay lineage must remain fail-visible",
+        )
+    for requirement in missing_rollback_requirements:
+        _add_blocker(
+            blockers,
+            candidate_statuses,
+            BLOCKED_BY_ROLLBACK_LINEAGE_GAP,
+            f"missing_rollback_requirement:{requirement}",
+            "rollback_lineage_gap",
+            50,
+            "required rollback lineage must remain fail-visible",
+        )
+    for failure in compatibility_failures:
+        _add_blocker(
+            blockers,
+            candidate_statuses,
+            BLOCKED_BY_COMPATIBILITY_FAILURE,
+            f"compatibility_failure:{failure}",
+            "compatibility_failure",
+            60,
+            "compatibility evidence must be deterministic and explicit",
+        )
+    for failure in environment_failures:
+        _add_blocker(
+            blockers,
+            candidate_statuses,
+            BLOCKED_BY_ENVIRONMENT_FAILURE,
+            f"environment_failure:{failure}",
+            "environment_failure",
+            70,
+            "environment requirements must preserve non-production isolation",
+        )
+    for state in unsupported_states:
+        _add_blocker(
+            blockers,
+            candidate_statuses,
+            UNSUPPORTED_ORCHESTRATION_REQUEST,
+            f"unsupported_state:{state}",
+            "unsupported_state",
+            80,
+            "unsupported orchestration states must remain explicit",
+        )
+    for domain in prohibited_domains:
+        _add_blocker(
+            blockers,
+            candidate_statuses,
+            PROHIBITED_ORCHESTRATION_REQUEST,
+            f"prohibited_domain:{domain}",
+            "prohibited_domain",
+            5,
+            "prohibited orchestration domains must not be downgraded",
+        )
+    if _prohibited_behavior_detected(contract):
+        _add_blocker(
+            blockers,
+            candidate_statuses,
+            PROHIBITED_ORCHESTRATION_REQUEST,
+            "prohibited_execution_or_consumption_behavior_detected",
+            "prohibited_behavior",
+            6,
+            "execution, routing, mutation, write, side-effect, or production consumption behavior is prohibited",
+        )
+    for reason in manual_review_reasons:
+        _add_blocker(
+            blockers,
+            candidate_statuses,
+            MANUAL_REVIEW_REQUIRED,
+            f"manual_review:{reason}",
+            "manual_review",
+            90,
+            "manual review requirement must remain explicit",
+        )
+
+    status = classify_readiness_status(candidate_statuses)
+    return OrchestrationReadinessResult(
+        readiness_status=status,
+        planning_ready=status == READY_FOR_FUTURE_ORCHESTRATION_PLANNING,
+        planning_only=True,
+        blockers=tuple(blockers),
+        unsupported_states=unsupported_states,
+        prohibited_domains=prohibited_domains,
+        missing_governance_dependencies=missing_governance_dependencies,
+        missing_replay_requirements=missing_replay_requirements,
+        missing_rollback_requirements=missing_rollback_requirements,
+        compatibility_failures=compatibility_failures,
+        environment_failures=environment_failures,
+        manual_review_reasons=manual_review_reasons,
+        deterministic_explanation_summary=_explanation_summary(status, blockers),
+        runtime_execution_enabled=False,
+        orchestration_execution_enabled=False,
+        routing_behavior_enabled=False,
+        mutation_behavior_enabled=False,
+        audit_log_writing_enabled=False,
+        production_consumption_enabled=False,
+    )
+
+
+def export_orchestration_readiness_result(
+    result: OrchestrationReadinessResult,
+) -> dict[str, Any]:
+    return export_readiness_result(result)
+
+
+def serialize_orchestration_readiness_result(result: OrchestrationReadinessResult) -> str:
+    return serialize_readiness_result(result)
+
+
+def hash_orchestration_readiness_input(source: OrchestrationReadinessEvaluationInput) -> str:
+    return deterministic_hash(
+        {
+            "contract": source.contract,
+            "required_governance_dependency_ids": source.required_governance_dependency_ids,
+            "required_replay_requirements": source.required_replay_requirements,
+            "required_rollback_requirements": source.required_rollback_requirements,
+            "required_compatibility_requirements": source.required_compatibility_requirements,
+            "expected_environment": source.expected_environment,
+            "allowed_orchestration_domains": source.allowed_orchestration_domains,
+            "prohibited_orchestration_domains": source.prohibited_orchestration_domains,
+            "manual_review_required": source.manual_review_required,
+            "manual_review_reasons": source.manual_review_reasons,
+        }
+    )
+
+
+def _missing_replay_requirements(source: OrchestrationReadinessEvaluationInput) -> tuple[str, ...]:
+    missing: list[str] = []
+    if "replay_lineage_id" in source.required_replay_requirements:
+        if not source.contract.replay_lineage_required or not source.contract.replay_lineage_id:
+            missing.append("replay_lineage_id")
+    return tuple(sorted(missing))
+
+
+def _missing_rollback_requirements(source: OrchestrationReadinessEvaluationInput) -> tuple[str, ...]:
+    missing: list[str] = []
+    if "rollback_lineage_id" in source.required_rollback_requirements:
+        if not source.contract.rollback_lineage_required or not source.contract.rollback_lineage_id:
+            missing.append("rollback_lineage_id")
+    return tuple(sorted(missing))
+
+
+def _compatibility_failures(source: OrchestrationReadinessEvaluationInput) -> tuple[str, ...]:
+    failures: list[str] = []
+    missing = set(source.required_compatibility_requirements) - set(source.contract.compatibility_requirements)
+    failures.extend(f"missing:{item}" for item in sorted(missing))
+    if not source.contract.compatibility_verified:
+        failures.append("compatibility_not_verified")
+    return tuple(sorted(failures))
+
+
+def _environment_failures(source: OrchestrationReadinessEvaluationInput) -> tuple[str, ...]:
+    failures: list[str] = []
+    if source.contract.environment != source.expected_environment:
+        failures.append("environment_mismatch")
+    if source.contract.environment != "non_production":
+        failures.append("non_production_environment_required")
+    if not source.contract.environment_isolated:
+        failures.append("environment_not_isolated")
+    if source.contract.orchestration_scope not in source.contract.boundary_model.isolated_orchestration_scopes:
+        failures.append("scope_not_isolated")
+    return tuple(sorted(set(failures)))
+
+
+def _prohibited_domains(source: OrchestrationReadinessEvaluationInput) -> tuple[str, ...]:
+    domains: list[str] = []
+    if source.contract.requested_orchestration_domain in source.prohibited_orchestration_domains:
+        domains.append(source.contract.requested_orchestration_domain)
+    if source.contract.requested_orchestration_domain not in source.allowed_orchestration_domains:
+        domains.append(source.contract.requested_orchestration_domain)
+    return tuple(sorted(set(domains)))
+
+
+def _prohibited_behavior_detected(contract: GovernanceConsumptionContract) -> bool:
+    return any(
+        (
+            contract.runtime_execution_enabled,
+            contract.orchestration_execution_enabled,
+            contract.autonomous_orchestration_enabled,
+            contract.recommendation_system_enabled,
+            contract.decision_routing_enabled,
+            contract.production_routing_enabled,
+            contract.persistent_mutation_enabled,
+            contract.state_writes_enabled,
+            contract.audit_log_writes_enabled,
+            contract.external_side_effects_enabled,
+            contract.production_authoritative_manifests_enabled,
+            contract.production_runtime_consumption_enabled,
+            contract.experiment_execution_enabled,
+            contract.self_modifying_orchestration_enabled,
+            contract.hidden_fallback_logic_enabled,
+        )
+    )
+
+
+def _add_blocker(
+    blockers: list[OrchestrationReadinessBlocker],
+    candidate_statuses: list[str],
+    status: str,
+    blocker_id: str,
+    category: str,
+    rank: int,
+    explanation: str,
+) -> None:
+    candidate_statuses.append(status)
+    blockers.append(
+        OrchestrationReadinessBlocker(
+            blocker_id=blocker_id,
+            readiness_status=status,
+            blocker_category=category,
+            deterministic_rank=rank,
+            fail_visible=True,
+            audit_safe=True,
+            explanation=explanation,
+        )
+    )
+
+
+def _explanation_summary(status: str, blockers: list[OrchestrationReadinessBlocker]) -> str:
+    if not blockers:
+        return (
+            "Readiness is planning-only and satisfied for future orchestration planning; "
+            "no execution, routing, mutation, audit writing, or production consumption is authorized."
+        )
+    blocker_ids = ", ".join(row.blocker_id for row in sorted(blockers, key=lambda row: (row.deterministic_rank, row.blocker_id)))
+    return f"Readiness classified as {status}; fail-visible blockers: {blocker_ids}."

--- a/backend/app/runtime_orchestration/orchestration_readiness_report_models.py
+++ b/backend/app/runtime_orchestration/orchestration_readiness_report_models.py
@@ -1,0 +1,83 @@
+"""Stable report models for v3.5 orchestration readiness evaluation."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import asdict, dataclass
+from typing import Any
+
+from app.runtime_intelligence.classification_hashing import deterministic_hash, stable_serialize
+
+
+@dataclass(frozen=True)
+class OrchestrationReadinessBlocker:
+    blocker_id: str
+    readiness_status: str
+    blocker_category: str
+    deterministic_rank: int
+    fail_visible: bool
+    audit_safe: bool
+    explanation: str
+
+
+@dataclass(frozen=True)
+class OrchestrationReadinessResult:
+    readiness_status: str
+    planning_ready: bool
+    planning_only: bool
+    blockers: tuple[OrchestrationReadinessBlocker, ...]
+    unsupported_states: tuple[str, ...]
+    prohibited_domains: tuple[str, ...]
+    missing_governance_dependencies: tuple[str, ...]
+    missing_replay_requirements: tuple[str, ...]
+    missing_rollback_requirements: tuple[str, ...]
+    compatibility_failures: tuple[str, ...]
+    environment_failures: tuple[str, ...]
+    manual_review_reasons: tuple[str, ...]
+    deterministic_explanation_summary: str
+    runtime_execution_enabled: bool
+    orchestration_execution_enabled: bool
+    routing_behavior_enabled: bool
+    mutation_behavior_enabled: bool
+    audit_log_writing_enabled: bool
+    production_consumption_enabled: bool
+
+
+def order_readiness_blockers(
+    blockers: tuple[OrchestrationReadinessBlocker, ...],
+) -> tuple[OrchestrationReadinessBlocker, ...]:
+    return tuple(sorted(blockers, key=lambda row: (row.deterministic_rank, row.blocker_id)))
+
+
+def export_readiness_result(result: OrchestrationReadinessResult) -> dict[str, Any]:
+    data = asdict(result)
+    data["blockers"] = [asdict(row) for row in order_readiness_blockers(result.blockers)]
+    for field in (
+        "unsupported_states",
+        "prohibited_domains",
+        "missing_governance_dependencies",
+        "missing_replay_requirements",
+        "missing_rollback_requirements",
+        "compatibility_failures",
+        "environment_failures",
+        "manual_review_reasons",
+    ):
+        data[field] = list(data[field])
+    data["deterministic_hash"] = hash_readiness_result(result)
+    return data
+
+
+def serialize_readiness_result(result: OrchestrationReadinessResult) -> str:
+    return stable_serialize(export_readiness_result(result))
+
+
+def hash_readiness_result(result: OrchestrationReadinessResult) -> str:
+    payload = asdict(result)
+    payload["blockers"] = [asdict(row) for row in order_readiness_blockers(result.blockers)]
+    return deterministic_hash(_without_hash(payload))
+
+
+def _without_hash(payload: dict[str, Any]) -> dict[str, Any]:
+    stable = deepcopy(payload)
+    stable.pop("deterministic_hash", None)
+    return stable

--- a/backend/app/runtime_orchestration/orchestration_readiness_status.py
+++ b/backend/app/runtime_orchestration/orchestration_readiness_status.py
@@ -1,0 +1,46 @@
+"""Deterministic readiness statuses for v3.5 orchestration planning."""
+
+from __future__ import annotations
+
+
+READY_FOR_FUTURE_ORCHESTRATION_PLANNING = "ready_for_future_orchestration_planning"
+BLOCKED_BY_GOVERNANCE_DEPENDENCY = "blocked_by_governance_dependency"
+BLOCKED_BY_AUTHORIZATION_FAILURE = "blocked_by_authorization_failure"
+BLOCKED_BY_REPLAY_LINEAGE_GAP = "blocked_by_replay_lineage_gap"
+BLOCKED_BY_ROLLBACK_LINEAGE_GAP = "blocked_by_rollback_lineage_gap"
+BLOCKED_BY_ENVIRONMENT_FAILURE = "blocked_by_environment_failure"
+BLOCKED_BY_COMPATIBILITY_FAILURE = "blocked_by_compatibility_failure"
+UNSUPPORTED_ORCHESTRATION_REQUEST = "unsupported_orchestration_request"
+PROHIBITED_ORCHESTRATION_REQUEST = "prohibited_orchestration_request"
+MANUAL_REVIEW_REQUIRED = "manual_review_required"
+
+READINESS_STATUS_PRIORITY: tuple[str, ...] = (
+    PROHIBITED_ORCHESTRATION_REQUEST,
+    BLOCKED_BY_GOVERNANCE_DEPENDENCY,
+    BLOCKED_BY_AUTHORIZATION_FAILURE,
+    BLOCKED_BY_REPLAY_LINEAGE_GAP,
+    BLOCKED_BY_ROLLBACK_LINEAGE_GAP,
+    BLOCKED_BY_ENVIRONMENT_FAILURE,
+    BLOCKED_BY_COMPATIBILITY_FAILURE,
+    UNSUPPORTED_ORCHESTRATION_REQUEST,
+    MANUAL_REVIEW_REQUIRED,
+    READY_FOR_FUTURE_ORCHESTRATION_PLANNING,
+)
+
+READINESS_STATUSES: tuple[str, ...] = READINESS_STATUS_PRIORITY
+
+
+def classify_readiness_status(candidate_statuses: tuple[str, ...] | list[str]) -> str:
+    """Select the highest-priority deterministic readiness status."""
+
+    if not candidate_statuses:
+        return READY_FOR_FUTURE_ORCHESTRATION_PLANNING
+    candidate_set = set(candidate_statuses)
+    for status in READINESS_STATUS_PRIORITY:
+        if status in candidate_set:
+            return status
+    return BLOCKED_BY_COMPATIBILITY_FAILURE
+
+
+def export_readiness_statuses() -> list[str]:
+    return list(READINESS_STATUSES)

--- a/backend/scripts/report_v3_5_orchestration_readiness_evaluation.py
+++ b/backend/scripts/report_v3_5_orchestration_readiness_evaluation.py
@@ -1,0 +1,307 @@
+"""Generate the v3.5 orchestration readiness evaluation report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.runtime_intelligence.classification_hashing import deterministic_hash  # noqa: E402
+from app.runtime_orchestration import (  # noqa: E402
+    BLOCKED_BY_AUTHORIZATION_FAILURE,
+    BLOCKED_BY_COMPATIBILITY_FAILURE,
+    BLOCKED_BY_ENVIRONMENT_FAILURE,
+    BLOCKED_BY_GOVERNANCE_DEPENDENCY,
+    BLOCKED_BY_REPLAY_LINEAGE_GAP,
+    BLOCKED_BY_ROLLBACK_LINEAGE_GAP,
+    MANUAL_REVIEW_REQUIRED,
+    PROHIBITED_ORCHESTRATION_REQUEST,
+    READINESS_STATUSES,
+    READY_FOR_FUTURE_ORCHESTRATION_PLANNING,
+    UNSUPPORTED_ORCHESTRATION_REQUEST,
+    OrchestrationReadinessEvaluationInput,
+    default_governance_consumption_contract,
+    default_orchestration_readiness_evaluation_input,
+    evaluate_orchestration_readiness,
+    export_orchestration_readiness_result,
+)
+
+
+DETERMINISTIC_GENERATED_AT = "2026-05-16T00:00:00+00:00"
+
+
+def build_v3_5_orchestration_readiness_evaluation_report() -> dict[str, Any]:
+    scenarios = _scenario_results()
+    focused = scenarios["fully_ready_planning_only_orchestration_request"]
+    report = {
+        "schema_version": "v3_5.orchestration_readiness_evaluation_report.1",
+        "generated_at": DETERMINISTIC_GENERATED_AT,
+        "phase_name": "v3.5_phase_2_orchestration_readiness_evaluation_contracts",
+        "planning_only": True,
+        "non_production": True,
+        "final_readiness_status": focused["readiness_status"],
+        "readiness_statuses_supported": list(READINESS_STATUSES),
+        "scenario_coverage": list(scenarios.keys()),
+        "scenario_results": scenarios,
+        "status_distribution": _status_distribution(scenarios),
+        "blocker_visibility_summary": _visibility_summary(scenarios, "blockers"),
+        "unsupported_state_visibility_summary": _list_summary(scenarios, "unsupported_states"),
+        "prohibited_domain_visibility_summary": _list_summary(scenarios, "prohibited_domains"),
+        "replay_lineage_validation_summary": _list_summary(scenarios, "missing_replay_requirements"),
+        "rollback_lineage_validation_summary": _list_summary(scenarios, "missing_rollback_requirements"),
+        "compatibility_validation_summary": _list_summary(scenarios, "compatibility_failures"),
+        "environment_validation_summary": _list_summary(scenarios, "environment_failures"),
+        "manual_review_summary": _list_summary(scenarios, "manual_review_reasons"),
+        "explicit_non_execution_guarantees": {
+            "runtime_execution_enabled": False,
+            "orchestration_execution_enabled": False,
+            "routing_behavior_enabled": False,
+            "mutation_behavior_enabled": False,
+            "audit_log_writing_enabled": False,
+            "production_consumption_enabled": False,
+            "default_runtime_manifest_consumption_enabled": False,
+            "production_authoritative_manifest_treatment_enabled": False,
+            "live_replay_execution_enabled": False,
+            "rollback_execution_enabled": False,
+            "automatic_remediation_enabled": False,
+        },
+        "summary": {
+            "scenario_count": len(scenarios),
+            "supported_status_count": len(READINESS_STATUSES),
+            "ready_scenario_count": sum(
+                1
+                for result in scenarios.values()
+                if result["readiness_status"] == READY_FOR_FUTURE_ORCHESTRATION_PLANNING
+            ),
+            "blocked_or_review_scenario_count": sum(
+                1
+                for result in scenarios.values()
+                if result["readiness_status"] != READY_FOR_FUTURE_ORCHESTRATION_PLANNING
+            ),
+            "deterministic_outputs": True,
+            "stable_serialization": True,
+            "replay_safe_output_stability": True,
+            "rollback_safe_output_stability": True,
+            "fail_visible_blockers": True,
+            "unsupported_state_preservation": True,
+            "prohibited_domain_preservation": True,
+        },
+        "remaining_limitations": [
+            "readiness evaluation classifies declarative planning inputs only",
+            "readiness evaluation does not authorize orchestration execution",
+            "readiness evaluation does not route requests",
+            "readiness evaluation does not mutate state or write audit logs",
+            "readiness evaluation does not consume runtime manifests by default",
+        ],
+    }
+    report["deterministic_hash"] = deterministic_hash(
+        {key: value for key, value in report.items() if key != "deterministic_hash"}
+    )
+    return report
+
+
+def write_markdown_report(report: dict[str, Any], output_path: Path) -> None:
+    lines = [
+        "# v3.5 Orchestration Readiness Evaluation",
+        "",
+        "## Phase Boundary",
+        "",
+        "v3.5 Phase 2 is a deterministic orchestration readiness evaluation layer.",
+        "",
+        "It does not execute orchestration.",
+        "",
+        "It does not authorize orchestration execution.",
+        "",
+        "It does not route requests.",
+        "",
+        "It does not mutate state.",
+        "",
+        "It does not write audit logs.",
+        "",
+        "It only classifies declarative orchestration planning inputs for future controlled orchestration planning.",
+        "",
+        f"- Final readiness status: `{report['final_readiness_status']}`",
+        f"- Deterministic hash: `{report['deterministic_hash']}`",
+        "",
+        "## Supported Readiness Statuses",
+        "",
+    ]
+    lines.extend(f"- `{status}`" for status in report["readiness_statuses_supported"])
+    lines.extend(
+        [
+            "",
+            "## Evaluation Inputs",
+            "",
+            "- orchestration request identity",
+            "- orchestration scope identity",
+            "- authorization requirements",
+            "- governance dependencies",
+            "- replay lineage requirements",
+            "- rollback lineage requirements",
+            "- compatibility requirements",
+            "- environment requirements",
+            "- unsupported states",
+            "- prohibited domains",
+            "- blocker presence",
+            "- manual review requirements",
+            "",
+            "## Evaluation Outputs",
+            "",
+            "- final readiness status",
+            "- blocker list",
+            "- unsupported-state list",
+            "- prohibited-domain list",
+            "- missing governance dependencies",
+            "- missing replay requirements",
+            "- missing rollback requirements",
+            "- compatibility failures",
+            "- environment failures",
+            "- manual review reasons",
+            "- deterministic explanation summary",
+            "",
+            "## Blocker Model",
+            "",
+            "Blockers are explicit, deterministic, fail-visible, and audit-safe. They are ordered by deterministic rank and blocker identity.",
+            "",
+            "## Unsupported-State Model",
+            "",
+            "Unsupported orchestration states are preserved as first-class readiness output and never silently converted into passing readiness.",
+            "",
+            "## Prohibited-Domain Model",
+            "",
+            "Prohibited orchestration domains remain hard blockers for readiness classification and cannot be downgraded by compatibility or manual review.",
+            "",
+            "## Manual-Review Model",
+            "",
+            "Manual review is an explicit readiness status for future planning review only. It does not authorize execution.",
+            "",
+            "## Deterministic Hash Behavior",
+            "",
+            "Report and result hashes use stable JSON serialization with sorted keys. The report avoids runtime-generated IDs and environment-dependent values.",
+            "",
+            "## Scenario Coverage",
+            "",
+        ]
+    )
+    for scenario_id, result in report["scenario_results"].items():
+        lines.append(f"- `{scenario_id}` -> `{result['readiness_status']}`")
+    lines.extend(
+        [
+            "",
+            "## Explicit Non-Execution Guarantees",
+            "",
+            "- Runtime execution remains prohibited.",
+            "- Orchestration execution remains prohibited.",
+            "- Routing behavior remains prohibited.",
+            "- Mutation behavior remains prohibited.",
+            "- Audit log writing remains prohibited.",
+            "- Production consumption remains prohibited.",
+            "- Default runtime manifest consumption remains disabled.",
+            "- Production-authoritative manifest treatment remains prohibited.",
+            "- The repository remains planning-only.",
+            "",
+            "## Remaining Limitations",
+            "",
+        ]
+    )
+    lines.extend(f"- {item}" for item in report["remaining_limitations"])
+    lines.append("")
+    output_path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def _scenario_results() -> dict[str, dict[str, Any]]:
+    base = default_orchestration_readiness_evaluation_input()
+    contract = default_governance_consumption_contract()
+    unsupported_contract = replace(contract, unsupported_orchestration_states=("unsupported_orchestration_scope",))
+    prohibited_contract = replace(contract, requested_orchestration_domain="runtime_execution")
+    scenarios = {
+        "fully_ready_planning_only_orchestration_request": base,
+        "missing_governance_dependency": replace(
+            base,
+            contract=replace(contract, governance_dependency_ids=contract.governance_dependency_ids[:-1]),
+        ),
+        "missing_authorization": replace(base, contract=replace(contract, authorization_state="missing")),
+        "missing_replay_lineage": replace(base, contract=replace(contract, replay_lineage_id="")),
+        "missing_rollback_lineage": replace(base, contract=replace(contract, rollback_lineage_id="")),
+        "unsupported_orchestration_request": replace(base, contract=unsupported_contract),
+        "prohibited_orchestration_request": replace(base, contract=prohibited_contract),
+        "compatibility_failure": replace(base, contract=replace(contract, compatibility_verified=False)),
+        "environment_failure": replace(base, contract=replace(contract, environment="production", environment_isolated=False)),
+        "manual_review_required": replace(
+            base,
+            manual_review_required=True,
+            manual_review_reasons=("governance_review_required",),
+        ),
+        "multiple_simultaneous_blockers": replace(
+            base,
+            contract=replace(
+                contract,
+                governance_dependency_ids=(),
+                authorization_state="missing",
+                replay_lineage_id="",
+                rollback_lineage_id="",
+                compatibility_verified=False,
+                environment="production",
+                requested_orchestration_domain="runtime_execution",
+            ),
+        ),
+    }
+    return {scenario_id: export_orchestration_readiness_result(evaluate_orchestration_readiness(source)) for scenario_id, source in scenarios.items()}
+
+
+def _status_distribution(results: dict[str, dict[str, Any]]) -> dict[str, int]:
+    return {
+        status: sum(1 for result in results.values() if result["readiness_status"] == status)
+        for status in READINESS_STATUSES
+    }
+
+
+def _visibility_summary(results: dict[str, dict[str, Any]], field: str) -> dict[str, int]:
+    return {
+        "scenario_count": len(results),
+        "scenarios_with_visible_entries": sum(1 for result in results.values() if result[field]),
+        "visible_entry_count": sum(len(result[field]) for result in results.values()),
+    }
+
+
+def _list_summary(results: dict[str, dict[str, Any]], field: str) -> dict[str, int]:
+    return {
+        "scenario_count": len(results),
+        "scenario_with_entries_count": sum(1 for result in results.values() if result[field]),
+        "entry_count": sum(len(result[field]) for result in results.values()),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=Path(__file__).resolve().parents[2])
+    parser.add_argument(
+        "--json-output",
+        type=Path,
+        default=Path("docs/generated/v3_5_orchestration_readiness_evaluation_report.json"),
+    )
+    parser.add_argument(
+        "--markdown-output",
+        type=Path,
+        default=Path("docs/migration/V3_5_ORCHESTRATION_READINESS_EVALUATION.md"),
+    )
+    args = parser.parse_args()
+    report = build_v3_5_orchestration_readiness_evaluation_report()
+    json_output = args.repo_root / args.json_output
+    markdown_output = args.repo_root / args.markdown_output
+    json_output.parent.mkdir(parents=True, exist_ok=True)
+    markdown_output.parent.mkdir(parents=True, exist_ok=True)
+    json_output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    write_markdown_report(report, markdown_output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_v3_5_orchestration_readiness_evaluation.py
+++ b/backend/tests/test_v3_5_orchestration_readiness_evaluation.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+
+from app.runtime_orchestration import (
+    BLOCKED_BY_AUTHORIZATION_FAILURE,
+    BLOCKED_BY_COMPATIBILITY_FAILURE,
+    BLOCKED_BY_ENVIRONMENT_FAILURE,
+    BLOCKED_BY_GOVERNANCE_DEPENDENCY,
+    BLOCKED_BY_REPLAY_LINEAGE_GAP,
+    BLOCKED_BY_ROLLBACK_LINEAGE_GAP,
+    MANUAL_REVIEW_REQUIRED,
+    PROHIBITED_ORCHESTRATION_REQUEST,
+    READY_FOR_FUTURE_ORCHESTRATION_PLANNING,
+    UNSUPPORTED_ORCHESTRATION_REQUEST,
+    default_governance_consumption_contract,
+    default_orchestration_readiness_evaluation_input,
+    evaluate_orchestration_readiness,
+    export_orchestration_readiness_result,
+    hash_readiness_result,
+    serialize_orchestration_readiness_result,
+)
+from scripts.report_v3_5_orchestration_readiness_evaluation import (
+    build_v3_5_orchestration_readiness_evaluation_report,
+)
+
+
+def _base_input():
+    return default_orchestration_readiness_evaluation_input()
+
+
+def _base_contract():
+    return default_governance_consumption_contract()
+
+
+def _result(source=None):
+    return evaluate_orchestration_readiness(source or _base_input())
+
+
+def _export(source=None):
+    return export_orchestration_readiness_result(_result(source))
+
+
+def test_deterministic_readiness_classification():
+    first = _export()
+    second = _export()
+
+    assert first["readiness_status"] == READY_FOR_FUTURE_ORCHESTRATION_PLANNING
+    assert first["deterministic_hash"] == second["deterministic_hash"]
+    assert first["planning_ready"] is True
+
+
+def test_stable_serialization():
+    first = _result()
+    second = _result()
+
+    assert serialize_orchestration_readiness_result(first) == serialize_orchestration_readiness_result(second)
+
+
+def test_stable_deterministic_hash_output():
+    first = _result()
+    second = _result()
+
+    assert hash_readiness_result(first) == hash_readiness_result(second)
+
+
+def test_blocker_ordering_stability():
+    source = replace(
+        _base_input(),
+        contract=replace(
+            _base_contract(),
+            authorization_state="missing",
+            governance_dependency_ids=(),
+            replay_lineage_id="",
+            rollback_lineage_id="",
+        ),
+    )
+    first = _export(source)["blockers"]
+    second = _export(source)["blockers"]
+
+    assert [row["blocker_id"] for row in first] == [row["blocker_id"] for row in second]
+    assert [row["deterministic_rank"] for row in first] == sorted(row["deterministic_rank"] for row in first)
+
+
+def test_unsupported_state_preservation():
+    source = replace(
+        _base_input(),
+        contract=replace(_base_contract(), unsupported_orchestration_states=("unsupported_orchestration_scope",)),
+    )
+    result = _export(source)
+
+    assert result["readiness_status"] == UNSUPPORTED_ORCHESTRATION_REQUEST
+    assert result["unsupported_states"] == ["unsupported_orchestration_scope"]
+
+
+def test_prohibited_domain_preservation():
+    source = replace(_base_input(), contract=replace(_base_contract(), requested_orchestration_domain="runtime_execution"))
+    result = _export(source)
+
+    assert result["readiness_status"] == PROHIBITED_ORCHESTRATION_REQUEST
+    assert result["prohibited_domains"] == ["runtime_execution"]
+
+
+def test_manual_review_preservation():
+    source = replace(
+        _base_input(),
+        manual_review_required=True,
+        manual_review_reasons=("governance_review_required",),
+    )
+    result = _export(source)
+
+    assert result["readiness_status"] == MANUAL_REVIEW_REQUIRED
+    assert result["manual_review_reasons"] == ["governance_review_required"]
+
+
+def test_missing_dependency_preservation():
+    contract = _base_contract()
+    source = replace(_base_input(), contract=replace(contract, governance_dependency_ids=contract.governance_dependency_ids[:-1]))
+    result = _export(source)
+
+    assert result["readiness_status"] == BLOCKED_BY_GOVERNANCE_DEPENDENCY
+    assert result["missing_governance_dependencies"] == ["v3_4_closeout_and_v3_5_readiness"]
+
+
+def test_replay_lineage_gap_preservation():
+    source = replace(_base_input(), contract=replace(_base_contract(), replay_lineage_id=""))
+    result = _export(source)
+
+    assert result["readiness_status"] == BLOCKED_BY_REPLAY_LINEAGE_GAP
+    assert result["missing_replay_requirements"] == ["replay_lineage_id"]
+
+
+def test_rollback_lineage_gap_preservation():
+    source = replace(_base_input(), contract=replace(_base_contract(), rollback_lineage_id=""))
+    result = _export(source)
+
+    assert result["readiness_status"] == BLOCKED_BY_ROLLBACK_LINEAGE_GAP
+    assert result["missing_rollback_requirements"] == ["rollback_lineage_id"]
+
+
+def test_authorization_failure_visibility():
+    source = replace(_base_input(), contract=replace(_base_contract(), authorization_state="missing"))
+    result = _export(source)
+
+    assert result["readiness_status"] == BLOCKED_BY_AUTHORIZATION_FAILURE
+    assert result["blockers"][0]["blocker_id"] == "authorization_not_satisfied"
+
+
+def test_compatibility_failure_visibility():
+    source = replace(_base_input(), contract=replace(_base_contract(), compatibility_verified=False))
+    result = _export(source)
+
+    assert result["readiness_status"] == BLOCKED_BY_COMPATIBILITY_FAILURE
+    assert result["compatibility_failures"] == ["compatibility_not_verified"]
+
+
+def test_environment_failure_visibility():
+    source = replace(_base_input(), contract=replace(_base_contract(), environment="production", environment_isolated=False))
+    result = _export(source)
+
+    assert result["readiness_status"] == BLOCKED_BY_ENVIRONMENT_FAILURE
+    assert "environment_mismatch" in result["environment_failures"]
+    assert "non_production_environment_required" in result["environment_failures"]
+
+
+def test_multiple_blocker_aggregation():
+    source = replace(
+        _base_input(),
+        contract=replace(
+            _base_contract(),
+            governance_dependency_ids=(),
+            authorization_state="missing",
+            replay_lineage_id="",
+            rollback_lineage_id="",
+            compatibility_verified=False,
+            environment="production",
+            requested_orchestration_domain="runtime_execution",
+        ),
+    )
+    result = _export(source)
+
+    assert result["readiness_status"] == PROHIBITED_ORCHESTRATION_REQUEST
+    assert len(result["blockers"]) >= 7
+    assert result["missing_governance_dependencies"]
+    assert result["missing_replay_requirements"]
+    assert result["missing_rollback_requirements"]
+    assert result["compatibility_failures"]
+    assert result["environment_failures"]
+    assert result["prohibited_domains"] == ["runtime_execution"]
+
+
+def test_non_execution_guarantees():
+    result = _export()
+
+    assert result["runtime_execution_enabled"] is False
+    assert result["orchestration_execution_enabled"] is False
+    assert result["routing_behavior_enabled"] is False
+    assert result["mutation_behavior_enabled"] is False
+    assert result["audit_log_writing_enabled"] is False
+    assert result["production_consumption_enabled"] is False
+
+
+def test_prohibited_behavior_is_not_exposed():
+    source = replace(_base_input(), contract=replace(_base_contract(), orchestration_execution_enabled=True))
+    result = _export(source)
+
+    assert result["readiness_status"] == PROHIBITED_ORCHESTRATION_REQUEST
+    assert result["orchestration_execution_enabled"] is False
+    assert any(row["blocker_id"] == "prohibited_execution_or_consumption_behavior_detected" for row in result["blockers"])
+
+
+def test_report_scenario_coverage_and_stability():
+    first = build_v3_5_orchestration_readiness_evaluation_report()
+    second = build_v3_5_orchestration_readiness_evaluation_report()
+    distribution = first["status_distribution"]
+
+    assert json.dumps(first, sort_keys=True) == json.dumps(second, sort_keys=True)
+    assert first["summary"]["scenario_count"] == 11
+    assert first["final_readiness_status"] == READY_FOR_FUTURE_ORCHESTRATION_PLANNING
+    assert distribution[READY_FOR_FUTURE_ORCHESTRATION_PLANNING] == 1
+    assert distribution[BLOCKED_BY_GOVERNANCE_DEPENDENCY] == 1
+    assert distribution[BLOCKED_BY_AUTHORIZATION_FAILURE] == 1
+    assert distribution[BLOCKED_BY_REPLAY_LINEAGE_GAP] == 1
+    assert distribution[BLOCKED_BY_ROLLBACK_LINEAGE_GAP] == 1
+    assert distribution[UNSUPPORTED_ORCHESTRATION_REQUEST] == 1
+    assert distribution[PROHIBITED_ORCHESTRATION_REQUEST] == 2
+    assert distribution[BLOCKED_BY_COMPATIBILITY_FAILURE] == 1
+    assert distribution[BLOCKED_BY_ENVIRONMENT_FAILURE] == 1
+    assert distribution[MANUAL_REVIEW_REQUIRED] == 1
+
+
+def test_report_preserves_non_execution_guarantees():
+    guarantees = build_v3_5_orchestration_readiness_evaluation_report()["explicit_non_execution_guarantees"]
+
+    assert guarantees["runtime_execution_enabled"] is False
+    assert guarantees["orchestration_execution_enabled"] is False
+    assert guarantees["routing_behavior_enabled"] is False
+    assert guarantees["mutation_behavior_enabled"] is False
+    assert guarantees["audit_log_writing_enabled"] is False
+    assert guarantees["production_consumption_enabled"] is False
+    assert guarantees["default_runtime_manifest_consumption_enabled"] is False
+    assert guarantees["production_authoritative_manifest_treatment_enabled"] is False

--- a/docs/generated/v3_5_orchestration_readiness_evaluation_report.json
+++ b/docs/generated/v3_5_orchestration_readiness_evaluation_report.json
@@ -1,0 +1,675 @@
+{
+  "blocker_visibility_summary": {
+    "scenario_count": 11,
+    "scenarios_with_visible_entries": 10,
+    "visible_entry_count": 29
+  },
+  "compatibility_validation_summary": {
+    "entry_count": 2,
+    "scenario_count": 11,
+    "scenario_with_entries_count": 2
+  },
+  "deterministic_hash": "68f65f6e7372140ccb97b5990012b2ccd900ebd3af5df71e5fa5f4f07cf22782",
+  "environment_validation_summary": {
+    "entry_count": 5,
+    "scenario_count": 11,
+    "scenario_with_entries_count": 2
+  },
+  "explicit_non_execution_guarantees": {
+    "audit_log_writing_enabled": false,
+    "automatic_remediation_enabled": false,
+    "default_runtime_manifest_consumption_enabled": false,
+    "live_replay_execution_enabled": false,
+    "mutation_behavior_enabled": false,
+    "orchestration_execution_enabled": false,
+    "production_authoritative_manifest_treatment_enabled": false,
+    "production_consumption_enabled": false,
+    "rollback_execution_enabled": false,
+    "routing_behavior_enabled": false,
+    "runtime_execution_enabled": false
+  },
+  "final_readiness_status": "ready_for_future_orchestration_planning",
+  "generated_at": "2026-05-16T00:00:00+00:00",
+  "manual_review_summary": {
+    "entry_count": 1,
+    "scenario_count": 11,
+    "scenario_with_entries_count": 1
+  },
+  "non_production": true,
+  "phase_name": "v3.5_phase_2_orchestration_readiness_evaluation_contracts",
+  "planning_only": true,
+  "prohibited_domain_visibility_summary": {
+    "entry_count": 2,
+    "scenario_count": 11,
+    "scenario_with_entries_count": 2
+  },
+  "readiness_statuses_supported": [
+    "prohibited_orchestration_request",
+    "blocked_by_governance_dependency",
+    "blocked_by_authorization_failure",
+    "blocked_by_replay_lineage_gap",
+    "blocked_by_rollback_lineage_gap",
+    "blocked_by_environment_failure",
+    "blocked_by_compatibility_failure",
+    "unsupported_orchestration_request",
+    "manual_review_required",
+    "ready_for_future_orchestration_planning"
+  ],
+  "remaining_limitations": [
+    "readiness evaluation classifies declarative planning inputs only",
+    "readiness evaluation does not authorize orchestration execution",
+    "readiness evaluation does not route requests",
+    "readiness evaluation does not mutate state or write audit logs",
+    "readiness evaluation does not consume runtime manifests by default"
+  ],
+  "replay_lineage_validation_summary": {
+    "entry_count": 2,
+    "scenario_count": 11,
+    "scenario_with_entries_count": 2
+  },
+  "rollback_lineage_validation_summary": {
+    "entry_count": 2,
+    "scenario_count": 11,
+    "scenario_with_entries_count": 2
+  },
+  "scenario_coverage": [
+    "fully_ready_planning_only_orchestration_request",
+    "missing_governance_dependency",
+    "missing_authorization",
+    "missing_replay_lineage",
+    "missing_rollback_lineage",
+    "unsupported_orchestration_request",
+    "prohibited_orchestration_request",
+    "compatibility_failure",
+    "environment_failure",
+    "manual_review_required",
+    "multiple_simultaneous_blockers"
+  ],
+  "scenario_results": {
+    "compatibility_failure": {
+      "audit_log_writing_enabled": false,
+      "blockers": [
+        {
+          "audit_safe": true,
+          "blocker_category": "compatibility_failure",
+          "blocker_id": "compatibility_failure:compatibility_not_verified",
+          "deterministic_rank": 60,
+          "explanation": "compatibility evidence must be deterministic and explicit",
+          "fail_visible": true,
+          "readiness_status": "blocked_by_compatibility_failure"
+        }
+      ],
+      "compatibility_failures": [
+        "compatibility_not_verified"
+      ],
+      "deterministic_explanation_summary": "Readiness classified as blocked_by_compatibility_failure; fail-visible blockers: compatibility_failure:compatibility_not_verified.",
+      "deterministic_hash": "560235818b1d61bc2540f5e4c3c5b9e6727bfa95c6ab482a1760ace82bcfb0bc",
+      "environment_failures": [],
+      "manual_review_reasons": [],
+      "missing_governance_dependencies": [],
+      "missing_replay_requirements": [],
+      "missing_rollback_requirements": [],
+      "mutation_behavior_enabled": false,
+      "orchestration_execution_enabled": false,
+      "planning_only": true,
+      "planning_ready": false,
+      "production_consumption_enabled": false,
+      "prohibited_domains": [],
+      "readiness_status": "blocked_by_compatibility_failure",
+      "routing_behavior_enabled": false,
+      "runtime_execution_enabled": false,
+      "unsupported_states": []
+    },
+    "environment_failure": {
+      "audit_log_writing_enabled": false,
+      "blockers": [
+        {
+          "audit_safe": true,
+          "blocker_category": "environment_failure",
+          "blocker_id": "environment_failure:environment_mismatch",
+          "deterministic_rank": 70,
+          "explanation": "environment requirements must preserve non-production isolation",
+          "fail_visible": true,
+          "readiness_status": "blocked_by_environment_failure"
+        },
+        {
+          "audit_safe": true,
+          "blocker_category": "environment_failure",
+          "blocker_id": "environment_failure:environment_not_isolated",
+          "deterministic_rank": 70,
+          "explanation": "environment requirements must preserve non-production isolation",
+          "fail_visible": true,
+          "readiness_status": "blocked_by_environment_failure"
+        },
+        {
+          "audit_safe": true,
+          "blocker_category": "environment_failure",
+          "blocker_id": "environment_failure:non_production_environment_required",
+          "deterministic_rank": 70,
+          "explanation": "environment requirements must preserve non-production isolation",
+          "fail_visible": true,
+          "readiness_status": "blocked_by_environment_failure"
+        }
+      ],
+      "compatibility_failures": [],
+      "deterministic_explanation_summary": "Readiness classified as blocked_by_environment_failure; fail-visible blockers: environment_failure:environment_mismatch, environment_failure:environment_not_isolated, environment_failure:non_production_environment_required.",
+      "deterministic_hash": "b0a0292b34fe4528169bd0cddac13e08eafd0bac658955810e73b5626991fcd1",
+      "environment_failures": [
+        "environment_mismatch",
+        "environment_not_isolated",
+        "non_production_environment_required"
+      ],
+      "manual_review_reasons": [],
+      "missing_governance_dependencies": [],
+      "missing_replay_requirements": [],
+      "missing_rollback_requirements": [],
+      "mutation_behavior_enabled": false,
+      "orchestration_execution_enabled": false,
+      "planning_only": true,
+      "planning_ready": false,
+      "production_consumption_enabled": false,
+      "prohibited_domains": [],
+      "readiness_status": "blocked_by_environment_failure",
+      "routing_behavior_enabled": false,
+      "runtime_execution_enabled": false,
+      "unsupported_states": []
+    },
+    "fully_ready_planning_only_orchestration_request": {
+      "audit_log_writing_enabled": false,
+      "blockers": [],
+      "compatibility_failures": [],
+      "deterministic_explanation_summary": "Readiness is planning-only and satisfied for future orchestration planning; no execution, routing, mutation, audit writing, or production consumption is authorized.",
+      "deterministic_hash": "f2cfe8eb78d504df42925c3ff2f182bc859a575a74a3dbb584aa5dc8a7584217",
+      "environment_failures": [],
+      "manual_review_reasons": [],
+      "missing_governance_dependencies": [],
+      "missing_replay_requirements": [],
+      "missing_rollback_requirements": [],
+      "mutation_behavior_enabled": false,
+      "orchestration_execution_enabled": false,
+      "planning_only": true,
+      "planning_ready": true,
+      "production_consumption_enabled": false,
+      "prohibited_domains": [],
+      "readiness_status": "ready_for_future_orchestration_planning",
+      "routing_behavior_enabled": false,
+      "runtime_execution_enabled": false,
+      "unsupported_states": []
+    },
+    "manual_review_required": {
+      "audit_log_writing_enabled": false,
+      "blockers": [
+        {
+          "audit_safe": true,
+          "blocker_category": "manual_review",
+          "blocker_id": "manual_review:governance_review_required",
+          "deterministic_rank": 90,
+          "explanation": "manual review requirement must remain explicit",
+          "fail_visible": true,
+          "readiness_status": "manual_review_required"
+        }
+      ],
+      "compatibility_failures": [],
+      "deterministic_explanation_summary": "Readiness classified as manual_review_required; fail-visible blockers: manual_review:governance_review_required.",
+      "deterministic_hash": "dbad5c3dd27a6e349b042c3405f3c382dc904d8a55122af66a88773be92b4176",
+      "environment_failures": [],
+      "manual_review_reasons": [
+        "governance_review_required"
+      ],
+      "missing_governance_dependencies": [],
+      "missing_replay_requirements": [],
+      "missing_rollback_requirements": [],
+      "mutation_behavior_enabled": false,
+      "orchestration_execution_enabled": false,
+      "planning_only": true,
+      "planning_ready": false,
+      "production_consumption_enabled": false,
+      "prohibited_domains": [],
+      "readiness_status": "manual_review_required",
+      "routing_behavior_enabled": false,
+      "runtime_execution_enabled": false,
+      "unsupported_states": []
+    },
+    "missing_authorization": {
+      "audit_log_writing_enabled": false,
+      "blockers": [
+        {
+          "audit_safe": true,
+          "blocker_category": "authorization_failure",
+          "blocker_id": "authorization_not_satisfied",
+          "deterministic_rank": 30,
+          "explanation": "non-production planning authorization must be explicit",
+          "fail_visible": true,
+          "readiness_status": "blocked_by_authorization_failure"
+        }
+      ],
+      "compatibility_failures": [],
+      "deterministic_explanation_summary": "Readiness classified as blocked_by_authorization_failure; fail-visible blockers: authorization_not_satisfied.",
+      "deterministic_hash": "734af6aef7c34603e180b34398fadbb613211ddabe1084b89b472b2e9789491b",
+      "environment_failures": [],
+      "manual_review_reasons": [],
+      "missing_governance_dependencies": [],
+      "missing_replay_requirements": [],
+      "missing_rollback_requirements": [],
+      "mutation_behavior_enabled": false,
+      "orchestration_execution_enabled": false,
+      "planning_only": true,
+      "planning_ready": false,
+      "production_consumption_enabled": false,
+      "prohibited_domains": [],
+      "readiness_status": "blocked_by_authorization_failure",
+      "routing_behavior_enabled": false,
+      "runtime_execution_enabled": false,
+      "unsupported_states": []
+    },
+    "missing_governance_dependency": {
+      "audit_log_writing_enabled": false,
+      "blockers": [
+        {
+          "audit_safe": true,
+          "blocker_category": "governance_dependency",
+          "blocker_id": "missing_governance_dependency:v3_4_closeout_and_v3_5_readiness",
+          "deterministic_rank": 20,
+          "explanation": "required governance dependency is missing",
+          "fail_visible": true,
+          "readiness_status": "blocked_by_governance_dependency"
+        }
+      ],
+      "compatibility_failures": [],
+      "deterministic_explanation_summary": "Readiness classified as blocked_by_governance_dependency; fail-visible blockers: missing_governance_dependency:v3_4_closeout_and_v3_5_readiness.",
+      "deterministic_hash": "500b92d108e8b49296cacffe82b3fcdf0c1add966ecbdac0c3ec0b6a53753776",
+      "environment_failures": [],
+      "manual_review_reasons": [],
+      "missing_governance_dependencies": [
+        "v3_4_closeout_and_v3_5_readiness"
+      ],
+      "missing_replay_requirements": [],
+      "missing_rollback_requirements": [],
+      "mutation_behavior_enabled": false,
+      "orchestration_execution_enabled": false,
+      "planning_only": true,
+      "planning_ready": false,
+      "production_consumption_enabled": false,
+      "prohibited_domains": [],
+      "readiness_status": "blocked_by_governance_dependency",
+      "routing_behavior_enabled": false,
+      "runtime_execution_enabled": false,
+      "unsupported_states": []
+    },
+    "missing_replay_lineage": {
+      "audit_log_writing_enabled": false,
+      "blockers": [
+        {
+          "audit_safe": true,
+          "blocker_category": "replay_lineage_gap",
+          "blocker_id": "missing_replay_requirement:replay_lineage_id",
+          "deterministic_rank": 40,
+          "explanation": "required replay lineage must remain fail-visible",
+          "fail_visible": true,
+          "readiness_status": "blocked_by_replay_lineage_gap"
+        }
+      ],
+      "compatibility_failures": [],
+      "deterministic_explanation_summary": "Readiness classified as blocked_by_replay_lineage_gap; fail-visible blockers: missing_replay_requirement:replay_lineage_id.",
+      "deterministic_hash": "c85e64c06ff3e1c5e16d831e1a887fffc3b88499d36904527bfbd58bdb26afb8",
+      "environment_failures": [],
+      "manual_review_reasons": [],
+      "missing_governance_dependencies": [],
+      "missing_replay_requirements": [
+        "replay_lineage_id"
+      ],
+      "missing_rollback_requirements": [],
+      "mutation_behavior_enabled": false,
+      "orchestration_execution_enabled": false,
+      "planning_only": true,
+      "planning_ready": false,
+      "production_consumption_enabled": false,
+      "prohibited_domains": [],
+      "readiness_status": "blocked_by_replay_lineage_gap",
+      "routing_behavior_enabled": false,
+      "runtime_execution_enabled": false,
+      "unsupported_states": []
+    },
+    "missing_rollback_lineage": {
+      "audit_log_writing_enabled": false,
+      "blockers": [
+        {
+          "audit_safe": true,
+          "blocker_category": "rollback_lineage_gap",
+          "blocker_id": "missing_rollback_requirement:rollback_lineage_id",
+          "deterministic_rank": 50,
+          "explanation": "required rollback lineage must remain fail-visible",
+          "fail_visible": true,
+          "readiness_status": "blocked_by_rollback_lineage_gap"
+        }
+      ],
+      "compatibility_failures": [],
+      "deterministic_explanation_summary": "Readiness classified as blocked_by_rollback_lineage_gap; fail-visible blockers: missing_rollback_requirement:rollback_lineage_id.",
+      "deterministic_hash": "934992568818ebff8fc4d5bac0611ec32a3ae1c84caa085f3e82bf629c42eae8",
+      "environment_failures": [],
+      "manual_review_reasons": [],
+      "missing_governance_dependencies": [],
+      "missing_replay_requirements": [],
+      "missing_rollback_requirements": [
+        "rollback_lineage_id"
+      ],
+      "mutation_behavior_enabled": false,
+      "orchestration_execution_enabled": false,
+      "planning_only": true,
+      "planning_ready": false,
+      "production_consumption_enabled": false,
+      "prohibited_domains": [],
+      "readiness_status": "blocked_by_rollback_lineage_gap",
+      "routing_behavior_enabled": false,
+      "runtime_execution_enabled": false,
+      "unsupported_states": []
+    },
+    "multiple_simultaneous_blockers": {
+      "audit_log_writing_enabled": false,
+      "blockers": [
+        {
+          "audit_safe": true,
+          "blocker_category": "prohibited_domain",
+          "blocker_id": "prohibited_domain:runtime_execution",
+          "deterministic_rank": 5,
+          "explanation": "prohibited orchestration domains must not be downgraded",
+          "fail_visible": true,
+          "readiness_status": "prohibited_orchestration_request"
+        },
+        {
+          "audit_safe": true,
+          "blocker_category": "governance_dependency",
+          "blocker_id": "missing_governance_dependency:v3_4_closeout_and_v3_5_readiness",
+          "deterministic_rank": 20,
+          "explanation": "required governance dependency is missing",
+          "fail_visible": true,
+          "readiness_status": "blocked_by_governance_dependency"
+        },
+        {
+          "audit_safe": true,
+          "blocker_category": "governance_dependency",
+          "blocker_id": "missing_governance_dependency:v3_4_controlled_execution_gate",
+          "deterministic_rank": 20,
+          "explanation": "required governance dependency is missing",
+          "fail_visible": true,
+          "readiness_status": "blocked_by_governance_dependency"
+        },
+        {
+          "audit_safe": true,
+          "blocker_category": "governance_dependency",
+          "blocker_id": "missing_governance_dependency:v3_4_controlled_execution_readiness_audit",
+          "deterministic_rank": 20,
+          "explanation": "required governance dependency is missing",
+          "fail_visible": true,
+          "readiness_status": "blocked_by_governance_dependency"
+        },
+        {
+          "audit_safe": true,
+          "blocker_category": "governance_dependency",
+          "blocker_id": "missing_governance_dependency:v3_4_execution_audit_logging",
+          "deterministic_rank": 20,
+          "explanation": "required governance dependency is missing",
+          "fail_visible": true,
+          "readiness_status": "blocked_by_governance_dependency"
+        },
+        {
+          "audit_safe": true,
+          "blocker_category": "governance_dependency",
+          "blocker_id": "missing_governance_dependency:v3_4_execution_drift_escalation",
+          "deterministic_rank": 20,
+          "explanation": "required governance dependency is missing",
+          "fail_visible": true,
+          "readiness_status": "blocked_by_governance_dependency"
+        },
+        {
+          "audit_safe": true,
+          "blocker_category": "governance_dependency",
+          "blocker_id": "missing_governance_dependency:v3_4_execution_session_sandboxing",
+          "deterministic_rank": 20,
+          "explanation": "required governance dependency is missing",
+          "fail_visible": true,
+          "readiness_status": "blocked_by_governance_dependency"
+        },
+        {
+          "audit_safe": true,
+          "blocker_category": "governance_dependency",
+          "blocker_id": "missing_governance_dependency:v3_4_experiment_isolation",
+          "deterministic_rank": 20,
+          "explanation": "required governance dependency is missing",
+          "fail_visible": true,
+          "readiness_status": "blocked_by_governance_dependency"
+        },
+        {
+          "audit_safe": true,
+          "blocker_category": "governance_dependency",
+          "blocker_id": "missing_governance_dependency:v3_4_non_production_authorization",
+          "deterministic_rank": 20,
+          "explanation": "required governance dependency is missing",
+          "fail_visible": true,
+          "readiness_status": "blocked_by_governance_dependency"
+        },
+        {
+          "audit_safe": true,
+          "blocker_category": "governance_dependency",
+          "blocker_id": "missing_governance_dependency:v3_4_replay_safe_execution_scope",
+          "deterministic_rank": 20,
+          "explanation": "required governance dependency is missing",
+          "fail_visible": true,
+          "readiness_status": "blocked_by_governance_dependency"
+        },
+        {
+          "audit_safe": true,
+          "blocker_category": "governance_dependency",
+          "blocker_id": "missing_governance_dependency:v3_4_rollback_execution_governance",
+          "deterministic_rank": 20,
+          "explanation": "required governance dependency is missing",
+          "fail_visible": true,
+          "readiness_status": "blocked_by_governance_dependency"
+        },
+        {
+          "audit_safe": true,
+          "blocker_category": "governance_dependency",
+          "blocker_id": "missing_governance_dependency:v3_4_runtime_mutation_boundary",
+          "deterministic_rank": 20,
+          "explanation": "required governance dependency is missing",
+          "fail_visible": true,
+          "readiness_status": "blocked_by_governance_dependency"
+        },
+        {
+          "audit_safe": true,
+          "blocker_category": "authorization_failure",
+          "blocker_id": "authorization_not_satisfied",
+          "deterministic_rank": 30,
+          "explanation": "non-production planning authorization must be explicit",
+          "fail_visible": true,
+          "readiness_status": "blocked_by_authorization_failure"
+        },
+        {
+          "audit_safe": true,
+          "blocker_category": "replay_lineage_gap",
+          "blocker_id": "missing_replay_requirement:replay_lineage_id",
+          "deterministic_rank": 40,
+          "explanation": "required replay lineage must remain fail-visible",
+          "fail_visible": true,
+          "readiness_status": "blocked_by_replay_lineage_gap"
+        },
+        {
+          "audit_safe": true,
+          "blocker_category": "rollback_lineage_gap",
+          "blocker_id": "missing_rollback_requirement:rollback_lineage_id",
+          "deterministic_rank": 50,
+          "explanation": "required rollback lineage must remain fail-visible",
+          "fail_visible": true,
+          "readiness_status": "blocked_by_rollback_lineage_gap"
+        },
+        {
+          "audit_safe": true,
+          "blocker_category": "compatibility_failure",
+          "blocker_id": "compatibility_failure:compatibility_not_verified",
+          "deterministic_rank": 60,
+          "explanation": "compatibility evidence must be deterministic and explicit",
+          "fail_visible": true,
+          "readiness_status": "blocked_by_compatibility_failure"
+        },
+        {
+          "audit_safe": true,
+          "blocker_category": "environment_failure",
+          "blocker_id": "environment_failure:environment_mismatch",
+          "deterministic_rank": 70,
+          "explanation": "environment requirements must preserve non-production isolation",
+          "fail_visible": true,
+          "readiness_status": "blocked_by_environment_failure"
+        },
+        {
+          "audit_safe": true,
+          "blocker_category": "environment_failure",
+          "blocker_id": "environment_failure:non_production_environment_required",
+          "deterministic_rank": 70,
+          "explanation": "environment requirements must preserve non-production isolation",
+          "fail_visible": true,
+          "readiness_status": "blocked_by_environment_failure"
+        }
+      ],
+      "compatibility_failures": [
+        "compatibility_not_verified"
+      ],
+      "deterministic_explanation_summary": "Readiness classified as prohibited_orchestration_request; fail-visible blockers: prohibited_domain:runtime_execution, missing_governance_dependency:v3_4_closeout_and_v3_5_readiness, missing_governance_dependency:v3_4_controlled_execution_gate, missing_governance_dependency:v3_4_controlled_execution_readiness_audit, missing_governance_dependency:v3_4_execution_audit_logging, missing_governance_dependency:v3_4_execution_drift_escalation, missing_governance_dependency:v3_4_execution_session_sandboxing, missing_governance_dependency:v3_4_experiment_isolation, missing_governance_dependency:v3_4_non_production_authorization, missing_governance_dependency:v3_4_replay_safe_execution_scope, missing_governance_dependency:v3_4_rollback_execution_governance, missing_governance_dependency:v3_4_runtime_mutation_boundary, authorization_not_satisfied, missing_replay_requirement:replay_lineage_id, missing_rollback_requirement:rollback_lineage_id, compatibility_failure:compatibility_not_verified, environment_failure:environment_mismatch, environment_failure:non_production_environment_required.",
+      "deterministic_hash": "f537289ffc563f8ee8c8a6e9bb9b5aea07cdc4bb9100c6228fcea94c91ecf28f",
+      "environment_failures": [
+        "environment_mismatch",
+        "non_production_environment_required"
+      ],
+      "manual_review_reasons": [],
+      "missing_governance_dependencies": [
+        "v3_4_closeout_and_v3_5_readiness",
+        "v3_4_controlled_execution_gate",
+        "v3_4_controlled_execution_readiness_audit",
+        "v3_4_execution_audit_logging",
+        "v3_4_execution_drift_escalation",
+        "v3_4_execution_session_sandboxing",
+        "v3_4_experiment_isolation",
+        "v3_4_non_production_authorization",
+        "v3_4_replay_safe_execution_scope",
+        "v3_4_rollback_execution_governance",
+        "v3_4_runtime_mutation_boundary"
+      ],
+      "missing_replay_requirements": [
+        "replay_lineage_id"
+      ],
+      "missing_rollback_requirements": [
+        "rollback_lineage_id"
+      ],
+      "mutation_behavior_enabled": false,
+      "orchestration_execution_enabled": false,
+      "planning_only": true,
+      "planning_ready": false,
+      "production_consumption_enabled": false,
+      "prohibited_domains": [
+        "runtime_execution"
+      ],
+      "readiness_status": "prohibited_orchestration_request",
+      "routing_behavior_enabled": false,
+      "runtime_execution_enabled": false,
+      "unsupported_states": []
+    },
+    "prohibited_orchestration_request": {
+      "audit_log_writing_enabled": false,
+      "blockers": [
+        {
+          "audit_safe": true,
+          "blocker_category": "prohibited_domain",
+          "blocker_id": "prohibited_domain:runtime_execution",
+          "deterministic_rank": 5,
+          "explanation": "prohibited orchestration domains must not be downgraded",
+          "fail_visible": true,
+          "readiness_status": "prohibited_orchestration_request"
+        }
+      ],
+      "compatibility_failures": [],
+      "deterministic_explanation_summary": "Readiness classified as prohibited_orchestration_request; fail-visible blockers: prohibited_domain:runtime_execution.",
+      "deterministic_hash": "51c52f5c72381679d986850371e9690518db8d78c904475af4c83821ed8f2bc2",
+      "environment_failures": [],
+      "manual_review_reasons": [],
+      "missing_governance_dependencies": [],
+      "missing_replay_requirements": [],
+      "missing_rollback_requirements": [],
+      "mutation_behavior_enabled": false,
+      "orchestration_execution_enabled": false,
+      "planning_only": true,
+      "planning_ready": false,
+      "production_consumption_enabled": false,
+      "prohibited_domains": [
+        "runtime_execution"
+      ],
+      "readiness_status": "prohibited_orchestration_request",
+      "routing_behavior_enabled": false,
+      "runtime_execution_enabled": false,
+      "unsupported_states": []
+    },
+    "unsupported_orchestration_request": {
+      "audit_log_writing_enabled": false,
+      "blockers": [
+        {
+          "audit_safe": true,
+          "blocker_category": "unsupported_state",
+          "blocker_id": "unsupported_state:unsupported_orchestration_scope",
+          "deterministic_rank": 80,
+          "explanation": "unsupported orchestration states must remain explicit",
+          "fail_visible": true,
+          "readiness_status": "unsupported_orchestration_request"
+        }
+      ],
+      "compatibility_failures": [],
+      "deterministic_explanation_summary": "Readiness classified as unsupported_orchestration_request; fail-visible blockers: unsupported_state:unsupported_orchestration_scope.",
+      "deterministic_hash": "730a22ff772341235f6f1345e17e3756b15357fdef6453f32dbc165818d78237",
+      "environment_failures": [],
+      "manual_review_reasons": [],
+      "missing_governance_dependencies": [],
+      "missing_replay_requirements": [],
+      "missing_rollback_requirements": [],
+      "mutation_behavior_enabled": false,
+      "orchestration_execution_enabled": false,
+      "planning_only": true,
+      "planning_ready": false,
+      "production_consumption_enabled": false,
+      "prohibited_domains": [],
+      "readiness_status": "unsupported_orchestration_request",
+      "routing_behavior_enabled": false,
+      "runtime_execution_enabled": false,
+      "unsupported_states": [
+        "unsupported_orchestration_scope"
+      ]
+    }
+  },
+  "schema_version": "v3_5.orchestration_readiness_evaluation_report.1",
+  "status_distribution": {
+    "blocked_by_authorization_failure": 1,
+    "blocked_by_compatibility_failure": 1,
+    "blocked_by_environment_failure": 1,
+    "blocked_by_governance_dependency": 1,
+    "blocked_by_replay_lineage_gap": 1,
+    "blocked_by_rollback_lineage_gap": 1,
+    "manual_review_required": 1,
+    "prohibited_orchestration_request": 2,
+    "ready_for_future_orchestration_planning": 1,
+    "unsupported_orchestration_request": 1
+  },
+  "summary": {
+    "blocked_or_review_scenario_count": 10,
+    "deterministic_outputs": true,
+    "fail_visible_blockers": true,
+    "prohibited_domain_preservation": true,
+    "ready_scenario_count": 1,
+    "replay_safe_output_stability": true,
+    "rollback_safe_output_stability": true,
+    "scenario_count": 11,
+    "stable_serialization": true,
+    "supported_status_count": 10,
+    "unsupported_state_preservation": true
+  },
+  "unsupported_state_visibility_summary": {
+    "entry_count": 1,
+    "scenario_count": 11,
+    "scenario_with_entries_count": 1
+  }
+}

--- a/docs/migration/V3_5_ORCHESTRATION_READINESS_EVALUATION.md
+++ b/docs/migration/V3_5_ORCHESTRATION_READINESS_EVALUATION.md
@@ -1,0 +1,116 @@
+# v3.5 Orchestration Readiness Evaluation
+
+## Phase Boundary
+
+v3.5 Phase 2 is a deterministic orchestration readiness evaluation layer.
+
+It does not execute orchestration.
+
+It does not authorize orchestration execution.
+
+It does not route requests.
+
+It does not mutate state.
+
+It does not write audit logs.
+
+It only classifies declarative orchestration planning inputs for future controlled orchestration planning.
+
+- Final readiness status: `ready_for_future_orchestration_planning`
+- Deterministic hash: `68f65f6e7372140ccb97b5990012b2ccd900ebd3af5df71e5fa5f4f07cf22782`
+
+## Supported Readiness Statuses
+
+- `prohibited_orchestration_request`
+- `blocked_by_governance_dependency`
+- `blocked_by_authorization_failure`
+- `blocked_by_replay_lineage_gap`
+- `blocked_by_rollback_lineage_gap`
+- `blocked_by_environment_failure`
+- `blocked_by_compatibility_failure`
+- `unsupported_orchestration_request`
+- `manual_review_required`
+- `ready_for_future_orchestration_planning`
+
+## Evaluation Inputs
+
+- orchestration request identity
+- orchestration scope identity
+- authorization requirements
+- governance dependencies
+- replay lineage requirements
+- rollback lineage requirements
+- compatibility requirements
+- environment requirements
+- unsupported states
+- prohibited domains
+- blocker presence
+- manual review requirements
+
+## Evaluation Outputs
+
+- final readiness status
+- blocker list
+- unsupported-state list
+- prohibited-domain list
+- missing governance dependencies
+- missing replay requirements
+- missing rollback requirements
+- compatibility failures
+- environment failures
+- manual review reasons
+- deterministic explanation summary
+
+## Blocker Model
+
+Blockers are explicit, deterministic, fail-visible, and audit-safe. They are ordered by deterministic rank and blocker identity.
+
+## Unsupported-State Model
+
+Unsupported orchestration states are preserved as first-class readiness output and never silently converted into passing readiness.
+
+## Prohibited-Domain Model
+
+Prohibited orchestration domains remain hard blockers for readiness classification and cannot be downgraded by compatibility or manual review.
+
+## Manual-Review Model
+
+Manual review is an explicit readiness status for future planning review only. It does not authorize execution.
+
+## Deterministic Hash Behavior
+
+Report and result hashes use stable JSON serialization with sorted keys. The report avoids runtime-generated IDs and environment-dependent values.
+
+## Scenario Coverage
+
+- `fully_ready_planning_only_orchestration_request` -> `ready_for_future_orchestration_planning`
+- `missing_governance_dependency` -> `blocked_by_governance_dependency`
+- `missing_authorization` -> `blocked_by_authorization_failure`
+- `missing_replay_lineage` -> `blocked_by_replay_lineage_gap`
+- `missing_rollback_lineage` -> `blocked_by_rollback_lineage_gap`
+- `unsupported_orchestration_request` -> `unsupported_orchestration_request`
+- `prohibited_orchestration_request` -> `prohibited_orchestration_request`
+- `compatibility_failure` -> `blocked_by_compatibility_failure`
+- `environment_failure` -> `blocked_by_environment_failure`
+- `manual_review_required` -> `manual_review_required`
+- `multiple_simultaneous_blockers` -> `prohibited_orchestration_request`
+
+## Explicit Non-Execution Guarantees
+
+- Runtime execution remains prohibited.
+- Orchestration execution remains prohibited.
+- Routing behavior remains prohibited.
+- Mutation behavior remains prohibited.
+- Audit log writing remains prohibited.
+- Production consumption remains prohibited.
+- Default runtime manifest consumption remains disabled.
+- Production-authoritative manifest treatment remains prohibited.
+- The repository remains planning-only.
+
+## Remaining Limitations
+
+- readiness evaluation classifies declarative planning inputs only
+- readiness evaluation does not authorize orchestration execution
+- readiness evaluation does not route requests
+- readiness evaluation does not mutate state or write audit logs
+- readiness evaluation does not consume runtime manifests by default


### PR DESCRIPTION
Add deterministic orchestration readiness evaluation contracts for v3.5 Phase 2.

Adds:

- readiness status models

- readiness evaluation helpers

- readiness report models

- deterministic readiness report generation

- validation coverage for blocker, unsupported, prohibited, replay, rollback, compatibility, environment, and manual-review states

Preserves:

- planning-only orchestration governance

- non-execution guarantees

- non-production enforcement

- fail-visible blockers

- deterministic serialization

- replay-safe and rollback-safe lineage visibility

Does NOT enable:

- runtime execution

- orchestration execution

- routing behavior

- mutation behavior

- audit-log writing

- production consumption