### PR TITLE
v3.7: implement graph planning integrity enforcement

### DIFF
--- a/backend/app/runtime_orchestration/v3_7_graph_integrity_audit.py
+++ b/backend/app/runtime_orchestration/v3_7_graph_integrity_audit.py
@@ -1,0 +1,269 @@
+"""Deterministic audit infrastructure for v3.7 graph planning integrity."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, replace
+from typing import Any
+
+from app.runtime_intelligence.classification_hashing import deterministic_hash, stable_serialize
+
+from .v3_7_graph_integrity_enforcement import (
+    enforce_v3_7_graph_planning_integrity,
+    graph_integrity_enforcement_identity_key,
+)
+from .v3_7_graph_integrity_explainability import (
+    V37_GRAPH_INTEGRITY_EXPLAINABILITY_STABLE,
+    explain_v3_7_graph_integrity,
+)
+from .v3_7_graph_integrity_models import (
+    V37_INTEGRITY_FINDING_BLOCKED,
+    V37_INTEGRITY_FINDING_EXECUTION_BOUNDARY_VIOLATION,
+    V37_INTEGRITY_FINDING_HIDDEN_PROHIBITED_STATE,
+    V37_INTEGRITY_FINDING_HIDDEN_UNKNOWN_STATE,
+    V37_INTEGRITY_FINDING_HIDDEN_UNSUPPORTED_STATE,
+    V37_INTEGRITY_FINDING_WARNING,
+    V37GraphIntegrityEnforcementResult,
+    validate_v3_7_graph_integrity_hash_stability,
+    validate_v3_7_graph_integrity_serialization_stability,
+)
+from .v3_7_graph_integrity_policies import graph_integrity_policy_identity_key
+from .v3_7_graph_integrity_provenance import (
+    V37_GRAPH_INTEGRITY_PROVENANCE_PRESERVED,
+    audit_v3_7_graph_integrity_provenance,
+)
+from .v3_7_graph_integrity_replay import validate_v3_7_graph_integrity_replay_evidence
+
+
+V37_GRAPH_INTEGRITY_AUDIT_STABLE = "v3_7_graph_integrity_audit_stable"
+V37_GRAPH_INTEGRITY_AUDIT_FAILED = "v3_7_graph_integrity_audit_failed"
+V37_INTEGRITY_AUDIT_VISIBLE_BLOCKED = "v3_7_graph_integrity_visible_blocked"
+V37_INTEGRITY_AUDIT_VISIBLE_WARNING = "v3_7_graph_integrity_visible_warning"
+V37_INTEGRITY_AUDIT_VISIBLE_EXECUTION_BOUNDARY = "v3_7_graph_integrity_visible_execution_boundary"
+V37_INTEGRITY_AUDIT_VISIBLE_HIDDEN_PROHIBITED = "v3_7_graph_integrity_visible_hidden_prohibited"
+V37_INTEGRITY_AUDIT_VISIBLE_HIDDEN_UNSUPPORTED = "v3_7_graph_integrity_visible_hidden_unsupported"
+V37_INTEGRITY_AUDIT_VISIBLE_HIDDEN_UNKNOWN = "v3_7_graph_integrity_visible_hidden_unknown"
+V37_INTEGRITY_AUDIT_BLOCKED_BY_POLICY_IDENTITY = "v3_7_graph_integrity_audit_blocked_by_policy_identity"
+V37_INTEGRITY_AUDIT_BLOCKED_BY_ENFORCEMENT_IDENTITY = "v3_7_graph_integrity_audit_blocked_by_enforcement_identity"
+V37_INTEGRITY_AUDIT_BLOCKED_BY_EVIDENCE_SOURCE = "v3_7_graph_integrity_audit_blocked_by_evidence_source"
+V37_INTEGRITY_AUDIT_BLOCKED_BY_REPLAY = "v3_7_graph_integrity_audit_blocked_by_replay"
+V37_INTEGRITY_AUDIT_BLOCKED_BY_ROLLBACK = "v3_7_graph_integrity_audit_blocked_by_rollback"
+V37_INTEGRITY_AUDIT_BLOCKED_BY_PROVENANCE = "v3_7_graph_integrity_audit_blocked_by_provenance"
+V37_INTEGRITY_AUDIT_BLOCKED_BY_EXPLAINABILITY = "v3_7_graph_integrity_audit_blocked_by_explainability"
+V37_INTEGRITY_AUDIT_BLOCKED_BY_FINDING_VISIBILITY = "v3_7_graph_integrity_audit_blocked_by_finding_visibility"
+V37_INTEGRITY_AUDIT_BLOCKED_BY_EXECUTION_BOUNDARY = "v3_7_graph_integrity_audit_blocked_by_execution_boundary"
+V37_INTEGRITY_AUDIT_BLOCKED_BY_SERIALIZATION = "v3_7_graph_integrity_audit_blocked_by_serialization"
+V37_INTEGRITY_AUDIT_BLOCKED_BY_HASH = "v3_7_graph_integrity_audit_blocked_by_hash"
+
+
+@dataclass(frozen=True)
+class V37GraphIntegrityAuditFinding:
+    finding_id: str
+    status: str
+    severity: str
+    subject_type: str
+    subject_id: str
+    message: str
+    fail_visible: bool = True
+
+
+@dataclass(frozen=True)
+class V37GraphIntegrityAuditResult:
+    audit_status: str
+    valid: bool
+    finding_count: int
+    error_count: int
+    visibility_finding_count: int
+    policy_identity_continuity_preserved: bool
+    enforcement_identity_continuity_preserved: bool
+    evidence_source_continuity_preserved: bool
+    graph_continuity_preserved: bool
+    governance_continuity_preserved: bool
+    compatibility_continuity_preserved: bool
+    evaluation_continuity_preserved: bool
+    session_continuity_preserved: bool
+    scenario_continuity_preserved: bool
+    aggregation_continuity_preserved: bool
+    replay_continuity_preserved: bool
+    rollback_continuity_preserved: bool
+    provenance_continuity_preserved: bool
+    explainability_continuity_preserved: bool
+    execution_boundary_continuity_preserved: bool
+    fail_visible_finding_preservation: bool
+    deterministic_serialization_stable: bool
+    deterministic_hash_stable: bool
+    deterministic_audit_hash: str
+    findings: tuple[V37GraphIntegrityAuditFinding, ...]
+
+
+def audit_v3_7_graph_integrity(
+    result: V37GraphIntegrityEnforcementResult | None = None,
+) -> V37GraphIntegrityAuditResult:
+    enforcement = result or enforce_v3_7_graph_planning_integrity()
+    findings: list[V37GraphIntegrityAuditFinding] = []
+    _add_visibility_findings(enforcement, findings)
+    source_types = set(enforcement.evidence_source_types)
+    policy_identity_ok = enforcement.policy.identity.stable_identity_key == graph_integrity_policy_identity_key(enforcement.policy.identity)
+    enforcement_identity_ok = enforcement.identity.stable_identity_key == graph_integrity_enforcement_identity_key(enforcement.identity)
+    required_sources = {
+        "graph_foundations",
+        "governance",
+        "compatibility",
+        "evaluation",
+        "session",
+        "scenario",
+        "aggregation",
+    }
+    evidence_source_ok = required_sources.issubset(source_types) and bool(enforcement.evidence_source_references)
+    replay = validate_v3_7_graph_integrity_replay_evidence(enforcement)
+    provenance = audit_v3_7_graph_integrity_provenance(enforcement)
+    explainability = explain_v3_7_graph_integrity(enforcement)
+    serialization = validate_v3_7_graph_integrity_serialization_stability(enforcement)
+    hashing = validate_v3_7_graph_integrity_hash_stability(enforcement)
+    rollback_ok = bool(enforcement.rollback_continuity_references) and replay["rollback_continuity_preserved"]
+    finding_visibility_ok = all(finding.fail_visible and not finding.hidden for finding in enforcement.findings)
+    execution_boundary_ok = _execution_boundary_preserved(enforcement)
+    _append_error_if_false(findings, policy_identity_ok, V37_INTEGRITY_AUDIT_BLOCKED_BY_POLICY_IDENTITY, "policy", enforcement.policy.identity.policy_id, "policy identity continuity is unstable")
+    _append_error_if_false(findings, enforcement_identity_ok, V37_INTEGRITY_AUDIT_BLOCKED_BY_ENFORCEMENT_IDENTITY, "enforcement", enforcement.identity.enforcement_id, "enforcement identity continuity is unstable")
+    _append_error_if_false(findings, evidence_source_ok, V37_INTEGRITY_AUDIT_BLOCKED_BY_EVIDENCE_SOURCE, "enforcement", enforcement.identity.enforcement_id, "evidence-source continuity is incomplete")
+    _append_error_if_false(findings, replay["replay_continuity_preserved"], V37_INTEGRITY_AUDIT_BLOCKED_BY_REPLAY, "enforcement", enforcement.identity.enforcement_id, "replay continuity is incomplete")
+    _append_error_if_false(findings, rollback_ok, V37_INTEGRITY_AUDIT_BLOCKED_BY_ROLLBACK, "enforcement", enforcement.identity.enforcement_id, "rollback continuity is incomplete")
+    _append_error_if_false(findings, provenance.provenance_status == V37_GRAPH_INTEGRITY_PROVENANCE_PRESERVED, V37_INTEGRITY_AUDIT_BLOCKED_BY_PROVENANCE, "enforcement", enforcement.identity.enforcement_id, "provenance continuity is incomplete")
+    _append_error_if_false(findings, explainability.explainability_status == V37_GRAPH_INTEGRITY_EXPLAINABILITY_STABLE, V37_INTEGRITY_AUDIT_BLOCKED_BY_EXPLAINABILITY, "enforcement", enforcement.identity.enforcement_id, "explainability continuity is incomplete")
+    _append_error_if_false(findings, finding_visibility_ok, V37_INTEGRITY_AUDIT_BLOCKED_BY_FINDING_VISIBILITY, "enforcement", enforcement.identity.enforcement_id, "integrity finding visibility is incomplete")
+    _append_error_if_false(findings, execution_boundary_ok, V37_INTEGRITY_AUDIT_BLOCKED_BY_EXECUTION_BOUNDARY, "enforcement", enforcement.identity.enforcement_id, "execution-boundary continuity is violated")
+    _append_error_if_false(findings, serialization["stable"], V37_INTEGRITY_AUDIT_BLOCKED_BY_SERIALIZATION, "enforcement", enforcement.identity.enforcement_id, "integrity serialization is unstable")
+    _append_error_if_false(findings, hashing["stable"], V37_INTEGRITY_AUDIT_BLOCKED_BY_HASH, "enforcement", enforcement.identity.enforcement_id, "integrity hash is unstable")
+    error_count = sum(1 for finding in findings if finding.severity == "error")
+    visibility_count = sum(1 for finding in findings if finding.severity == "visibility")
+    audit = V37GraphIntegrityAuditResult(
+        audit_status=V37_GRAPH_INTEGRITY_AUDIT_STABLE if error_count == 0 else V37_GRAPH_INTEGRITY_AUDIT_FAILED,
+        valid=error_count == 0,
+        finding_count=len(findings),
+        error_count=error_count,
+        visibility_finding_count=visibility_count,
+        policy_identity_continuity_preserved=policy_identity_ok,
+        enforcement_identity_continuity_preserved=enforcement_identity_ok,
+        evidence_source_continuity_preserved=evidence_source_ok,
+        graph_continuity_preserved="graph_foundations" in source_types,
+        governance_continuity_preserved="governance" in source_types,
+        compatibility_continuity_preserved="compatibility" in source_types,
+        evaluation_continuity_preserved="evaluation" in source_types,
+        session_continuity_preserved="session" in source_types,
+        scenario_continuity_preserved="scenario" in source_types,
+        aggregation_continuity_preserved="aggregation" in source_types,
+        replay_continuity_preserved=replay["replay_continuity_preserved"],
+        rollback_continuity_preserved=rollback_ok,
+        provenance_continuity_preserved=provenance.provenance_status == V37_GRAPH_INTEGRITY_PROVENANCE_PRESERVED,
+        explainability_continuity_preserved=explainability.explainability_status == V37_GRAPH_INTEGRITY_EXPLAINABILITY_STABLE,
+        execution_boundary_continuity_preserved=execution_boundary_ok,
+        fail_visible_finding_preservation=finding_visibility_ok,
+        deterministic_serialization_stable=serialization["stable"],
+        deterministic_hash_stable=hashing["stable"],
+        deterministic_audit_hash="",
+        findings=tuple(sorted(findings, key=lambda item: item.finding_id)),
+    )
+    return replace(audit, deterministic_audit_hash=hash_v3_7_graph_integrity_audit_result(audit))
+
+
+def export_v3_7_graph_integrity_audit_finding(finding: V37GraphIntegrityAuditFinding) -> dict[str, Any]:
+    return asdict(finding)
+
+
+def export_v3_7_graph_integrity_audit_result(result: V37GraphIntegrityAuditResult) -> dict[str, Any]:
+    data = asdict(result)
+    data["findings"] = [
+        export_v3_7_graph_integrity_audit_finding(finding)
+        for finding in sorted(result.findings, key=lambda item: item.finding_id)
+    ]
+    return data
+
+
+def serialize_v3_7_graph_integrity_audit_result(result: V37GraphIntegrityAuditResult) -> str:
+    return stable_serialize(export_v3_7_graph_integrity_audit_result(result))
+
+
+def hash_v3_7_graph_integrity_audit_result(result: V37GraphIntegrityAuditResult) -> str:
+    data = export_v3_7_graph_integrity_audit_result(result)
+    data.pop("deterministic_audit_hash", None)
+    return deterministic_hash(data)
+
+
+def _add_visibility_findings(
+    enforcement: V37GraphIntegrityEnforcementResult,
+    findings: list[V37GraphIntegrityAuditFinding],
+) -> None:
+    status_map = {
+        V37_INTEGRITY_FINDING_BLOCKED: V37_INTEGRITY_AUDIT_VISIBLE_BLOCKED,
+        V37_INTEGRITY_FINDING_WARNING: V37_INTEGRITY_AUDIT_VISIBLE_WARNING,
+        V37_INTEGRITY_FINDING_EXECUTION_BOUNDARY_VIOLATION: V37_INTEGRITY_AUDIT_VISIBLE_EXECUTION_BOUNDARY,
+        V37_INTEGRITY_FINDING_HIDDEN_PROHIBITED_STATE: V37_INTEGRITY_AUDIT_VISIBLE_HIDDEN_PROHIBITED,
+        V37_INTEGRITY_FINDING_HIDDEN_UNSUPPORTED_STATE: V37_INTEGRITY_AUDIT_VISIBLE_HIDDEN_UNSUPPORTED,
+        V37_INTEGRITY_FINDING_HIDDEN_UNKNOWN_STATE: V37_INTEGRITY_AUDIT_VISIBLE_HIDDEN_UNKNOWN,
+    }
+    for finding in enforcement.findings:
+        status = status_map.get(finding.finding_classification)
+        if status:
+            findings.append(_finding(status, "integrity_finding", finding.finding_id, f"{finding.finding_classification} remains fail-visible", "visibility"))
+
+
+def _append_error_if_false(findings, condition: bool, status: str, subject_type: str, subject_id: str, message: str) -> None:
+    if not condition:
+        findings.append(_finding(status, subject_type, subject_id, message))
+
+
+def _execution_boundary_preserved(enforcement: V37GraphIntegrityEnforcementResult) -> bool:
+    return all(
+        (
+            enforcement.integrity_enforcement_is_non_executable,
+            enforcement.integrity_enforcement_validates_planning_evidence_only,
+            enforcement.valid_integrity_does_not_authorize_execution,
+            enforcement.blocked_integrity_does_not_perform_runtime_blocking,
+            enforcement.enforcement_outcomes_are_planning_validation_only,
+            enforcement.integrity_enforcement_does_not_route_schedule_dispatch_traverse_optimize_recommend_or_execute,
+            not enforcement.graph_execution_enabled,
+            not enforcement.integrity_driven_execution_enabled,
+            not enforcement.orchestration_authorization_enabled,
+            not enforcement.routing_enabled,
+            not enforcement.scheduling_enabled,
+            not enforcement.dispatch_enabled,
+            not enforcement.traversal_logic_enabled,
+            not enforcement.path_selection_enabled,
+            not enforcement.scenario_selection_enabled,
+            not enforcement.optimization_engine_enabled,
+            not enforcement.recommendation_enabled,
+            not enforcement.autonomous_orchestration_enabled,
+            not enforcement.runtime_mutation_enabled,
+            not enforcement.persistent_runtime_writes_enabled,
+            not enforcement.runtime_decision_making_enabled,
+            not enforcement.execution_gates_enabled,
+            not enforcement.callable_orchestration_flows_enabled,
+            not enforcement.runtime_control_system_enabled,
+            all(
+                not any(
+                    (
+                        finding.execution_authorization,
+                        finding.routing_authorization,
+                        finding.scheduling_authorization,
+                        finding.dispatch_authorization,
+                        finding.traversal_authorization,
+                    )
+                )
+                for finding in enforcement.findings
+            ),
+            all(
+                item.non_executable_replay_evidence and not item.runtime_replay and not item.execution_authorization
+                for item in enforcement.replay_evidence
+            ),
+        )
+    )
+
+
+def _finding(status: str, subject_type: str, subject_id: str, message: str, severity: str = "error") -> V37GraphIntegrityAuditFinding:
+    return V37GraphIntegrityAuditFinding(
+        finding_id=f"{status}:{subject_type}:{subject_id}",
+        status=status,
+        severity=severity,
+        subject_type=subject_type,
+        subject_id=subject_id,
+        message=message,
+    )

--- a/backend/app/runtime_orchestration/v3_7_graph_integrity_enforcement.py
+++ b/backend/app/runtime_orchestration/v3_7_graph_integrity_enforcement.py
@@ -1,0 +1,262 @@
+"""Deterministic integrity enforcement over v3.7 planning evidence."""
+
+from __future__ import annotations
+
+from app.runtime_intelligence.classification_hashing import deterministic_hash
+
+from .v3_7_graph_integrity_findings import build_v3_7_graph_integrity_findings
+from .v3_7_graph_integrity_models import (
+    V3_7_GRAPH_INTEGRITY_PHASE_ID,
+    V37_INTEGRITY_OUTCOME_BLOCKED,
+    V37_INTEGRITY_OUTCOME_INVALID,
+    V37_INTEGRITY_OUTCOME_VALID,
+    V37GraphIntegrityEnforcementIdentity,
+    V37GraphIntegrityEnforcementResult,
+    V37GraphIntegrityPolicy,
+    V37GraphIntegrityPolicyMetadata,
+    V37GraphIntegrityReplayEvidence,
+)
+from .v3_7_graph_integrity_policies import build_v3_7_graph_integrity_policy
+from .v3_7_graph_intelligence_aggregation import build_v3_7_graph_planning_intelligence_aggregation
+from .v3_7_graph_intelligence_audit import (
+    V37_GRAPH_INTELLIGENCE_AUDIT_STABLE,
+    audit_v3_7_graph_intelligence,
+)
+from .v3_7_graph_intelligence_explainability import (
+    V37_GRAPH_INTELLIGENCE_EXPLAINABILITY_STABLE,
+    explain_v3_7_graph_intelligence,
+)
+from .v3_7_graph_intelligence_models import (
+    V37GraphPlanningIntelligenceAggregation,
+    hash_v3_7_graph_planning_intelligence_aggregation,
+)
+from .v3_7_graph_intelligence_provenance import (
+    V37_GRAPH_INTELLIGENCE_PROVENANCE_PRESERVED,
+    audit_v3_7_graph_intelligence_provenance,
+)
+from .v3_7_graph_intelligence_replay import validate_v3_7_graph_intelligence_replay_evidence
+from .v3_7_graph_intelligence_validation import (
+    V37_GRAPH_INTELLIGENCE_VALIDATION_STABLE,
+    validate_v3_7_graph_intelligence,
+)
+from .v3_7_graph_models import default_v3_7_graph_provenance
+
+
+DEFAULT_V37_GRAPH_INTEGRITY_ENFORCEMENT_ID = "v3_7_graph_integrity_enforcement_default"
+
+
+def build_v3_7_graph_integrity_enforcement_identity(
+    policy_id: str,
+    aggregation_id: str,
+) -> V37GraphIntegrityEnforcementIdentity:
+    key_payload = {
+        "enforcement_id": DEFAULT_V37_GRAPH_INTEGRITY_ENFORCEMENT_ID,
+        "policy_id": policy_id,
+        "aggregation_id": aggregation_id,
+        "enforcement_version": "v3.7",
+        "phase_id": V3_7_GRAPH_INTEGRITY_PHASE_ID,
+    }
+    return V37GraphIntegrityEnforcementIdentity(
+        enforcement_id=DEFAULT_V37_GRAPH_INTEGRITY_ENFORCEMENT_ID,
+        policy_id=policy_id,
+        aggregation_id=aggregation_id,
+        enforcement_version="v3.7",
+        phase_id=V3_7_GRAPH_INTEGRITY_PHASE_ID,
+        stable_identity_key=deterministic_hash(key_payload),
+    )
+
+
+def graph_integrity_enforcement_identity_key(identity: V37GraphIntegrityEnforcementIdentity) -> str:
+    return deterministic_hash(
+        {
+            "enforcement_id": identity.enforcement_id,
+            "policy_id": identity.policy_id,
+            "aggregation_id": identity.aggregation_id,
+            "enforcement_version": identity.enforcement_version,
+            "phase_id": identity.phase_id,
+        }
+    )
+
+
+def graph_integrity_enforcement_identities_are_unique(
+    identities: tuple[V37GraphIntegrityEnforcementIdentity, ...],
+) -> bool:
+    keys = [identity.stable_identity_key for identity in identities]
+    return len(keys) == len(set(keys))
+
+
+def enforce_v3_7_graph_planning_integrity(
+    aggregation: V37GraphPlanningIntelligenceAggregation | None = None,
+    policy: V37GraphIntegrityPolicy | None = None,
+) -> V37GraphIntegrityEnforcementResult:
+    planning_intelligence = aggregation or build_v3_7_graph_planning_intelligence_aggregation()
+    integrity_policy = policy or build_v3_7_graph_integrity_policy()
+    identity = build_v3_7_graph_integrity_enforcement_identity(
+        integrity_policy.identity.policy_id,
+        planning_intelligence.identity.aggregation_id,
+    )
+    validation = validate_v3_7_graph_intelligence((planning_intelligence,))
+    audit = audit_v3_7_graph_intelligence(planning_intelligence)
+    provenance = audit_v3_7_graph_intelligence_provenance(planning_intelligence)
+    explainability = explain_v3_7_graph_intelligence(planning_intelligence)
+    replay = validate_v3_7_graph_intelligence_replay_evidence(planning_intelligence)
+    source_ids = tuple(sorted(source.source_id for source in planning_intelligence.evidence_sources)) + (
+        planning_intelligence.identity.aggregation_id,
+    )
+    source_types = tuple(sorted(source.source_type for source in planning_intelligence.evidence_sources)) + (
+        "aggregation",
+    )
+    integrity_totals = _integrity_totals(planning_intelligence, validation, audit, provenance, explainability, replay)
+    findings = build_v3_7_graph_integrity_findings(integrity_totals, source_ids)
+    active_blocking_findings = tuple(
+        finding.finding_id for finding in findings if finding.blocks_validation or finding.active_violation
+    )
+    continuity_hashes = tuple(
+        sorted(
+            set(planning_intelligence.continuity_hash_references)
+            | {hash_v3_7_graph_planning_intelligence_aggregation(planning_intelligence)}
+            | {validation.deterministic_validation_hash}
+            | {audit.deterministic_audit_hash}
+            | {provenance.deterministic_provenance_hash}
+            | {explainability.deterministic_explainability_hash}
+        )
+    )
+    replay_evidence = (
+        V37GraphIntegrityReplayEvidence(
+            replay_evidence_id="v3_7_graph_integrity_replay_evidence_default",
+            enforcement_id=identity.enforcement_id,
+            policy_id=integrity_policy.identity.policy_id,
+            evidence_source_references=source_ids,
+            integrity_finding_references=tuple(finding.finding_id for finding in findings),
+            blocked_finding_references=active_blocking_findings,
+            provenance_references=tuple(
+                sorted(
+                    set(source.provenance_references[0] for source in planning_intelligence.evidence_sources if source.provenance_references)
+                    | {planning_intelligence.provenance.provenance_id}
+                    | {integrity_policy.provenance.provenance_id}
+                )
+            ),
+            explainability_references=tuple(
+                sorted(
+                    set(planning_intelligence.explainability_reference_ids)
+                    | set(reference for source in planning_intelligence.evidence_sources for reference in source.explainability_references)
+                    | {"v3_7_graph_integrity_explainability"}
+                )
+            ),
+            continuity_hashes=continuity_hashes,
+            non_executable_replay_evidence=True,
+            runtime_replay=False,
+            execution_authorization=False,
+        ),
+    )
+    outcome = _outcome_from_findings(findings, validation.validation_status, audit.audit_status)
+    return V37GraphIntegrityEnforcementResult(
+        identity=identity,
+        policy=integrity_policy,
+        metadata=(
+            V37GraphIntegrityPolicyMetadata("enforcement_semantics", "deterministic_planning_integrity_validation"),
+            V37GraphIntegrityPolicyMetadata("runtime_capability", "none"),
+            V37GraphIntegrityPolicyMetadata("execution_boundary", "valid_integrity_does_not_authorize_execution"),
+        ),
+        evidence_source_references=source_ids,
+        evidence_source_types=source_types,
+        enforcement_outcome=outcome,
+        findings=findings,
+        replay_evidence=replay_evidence,
+        rollback_continuity_references=planning_intelligence.rollback_continuity_references,
+        provenance=default_v3_7_graph_provenance(identity.enforcement_id, "graph_planning_integrity_enforcement"),
+        explainability_reference_ids=("v3_7_graph_integrity_explainability",),
+        continuity_hash_references=continuity_hashes,
+    )
+
+
+def _integrity_totals(aggregation, validation, audit, provenance, explainability, replay) -> dict[str, int | bool]:
+    execution_boundary_violation = _execution_boundary_violation(aggregation)
+    return {
+        "invalid_integrity_count": 0 if validation.valid and audit.valid else 1,
+        "blocked_integrity_count": 0,
+        "warning_integrity_count": 0,
+        "continuity_violation_count": 0
+        if all(
+            (
+                validation.deterministic_serialization_stable,
+                validation.deterministic_hash_stable,
+                validation.replay_continuity_preserved,
+                validation.rollback_continuity_preserved,
+                audit.evidence_source_continuity_preserved,
+                audit.governance_aggregation_continuity_preserved,
+                audit.compatibility_aggregation_continuity_preserved,
+                audit.evaluation_aggregation_continuity_preserved,
+                audit.session_aggregation_continuity_preserved,
+                audit.scenario_aggregation_continuity_preserved,
+            )
+        )
+        else 1,
+        "provenance_violation_count": 0
+        if provenance.provenance_status == V37_GRAPH_INTELLIGENCE_PROVENANCE_PRESERVED
+        else 1,
+        "explainability_violation_count": 0
+        if explainability.explainability_status == V37_GRAPH_INTELLIGENCE_EXPLAINABILITY_STABLE
+        else 1,
+        "replay_violation_count": 0 if replay["replay_continuity_preserved"] else 1,
+        "rollback_violation_count": 0 if replay["rollback_continuity_preserved"] else 1,
+        "execution_boundary_violation_count": 1 if execution_boundary_violation else 0,
+        "hidden_prohibited_state_count": validation.hidden_prohibited_finding_count,
+        "hidden_unsupported_state_count": validation.hidden_unsupported_finding_count,
+        "hidden_unknown_state_count": validation.hidden_unknown_finding_count,
+    }
+
+
+def _outcome_from_findings(findings, validation_status: str, audit_status: str) -> str:
+    if any(finding.blocks_validation for finding in findings):
+        return V37_INTEGRITY_OUTCOME_BLOCKED
+    if validation_status != V37_GRAPH_INTELLIGENCE_VALIDATION_STABLE:
+        return V37_INTEGRITY_OUTCOME_INVALID
+    if audit_status != V37_GRAPH_INTELLIGENCE_AUDIT_STABLE:
+        return V37_INTEGRITY_OUTCOME_INVALID
+    return V37_INTEGRITY_OUTCOME_VALID
+
+
+def _execution_boundary_violation(aggregation: V37GraphPlanningIntelligenceAggregation) -> bool:
+    blocked_phrases = (
+        "should execute",
+        "recommend execution",
+        "select runtime path",
+        "authorize orchestration",
+        "rank for execution",
+        "runtime guidance",
+        "route graph",
+        "dispatch graph",
+        "schedule graph",
+        "traverse graph",
+    )
+    return any(
+        (
+            aggregation.graph_execution_enabled,
+            aggregation.aggregation_driven_execution_enabled,
+            aggregation.orchestration_selection_enabled,
+            aggregation.routing_enabled,
+            aggregation.scheduling_enabled,
+            aggregation.dispatch_enabled,
+            aggregation.graph_traversal_execution_enabled,
+            aggregation.optimization_engine_enabled,
+            aggregation.recommendation_enabled,
+            aggregation.runtime_decision_making_enabled,
+            aggregation.path_ranking_for_execution_enabled,
+            aggregation.scenario_selection_for_execution_enabled,
+            aggregation.executable_planning_insights_enabled,
+            any(
+                insight.recommends_execution
+                or insight.selects_runtime_path
+                or insight.authorizes_orchestration
+                or any(phrase in insight.summary.lower() for phrase in blocked_phrases)
+                for insight in aggregation.insights
+            ),
+            any(
+                finding.execution_recommendation
+                or finding.runtime_path_selection
+                or any(phrase in finding.summary.lower() for phrase in blocked_phrases)
+                for finding in aggregation.findings
+            ),
+        )
+    )

--- a/backend/app/runtime_orchestration/v3_7_graph_integrity_explainability.py
+++ b/backend/app/runtime_orchestration/v3_7_graph_integrity_explainability.py
@@ -1,0 +1,187 @@
+"""Deterministic explainability for v3.7 graph planning integrity enforcement."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, replace
+from typing import Any
+
+from app.runtime_intelligence.classification_hashing import deterministic_hash, stable_serialize
+
+from .v3_7_graph_integrity_enforcement import enforce_v3_7_graph_planning_integrity
+from .v3_7_graph_integrity_models import V37GraphIntegrityEnforcementResult
+
+
+V37_GRAPH_INTEGRITY_EXPLAINABILITY_STABLE = "v3_7_graph_integrity_explainability_stable"
+V37_GRAPH_INTEGRITY_EXPLAINABILITY_BLOCKED = "v3_7_graph_integrity_explainability_blocked"
+
+
+@dataclass(frozen=True)
+class V37GraphIntegrityExplanation:
+    explanation_id: str
+    explanation_type: str
+    subject_id: str
+    summary: str
+    evidence_references: tuple[str, ...]
+    deterministic_order: int
+    replay_safe: bool = True
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "evidence_references", tuple(self.evidence_references or ()))
+
+
+@dataclass(frozen=True)
+class V37GraphIntegrityExplainabilityResult:
+    explainability_status: str
+    explanation_count: int
+    enforcement_explanation_count: int
+    policy_explanation_count: int
+    evidence_source_explanation_count: int
+    finding_explanation_count: int
+    warning_explanation_count: int
+    blocked_explanation_count: int
+    continuity_explanation_count: int
+    provenance_explanation_count: int
+    execution_boundary_explanation_count: int
+    does_not_authorize_explanation_count: int
+    deterministic_explainability_hash: str
+    explanations: tuple[V37GraphIntegrityExplanation, ...]
+
+
+def explain_v3_7_graph_integrity(
+    result: V37GraphIntegrityEnforcementResult | None = None,
+) -> V37GraphIntegrityExplainabilityResult:
+    enforcement = result or enforce_v3_7_graph_planning_integrity()
+    explanations: list[V37GraphIntegrityExplanation] = []
+    order = 0
+
+    def add(explanation_type: str, subject_id: str, summary: str, evidence: tuple[str, ...]) -> None:
+        nonlocal order
+        order += 1
+        explanations.append(
+            V37GraphIntegrityExplanation(
+                explanation_id=f"v3_7_graph_integrity_explanation_{order:03d}_{explanation_type}",
+                explanation_type=explanation_type,
+                subject_id=subject_id,
+                summary=summary,
+                evidence_references=evidence,
+                deterministic_order=order,
+            )
+        )
+
+    add(
+        "enforcement",
+        enforcement.identity.enforcement_id,
+        "integrity enforcement exists to validate cross-system planning evidence deterministically",
+        (enforcement.identity.enforcement_id,),
+    )
+    add(
+        "policy",
+        enforcement.policy.identity.policy_id,
+        "the enforced policy requires evidence-source, continuity, provenance, explainability, and execution-boundary integrity",
+        (enforcement.policy.identity.policy_id,),
+    )
+    for source_id in sorted(enforcement.evidence_source_references):
+        add("evidence_source", source_id, f"evidence source {source_id} is included in integrity validation", (source_id,))
+    for finding in sorted(enforcement.findings, key=lambda item: item.finding_id):
+        add(
+            "finding",
+            finding.finding_id,
+            f"{finding.finding_classification} remains fail-visible; active_violation={finding.active_violation}",
+            finding.evidence_references,
+        )
+    if any(finding.severity == "warning" for finding in enforcement.findings):
+        add(
+            "warning",
+            enforcement.identity.enforcement_id,
+            "warning findings are visible planning validation evidence",
+            tuple(finding.finding_id for finding in enforcement.findings if finding.severity == "warning"),
+        )
+    blocked = tuple(finding.finding_id for finding in enforcement.findings if finding.blocks_validation)
+    add(
+        "blocked",
+        enforcement.identity.enforcement_id,
+        "blocked findings remain visible and would block integrity validation when active",
+        blocked or (enforcement.identity.enforcement_id,),
+    )
+    add(
+        "continuity",
+        enforcement.identity.enforcement_id,
+        "continuity hashes preserve deterministic graph, governance, compatibility, evaluation, session, scenario, and aggregation evidence",
+        enforcement.continuity_hash_references,
+    )
+    add(
+        "provenance",
+        enforcement.identity.enforcement_id,
+        "provenance references preserve replay-safe and rollback-safe integrity lineage",
+        (enforcement.provenance.provenance_id, enforcement.policy.provenance.provenance_id),
+    )
+    add(
+        "execution_boundary",
+        enforcement.identity.enforcement_id,
+        "execution-boundary integrity is preserved when no execution, routing, scheduling, dispatch, traversal, path selection, scenario selection, optimization, or recommendation authorization is present",
+        enforcement.evidence_source_references,
+    )
+    add(
+        "does_not_authorize",
+        enforcement.identity.enforcement_id,
+        "valid integrity remains planning validation only and does not authorize runtime orchestration",
+        (enforcement.identity.enforcement_id,),
+    )
+    ordered = tuple(sorted(explanations, key=lambda item: item.deterministic_order))
+    result_obj = V37GraphIntegrityExplainabilityResult(
+        explainability_status=(
+            V37_GRAPH_INTEGRITY_EXPLAINABILITY_STABLE
+            if all(explanation.replay_safe and explanation.evidence_references for explanation in ordered)
+            else V37_GRAPH_INTEGRITY_EXPLAINABILITY_BLOCKED
+        ),
+        explanation_count=len(ordered),
+        enforcement_explanation_count=sum(1 for item in ordered if item.explanation_type == "enforcement"),
+        policy_explanation_count=sum(1 for item in ordered if item.explanation_type == "policy"),
+        evidence_source_explanation_count=sum(1 for item in ordered if item.explanation_type == "evidence_source"),
+        finding_explanation_count=sum(1 for item in ordered if item.explanation_type == "finding"),
+        warning_explanation_count=sum(1 for item in ordered if item.explanation_type == "warning"),
+        blocked_explanation_count=sum(1 for item in ordered if item.explanation_type == "blocked"),
+        continuity_explanation_count=sum(1 for item in ordered if item.explanation_type == "continuity"),
+        provenance_explanation_count=sum(1 for item in ordered if item.explanation_type == "provenance"),
+        execution_boundary_explanation_count=sum(
+            1 for item in ordered if item.explanation_type == "execution_boundary"
+        ),
+        does_not_authorize_explanation_count=sum(
+            1 for item in ordered if item.explanation_type == "does_not_authorize"
+        ),
+        deterministic_explainability_hash="",
+        explanations=ordered,
+    )
+    return replace(
+        result_obj,
+        deterministic_explainability_hash=hash_v3_7_graph_integrity_explainability_result(result_obj),
+    )
+
+
+def export_v3_7_graph_integrity_explanation(explanation: V37GraphIntegrityExplanation) -> dict[str, Any]:
+    data = asdict(explanation)
+    data["evidence_references"] = sorted(data["evidence_references"])
+    return data
+
+
+def export_v3_7_graph_integrity_explainability_result(
+    result: V37GraphIntegrityExplainabilityResult,
+) -> dict[str, Any]:
+    data = asdict(result)
+    data["explanations"] = [
+        export_v3_7_graph_integrity_explanation(explanation)
+        for explanation in sorted(result.explanations, key=lambda item: item.deterministic_order)
+    ]
+    return data
+
+
+def serialize_v3_7_graph_integrity_explainability_result(
+    result: V37GraphIntegrityExplainabilityResult,
+) -> str:
+    return stable_serialize(export_v3_7_graph_integrity_explainability_result(result))
+
+
+def hash_v3_7_graph_integrity_explainability_result(result: V37GraphIntegrityExplainabilityResult) -> str:
+    data = export_v3_7_graph_integrity_explainability_result(result)
+    data.pop("deterministic_explainability_hash", None)
+    return deterministic_hash(data)

--- a/backend/app/runtime_orchestration/v3_7_graph_integrity_findings.py
+++ b/backend/app/runtime_orchestration/v3_7_graph_integrity_findings.py
@@ -1,0 +1,184 @@
+"""Fail-visible integrity findings for v3.7 graph planning evidence."""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any
+
+from .v3_7_graph_integrity_models import (
+    V37_INTEGRITY_FINDING_BLOCKED,
+    V37_INTEGRITY_FINDING_CLASSIFICATIONS,
+    V37_INTEGRITY_FINDING_CONTINUITY_VIOLATION,
+    V37_INTEGRITY_FINDING_EXECUTION_BOUNDARY_VIOLATION,
+    V37_INTEGRITY_FINDING_EXPLAINABILITY_VIOLATION,
+    V37_INTEGRITY_FINDING_HIDDEN_PROHIBITED_STATE,
+    V37_INTEGRITY_FINDING_HIDDEN_UNKNOWN_STATE,
+    V37_INTEGRITY_FINDING_HIDDEN_UNSUPPORTED_STATE,
+    V37_INTEGRITY_FINDING_INVALID,
+    V37_INTEGRITY_FINDING_PROVENANCE_VIOLATION,
+    V37_INTEGRITY_FINDING_REPLAY_VIOLATION,
+    V37_INTEGRITY_FINDING_ROLLBACK_VIOLATION,
+    V37_INTEGRITY_FINDING_VALID,
+    V37_INTEGRITY_FINDING_WARNING,
+    V37GraphIntegrityFinding,
+    export_v3_7_graph_integrity_finding,
+)
+
+
+def build_v3_7_graph_integrity_findings(
+    integrity_totals: dict[str, int | bool],
+    evidence_source_ids: tuple[str, ...],
+) -> tuple[V37GraphIntegrityFinding, ...]:
+    specs = (
+        (
+            V37_INTEGRITY_FINDING_VALID,
+            "integrity",
+            "valid",
+            "info",
+            "integrity policy evaluation completed as deterministic planning validation",
+            False,
+        ),
+        (
+            V37_INTEGRITY_FINDING_INVALID,
+            "integrity",
+            "invalid",
+            "visibility",
+            "invalid integrity states remain fail-visible",
+            bool(integrity_totals["invalid_integrity_count"]),
+        ),
+        (
+            V37_INTEGRITY_FINDING_BLOCKED,
+            "integrity",
+            "blocked",
+            "visibility",
+            "blocked planning evidence remains fail-visible",
+            bool(integrity_totals["blocked_integrity_count"]),
+        ),
+        (
+            V37_INTEGRITY_FINDING_WARNING,
+            "integrity",
+            "warning",
+            "warning",
+            "warning planning evidence remains fail-visible",
+            bool(integrity_totals["warning_integrity_count"]),
+        ),
+        (
+            V37_INTEGRITY_FINDING_CONTINUITY_VIOLATION,
+            "continuity",
+            "continuity",
+            "blocked",
+            "continuity violations are blocked when active",
+            bool(integrity_totals["continuity_violation_count"]),
+        ),
+        (
+            V37_INTEGRITY_FINDING_PROVENANCE_VIOLATION,
+            "provenance",
+            "provenance",
+            "blocked",
+            "provenance violations are blocked when active",
+            bool(integrity_totals["provenance_violation_count"]),
+        ),
+        (
+            V37_INTEGRITY_FINDING_EXPLAINABILITY_VIOLATION,
+            "explainability",
+            "explainability",
+            "blocked",
+            "explainability violations are blocked when active",
+            bool(integrity_totals["explainability_violation_count"]),
+        ),
+        (
+            V37_INTEGRITY_FINDING_REPLAY_VIOLATION,
+            "replay",
+            "replay",
+            "blocked",
+            "replay violations are blocked when active",
+            bool(integrity_totals["replay_violation_count"]),
+        ),
+        (
+            V37_INTEGRITY_FINDING_ROLLBACK_VIOLATION,
+            "rollback",
+            "rollback",
+            "blocked",
+            "rollback violations are blocked when active",
+            bool(integrity_totals["rollback_violation_count"]),
+        ),
+        (
+            V37_INTEGRITY_FINDING_EXECUTION_BOUNDARY_VIOLATION,
+            "execution_boundary",
+            "execution_boundary",
+            "blocked",
+            "execution-boundary violations are blocked when active",
+            bool(integrity_totals["execution_boundary_violation_count"]),
+        ),
+        (
+            V37_INTEGRITY_FINDING_HIDDEN_PROHIBITED_STATE,
+            "finding_visibility",
+            "prohibited",
+            "blocked",
+            "hidden prohibited states are blocked when active",
+            bool(integrity_totals["hidden_prohibited_state_count"]),
+        ),
+        (
+            V37_INTEGRITY_FINDING_HIDDEN_UNSUPPORTED_STATE,
+            "finding_visibility",
+            "unsupported",
+            "blocked",
+            "hidden unsupported states are blocked when active",
+            bool(integrity_totals["hidden_unsupported_state_count"]),
+        ),
+        (
+            V37_INTEGRITY_FINDING_HIDDEN_UNKNOWN_STATE,
+            "finding_visibility",
+            "unknown",
+            "blocked",
+            "hidden unknown states are blocked when active",
+            bool(integrity_totals["hidden_unknown_state_count"]),
+        ),
+    )
+    findings = []
+    for classification, subject_type, subject_id, severity, summary, active in specs:
+        blocks_validation = active and severity in {"blocked", "error"}
+        findings.append(
+            V37GraphIntegrityFinding(
+                finding_id=f"v3_7_graph_integrity_{classification}",
+                finding_classification=classification,
+                subject_type=subject_type,
+                subject_id=f"{subject_id}:{int(active)}",
+                severity=severity,
+                summary=summary,
+                evidence_references=evidence_source_ids,
+                fail_visible=True,
+                hidden=False,
+                active_violation=active,
+                blocks_validation=blocks_validation,
+                execution_authorization=False,
+                routing_authorization=False,
+                scheduling_authorization=False,
+                dispatch_authorization=False,
+                traversal_authorization=False,
+            )
+        )
+    return tuple(sorted(findings, key=lambda item: item.finding_id))
+
+
+def count_v3_7_graph_integrity_findings_by_classification(
+    findings: tuple[V37GraphIntegrityFinding, ...],
+) -> dict[str, int]:
+    counts = Counter(finding.finding_classification for finding in findings)
+    return {
+        classification: counts.get(classification, 0)
+        for classification in V37_INTEGRITY_FINDING_CLASSIFICATIONS
+    }
+
+
+def export_v3_7_graph_integrity_finding_classifications() -> list[str]:
+    return list(V37_INTEGRITY_FINDING_CLASSIFICATIONS)
+
+
+def export_v3_7_graph_integrity_finding_records(
+    findings: tuple[V37GraphIntegrityFinding, ...],
+) -> list[dict[str, Any]]:
+    return [
+        export_v3_7_graph_integrity_finding(finding)
+        for finding in sorted(findings, key=lambda item: item.finding_id)
+    ]

--- a/backend/app/runtime_orchestration/v3_7_graph_integrity_models.py
+++ b/backend/app/runtime_orchestration/v3_7_graph_integrity_models.py
@@ -1,0 +1,415 @@
+"""Deterministic v3.7 graph planning integrity enforcement models.
+
+Integrity enforcement validates planning evidence only. It does not authorize
+execution, route work, schedule work, dispatch work, traverse graphs, optimize
+runtime decisions, or control orchestration.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any, Iterable
+
+from app.runtime_intelligence.classification_hashing import deterministic_hash, stable_serialize
+
+from .v3_7_graph_models import V37GraphProvenance
+
+
+V3_7_GRAPH_INTEGRITY_PHASE_ID = "v3_7_graph_planning_integrity_enforcement"
+V37_INTEGRITY_OUTCOME_VALID = "valid"
+V37_INTEGRITY_OUTCOME_INVALID = "invalid"
+V37_INTEGRITY_OUTCOME_BLOCKED = "blocked"
+V37_INTEGRITY_OUTCOME_WARNING = "warning"
+V37_INTEGRITY_OUTCOME_AUDIT_FAILED = "audit_failed"
+V37_INTEGRITY_OUTCOMES: tuple[str, ...] = (
+    V37_INTEGRITY_OUTCOME_VALID,
+    V37_INTEGRITY_OUTCOME_INVALID,
+    V37_INTEGRITY_OUTCOME_BLOCKED,
+    V37_INTEGRITY_OUTCOME_WARNING,
+    V37_INTEGRITY_OUTCOME_AUDIT_FAILED,
+)
+
+V37_INTEGRITY_FINDING_VALID = "integrity_valid"
+V37_INTEGRITY_FINDING_INVALID = "integrity_invalid"
+V37_INTEGRITY_FINDING_BLOCKED = "integrity_blocked"
+V37_INTEGRITY_FINDING_WARNING = "integrity_warning"
+V37_INTEGRITY_FINDING_CONTINUITY_VIOLATION = "continuity_violation"
+V37_INTEGRITY_FINDING_PROVENANCE_VIOLATION = "provenance_violation"
+V37_INTEGRITY_FINDING_EXPLAINABILITY_VIOLATION = "explainability_violation"
+V37_INTEGRITY_FINDING_REPLAY_VIOLATION = "replay_violation"
+V37_INTEGRITY_FINDING_ROLLBACK_VIOLATION = "rollback_violation"
+V37_INTEGRITY_FINDING_EXECUTION_BOUNDARY_VIOLATION = "execution_boundary_violation"
+V37_INTEGRITY_FINDING_HIDDEN_PROHIBITED_STATE = "hidden_prohibited_state"
+V37_INTEGRITY_FINDING_HIDDEN_UNSUPPORTED_STATE = "hidden_unsupported_state"
+V37_INTEGRITY_FINDING_HIDDEN_UNKNOWN_STATE = "hidden_unknown_state"
+V37_INTEGRITY_FINDING_CLASSIFICATIONS: tuple[str, ...] = (
+    V37_INTEGRITY_FINDING_VALID,
+    V37_INTEGRITY_FINDING_INVALID,
+    V37_INTEGRITY_FINDING_BLOCKED,
+    V37_INTEGRITY_FINDING_WARNING,
+    V37_INTEGRITY_FINDING_CONTINUITY_VIOLATION,
+    V37_INTEGRITY_FINDING_PROVENANCE_VIOLATION,
+    V37_INTEGRITY_FINDING_EXPLAINABILITY_VIOLATION,
+    V37_INTEGRITY_FINDING_REPLAY_VIOLATION,
+    V37_INTEGRITY_FINDING_ROLLBACK_VIOLATION,
+    V37_INTEGRITY_FINDING_EXECUTION_BOUNDARY_VIOLATION,
+    V37_INTEGRITY_FINDING_HIDDEN_PROHIBITED_STATE,
+    V37_INTEGRITY_FINDING_HIDDEN_UNSUPPORTED_STATE,
+    V37_INTEGRITY_FINDING_HIDDEN_UNKNOWN_STATE,
+)
+
+
+def _as_tuple(values: Iterable[str] | tuple[str, ...] | None) -> tuple[str, ...]:
+    return tuple(values or ())
+
+
+def _set_tuple_field(source: object, field_name: str) -> None:
+    object.__setattr__(source, field_name, _as_tuple(getattr(source, field_name)))
+
+
+@dataclass(frozen=True)
+class V37GraphIntegrityPolicyIdentity:
+    policy_id: str
+    policy_version: str
+    phase_id: str
+    stable_identity_key: str
+
+
+@dataclass(frozen=True)
+class V37GraphIntegrityPolicyMetadata:
+    metadata_key: str
+    metadata_value: str
+
+
+@dataclass(frozen=True)
+class V37GraphIntegrityPolicyRequirement:
+    requirement_id: str
+    requirement_type: str
+    required_reference_type: str
+    description: str
+    fail_visible: bool = True
+
+
+@dataclass(frozen=True)
+class V37GraphIntegrityPolicy:
+    identity: V37GraphIntegrityPolicyIdentity
+    metadata: tuple[V37GraphIntegrityPolicyMetadata, ...]
+    requirements: tuple[V37GraphIntegrityPolicyRequirement, ...]
+    provenance: V37GraphProvenance
+    execution_boundary_requirements: tuple[str, ...]
+    policy_is_non_executable: bool = True
+    validates_planning_evidence_only: bool = True
+    valid_integrity_does_not_authorize_execution: bool = True
+    enforcement_outcomes_are_planning_validation_only: bool = True
+    execution_boundary_violations_blocked: bool = True
+    execution_authorization_enabled: bool = False
+    routing_authorization_enabled: bool = False
+    scheduling_authorization_enabled: bool = False
+    dispatch_authorization_enabled: bool = False
+    traversal_authorization_enabled: bool = False
+
+    def __post_init__(self) -> None:
+        for field_name in ("metadata", "requirements", "execution_boundary_requirements"):
+            object.__setattr__(self, field_name, tuple(getattr(self, field_name) or ()))
+
+
+@dataclass(frozen=True)
+class V37GraphIntegrityFinding:
+    finding_id: str
+    finding_classification: str
+    subject_type: str
+    subject_id: str
+    severity: str
+    summary: str
+    evidence_references: tuple[str, ...]
+    fail_visible: bool = True
+    hidden: bool = False
+    active_violation: bool = False
+    blocks_validation: bool = False
+    execution_authorization: bool = False
+    routing_authorization: bool = False
+    scheduling_authorization: bool = False
+    dispatch_authorization: bool = False
+    traversal_authorization: bool = False
+
+    def __post_init__(self) -> None:
+        _set_tuple_field(self, "evidence_references")
+
+
+@dataclass(frozen=True)
+class V37GraphIntegrityEnforcementIdentity:
+    enforcement_id: str
+    policy_id: str
+    aggregation_id: str
+    enforcement_version: str
+    phase_id: str
+    stable_identity_key: str
+
+
+@dataclass(frozen=True)
+class V37GraphIntegrityReplayEvidence:
+    replay_evidence_id: str
+    enforcement_id: str
+    policy_id: str
+    evidence_source_references: tuple[str, ...]
+    integrity_finding_references: tuple[str, ...]
+    blocked_finding_references: tuple[str, ...]
+    provenance_references: tuple[str, ...]
+    explainability_references: tuple[str, ...]
+    continuity_hashes: tuple[str, ...]
+    non_executable_replay_evidence: bool = True
+    runtime_replay: bool = False
+    execution_authorization: bool = False
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "evidence_source_references",
+            "integrity_finding_references",
+            "blocked_finding_references",
+            "provenance_references",
+            "explainability_references",
+            "continuity_hashes",
+        ):
+            _set_tuple_field(self, field_name)
+
+
+@dataclass(frozen=True)
+class V37GraphIntegrityEnforcementResult:
+    identity: V37GraphIntegrityEnforcementIdentity
+    policy: V37GraphIntegrityPolicy
+    metadata: tuple[V37GraphIntegrityPolicyMetadata, ...]
+    evidence_source_references: tuple[str, ...]
+    evidence_source_types: tuple[str, ...]
+    enforcement_outcome: str
+    findings: tuple[V37GraphIntegrityFinding, ...]
+    replay_evidence: tuple[V37GraphIntegrityReplayEvidence, ...]
+    rollback_continuity_references: tuple[str, ...]
+    provenance: V37GraphProvenance
+    explainability_reference_ids: tuple[str, ...]
+    continuity_hash_references: tuple[str, ...]
+    integrity_enforcement_is_non_executable: bool = True
+    integrity_enforcement_validates_planning_evidence_only: bool = True
+    valid_integrity_does_not_authorize_execution: bool = True
+    blocked_integrity_does_not_perform_runtime_blocking: bool = True
+    enforcement_outcomes_are_planning_validation_only: bool = True
+    integrity_enforcement_does_not_route_schedule_dispatch_traverse_optimize_recommend_or_execute: bool = True
+    graph_execution_enabled: bool = False
+    integrity_driven_execution_enabled: bool = False
+    orchestration_authorization_enabled: bool = False
+    routing_enabled: bool = False
+    scheduling_enabled: bool = False
+    dispatch_enabled: bool = False
+    traversal_logic_enabled: bool = False
+    path_selection_enabled: bool = False
+    scenario_selection_enabled: bool = False
+    optimization_engine_enabled: bool = False
+    recommendation_enabled: bool = False
+    autonomous_orchestration_enabled: bool = False
+    runtime_mutation_enabled: bool = False
+    persistent_runtime_writes_enabled: bool = False
+    runtime_decision_making_enabled: bool = False
+    execution_gates_enabled: bool = False
+    callable_orchestration_flows_enabled: bool = False
+    runtime_control_system_enabled: bool = False
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "metadata",
+            "evidence_source_references",
+            "evidence_source_types",
+            "findings",
+            "replay_evidence",
+            "rollback_continuity_references",
+            "explainability_reference_ids",
+            "continuity_hash_references",
+        ):
+            object.__setattr__(self, field_name, tuple(getattr(self, field_name) or ()))
+
+
+def export_v3_7_graph_integrity_policy_identity(identity: V37GraphIntegrityPolicyIdentity) -> dict[str, Any]:
+    return asdict(identity)
+
+
+def export_v3_7_graph_integrity_policy_metadata(metadata: V37GraphIntegrityPolicyMetadata) -> dict[str, Any]:
+    return asdict(metadata)
+
+
+def export_v3_7_graph_integrity_policy_requirement(requirement: V37GraphIntegrityPolicyRequirement) -> dict[str, Any]:
+    return asdict(requirement)
+
+
+def export_v3_7_graph_integrity_policy(policy: V37GraphIntegrityPolicy) -> dict[str, Any]:
+    return {
+        "identity": export_v3_7_graph_integrity_policy_identity(policy.identity),
+        "metadata": [
+            export_v3_7_graph_integrity_policy_metadata(metadata)
+            for metadata in sorted(policy.metadata, key=lambda item: item.metadata_key)
+        ],
+        "requirements": [
+            export_v3_7_graph_integrity_policy_requirement(requirement)
+            for requirement in sorted(policy.requirements, key=lambda item: item.requirement_id)
+        ],
+        "provenance": _export_provenance(policy.provenance),
+        "execution_boundary_requirements": sorted(policy.execution_boundary_requirements),
+        "policy_is_non_executable": policy.policy_is_non_executable,
+        "validates_planning_evidence_only": policy.validates_planning_evidence_only,
+        "valid_integrity_does_not_authorize_execution": policy.valid_integrity_does_not_authorize_execution,
+        "enforcement_outcomes_are_planning_validation_only": policy.enforcement_outcomes_are_planning_validation_only,
+        "execution_boundary_violations_blocked": policy.execution_boundary_violations_blocked,
+        "execution_authorization_enabled": policy.execution_authorization_enabled,
+        "routing_authorization_enabled": policy.routing_authorization_enabled,
+        "scheduling_authorization_enabled": policy.scheduling_authorization_enabled,
+        "dispatch_authorization_enabled": policy.dispatch_authorization_enabled,
+        "traversal_authorization_enabled": policy.traversal_authorization_enabled,
+    }
+
+
+def export_v3_7_graph_integrity_finding(finding: V37GraphIntegrityFinding) -> dict[str, Any]:
+    data = asdict(finding)
+    data["evidence_references"] = sorted(data["evidence_references"])
+    return data
+
+
+def export_v3_7_graph_integrity_enforcement_identity(
+    identity: V37GraphIntegrityEnforcementIdentity,
+) -> dict[str, Any]:
+    return asdict(identity)
+
+
+def export_v3_7_graph_integrity_replay_evidence(evidence: V37GraphIntegrityReplayEvidence) -> dict[str, Any]:
+    data = asdict(evidence)
+    for field_name in (
+        "evidence_source_references",
+        "integrity_finding_references",
+        "blocked_finding_references",
+        "provenance_references",
+        "explainability_references",
+        "continuity_hashes",
+    ):
+        data[field_name] = sorted(data[field_name])
+    return data
+
+
+def export_v3_7_graph_integrity_enforcement_result(
+    result: V37GraphIntegrityEnforcementResult,
+) -> dict[str, Any]:
+    return {
+        "identity": export_v3_7_graph_integrity_enforcement_identity(result.identity),
+        "policy": export_v3_7_graph_integrity_policy(result.policy),
+        "metadata": [
+            export_v3_7_graph_integrity_policy_metadata(metadata)
+            for metadata in sorted(result.metadata, key=lambda item: item.metadata_key)
+        ],
+        "evidence_source_references": sorted(result.evidence_source_references),
+        "evidence_source_types": sorted(result.evidence_source_types),
+        "enforcement_outcome": result.enforcement_outcome,
+        "findings": [
+            export_v3_7_graph_integrity_finding(finding)
+            for finding in sorted(result.findings, key=lambda item: item.finding_id)
+        ],
+        "replay_evidence": [
+            export_v3_7_graph_integrity_replay_evidence(evidence)
+            for evidence in sorted(result.replay_evidence, key=lambda item: item.replay_evidence_id)
+        ],
+        "rollback_continuity_references": sorted(result.rollback_continuity_references),
+        "provenance": _export_provenance(result.provenance),
+        "explainability_reference_ids": sorted(result.explainability_reference_ids),
+        "continuity_hash_references": sorted(result.continuity_hash_references),
+        "integrity_enforcement_is_non_executable": result.integrity_enforcement_is_non_executable,
+        "integrity_enforcement_validates_planning_evidence_only": result.integrity_enforcement_validates_planning_evidence_only,
+        "valid_integrity_does_not_authorize_execution": result.valid_integrity_does_not_authorize_execution,
+        "blocked_integrity_does_not_perform_runtime_blocking": result.blocked_integrity_does_not_perform_runtime_blocking,
+        "enforcement_outcomes_are_planning_validation_only": result.enforcement_outcomes_are_planning_validation_only,
+        "integrity_enforcement_does_not_route_schedule_dispatch_traverse_optimize_recommend_or_execute": result.integrity_enforcement_does_not_route_schedule_dispatch_traverse_optimize_recommend_or_execute,
+        "graph_execution_enabled": result.graph_execution_enabled,
+        "integrity_driven_execution_enabled": result.integrity_driven_execution_enabled,
+        "orchestration_authorization_enabled": result.orchestration_authorization_enabled,
+        "routing_enabled": result.routing_enabled,
+        "scheduling_enabled": result.scheduling_enabled,
+        "dispatch_enabled": result.dispatch_enabled,
+        "traversal_logic_enabled": result.traversal_logic_enabled,
+        "path_selection_enabled": result.path_selection_enabled,
+        "scenario_selection_enabled": result.scenario_selection_enabled,
+        "optimization_engine_enabled": result.optimization_engine_enabled,
+        "recommendation_enabled": result.recommendation_enabled,
+        "autonomous_orchestration_enabled": result.autonomous_orchestration_enabled,
+        "runtime_mutation_enabled": result.runtime_mutation_enabled,
+        "persistent_runtime_writes_enabled": result.persistent_runtime_writes_enabled,
+        "runtime_decision_making_enabled": result.runtime_decision_making_enabled,
+        "execution_gates_enabled": result.execution_gates_enabled,
+        "callable_orchestration_flows_enabled": result.callable_orchestration_flows_enabled,
+        "runtime_control_system_enabled": result.runtime_control_system_enabled,
+    }
+
+
+def export_v3_7_graph_integrity_counts(result: V37GraphIntegrityEnforcementResult) -> dict[str, int]:
+    return {
+        "integrity_policy_count": 1,
+        "enforcement_result_count": 1,
+        "evidence_source_count": len(result.evidence_source_references),
+        "integrity_finding_count": len(result.findings),
+        "blocked_finding_count": sum(1 for finding in result.findings if finding.blocks_validation),
+        "warning_finding_count": sum(1 for finding in result.findings if finding.severity == "warning"),
+        "replay_evidence_count": len(result.replay_evidence),
+        "rollback_continuity_reference_count": len(result.rollback_continuity_references),
+    }
+
+
+def serialize_v3_7_graph_integrity_policy(policy: V37GraphIntegrityPolicy) -> str:
+    return stable_serialize(export_v3_7_graph_integrity_policy(policy))
+
+
+def hash_v3_7_graph_integrity_policy(policy: V37GraphIntegrityPolicy) -> str:
+    return deterministic_hash(export_v3_7_graph_integrity_policy(policy))
+
+
+def serialize_v3_7_graph_integrity_enforcement_result(
+    result: V37GraphIntegrityEnforcementResult,
+) -> str:
+    return stable_serialize(export_v3_7_graph_integrity_enforcement_result(result))
+
+
+def hash_v3_7_graph_integrity_enforcement_result(
+    result: V37GraphIntegrityEnforcementResult,
+) -> str:
+    return deterministic_hash(export_v3_7_graph_integrity_enforcement_result(result))
+
+
+def validate_v3_7_graph_integrity_serialization_stability(
+    result: V37GraphIntegrityEnforcementResult,
+) -> dict[str, Any]:
+    first = serialize_v3_7_graph_integrity_enforcement_result(result)
+    second = serialize_v3_7_graph_integrity_enforcement_result(result)
+    return {
+        "stable": first == second,
+        "serializer": "json_sort_keys_stable_graph_planning_integrity_enforcement",
+        "first_length": len(first),
+        "second_length": len(second),
+    }
+
+
+def validate_v3_7_graph_integrity_hash_stability(
+    result: V37GraphIntegrityEnforcementResult,
+) -> dict[str, Any]:
+    first = hash_v3_7_graph_integrity_enforcement_result(result)
+    second = hash_v3_7_graph_integrity_enforcement_result(result)
+    return {
+        "stable": first == second,
+        "first_hash": first,
+        "second_hash": second,
+        "hash_algorithm": "sha256_stable_json_graph_planning_integrity_enforcement",
+    }
+
+
+def _export_provenance(provenance: V37GraphProvenance) -> dict[str, Any]:
+    data = asdict(provenance)
+    for field_name in (
+        "lineage_references",
+        "replay_lineage_references",
+        "rollback_lineage_references",
+        "governance_references",
+        "compatibility_references",
+        "explainability_references",
+    ):
+        data[field_name] = sorted(data[field_name])
+    return data

--- a/backend/app/runtime_orchestration/v3_7_graph_integrity_policies.py
+++ b/backend/app/runtime_orchestration/v3_7_graph_integrity_policies.py
@@ -1,0 +1,154 @@
+"""Deterministic integrity policies for v3.7 graph planning evidence."""
+
+from __future__ import annotations
+
+from app.runtime_intelligence.classification_hashing import deterministic_hash
+
+from .v3_7_graph_integrity_models import (
+    V3_7_GRAPH_INTEGRITY_PHASE_ID,
+    V37GraphIntegrityPolicy,
+    V37GraphIntegrityPolicyIdentity,
+    V37GraphIntegrityPolicyMetadata,
+    V37GraphIntegrityPolicyRequirement,
+)
+from .v3_7_graph_models import default_v3_7_graph_provenance
+
+
+DEFAULT_V37_GRAPH_INTEGRITY_POLICY_ID = "v3_7_graph_integrity_policy_default"
+
+
+def build_v3_7_graph_integrity_policy_identity() -> V37GraphIntegrityPolicyIdentity:
+    key_payload = {
+        "policy_id": DEFAULT_V37_GRAPH_INTEGRITY_POLICY_ID,
+        "policy_version": "v3.7",
+        "phase_id": V3_7_GRAPH_INTEGRITY_PHASE_ID,
+    }
+    return V37GraphIntegrityPolicyIdentity(
+        policy_id=DEFAULT_V37_GRAPH_INTEGRITY_POLICY_ID,
+        policy_version="v3.7",
+        phase_id=V3_7_GRAPH_INTEGRITY_PHASE_ID,
+        stable_identity_key=deterministic_hash(key_payload),
+    )
+
+
+def graph_integrity_policy_identity_key(identity: V37GraphIntegrityPolicyIdentity) -> str:
+    return deterministic_hash(
+        {
+            "policy_id": identity.policy_id,
+            "policy_version": identity.policy_version,
+            "phase_id": identity.phase_id,
+        }
+    )
+
+
+def graph_integrity_policy_identities_are_unique(
+    identities: tuple[V37GraphIntegrityPolicyIdentity, ...],
+) -> bool:
+    keys = [identity.stable_identity_key for identity in identities]
+    return len(keys) == len(set(keys))
+
+
+def build_v3_7_graph_integrity_policy() -> V37GraphIntegrityPolicy:
+    identity = build_v3_7_graph_integrity_policy_identity()
+    requirements = (
+        V37GraphIntegrityPolicyRequirement(
+            "v3_7_integrity_requires_graph_evidence",
+            "evidence_source",
+            "graph_foundations",
+            "graph foundation evidence must remain referenced",
+        ),
+        V37GraphIntegrityPolicyRequirement(
+            "v3_7_integrity_requires_governance_evidence",
+            "evidence_source",
+            "governance",
+            "governance boundary evidence must remain referenced",
+        ),
+        V37GraphIntegrityPolicyRequirement(
+            "v3_7_integrity_requires_compatibility_evidence",
+            "evidence_source",
+            "compatibility",
+            "compatibility reasoning evidence must remain referenced",
+        ),
+        V37GraphIntegrityPolicyRequirement(
+            "v3_7_integrity_requires_evaluation_evidence",
+            "evidence_source",
+            "evaluation",
+            "evaluation reasoning evidence must remain referenced",
+        ),
+        V37GraphIntegrityPolicyRequirement(
+            "v3_7_integrity_requires_session_evidence",
+            "evidence_source",
+            "session",
+            "planning session evidence must remain referenced",
+        ),
+        V37GraphIntegrityPolicyRequirement(
+            "v3_7_integrity_requires_scenario_evidence",
+            "evidence_source",
+            "scenario",
+            "planning scenario evidence must remain referenced",
+        ),
+        V37GraphIntegrityPolicyRequirement(
+            "v3_7_integrity_requires_aggregation_evidence",
+            "evidence_source",
+            "aggregation",
+            "planning intelligence aggregation evidence must remain referenced",
+        ),
+        V37GraphIntegrityPolicyRequirement(
+            "v3_7_integrity_requires_replay_continuity",
+            "continuity",
+            "replay",
+            "replay continuity evidence must remain non-executable and referenced",
+        ),
+        V37GraphIntegrityPolicyRequirement(
+            "v3_7_integrity_requires_rollback_continuity",
+            "continuity",
+            "rollback",
+            "rollback continuity evidence must remain referenced",
+        ),
+        V37GraphIntegrityPolicyRequirement(
+            "v3_7_integrity_requires_provenance_continuity",
+            "provenance",
+            "provenance",
+            "provenance continuity must remain complete",
+        ),
+        V37GraphIntegrityPolicyRequirement(
+            "v3_7_integrity_requires_explainability_continuity",
+            "explainability",
+            "explainability",
+            "explainability continuity must remain complete",
+        ),
+        V37GraphIntegrityPolicyRequirement(
+            "v3_7_integrity_requires_fail_visible_findings",
+            "finding_visibility",
+            "fail_visible",
+            "prohibited, unsupported, unknown, blocked, and warning evidence must remain visible",
+        ),
+        V37GraphIntegrityPolicyRequirement(
+            "v3_7_integrity_requires_execution_boundary",
+            "execution_boundary",
+            "non_executable",
+            "integrity enforcement must block execution-boundary violations",
+        ),
+    )
+    return V37GraphIntegrityPolicy(
+        identity=identity,
+        metadata=(
+            V37GraphIntegrityPolicyMetadata("policy_semantics", "deterministic_planning_integrity_validation"),
+            V37GraphIntegrityPolicyMetadata("runtime_capability", "none"),
+            V37GraphIntegrityPolicyMetadata("validity_boundary", "valid_evidence_does_not_authorize_execution"),
+        ),
+        requirements=requirements,
+        provenance=default_v3_7_graph_provenance(identity.policy_id, "graph_planning_integrity_policy"),
+        execution_boundary_requirements=(
+            "execution_authorization",
+            "routing_authorization",
+            "scheduling_authorization",
+            "dispatch_authorization",
+            "traversal_authorization",
+            "runtime_path_selection",
+            "scenario_execution_selection",
+            "optimization_for_execution",
+            "recommendation_to_execute",
+            "callable_execution_flow_reference",
+        ),
+    )

--- a/backend/app/runtime_orchestration/v3_7_graph_integrity_provenance.py
+++ b/backend/app/runtime_orchestration/v3_7_graph_integrity_provenance.py
@@ -1,0 +1,129 @@
+"""Provenance continuity for v3.7 graph planning integrity enforcement."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, replace
+from typing import Any
+
+from app.runtime_intelligence.classification_hashing import deterministic_hash, stable_serialize
+
+from .v3_7_graph_integrity_enforcement import enforce_v3_7_graph_planning_integrity
+from .v3_7_graph_integrity_models import V37GraphIntegrityEnforcementResult
+
+
+V37_GRAPH_INTEGRITY_PROVENANCE_PRESERVED = "v3_7_graph_integrity_provenance_preserved"
+V37_GRAPH_INTEGRITY_PROVENANCE_BLOCKED = "v3_7_graph_integrity_provenance_blocked"
+
+
+@dataclass(frozen=True)
+class V37GraphIntegrityProvenanceResult:
+    provenance_status: str
+    provenance_record_count: int
+    enforcement_provenance_preserved: bool
+    policy_provenance_preserved: bool
+    graph_provenance_preserved: bool
+    governance_provenance_preserved: bool
+    compatibility_provenance_preserved: bool
+    evaluation_provenance_preserved: bool
+    session_provenance_preserved: bool
+    scenario_provenance_preserved: bool
+    aggregation_provenance_preserved: bool
+    replay_provenance_preserved: bool
+    rollback_provenance_preserved: bool
+    explainability_provenance_preserved: bool
+    continuity_provenance_preserved: bool
+    deterministic_provenance_hash: str
+    provenance_records: tuple[str, ...]
+
+
+def audit_v3_7_graph_integrity_provenance(
+    result: V37GraphIntegrityEnforcementResult | None = None,
+) -> V37GraphIntegrityProvenanceResult:
+    enforcement = result or enforce_v3_7_graph_planning_integrity()
+    records = collect_v3_7_graph_integrity_provenance(enforcement)
+    source_types = set(enforcement.evidence_source_types)
+    replay_ok = all(item.provenance_references for item in enforcement.replay_evidence)
+    rollback_ok = bool(enforcement.rollback_continuity_references)
+    explainability_ok = bool(enforcement.explainability_reference_ids)
+    continuity_ok = bool(enforcement.continuity_hash_references)
+    checks = {
+        "enforcement": bool(enforcement.provenance.provenance_id),
+        "policy": bool(enforcement.policy.provenance.provenance_id),
+        "graph": "graph_foundations" in source_types,
+        "governance": "governance" in source_types,
+        "compatibility": "compatibility" in source_types,
+        "evaluation": "evaluation" in source_types,
+        "session": "session" in source_types,
+        "scenario": "scenario" in source_types,
+        "aggregation": "aggregation" in source_types,
+        "replay": replay_ok,
+        "rollback": rollback_ok,
+        "explainability": explainability_ok,
+        "continuity": continuity_ok,
+    }
+    status = (
+        V37_GRAPH_INTEGRITY_PROVENANCE_PRESERVED
+        if all(checks.values())
+        else V37_GRAPH_INTEGRITY_PROVENANCE_BLOCKED
+    )
+    audit = V37GraphIntegrityProvenanceResult(
+        provenance_status=status,
+        provenance_record_count=len(records),
+        enforcement_provenance_preserved=checks["enforcement"],
+        policy_provenance_preserved=checks["policy"],
+        graph_provenance_preserved=checks["graph"],
+        governance_provenance_preserved=checks["governance"],
+        compatibility_provenance_preserved=checks["compatibility"],
+        evaluation_provenance_preserved=checks["evaluation"],
+        session_provenance_preserved=checks["session"],
+        scenario_provenance_preserved=checks["scenario"],
+        aggregation_provenance_preserved=checks["aggregation"],
+        replay_provenance_preserved=checks["replay"],
+        rollback_provenance_preserved=checks["rollback"],
+        explainability_provenance_preserved=checks["explainability"],
+        continuity_provenance_preserved=checks["continuity"],
+        deterministic_provenance_hash="",
+        provenance_records=records,
+    )
+    return replace(audit, deterministic_provenance_hash=hash_v3_7_graph_integrity_provenance_result(audit))
+
+
+def collect_v3_7_graph_integrity_provenance(
+    result: V37GraphIntegrityEnforcementResult,
+) -> tuple[str, ...]:
+    return tuple(
+        sorted(
+            set(
+                (
+                    result.provenance.provenance_id,
+                    result.policy.provenance.provenance_id,
+                    *(
+                        reference
+                        for evidence in result.replay_evidence
+                        for reference in evidence.provenance_references
+                    ),
+                    *result.rollback_continuity_references,
+                    *result.explainability_reference_ids,
+                    *result.continuity_hash_references,
+                )
+            )
+        )
+    )
+
+
+def export_v3_7_graph_integrity_provenance_result(
+    result: V37GraphIntegrityProvenanceResult,
+) -> dict[str, Any]:
+    data = asdict(result)
+    data["provenance_records"] = sorted(data["provenance_records"])
+    return data
+
+
+def serialize_v3_7_graph_integrity_provenance_result(result: V37GraphIntegrityProvenanceResult) -> str:
+    return stable_serialize(export_v3_7_graph_integrity_provenance_result(result))
+
+
+def hash_v3_7_graph_integrity_provenance_result(result: V37GraphIntegrityProvenanceResult) -> str:
+    data = export_v3_7_graph_integrity_provenance_result(result)
+    data.pop("deterministic_provenance_hash", None)
+    return deterministic_hash(data)

--- a/backend/app/runtime_orchestration/v3_7_graph_integrity_replay.py
+++ b/backend/app/runtime_orchestration/v3_7_graph_integrity_replay.py
@@ -1,0 +1,52 @@
+"""Non-executable replay evidence for v3.7 graph planning integrity."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .v3_7_graph_integrity_enforcement import enforce_v3_7_graph_planning_integrity
+from .v3_7_graph_integrity_models import (
+    V37GraphIntegrityEnforcementResult,
+    V37GraphIntegrityReplayEvidence,
+    export_v3_7_graph_integrity_replay_evidence,
+)
+
+
+def build_v3_7_graph_integrity_replay_evidence(
+    result: V37GraphIntegrityEnforcementResult | None = None,
+) -> tuple[V37GraphIntegrityReplayEvidence, ...]:
+    enforcement = result or enforce_v3_7_graph_planning_integrity()
+    return enforcement.replay_evidence
+
+
+def validate_v3_7_graph_integrity_replay_evidence(
+    result: V37GraphIntegrityEnforcementResult | None = None,
+) -> dict[str, Any]:
+    enforcement = result or enforce_v3_7_graph_planning_integrity()
+    replay = enforcement.replay_evidence
+    return {
+        "replay_evidence_count": len(replay),
+        "rollback_reference_count": len(enforcement.rollback_continuity_references),
+        "non_executable_replay_evidence": all(item.non_executable_replay_evidence for item in replay),
+        "runtime_replay": any(item.runtime_replay for item in replay),
+        "execution_authorization": any(item.execution_authorization for item in replay),
+        "replay_continuity_preserved": all(
+            item.evidence_source_references
+            and item.integrity_finding_references
+            and item.provenance_references
+            and item.explainability_references
+            and item.continuity_hashes
+            for item in replay
+        ),
+        "rollback_continuity_preserved": bool(enforcement.rollback_continuity_references)
+        and all(item.continuity_hashes for item in replay),
+    }
+
+
+def export_v3_7_graph_integrity_replay_evidence_records(
+    evidence: tuple[V37GraphIntegrityReplayEvidence, ...],
+) -> list[dict[str, Any]]:
+    return [
+        export_v3_7_graph_integrity_replay_evidence(item)
+        for item in sorted(evidence, key=lambda record: record.replay_evidence_id)
+    ]

--- a/backend/app/runtime_orchestration/v3_7_graph_integrity_validation.py
+++ b/backend/app/runtime_orchestration/v3_7_graph_integrity_validation.py
@@ -1,0 +1,304 @@
+"""Fail-visible validation for v3.7 graph planning integrity enforcement."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, replace
+from typing import Any
+
+from app.runtime_intelligence.classification_hashing import deterministic_hash, stable_serialize
+
+from .v3_7_graph_integrity_audit import (
+    V37_GRAPH_INTEGRITY_AUDIT_STABLE,
+    audit_v3_7_graph_integrity,
+)
+from .v3_7_graph_integrity_enforcement import (
+    enforce_v3_7_graph_planning_integrity,
+    graph_integrity_enforcement_identities_are_unique,
+)
+from .v3_7_graph_integrity_explainability import (
+    V37_GRAPH_INTEGRITY_EXPLAINABILITY_STABLE,
+    explain_v3_7_graph_integrity,
+)
+from .v3_7_graph_integrity_models import (
+    V37_INTEGRITY_FINDING_EXECUTION_BOUNDARY_VIOLATION,
+    V37_INTEGRITY_FINDING_HIDDEN_PROHIBITED_STATE,
+    V37_INTEGRITY_FINDING_HIDDEN_UNKNOWN_STATE,
+    V37_INTEGRITY_FINDING_HIDDEN_UNSUPPORTED_STATE,
+    V37GraphIntegrityEnforcementResult,
+    hash_v3_7_graph_integrity_enforcement_result,
+    validate_v3_7_graph_integrity_hash_stability,
+    validate_v3_7_graph_integrity_serialization_stability,
+)
+from .v3_7_graph_integrity_policies import graph_integrity_policy_identities_are_unique
+from .v3_7_graph_integrity_provenance import (
+    V37_GRAPH_INTEGRITY_PROVENANCE_PRESERVED,
+    audit_v3_7_graph_integrity_provenance,
+)
+from .v3_7_graph_integrity_replay import validate_v3_7_graph_integrity_replay_evidence
+
+
+V37_GRAPH_INTEGRITY_VALIDATION_STABLE = "v3_7_graph_integrity_validation_stable"
+V37_GRAPH_INTEGRITY_VALIDATION_BLOCKED = "v3_7_graph_integrity_validation_blocked"
+V37_INTEGRITY_VALIDATION_VISIBLE_BLOCKED = "v3_7_graph_integrity_validation_visible_blocked"
+V37_INTEGRITY_VALIDATION_VISIBLE_WARNING = "v3_7_graph_integrity_validation_visible_warning"
+V37_INTEGRITY_VALIDATION_VISIBLE_EXECUTION_BOUNDARY = "v3_7_graph_integrity_validation_visible_execution_boundary"
+V37_INTEGRITY_VALIDATION_BLOCKED_BY_DUPLICATE_POLICY = "v3_7_graph_integrity_blocked_by_duplicate_policy_identity"
+V37_INTEGRITY_VALIDATION_BLOCKED_BY_DUPLICATE_ENFORCEMENT = "v3_7_graph_integrity_blocked_by_duplicate_enforcement_identity"
+V37_INTEGRITY_VALIDATION_BLOCKED_BY_MISSING_EVIDENCE_SOURCE = "v3_7_graph_integrity_blocked_by_missing_evidence_source"
+V37_INTEGRITY_VALIDATION_BLOCKED_BY_INVALID_EVIDENCE_SOURCE = "v3_7_graph_integrity_blocked_by_invalid_evidence_source"
+V37_INTEGRITY_VALIDATION_BLOCKED_BY_PROVENANCE = "v3_7_graph_integrity_blocked_by_provenance"
+V37_INTEGRITY_VALIDATION_BLOCKED_BY_EXPLAINABILITY = "v3_7_graph_integrity_blocked_by_explainability"
+V37_INTEGRITY_VALIDATION_BLOCKED_BY_REPLAY = "v3_7_graph_integrity_blocked_by_replay"
+V37_INTEGRITY_VALIDATION_BLOCKED_BY_ROLLBACK = "v3_7_graph_integrity_blocked_by_rollback"
+V37_INTEGRITY_VALIDATION_BLOCKED_BY_HIDDEN_STATE = "v3_7_graph_integrity_blocked_by_hidden_state"
+V37_INTEGRITY_VALIDATION_BLOCKED_BY_EXECUTION_BOUNDARY = "v3_7_graph_integrity_blocked_by_execution_boundary"
+V37_INTEGRITY_VALIDATION_BLOCKED_BY_SERIALIZATION = "v3_7_graph_integrity_blocked_by_serialization"
+V37_INTEGRITY_VALIDATION_BLOCKED_BY_HASH = "v3_7_graph_integrity_blocked_by_hash"
+
+
+@dataclass(frozen=True)
+class V37GraphIntegrityValidationFinding:
+    finding_id: str
+    status: str
+    severity: str
+    subject_type: str
+    subject_id: str
+    message: str
+    fail_visible: bool = True
+
+
+@dataclass(frozen=True)
+class V37GraphIntegrityValidationResult:
+    validation_status: str
+    valid: bool
+    finding_count: int
+    error_count: int
+    visibility_finding_count: int
+    duplicate_policy_identity_count: int
+    duplicate_enforcement_identity_count: int
+    missing_evidence_source_reference_count: int
+    invalid_evidence_source_reference_count: int
+    missing_provenance_evidence_count: int
+    missing_explainability_evidence_count: int
+    missing_replay_evidence_count: int
+    missing_rollback_evidence_count: int
+    hidden_prohibited_finding_count: int
+    hidden_unsupported_finding_count: int
+    hidden_unknown_finding_count: int
+    execution_boundary_violation_count: int
+    provenance_continuity_preserved: bool
+    explainability_continuity_preserved: bool
+    replay_continuity_preserved: bool
+    rollback_continuity_preserved: bool
+    deterministic_serialization_stable: bool
+    deterministic_hash_stable: bool
+    integrity_enforcement_non_executable: bool
+    valid_integrity_does_not_authorize_execution: bool
+    execution_boundary_violations_blocked: bool
+    deterministic_integrity_hash: str
+    findings: tuple[V37GraphIntegrityValidationFinding, ...]
+    deterministic_validation_hash: str = ""
+
+
+def validate_v3_7_graph_integrity(
+    results: tuple[V37GraphIntegrityEnforcementResult, ...] | None = None,
+) -> V37GraphIntegrityValidationResult:
+    enforcement_results = results or (enforce_v3_7_graph_planning_integrity(),)
+    primary = enforcement_results[0]
+    findings: list[V37GraphIntegrityValidationFinding] = []
+    duplicate_policy_count = 0 if graph_integrity_policy_identities_are_unique(tuple(item.policy.identity for item in enforcement_results)) else 1
+    duplicate_enforcement_count = 0 if graph_integrity_enforcement_identities_are_unique(tuple(item.identity for item in enforcement_results)) else 1
+    if duplicate_policy_count:
+        findings.append(_finding(V37_INTEGRITY_VALIDATION_BLOCKED_BY_DUPLICATE_POLICY, "policy", primary.policy.identity.policy_id, "duplicate policy identity detected"))
+    if duplicate_enforcement_count:
+        findings.append(_finding(V37_INTEGRITY_VALIDATION_BLOCKED_BY_DUPLICATE_ENFORCEMENT, "enforcement", primary.identity.enforcement_id, "duplicate enforcement identity detected"))
+    for result in enforcement_results:
+        _add_visibility_findings(result, findings)
+        if not result.evidence_source_references:
+            findings.append(_finding(V37_INTEGRITY_VALIDATION_BLOCKED_BY_MISSING_EVIDENCE_SOURCE, "enforcement", result.identity.enforcement_id, "missing evidence-source references"))
+        required_sources = {
+            "graph_foundations",
+            "governance",
+            "compatibility",
+            "evaluation",
+            "session",
+            "scenario",
+            "aggregation",
+        }
+        if not required_sources.issubset(set(result.evidence_source_types)):
+            findings.append(_finding(V37_INTEGRITY_VALIDATION_BLOCKED_BY_INVALID_EVIDENCE_SOURCE, "enforcement", result.identity.enforcement_id, "invalid or incomplete evidence-source references"))
+        for integrity_finding in result.findings:
+            if integrity_finding.finding_classification in (
+                V37_INTEGRITY_FINDING_HIDDEN_PROHIBITED_STATE,
+                V37_INTEGRITY_FINDING_HIDDEN_UNSUPPORTED_STATE,
+                V37_INTEGRITY_FINDING_HIDDEN_UNKNOWN_STATE,
+            ) and (integrity_finding.hidden or not integrity_finding.fail_visible or integrity_finding.active_violation):
+                findings.append(_finding(V37_INTEGRITY_VALIDATION_BLOCKED_BY_HIDDEN_STATE, "integrity_finding", integrity_finding.finding_id, f"hidden {integrity_finding.finding_classification} finding detected"))
+            if integrity_finding.finding_classification == V37_INTEGRITY_FINDING_EXECUTION_BOUNDARY_VIOLATION and integrity_finding.active_violation:
+                findings.append(_finding(V37_INTEGRITY_VALIDATION_BLOCKED_BY_EXECUTION_BOUNDARY, "integrity_finding", integrity_finding.finding_id, "execution-boundary violation is active"))
+        if _execution_boundary_violation(result):
+            findings.append(_finding(V37_INTEGRITY_VALIDATION_BLOCKED_BY_EXECUTION_BOUNDARY, "enforcement", result.identity.enforcement_id, "integrity enforcement exposed execution-boundary authorization"))
+
+    audit = audit_v3_7_graph_integrity(primary)
+    provenance = audit_v3_7_graph_integrity_provenance(primary)
+    explainability = explain_v3_7_graph_integrity(primary)
+    replay = validate_v3_7_graph_integrity_replay_evidence(primary)
+    serialization = validate_v3_7_graph_integrity_serialization_stability(primary)
+    hashing = validate_v3_7_graph_integrity_hash_stability(primary)
+    if audit.audit_status != V37_GRAPH_INTEGRITY_AUDIT_STABLE:
+        findings.append(_finding(V37_INTEGRITY_VALIDATION_BLOCKED_BY_INVALID_EVIDENCE_SOURCE, "enforcement", primary.identity.enforcement_id, "integrity audit is unstable"))
+    if provenance.provenance_status != V37_GRAPH_INTEGRITY_PROVENANCE_PRESERVED:
+        findings.append(_finding(V37_INTEGRITY_VALIDATION_BLOCKED_BY_PROVENANCE, "enforcement", primary.identity.enforcement_id, "integrity provenance continuity is incomplete"))
+    if explainability.explainability_status != V37_GRAPH_INTEGRITY_EXPLAINABILITY_STABLE:
+        findings.append(_finding(V37_INTEGRITY_VALIDATION_BLOCKED_BY_EXPLAINABILITY, "enforcement", primary.identity.enforcement_id, "integrity explainability continuity is incomplete"))
+    if not replay["replay_continuity_preserved"] or replay["runtime_replay"] or replay["execution_authorization"]:
+        findings.append(_finding(V37_INTEGRITY_VALIDATION_BLOCKED_BY_REPLAY, "enforcement", primary.identity.enforcement_id, "integrity replay evidence is invalid"))
+    if not replay["rollback_continuity_preserved"]:
+        findings.append(_finding(V37_INTEGRITY_VALIDATION_BLOCKED_BY_ROLLBACK, "enforcement", primary.identity.enforcement_id, "integrity rollback evidence is invalid"))
+    if not serialization["stable"]:
+        findings.append(_finding(V37_INTEGRITY_VALIDATION_BLOCKED_BY_SERIALIZATION, "enforcement", primary.identity.enforcement_id, "integrity serialization is unstable"))
+    if not hashing["stable"]:
+        findings.append(_finding(V37_INTEGRITY_VALIDATION_BLOCKED_BY_HASH, "enforcement", primary.identity.enforcement_id, "integrity hash is unstable"))
+    error_count = sum(1 for finding in findings if finding.severity == "error")
+    visibility_count = sum(1 for finding in findings if finding.severity == "visibility")
+    result = V37GraphIntegrityValidationResult(
+        validation_status=V37_GRAPH_INTEGRITY_VALIDATION_STABLE if error_count == 0 else V37_GRAPH_INTEGRITY_VALIDATION_BLOCKED,
+        valid=error_count == 0,
+        finding_count=len(findings),
+        error_count=error_count,
+        visibility_finding_count=visibility_count,
+        duplicate_policy_identity_count=duplicate_policy_count,
+        duplicate_enforcement_identity_count=duplicate_enforcement_count,
+        missing_evidence_source_reference_count=sum(1 for finding in findings if finding.status == V37_INTEGRITY_VALIDATION_BLOCKED_BY_MISSING_EVIDENCE_SOURCE),
+        invalid_evidence_source_reference_count=sum(1 for finding in findings if finding.status == V37_INTEGRITY_VALIDATION_BLOCKED_BY_INVALID_EVIDENCE_SOURCE),
+        missing_provenance_evidence_count=sum(1 for finding in findings if finding.status == V37_INTEGRITY_VALIDATION_BLOCKED_BY_PROVENANCE),
+        missing_explainability_evidence_count=sum(1 for finding in findings if finding.status == V37_INTEGRITY_VALIDATION_BLOCKED_BY_EXPLAINABILITY),
+        missing_replay_evidence_count=sum(1 for finding in findings if finding.status == V37_INTEGRITY_VALIDATION_BLOCKED_BY_REPLAY),
+        missing_rollback_evidence_count=sum(1 for finding in findings if finding.status == V37_INTEGRITY_VALIDATION_BLOCKED_BY_ROLLBACK),
+        hidden_prohibited_finding_count=_hidden_count(enforcement_results, V37_INTEGRITY_FINDING_HIDDEN_PROHIBITED_STATE),
+        hidden_unsupported_finding_count=_hidden_count(enforcement_results, V37_INTEGRITY_FINDING_HIDDEN_UNSUPPORTED_STATE),
+        hidden_unknown_finding_count=_hidden_count(enforcement_results, V37_INTEGRITY_FINDING_HIDDEN_UNKNOWN_STATE),
+        execution_boundary_violation_count=sum(1 for item in enforcement_results if _execution_boundary_violation(item)),
+        provenance_continuity_preserved=provenance.provenance_status == V37_GRAPH_INTEGRITY_PROVENANCE_PRESERVED,
+        explainability_continuity_preserved=explainability.explainability_status == V37_GRAPH_INTEGRITY_EXPLAINABILITY_STABLE,
+        replay_continuity_preserved=replay["replay_continuity_preserved"],
+        rollback_continuity_preserved=replay["rollback_continuity_preserved"],
+        deterministic_serialization_stable=serialization["stable"],
+        deterministic_hash_stable=hashing["stable"],
+        integrity_enforcement_non_executable=primary.integrity_enforcement_is_non_executable,
+        valid_integrity_does_not_authorize_execution=primary.valid_integrity_does_not_authorize_execution,
+        execution_boundary_violations_blocked=all(
+            finding.blocks_validation
+            for item in enforcement_results
+            for finding in item.findings
+            if finding.finding_classification == V37_INTEGRITY_FINDING_EXECUTION_BOUNDARY_VIOLATION
+            and finding.active_violation
+        ),
+        deterministic_integrity_hash=hash_v3_7_graph_integrity_enforcement_result(primary),
+        findings=tuple(sorted(findings, key=lambda item: item.finding_id)),
+    )
+    return replace(result, deterministic_validation_hash=hash_v3_7_graph_integrity_validation_result(result))
+
+
+def export_v3_7_graph_integrity_validation_finding(finding: V37GraphIntegrityValidationFinding) -> dict[str, Any]:
+    return asdict(finding)
+
+
+def export_v3_7_graph_integrity_validation_result(result: V37GraphIntegrityValidationResult) -> dict[str, Any]:
+    data = asdict(result)
+    data["findings"] = [
+        export_v3_7_graph_integrity_validation_finding(finding)
+        for finding in sorted(result.findings, key=lambda item: item.finding_id)
+    ]
+    return data
+
+
+def serialize_v3_7_graph_integrity_validation_result(result: V37GraphIntegrityValidationResult) -> str:
+    return stable_serialize(export_v3_7_graph_integrity_validation_result(result))
+
+
+def hash_v3_7_graph_integrity_validation_result(result: V37GraphIntegrityValidationResult) -> str:
+    data = export_v3_7_graph_integrity_validation_result(result)
+    data.pop("deterministic_validation_hash", None)
+    return deterministic_hash(data)
+
+
+def _add_visibility_findings(
+    result: V37GraphIntegrityEnforcementResult,
+    findings: list[V37GraphIntegrityValidationFinding],
+) -> None:
+    for finding in result.findings:
+        if finding.finding_classification.endswith("_violation"):
+            findings.append(_finding(V37_INTEGRITY_VALIDATION_VISIBLE_EXECUTION_BOUNDARY if finding.finding_classification == V37_INTEGRITY_FINDING_EXECUTION_BOUNDARY_VIOLATION else V37_INTEGRITY_VALIDATION_VISIBLE_BLOCKED, "integrity_finding", finding.finding_id, f"{finding.finding_classification} remains fail-visible", "visibility"))
+        if finding.severity == "warning":
+            findings.append(_finding(V37_INTEGRITY_VALIDATION_VISIBLE_WARNING, "integrity_finding", finding.finding_id, "warning finding remains fail-visible", "visibility"))
+
+
+def _hidden_count(results: tuple[V37GraphIntegrityEnforcementResult, ...], classification: str) -> int:
+    return sum(
+        1
+        for result in results
+        for finding in result.findings
+        if finding.finding_classification == classification
+        and (finding.hidden or not finding.fail_visible or finding.active_violation)
+    )
+
+
+def _execution_boundary_violation(result: V37GraphIntegrityEnforcementResult) -> bool:
+    return any(
+        (
+            not result.integrity_enforcement_is_non_executable,
+            not result.integrity_enforcement_validates_planning_evidence_only,
+            not result.valid_integrity_does_not_authorize_execution,
+            not result.blocked_integrity_does_not_perform_runtime_blocking,
+            not result.enforcement_outcomes_are_planning_validation_only,
+            not result.integrity_enforcement_does_not_route_schedule_dispatch_traverse_optimize_recommend_or_execute,
+            result.graph_execution_enabled,
+            result.integrity_driven_execution_enabled,
+            result.orchestration_authorization_enabled,
+            result.routing_enabled,
+            result.scheduling_enabled,
+            result.dispatch_enabled,
+            result.traversal_logic_enabled,
+            result.path_selection_enabled,
+            result.scenario_selection_enabled,
+            result.optimization_engine_enabled,
+            result.recommendation_enabled,
+            result.autonomous_orchestration_enabled,
+            result.runtime_mutation_enabled,
+            result.persistent_runtime_writes_enabled,
+            result.runtime_decision_making_enabled,
+            result.execution_gates_enabled,
+            result.callable_orchestration_flows_enabled,
+            result.runtime_control_system_enabled,
+            any(
+                (
+                    finding.execution_authorization
+                    or finding.routing_authorization
+                    or finding.scheduling_authorization
+                    or finding.dispatch_authorization
+                    or finding.traversal_authorization
+                    or (
+                        finding.finding_classification == V37_INTEGRITY_FINDING_EXECUTION_BOUNDARY_VIOLATION
+                        and finding.active_violation
+                    )
+                )
+                for finding in result.findings
+            ),
+            any(
+                not replay.non_executable_replay_evidence or replay.runtime_replay or replay.execution_authorization
+                for replay in result.replay_evidence
+            ),
+        )
+    )
+
+
+def _finding(status: str, subject_type: str, subject_id: str, message: str, severity: str = "error") -> V37GraphIntegrityValidationFinding:
+    return V37GraphIntegrityValidationFinding(
+        finding_id=f"{status}:{subject_type}:{subject_id}",
+        status=status,
+        severity=severity,
+        subject_type=subject_type,
+        subject_id=subject_id,
+        message=message,
+    )

--- a/backend/scripts/report_v3_7_graph_planning_integrity_enforcement.py
+++ b/backend/scripts/report_v3_7_graph_planning_integrity_enforcement.py
@@ -1,0 +1,340 @@
+"""Generate the v3.7 graph planning integrity enforcement report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.runtime_intelligence.classification_hashing import deterministic_hash  # noqa: E402
+from app.runtime_orchestration.v3_7_graph_integrity_audit import (  # noqa: E402
+    V37_GRAPH_INTEGRITY_AUDIT_STABLE,
+    audit_v3_7_graph_integrity,
+    export_v3_7_graph_integrity_audit_result,
+)
+from app.runtime_orchestration.v3_7_graph_integrity_enforcement import (  # noqa: E402
+    enforce_v3_7_graph_planning_integrity,
+)
+from app.runtime_orchestration.v3_7_graph_integrity_explainability import (  # noqa: E402
+    V37_GRAPH_INTEGRITY_EXPLAINABILITY_STABLE,
+    explain_v3_7_graph_integrity,
+    export_v3_7_graph_integrity_explainability_result,
+)
+from app.runtime_orchestration.v3_7_graph_integrity_findings import (  # noqa: E402
+    count_v3_7_graph_integrity_findings_by_classification,
+    export_v3_7_graph_integrity_finding_records,
+)
+from app.runtime_orchestration.v3_7_graph_integrity_models import (  # noqa: E402
+    export_v3_7_graph_integrity_counts,
+    export_v3_7_graph_integrity_enforcement_result,
+    hash_v3_7_graph_integrity_enforcement_result,
+    hash_v3_7_graph_integrity_policy,
+    validate_v3_7_graph_integrity_hash_stability,
+    validate_v3_7_graph_integrity_serialization_stability,
+)
+from app.runtime_orchestration.v3_7_graph_integrity_provenance import (  # noqa: E402
+    V37_GRAPH_INTEGRITY_PROVENANCE_PRESERVED,
+    audit_v3_7_graph_integrity_provenance,
+    export_v3_7_graph_integrity_provenance_result,
+)
+from app.runtime_orchestration.v3_7_graph_integrity_replay import (  # noqa: E402
+    export_v3_7_graph_integrity_replay_evidence_records,
+    validate_v3_7_graph_integrity_replay_evidence,
+)
+from app.runtime_orchestration.v3_7_graph_integrity_validation import (  # noqa: E402
+    V37_GRAPH_INTEGRITY_VALIDATION_STABLE,
+    export_v3_7_graph_integrity_validation_result,
+    validate_v3_7_graph_integrity,
+)
+
+
+DETERMINISTIC_GENERATED_AT = "2026-05-16T00:00:00+00:00"
+
+
+def build_v3_7_graph_planning_integrity_enforcement_report(repo_root: Path | None = None) -> dict[str, Any]:
+    root = repo_root or Path(__file__).resolve().parents[2]
+    enforcement = enforce_v3_7_graph_planning_integrity()
+    validation = validate_v3_7_graph_integrity((enforcement,))
+    audit = audit_v3_7_graph_integrity(enforcement)
+    provenance = audit_v3_7_graph_integrity_provenance(enforcement)
+    explainability = explain_v3_7_graph_integrity(enforcement)
+    replay = validate_v3_7_graph_integrity_replay_evidence(enforcement)
+    serialization = validate_v3_7_graph_integrity_serialization_stability(enforcement)
+    hashing = validate_v3_7_graph_integrity_hash_stability(enforcement)
+    counts = export_v3_7_graph_integrity_counts(enforcement)
+    report = {
+        "schema_version": "v3_7.graph_planning_integrity_enforcement_report.1",
+        "generated_at": DETERMINISTIC_GENERATED_AT,
+        "phase_name": "v3.7_graph_planning_integrity_enforcement",
+        "repo_root": str(root),
+        "architectural_purpose": "deterministic graph planning integrity enforcement",
+        "integrity_enforcement_is_non_executable": True,
+        "integrity_enforcement_validates_planning_evidence_only": True,
+        "valid_integrity_does_not_authorize_execution": True,
+        "blocked_integrity_does_not_perform_runtime_blocking": True,
+        "enforcement_outcomes_are_planning_validation_only": True,
+        "integrity_enforcement_does_not_route_schedule_dispatch_traverse_optimize_recommend_or_execute": True,
+        "graph_execution_enabled": False,
+        "integrity_driven_execution_enabled": False,
+        "orchestration_authorization_enabled": False,
+        "routing_enabled": False,
+        "scheduling_enabled": False,
+        "dispatch_enabled": False,
+        "traversal_logic_enabled": False,
+        "path_selection_enabled": False,
+        "scenario_selection_enabled": False,
+        "optimization_engine_enabled": False,
+        "recommendation_enabled": False,
+        "autonomous_orchestration_enabled": False,
+        "runtime_mutation_enabled": False,
+        "persistent_runtime_writes_enabled": False,
+        "runtime_decision_making_enabled": False,
+        "execution_gates_enabled": False,
+        "callable_orchestration_flows_enabled": False,
+        "runtime_control_system_enabled": False,
+        "integrity_policy_counts": {
+            "policy_count": counts["integrity_policy_count"],
+            "policy_requirement_count": len(enforcement.policy.requirements),
+            "execution_boundary_requirement_count": len(enforcement.policy.execution_boundary_requirements),
+        },
+        "enforcement_result_counts": {
+            "enforcement_result_count": counts["enforcement_result_count"],
+            "enforcement_outcome": enforcement.enforcement_outcome,
+            "evidence_source_count": counts["evidence_source_count"],
+        },
+        "integrity_finding_totals": {
+            "integrity_finding_count": counts["integrity_finding_count"],
+            "finding_classification_counts": count_v3_7_graph_integrity_findings_by_classification(enforcement.findings),
+        },
+        "blocked_finding_totals": {
+            "blocked_finding_count": counts["blocked_finding_count"],
+            "active_blocking_finding_count": sum(1 for finding in enforcement.findings if finding.blocks_validation),
+        },
+        "warning_finding_totals": {
+            "warning_finding_count": counts["warning_finding_count"],
+        },
+        "execution_boundary_violation_totals": {
+            "execution_boundary_violation_count": validation.execution_boundary_violation_count,
+            "execution_boundary_violations_blocked": validation.execution_boundary_violations_blocked,
+            "execution_boundary_continuity_preserved": audit.execution_boundary_continuity_preserved,
+        },
+        "evidence_source_counts": {
+            "evidence_source_count": len(enforcement.evidence_source_references),
+            "graph_source_count": _source_type_count(enforcement, "graph_foundations"),
+            "governance_source_count": _source_type_count(enforcement, "governance"),
+            "compatibility_source_count": _source_type_count(enforcement, "compatibility"),
+            "evaluation_source_count": _source_type_count(enforcement, "evaluation"),
+            "session_source_count": _source_type_count(enforcement, "session"),
+            "scenario_source_count": _source_type_count(enforcement, "scenario"),
+            "aggregation_source_count": _source_type_count(enforcement, "aggregation"),
+        },
+        "replay_evidence_counts": {
+            "replay_evidence_count": replay["replay_evidence_count"],
+            "non_executable_replay_evidence": replay["non_executable_replay_evidence"],
+            "runtime_replay": replay["runtime_replay"],
+            "execution_authorization": replay["execution_authorization"],
+        },
+        "rollback_continuity_counts": {
+            "rollback_reference_count": replay["rollback_reference_count"],
+            "rollback_continuity_preserved": replay["rollback_continuity_preserved"],
+        },
+        "provenance_continuity_totals": {
+            "provenance_status": provenance.provenance_status,
+            "provenance_record_count": provenance.provenance_record_count,
+            "enforcement_provenance_preserved": provenance.enforcement_provenance_preserved,
+            "policy_provenance_preserved": provenance.policy_provenance_preserved,
+            "graph_provenance_preserved": provenance.graph_provenance_preserved,
+            "governance_provenance_preserved": provenance.governance_provenance_preserved,
+            "compatibility_provenance_preserved": provenance.compatibility_provenance_preserved,
+            "evaluation_provenance_preserved": provenance.evaluation_provenance_preserved,
+            "session_provenance_preserved": provenance.session_provenance_preserved,
+            "scenario_provenance_preserved": provenance.scenario_provenance_preserved,
+            "aggregation_provenance_preserved": provenance.aggregation_provenance_preserved,
+            "replay_provenance_preserved": provenance.replay_provenance_preserved,
+            "rollback_provenance_preserved": provenance.rollback_provenance_preserved,
+            "explainability_provenance_preserved": provenance.explainability_provenance_preserved,
+            "continuity_provenance_preserved": provenance.continuity_provenance_preserved,
+        },
+        "explainability_continuity_totals": {
+            "explainability_status": explainability.explainability_status,
+            "explanation_count": explainability.explanation_count,
+            "enforcement_explanation_count": explainability.enforcement_explanation_count,
+            "policy_explanation_count": explainability.policy_explanation_count,
+            "evidence_source_explanation_count": explainability.evidence_source_explanation_count,
+            "finding_explanation_count": explainability.finding_explanation_count,
+            "warning_explanation_count": explainability.warning_explanation_count,
+            "blocked_explanation_count": explainability.blocked_explanation_count,
+            "execution_boundary_explanation_count": explainability.execution_boundary_explanation_count,
+            "does_not_authorize_explanation_count": explainability.does_not_authorize_explanation_count,
+        },
+        "validation_totals": {
+            "validation_status": validation.validation_status,
+            "valid": validation.valid,
+            "finding_count": validation.finding_count,
+            "error_count": validation.error_count,
+            "visibility_finding_count": validation.visibility_finding_count,
+            "duplicate_policy_identity_count": validation.duplicate_policy_identity_count,
+            "duplicate_enforcement_identity_count": validation.duplicate_enforcement_identity_count,
+            "hidden_prohibited_finding_count": validation.hidden_prohibited_finding_count,
+            "hidden_unsupported_finding_count": validation.hidden_unsupported_finding_count,
+            "hidden_unknown_finding_count": validation.hidden_unknown_finding_count,
+            "execution_boundary_violation_count": validation.execution_boundary_violation_count,
+            "integrity_enforcement_non_executable": validation.integrity_enforcement_non_executable,
+            "valid_integrity_does_not_authorize_execution": validation.valid_integrity_does_not_authorize_execution,
+            "execution_boundary_violations_blocked": validation.execution_boundary_violations_blocked,
+        },
+        "deterministic_guarantees": {
+            "serialization_stable": serialization["stable"],
+            "hash_stable": hashing["stable"],
+            "policy_hash": hash_v3_7_graph_integrity_policy(enforcement.policy),
+            "integrity_hash": hash_v3_7_graph_integrity_enforcement_result(enforcement),
+            "validation_hash": validation.deterministic_validation_hash,
+            "audit_hash": audit.deterministic_audit_hash,
+            "provenance_hash": provenance.deterministic_provenance_hash,
+            "explainability_hash": explainability.deterministic_explainability_hash,
+        },
+        "coverage": {
+            "validation_coverage": validation.validation_status == V37_GRAPH_INTEGRITY_VALIDATION_STABLE,
+            "audit_coverage": audit.audit_status == V37_GRAPH_INTEGRITY_AUDIT_STABLE,
+            "provenance_coverage": provenance.provenance_status == V37_GRAPH_INTEGRITY_PROVENANCE_PRESERVED,
+            "explainability_coverage": explainability.explainability_status == V37_GRAPH_INTEGRITY_EXPLAINABILITY_STABLE,
+            "replay_continuity_coverage": replay["replay_continuity_preserved"],
+            "rollback_continuity_coverage": replay["rollback_continuity_preserved"],
+            "non_executable_confirmation": validation.integrity_enforcement_non_executable,
+            "no_execution_authorization_confirmation": validation.valid_integrity_does_not_authorize_execution,
+            "execution_boundary_enforcement_confirmation": validation.execution_boundary_violations_blocked,
+        },
+        "integrity_enforcement_record": export_v3_7_graph_integrity_enforcement_result(enforcement),
+        "finding_records": export_v3_7_graph_integrity_finding_records(enforcement.findings),
+        "replay_evidence_records": export_v3_7_graph_integrity_replay_evidence_records(enforcement.replay_evidence),
+        "validation_result": export_v3_7_graph_integrity_validation_result(validation),
+        "audit_result": export_v3_7_graph_integrity_audit_result(audit),
+        "provenance_result": export_v3_7_graph_integrity_provenance_result(provenance),
+        "explainability_result": export_v3_7_graph_integrity_explainability_result(explainability),
+        "explicit_limitations": [
+            "integrity enforcement is non-executable",
+            "integrity enforcement validates planning evidence only",
+            "valid integrity does not authorize execution",
+            "blocked integrity does not perform runtime blocking",
+            "enforcement outcomes are planning validation outcomes only",
+            "integrity enforcement does not route, schedule, dispatch, traverse, optimize, recommend, or execute",
+        ],
+        "summary": {
+            "enforcement_outcome": enforcement.enforcement_outcome,
+            "validation_status": validation.validation_status,
+            "deterministic_serialization_verified": serialization["stable"],
+            "deterministic_hashing_verified": hashing["stable"],
+            "provenance_continuity_verified": validation.provenance_continuity_preserved,
+            "explainability_continuity_verified": validation.explainability_continuity_preserved,
+            "replay_continuity_verified": validation.replay_continuity_preserved,
+            "rollback_continuity_verified": validation.rollback_continuity_preserved,
+            "non_executable_verified": validation.integrity_enforcement_non_executable,
+            "no_execution_authorization_verified": validation.valid_integrity_does_not_authorize_execution,
+            "execution_boundary_enforcement_verified": validation.execution_boundary_violations_blocked,
+        },
+    }
+    report["deterministic_report_hash"] = deterministic_hash(
+        {key: value for key, value in report.items() if key != "deterministic_report_hash"}
+    )
+    return report
+
+
+def write_markdown_report(report: dict[str, Any], output_path: Path) -> None:
+    lines = [
+        "# v3.7 Graph Planning Integrity Enforcement",
+        "",
+        "## Architectural Purpose",
+        "",
+        "v3.7 Phase 8 adds deterministic graph planning integrity enforcement.",
+        "",
+        "Integrity enforcement is NON-executable.",
+        "",
+        "Integrity enforcement validates planning evidence only.",
+        "",
+        "Valid integrity does NOT authorize execution.",
+        "",
+        "Blocked integrity does NOT perform runtime blocking.",
+        "",
+        "Enforcement outcomes are planning validation outcomes only.",
+        "",
+        "Integrity enforcement does NOT route, schedule, dispatch, traverse, optimize, recommend, or execute.",
+        "",
+        "Planning integrity enforcement checks deterministic planning evidence. Runtime orchestration control would control runtime behavior. This phase implements planning integrity enforcement only, not runtime orchestration control.",
+        "",
+        "## Deterministic Scope",
+        "",
+        f"- Enforcement outcome: `{report['enforcement_result_counts']['enforcement_outcome']}`",
+        f"- Validation status: `{report['validation_totals']['validation_status']}`",
+        f"- Integrity findings: `{report['integrity_finding_totals']['integrity_finding_count']}`",
+        f"- Evidence sources: `{report['evidence_source_counts']['evidence_source_count']}`",
+        f"- Execution-boundary violations: `{report['execution_boundary_violation_totals']['execution_boundary_violation_count']}`",
+        f"- Serialization stable: `{report['deterministic_guarantees']['serialization_stable']}`",
+        f"- Hash stable: `{report['deterministic_guarantees']['hash_stable']}`",
+        "",
+        "## Explicit Non-Execution Guarantees",
+        "",
+        "- Graph execution remains disabled.",
+        "- Integrity-driven execution remains disabled.",
+        "- Orchestration authorization remains disabled.",
+        "- Routing remains disabled.",
+        "- Scheduling remains disabled.",
+        "- Dispatch remains disabled.",
+        "- Traversal remains disabled.",
+        "- Runtime path selection remains disabled.",
+        "- Scenario execution selection remains disabled.",
+        "- Optimization for execution remains disabled.",
+        "- Recommendation to execute remains disabled.",
+        "- Callable execution flow references remain prohibited.",
+        "",
+        "## Planning Integrity Enforcement vs Runtime Orchestration Control",
+        "",
+        "Planning integrity enforcement validates deterministic evidence continuity, provenance, explainability, replay, rollback, and execution-boundary preservation.",
+        "",
+        "Runtime orchestration control would authorize or direct runtime behavior. This phase does not implement runtime orchestration control.",
+        "",
+        "## Generated Evidence",
+        "",
+        f"- Deterministic report hash: `{report['deterministic_report_hash']}`",
+        f"- Integrity hash: `{report['deterministic_guarantees']['integrity_hash']}`",
+        f"- Policy hash: `{report['deterministic_guarantees']['policy_hash']}`",
+        f"- Validation hash: `{report['deterministic_guarantees']['validation_hash']}`",
+        f"- Audit hash: `{report['deterministic_guarantees']['audit_hash']}`",
+    ]
+    output_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _source_type_count(enforcement, source_type: str) -> int:
+    return sum(1 for item in enforcement.evidence_source_types if item == source_type)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=Path(__file__).resolve().parents[2])
+    parser.add_argument(
+        "--json-output",
+        type=Path,
+        default=Path(__file__).resolve().parents[2] / "docs" / "generated" / "v3_7_graph_planning_integrity_enforcement_report.json",
+    )
+    parser.add_argument(
+        "--markdown-output",
+        type=Path,
+        default=Path(__file__).resolve().parents[2] / "docs" / "migration" / "V3_7_GRAPH_PLANNING_INTEGRITY_ENFORCEMENT.md",
+    )
+    args = parser.parse_args(argv)
+    report = build_v3_7_graph_planning_integrity_enforcement_report(args.repo_root)
+    args.json_output.parent.mkdir(parents=True, exist_ok=True)
+    args.markdown_output.parent.mkdir(parents=True, exist_ok=True)
+    args.json_output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    write_markdown_report(report, args.markdown_output)
+    print(json.dumps(report["summary"], indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_v3_7_graph_integrity_audit.py
+++ b/backend/tests/test_v3_7_graph_integrity_audit.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+from app.runtime_orchestration.v3_7_graph_integrity_audit import (
+    V37_GRAPH_INTEGRITY_AUDIT_FAILED,
+    V37_GRAPH_INTEGRITY_AUDIT_STABLE,
+    V37_INTEGRITY_AUDIT_BLOCKED_BY_EXECUTION_BOUNDARY,
+    V37_INTEGRITY_AUDIT_BLOCKED_BY_FINDING_VISIBILITY,
+    V37_INTEGRITY_AUDIT_BLOCKED_BY_REPLAY,
+    V37_INTEGRITY_AUDIT_VISIBLE_BLOCKED,
+    V37_INTEGRITY_AUDIT_VISIBLE_WARNING,
+    audit_v3_7_graph_integrity,
+    hash_v3_7_graph_integrity_audit_result,
+    serialize_v3_7_graph_integrity_audit_result,
+)
+from app.runtime_orchestration.v3_7_graph_integrity_enforcement import enforce_v3_7_graph_planning_integrity
+
+
+def test_integrity_audit_is_stable_and_preserves_all_layers():
+    result = audit_v3_7_graph_integrity()
+
+    assert result.audit_status == V37_GRAPH_INTEGRITY_AUDIT_STABLE
+    assert result.valid is True
+    assert result.error_count == 0
+    assert result.visibility_finding_count == 6
+    assert result.policy_identity_continuity_preserved is True
+    assert result.enforcement_identity_continuity_preserved is True
+    assert result.graph_continuity_preserved is True
+    assert result.governance_continuity_preserved is True
+    assert result.compatibility_continuity_preserved is True
+    assert result.evaluation_continuity_preserved is True
+    assert result.session_continuity_preserved is True
+    assert result.scenario_continuity_preserved is True
+    assert result.aggregation_continuity_preserved is True
+    assert result.execution_boundary_continuity_preserved is True
+    assert result.deterministic_audit_hash == hash_v3_7_graph_integrity_audit_result(result)
+    assert serialize_v3_7_graph_integrity_audit_result(result) == serialize_v3_7_graph_integrity_audit_result(result)
+
+
+def test_integrity_audit_keeps_blocked_and_warning_findings_visible():
+    result = audit_v3_7_graph_integrity()
+
+    assert any(finding.status == V37_INTEGRITY_AUDIT_VISIBLE_BLOCKED for finding in result.findings)
+    assert any(finding.status == V37_INTEGRITY_AUDIT_VISIBLE_WARNING for finding in result.findings)
+
+
+def test_integrity_audit_detects_hidden_finding():
+    enforcement = enforce_v3_7_graph_planning_integrity()
+    hidden_finding = replace(enforcement.findings[0], hidden=True)
+    result = audit_v3_7_graph_integrity(replace(enforcement, findings=(hidden_finding,) + enforcement.findings[1:]))
+
+    assert result.audit_status == V37_GRAPH_INTEGRITY_AUDIT_FAILED
+    assert any(finding.status == V37_INTEGRITY_AUDIT_BLOCKED_BY_FINDING_VISIBILITY for finding in result.findings)
+
+
+def test_integrity_audit_detects_replay_gap_and_execution_boundary():
+    enforcement = enforce_v3_7_graph_planning_integrity()
+    broken_replay = replace(enforcement.replay_evidence[0], evidence_source_references=())
+    replay_result = audit_v3_7_graph_integrity(replace(enforcement, replay_evidence=(broken_replay,)))
+    execution_result = audit_v3_7_graph_integrity(replace(enforcement, routing_enabled=True))
+
+    assert replay_result.audit_status == V37_GRAPH_INTEGRITY_AUDIT_FAILED
+    assert any(finding.status == V37_INTEGRITY_AUDIT_BLOCKED_BY_REPLAY for finding in replay_result.findings)
+    assert execution_result.audit_status == V37_GRAPH_INTEGRITY_AUDIT_FAILED
+    assert any(finding.status == V37_INTEGRITY_AUDIT_BLOCKED_BY_EXECUTION_BOUNDARY for finding in execution_result.findings)

--- a/backend/tests/test_v3_7_graph_integrity_enforcement.py
+++ b/backend/tests/test_v3_7_graph_integrity_enforcement.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+from app.runtime_orchestration.v3_7_graph_integrity_enforcement import (
+    enforce_v3_7_graph_planning_integrity,
+    graph_integrity_enforcement_identities_are_unique,
+    graph_integrity_enforcement_identity_key,
+)
+from app.runtime_orchestration.v3_7_graph_integrity_models import (
+    V37_INTEGRITY_FINDING_EXECUTION_BOUNDARY_VIOLATION,
+    V37_INTEGRITY_OUTCOME_BLOCKED,
+    V37_INTEGRITY_OUTCOME_VALID,
+)
+from app.runtime_orchestration.v3_7_graph_intelligence_aggregation import (
+    build_v3_7_graph_planning_intelligence_aggregation,
+)
+
+
+def test_default_integrity_enforcement_is_valid_and_cross_system():
+    result = enforce_v3_7_graph_planning_integrity()
+
+    assert result.enforcement_outcome == V37_INTEGRITY_OUTCOME_VALID
+    assert result.identity.stable_identity_key == graph_integrity_enforcement_identity_key(result.identity)
+    assert graph_integrity_enforcement_identities_are_unique((result.identity,)) is True
+    assert {
+        "graph_foundations",
+        "governance",
+        "compatibility",
+        "evaluation",
+        "session",
+        "scenario",
+        "aggregation",
+    }.issubset(set(result.evidence_source_types))
+    assert result.integrity_enforcement_is_non_executable is True
+
+
+def test_integrity_enforcement_blocks_execution_boundary_violations():
+    aggregation = build_v3_7_graph_planning_intelligence_aggregation()
+    result = enforce_v3_7_graph_planning_integrity(replace(aggregation, routing_enabled=True))
+    execution_boundary = next(
+        finding
+        for finding in result.findings
+        if finding.finding_classification == V37_INTEGRITY_FINDING_EXECUTION_BOUNDARY_VIOLATION
+    )
+
+    assert result.enforcement_outcome == V37_INTEGRITY_OUTCOME_BLOCKED
+    assert execution_boundary.active_violation is True
+    assert execution_boundary.blocks_validation is True
+
+
+def test_integrity_enforcement_does_not_create_execution_controls():
+    result = enforce_v3_7_graph_planning_integrity()
+
+    assert result.orchestration_authorization_enabled is False
+    assert result.path_selection_enabled is False
+    assert result.scenario_selection_enabled is False
+    assert result.execution_gates_enabled is False
+    assert result.callable_orchestration_flows_enabled is False

--- a/backend/tests/test_v3_7_graph_integrity_explainability.py
+++ b/backend/tests/test_v3_7_graph_integrity_explainability.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from app.runtime_orchestration.v3_7_graph_integrity_explainability import (
+    V37_GRAPH_INTEGRITY_EXPLAINABILITY_STABLE,
+    explain_v3_7_graph_integrity,
+    hash_v3_7_graph_integrity_explainability_result,
+    serialize_v3_7_graph_integrity_explainability_result,
+)
+
+
+def test_integrity_explainability_is_stable_and_replay_safe():
+    result = explain_v3_7_graph_integrity()
+
+    assert result.explainability_status == V37_GRAPH_INTEGRITY_EXPLAINABILITY_STABLE
+    assert result.enforcement_explanation_count == 1
+    assert result.policy_explanation_count == 1
+    assert result.evidence_source_explanation_count == 7
+    assert result.finding_explanation_count == 13
+    assert result.execution_boundary_explanation_count == 1
+    assert result.does_not_authorize_explanation_count == 1
+    assert all(explanation.replay_safe for explanation in result.explanations)
+    assert result.deterministic_explainability_hash == hash_v3_7_graph_integrity_explainability_result(result)
+    assert serialize_v3_7_graph_integrity_explainability_result(result) == serialize_v3_7_graph_integrity_explainability_result(result)
+
+
+def test_integrity_explainability_states_non_execution_boundary():
+    result = explain_v3_7_graph_integrity()
+    summaries = " ".join(explanation.summary for explanation in result.explanations)
+
+    assert "does not authorize runtime orchestration" in summaries
+    assert "execution-boundary integrity is preserved" in summaries

--- a/backend/tests/test_v3_7_graph_integrity_findings.py
+++ b/backend/tests/test_v3_7_graph_integrity_findings.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from app.runtime_orchestration.v3_7_graph_integrity_enforcement import enforce_v3_7_graph_planning_integrity
+from app.runtime_orchestration.v3_7_graph_integrity_findings import (
+    count_v3_7_graph_integrity_findings_by_classification,
+    export_v3_7_graph_integrity_finding_classifications,
+    export_v3_7_graph_integrity_finding_records,
+)
+from app.runtime_orchestration.v3_7_graph_integrity_models import (
+    V37_INTEGRITY_FINDING_BLOCKED,
+    V37_INTEGRITY_FINDING_CLASSIFICATIONS,
+    V37_INTEGRITY_FINDING_WARNING,
+)
+
+
+def test_integrity_finding_classifications_are_exported_deterministically():
+    assert export_v3_7_graph_integrity_finding_classifications() == list(V37_INTEGRITY_FINDING_CLASSIFICATIONS)
+
+
+def test_integrity_findings_are_fail_visible_and_complete():
+    result = enforce_v3_7_graph_planning_integrity()
+    counts = count_v3_7_graph_integrity_findings_by_classification(result.findings)
+
+    assert all(count == 1 for count in counts.values())
+    assert all(finding.fail_visible and not finding.hidden for finding in result.findings)
+    assert any(finding.finding_classification == V37_INTEGRITY_FINDING_BLOCKED for finding in result.findings)
+    assert any(finding.finding_classification == V37_INTEGRITY_FINDING_WARNING for finding in result.findings)
+
+
+def test_integrity_finding_records_are_sorted():
+    result = enforce_v3_7_graph_planning_integrity()
+    records = export_v3_7_graph_integrity_finding_records(tuple(reversed(result.findings)))
+
+    assert [record["finding_id"] for record in records] == sorted(record["finding_id"] for record in records)

--- a/backend/tests/test_v3_7_graph_integrity_models.py
+++ b/backend/tests/test_v3_7_graph_integrity_models.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import json
+from dataclasses import FrozenInstanceError, replace
+from pathlib import Path
+
+import pytest
+
+from app.runtime_orchestration.v3_7_graph_integrity_enforcement import enforce_v3_7_graph_planning_integrity
+from app.runtime_orchestration.v3_7_graph_integrity_models import (
+    V37_INTEGRITY_FINDING_CLASSIFICATIONS,
+    V37_INTEGRITY_OUTCOMES,
+    export_v3_7_graph_integrity_counts,
+    hash_v3_7_graph_integrity_enforcement_result,
+    serialize_v3_7_graph_integrity_enforcement_result,
+    validate_v3_7_graph_integrity_hash_stability,
+    validate_v3_7_graph_integrity_serialization_stability,
+)
+from scripts.report_v3_7_graph_planning_integrity_enforcement import (
+    build_v3_7_graph_planning_integrity_enforcement_report,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_integrity_outcomes_and_findings_are_explicit():
+    assert V37_INTEGRITY_OUTCOMES == (
+        "valid",
+        "invalid",
+        "blocked",
+        "warning",
+        "audit_failed",
+    )
+    assert V37_INTEGRITY_FINDING_CLASSIFICATIONS == (
+        "integrity_valid",
+        "integrity_invalid",
+        "integrity_blocked",
+        "integrity_warning",
+        "continuity_violation",
+        "provenance_violation",
+        "explainability_violation",
+        "replay_violation",
+        "rollback_violation",
+        "execution_boundary_violation",
+        "hidden_prohibited_state",
+        "hidden_unsupported_state",
+        "hidden_unknown_state",
+    )
+
+
+def test_integrity_enforcement_is_immutable_and_non_executable():
+    result = enforce_v3_7_graph_planning_integrity()
+
+    with pytest.raises(FrozenInstanceError):
+        result.routing_enabled = True
+
+    assert result.integrity_enforcement_is_non_executable is True
+    assert result.integrity_enforcement_validates_planning_evidence_only is True
+    assert result.valid_integrity_does_not_authorize_execution is True
+    assert result.blocked_integrity_does_not_perform_runtime_blocking is True
+    assert result.graph_execution_enabled is False
+    assert result.routing_enabled is False
+    assert result.scheduling_enabled is False
+    assert result.dispatch_enabled is False
+    assert result.traversal_logic_enabled is False
+    assert result.runtime_control_system_enabled is False
+
+
+def test_integrity_serialization_and_hash_are_deterministic():
+    result = enforce_v3_7_graph_planning_integrity()
+    reordered = replace(
+        result,
+        metadata=tuple(reversed(result.metadata)),
+        evidence_source_references=tuple(reversed(result.evidence_source_references)),
+        evidence_source_types=tuple(reversed(result.evidence_source_types)),
+        findings=tuple(reversed(result.findings)),
+        replay_evidence=tuple(reversed(result.replay_evidence)),
+        rollback_continuity_references=tuple(reversed(result.rollback_continuity_references)),
+    )
+
+    assert serialize_v3_7_graph_integrity_enforcement_result(result) == serialize_v3_7_graph_integrity_enforcement_result(reordered)
+    assert hash_v3_7_graph_integrity_enforcement_result(result) == hash_v3_7_graph_integrity_enforcement_result(reordered)
+    assert validate_v3_7_graph_integrity_serialization_stability(result)["stable"] is True
+    assert validate_v3_7_graph_integrity_hash_stability(result)["stable"] is True
+    assert json.loads(serialize_v3_7_graph_integrity_enforcement_result(result))["dispatch_enabled"] is False
+
+
+def test_integrity_counts_and_report_are_deterministic():
+    result = enforce_v3_7_graph_planning_integrity()
+    first = build_v3_7_graph_planning_integrity_enforcement_report(REPO_ROOT)
+    second = build_v3_7_graph_planning_integrity_enforcement_report(REPO_ROOT)
+
+    assert export_v3_7_graph_integrity_counts(result) == {
+        "integrity_policy_count": 1,
+        "enforcement_result_count": 1,
+        "evidence_source_count": 7,
+        "integrity_finding_count": 13,
+        "blocked_finding_count": 0,
+        "warning_finding_count": 1,
+        "replay_evidence_count": 1,
+        "rollback_continuity_reference_count": 1,
+    }
+    assert json.dumps(first, sort_keys=True) == json.dumps(second, sort_keys=True)
+    assert first["integrity_enforcement_is_non_executable"] is True
+    assert first["valid_integrity_does_not_authorize_execution"] is True
+    assert first["routing_enabled"] is False

--- a/backend/tests/test_v3_7_graph_integrity_policies.py
+++ b/backend/tests/test_v3_7_graph_integrity_policies.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from app.runtime_orchestration.v3_7_graph_integrity_models import (
+    hash_v3_7_graph_integrity_policy,
+    serialize_v3_7_graph_integrity_policy,
+)
+from app.runtime_orchestration.v3_7_graph_integrity_policies import (
+    build_v3_7_graph_integrity_policy,
+    graph_integrity_policy_identities_are_unique,
+    graph_integrity_policy_identity_key,
+)
+
+
+def test_integrity_policy_identity_is_stable_and_unique():
+    policy = build_v3_7_graph_integrity_policy()
+
+    assert policy.identity.stable_identity_key == graph_integrity_policy_identity_key(policy.identity)
+    assert graph_integrity_policy_identities_are_unique((policy.identity,)) is True
+    assert graph_integrity_policy_identities_are_unique((policy.identity, policy.identity)) is False
+
+
+def test_integrity_policy_requirements_cover_all_evidence_layers():
+    policy = build_v3_7_graph_integrity_policy()
+    required_types = {requirement.required_reference_type for requirement in policy.requirements}
+
+    assert {
+        "graph_foundations",
+        "governance",
+        "compatibility",
+        "evaluation",
+        "session",
+        "scenario",
+        "aggregation",
+        "replay",
+        "rollback",
+        "provenance",
+        "explainability",
+        "fail_visible",
+        "non_executable",
+    }.issubset(required_types)
+    assert policy.policy_is_non_executable is True
+    assert policy.valid_integrity_does_not_authorize_execution is True
+    assert policy.execution_boundary_violations_blocked is True
+
+
+def test_integrity_policy_serialization_and_hash_are_stable():
+    policy = build_v3_7_graph_integrity_policy()
+
+    assert serialize_v3_7_graph_integrity_policy(policy) == serialize_v3_7_graph_integrity_policy(policy)
+    assert hash_v3_7_graph_integrity_policy(policy) == hash_v3_7_graph_integrity_policy(policy)
+    assert policy.execution_authorization_enabled is False
+    assert policy.routing_authorization_enabled is False
+    assert policy.dispatch_authorization_enabled is False

--- a/backend/tests/test_v3_7_graph_integrity_provenance.py
+++ b/backend/tests/test_v3_7_graph_integrity_provenance.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+from app.runtime_orchestration.v3_7_graph_integrity_enforcement import enforce_v3_7_graph_planning_integrity
+from app.runtime_orchestration.v3_7_graph_integrity_provenance import (
+    V37_GRAPH_INTEGRITY_PROVENANCE_BLOCKED,
+    V37_GRAPH_INTEGRITY_PROVENANCE_PRESERVED,
+    audit_v3_7_graph_integrity_provenance,
+    hash_v3_7_graph_integrity_provenance_result,
+    serialize_v3_7_graph_integrity_provenance_result,
+)
+
+
+def test_integrity_provenance_preserves_all_layers():
+    result = audit_v3_7_graph_integrity_provenance()
+
+    assert result.provenance_status == V37_GRAPH_INTEGRITY_PROVENANCE_PRESERVED
+    assert result.enforcement_provenance_preserved is True
+    assert result.policy_provenance_preserved is True
+    assert result.graph_provenance_preserved is True
+    assert result.governance_provenance_preserved is True
+    assert result.compatibility_provenance_preserved is True
+    assert result.evaluation_provenance_preserved is True
+    assert result.session_provenance_preserved is True
+    assert result.scenario_provenance_preserved is True
+    assert result.aggregation_provenance_preserved is True
+    assert result.replay_provenance_preserved is True
+    assert result.rollback_provenance_preserved is True
+    assert result.deterministic_provenance_hash == hash_v3_7_graph_integrity_provenance_result(result)
+    assert serialize_v3_7_graph_integrity_provenance_result(result) == serialize_v3_7_graph_integrity_provenance_result(result)
+
+
+def test_integrity_provenance_detects_replay_provenance_gap():
+    enforcement = enforce_v3_7_graph_planning_integrity()
+    broken_replay = replace(enforcement.replay_evidence[0], provenance_references=())
+    result = audit_v3_7_graph_integrity_provenance(replace(enforcement, replay_evidence=(broken_replay,)))
+
+    assert result.provenance_status == V37_GRAPH_INTEGRITY_PROVENANCE_BLOCKED
+    assert result.replay_provenance_preserved is False

--- a/backend/tests/test_v3_7_graph_integrity_replay.py
+++ b/backend/tests/test_v3_7_graph_integrity_replay.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+from app.runtime_orchestration.v3_7_graph_integrity_enforcement import enforce_v3_7_graph_planning_integrity
+from app.runtime_orchestration.v3_7_graph_integrity_replay import (
+    build_v3_7_graph_integrity_replay_evidence,
+    export_v3_7_graph_integrity_replay_evidence_records,
+    validate_v3_7_graph_integrity_replay_evidence,
+)
+
+
+def test_integrity_replay_evidence_is_non_executable_and_stable():
+    enforcement = enforce_v3_7_graph_planning_integrity()
+    replay = build_v3_7_graph_integrity_replay_evidence(enforcement)
+    validation = validate_v3_7_graph_integrity_replay_evidence(enforcement)
+
+    assert len(replay) == 1
+    assert validation["replay_evidence_count"] == 1
+    assert validation["non_executable_replay_evidence"] is True
+    assert validation["runtime_replay"] is False
+    assert validation["execution_authorization"] is False
+    assert validation["replay_continuity_preserved"] is True
+    assert validation["rollback_continuity_preserved"] is True
+
+
+def test_integrity_replay_detects_runtime_replay_flag():
+    enforcement = enforce_v3_7_graph_planning_integrity()
+    broken_replay = replace(enforcement.replay_evidence[0], runtime_replay=True)
+    validation = validate_v3_7_graph_integrity_replay_evidence(replace(enforcement, replay_evidence=(broken_replay,)))
+
+    assert validation["runtime_replay"] is True
+    assert validation["non_executable_replay_evidence"] is True
+
+
+def test_integrity_replay_records_are_sorted():
+    enforcement = enforce_v3_7_graph_planning_integrity()
+    records = export_v3_7_graph_integrity_replay_evidence_records(enforcement.replay_evidence)
+
+    assert [record["replay_evidence_id"] for record in records] == sorted(record["replay_evidence_id"] for record in records)

--- a/backend/tests/test_v3_7_graph_integrity_validation.py
+++ b/backend/tests/test_v3_7_graph_integrity_validation.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+from app.runtime_orchestration.v3_7_graph_integrity_enforcement import enforce_v3_7_graph_planning_integrity
+from app.runtime_orchestration.v3_7_graph_integrity_models import (
+    V37_INTEGRITY_FINDING_HIDDEN_PROHIBITED_STATE,
+    V37_INTEGRITY_FINDING_HIDDEN_UNKNOWN_STATE,
+    V37_INTEGRITY_FINDING_HIDDEN_UNSUPPORTED_STATE,
+)
+from app.runtime_orchestration.v3_7_graph_integrity_validation import (
+    V37_GRAPH_INTEGRITY_VALIDATION_BLOCKED,
+    V37_GRAPH_INTEGRITY_VALIDATION_STABLE,
+    V37_INTEGRITY_VALIDATION_BLOCKED_BY_DUPLICATE_ENFORCEMENT,
+    V37_INTEGRITY_VALIDATION_BLOCKED_BY_EXECUTION_BOUNDARY,
+    V37_INTEGRITY_VALIDATION_BLOCKED_BY_HIDDEN_STATE,
+    V37_INTEGRITY_VALIDATION_BLOCKED_BY_INVALID_EVIDENCE_SOURCE,
+    validate_v3_7_graph_integrity,
+)
+
+
+def test_default_integrity_validation_is_stable_and_fail_visible():
+    result = validate_v3_7_graph_integrity()
+
+    assert result.validation_status == V37_GRAPH_INTEGRITY_VALIDATION_STABLE
+    assert result.valid is True
+    assert result.error_count == 0
+    assert result.visibility_finding_count >= 4
+    assert result.provenance_continuity_preserved is True
+    assert result.explainability_continuity_preserved is True
+    assert result.replay_continuity_preserved is True
+    assert result.rollback_continuity_preserved is True
+    assert result.integrity_enforcement_non_executable is True
+    assert result.valid_integrity_does_not_authorize_execution is True
+    assert result.execution_boundary_violations_blocked is True
+
+
+def test_validation_detects_duplicate_enforcement_identity():
+    enforcement = enforce_v3_7_graph_planning_integrity()
+    result = validate_v3_7_graph_integrity((enforcement, enforcement))
+
+    assert result.validation_status == V37_GRAPH_INTEGRITY_VALIDATION_BLOCKED
+    assert result.duplicate_enforcement_identity_count == 1
+    assert any(finding.status == V37_INTEGRITY_VALIDATION_BLOCKED_BY_DUPLICATE_ENFORCEMENT for finding in result.findings)
+
+
+def test_validation_detects_missing_scenario_source():
+    enforcement = enforce_v3_7_graph_planning_integrity()
+    filtered_types = tuple(source_type for source_type in enforcement.evidence_source_types if source_type != "scenario")
+    result = validate_v3_7_graph_integrity((replace(enforcement, evidence_source_types=filtered_types),))
+
+    assert result.validation_status == V37_GRAPH_INTEGRITY_VALIDATION_BLOCKED
+    assert any(finding.status == V37_INTEGRITY_VALIDATION_BLOCKED_BY_INVALID_EVIDENCE_SOURCE for finding in result.findings)
+
+
+def test_validation_detects_hidden_risk_states():
+    enforcement = enforce_v3_7_graph_planning_integrity()
+    hidden_findings = tuple(
+        replace(finding, hidden=True)
+        if finding.finding_classification
+        in (
+            V37_INTEGRITY_FINDING_HIDDEN_PROHIBITED_STATE,
+            V37_INTEGRITY_FINDING_HIDDEN_UNSUPPORTED_STATE,
+            V37_INTEGRITY_FINDING_HIDDEN_UNKNOWN_STATE,
+        )
+        else finding
+        for finding in enforcement.findings
+    )
+    result = validate_v3_7_graph_integrity((replace(enforcement, findings=hidden_findings),))
+
+    assert result.validation_status == V37_GRAPH_INTEGRITY_VALIDATION_BLOCKED
+    assert any(finding.status == V37_INTEGRITY_VALIDATION_BLOCKED_BY_HIDDEN_STATE for finding in result.findings)
+    assert result.hidden_prohibited_finding_count == 1
+    assert result.hidden_unsupported_finding_count == 1
+    assert result.hidden_unknown_finding_count == 1
+
+
+def test_validation_detects_execution_boundary_violation():
+    enforcement = enforce_v3_7_graph_planning_integrity()
+    result = validate_v3_7_graph_integrity((replace(enforcement, routing_enabled=True),))
+
+    assert result.validation_status == V37_GRAPH_INTEGRITY_VALIDATION_BLOCKED
+    assert result.execution_boundary_violation_count == 1
+    assert any(finding.status == V37_INTEGRITY_VALIDATION_BLOCKED_BY_EXECUTION_BOUNDARY for finding in result.findings)

--- a/docs/generated/v3_7_graph_planning_integrity_enforcement_report.json
+++ b/docs/generated/v3_7_graph_planning_integrity_enforcement_report.json
@@ -1,0 +1,1949 @@
+{
+  "architectural_purpose": "deterministic graph planning integrity enforcement",
+  "audit_result": {
+    "aggregation_continuity_preserved": true,
+    "audit_status": "v3_7_graph_integrity_audit_stable",
+    "compatibility_continuity_preserved": true,
+    "deterministic_audit_hash": "07873830883750c0dd5648ea754d426abcb8fdd680c1f38f3c94cbcf38d87d7c",
+    "deterministic_hash_stable": true,
+    "deterministic_serialization_stable": true,
+    "enforcement_identity_continuity_preserved": true,
+    "error_count": 0,
+    "evaluation_continuity_preserved": true,
+    "evidence_source_continuity_preserved": true,
+    "execution_boundary_continuity_preserved": true,
+    "explainability_continuity_preserved": true,
+    "fail_visible_finding_preservation": true,
+    "finding_count": 6,
+    "findings": [
+      {
+        "fail_visible": true,
+        "finding_id": "v3_7_graph_integrity_visible_blocked:integrity_finding:v3_7_graph_integrity_integrity_blocked",
+        "message": "integrity_blocked remains fail-visible",
+        "severity": "visibility",
+        "status": "v3_7_graph_integrity_visible_blocked",
+        "subject_id": "v3_7_graph_integrity_integrity_blocked",
+        "subject_type": "integrity_finding"
+      },
+      {
+        "fail_visible": true,
+        "finding_id": "v3_7_graph_integrity_visible_execution_boundary:integrity_finding:v3_7_graph_integrity_execution_boundary_violation",
+        "message": "execution_boundary_violation remains fail-visible",
+        "severity": "visibility",
+        "status": "v3_7_graph_integrity_visible_execution_boundary",
+        "subject_id": "v3_7_graph_integrity_execution_boundary_violation",
+        "subject_type": "integrity_finding"
+      },
+      {
+        "fail_visible": true,
+        "finding_id": "v3_7_graph_integrity_visible_hidden_prohibited:integrity_finding:v3_7_graph_integrity_hidden_prohibited_state",
+        "message": "hidden_prohibited_state remains fail-visible",
+        "severity": "visibility",
+        "status": "v3_7_graph_integrity_visible_hidden_prohibited",
+        "subject_id": "v3_7_graph_integrity_hidden_prohibited_state",
+        "subject_type": "integrity_finding"
+      },
+      {
+        "fail_visible": true,
+        "finding_id": "v3_7_graph_integrity_visible_hidden_unknown:integrity_finding:v3_7_graph_integrity_hidden_unknown_state",
+        "message": "hidden_unknown_state remains fail-visible",
+        "severity": "visibility",
+        "status": "v3_7_graph_integrity_visible_hidden_unknown",
+        "subject_id": "v3_7_graph_integrity_hidden_unknown_state",
+        "subject_type": "integrity_finding"
+      },
+      {
+        "fail_visible": true,
+        "finding_id": "v3_7_graph_integrity_visible_hidden_unsupported:integrity_finding:v3_7_graph_integrity_hidden_unsupported_state",
+        "message": "hidden_unsupported_state remains fail-visible",
+        "severity": "visibility",
+        "status": "v3_7_graph_integrity_visible_hidden_unsupported",
+        "subject_id": "v3_7_graph_integrity_hidden_unsupported_state",
+        "subject_type": "integrity_finding"
+      },
+      {
+        "fail_visible": true,
+        "finding_id": "v3_7_graph_integrity_visible_warning:integrity_finding:v3_7_graph_integrity_integrity_warning",
+        "message": "integrity_warning remains fail-visible",
+        "severity": "visibility",
+        "status": "v3_7_graph_integrity_visible_warning",
+        "subject_id": "v3_7_graph_integrity_integrity_warning",
+        "subject_type": "integrity_finding"
+      }
+    ],
+    "governance_continuity_preserved": true,
+    "graph_continuity_preserved": true,
+    "policy_identity_continuity_preserved": true,
+    "provenance_continuity_preserved": true,
+    "replay_continuity_preserved": true,
+    "rollback_continuity_preserved": true,
+    "scenario_continuity_preserved": true,
+    "session_continuity_preserved": true,
+    "valid": true,
+    "visibility_finding_count": 6
+  },
+  "autonomous_orchestration_enabled": false,
+  "blocked_finding_totals": {
+    "active_blocking_finding_count": 0,
+    "blocked_finding_count": 0
+  },
+  "blocked_integrity_does_not_perform_runtime_blocking": true,
+  "callable_orchestration_flows_enabled": false,
+  "coverage": {
+    "audit_coverage": true,
+    "execution_boundary_enforcement_confirmation": true,
+    "explainability_coverage": true,
+    "no_execution_authorization_confirmation": true,
+    "non_executable_confirmation": true,
+    "provenance_coverage": true,
+    "replay_continuity_coverage": true,
+    "rollback_continuity_coverage": true,
+    "validation_coverage": true
+  },
+  "deterministic_guarantees": {
+    "audit_hash": "07873830883750c0dd5648ea754d426abcb8fdd680c1f38f3c94cbcf38d87d7c",
+    "explainability_hash": "99de56359c83669667b972f2c509f9313dd54902ad11c14f3cff87e1916abe8e",
+    "hash_stable": true,
+    "integrity_hash": "39c2526ae964dce0717a80e432f8950e61d51d55b77feb8445ec0c43a9a2b8c7",
+    "policy_hash": "af59d7bc53374ce02ac76cc00ca6a18bf2643992337549d751ea2e42004edfb7",
+    "provenance_hash": "84de304ec2230b15c9caa7a73c985a17ce5b7cafbb0e4890b87c576bb677a270",
+    "serialization_stable": true,
+    "validation_hash": "66eb73dca76eca1872e6189542d52cd4487fe0db06432b4909966f553c446c53"
+  },
+  "deterministic_report_hash": "4296e694eb12245d900ec0cb9582b0ae64609cab14d0a1e4cfb2b6dbdb3cf4a0",
+  "dispatch_enabled": false,
+  "enforcement_outcomes_are_planning_validation_only": true,
+  "enforcement_result_counts": {
+    "enforcement_outcome": "valid",
+    "enforcement_result_count": 1,
+    "evidence_source_count": 7
+  },
+  "evidence_source_counts": {
+    "aggregation_source_count": 1,
+    "compatibility_source_count": 1,
+    "evaluation_source_count": 1,
+    "evidence_source_count": 7,
+    "governance_source_count": 1,
+    "graph_source_count": 1,
+    "scenario_source_count": 1,
+    "session_source_count": 1
+  },
+  "execution_boundary_violation_totals": {
+    "execution_boundary_continuity_preserved": true,
+    "execution_boundary_violation_count": 0,
+    "execution_boundary_violations_blocked": true
+  },
+  "execution_gates_enabled": false,
+  "explainability_continuity_totals": {
+    "blocked_explanation_count": 1,
+    "does_not_authorize_explanation_count": 1,
+    "enforcement_explanation_count": 1,
+    "evidence_source_explanation_count": 7,
+    "execution_boundary_explanation_count": 1,
+    "explainability_status": "v3_7_graph_integrity_explainability_stable",
+    "explanation_count": 28,
+    "finding_explanation_count": 13,
+    "policy_explanation_count": 1,
+    "warning_explanation_count": 1
+  },
+  "explainability_result": {
+    "blocked_explanation_count": 1,
+    "continuity_explanation_count": 1,
+    "deterministic_explainability_hash": "99de56359c83669667b972f2c509f9313dd54902ad11c14f3cff87e1916abe8e",
+    "does_not_authorize_explanation_count": 1,
+    "enforcement_explanation_count": 1,
+    "evidence_source_explanation_count": 7,
+    "execution_boundary_explanation_count": 1,
+    "explainability_status": "v3_7_graph_integrity_explainability_stable",
+    "explanation_count": 28,
+    "explanations": [
+      {
+        "deterministic_order": 1,
+        "evidence_references": [
+          "v3_7_graph_integrity_enforcement_default"
+        ],
+        "explanation_id": "v3_7_graph_integrity_explanation_001_enforcement",
+        "explanation_type": "enforcement",
+        "replay_safe": true,
+        "subject_id": "v3_7_graph_integrity_enforcement_default",
+        "summary": "integrity enforcement exists to validate cross-system planning evidence deterministically"
+      },
+      {
+        "deterministic_order": 2,
+        "evidence_references": [
+          "v3_7_graph_integrity_policy_default"
+        ],
+        "explanation_id": "v3_7_graph_integrity_explanation_002_policy",
+        "explanation_type": "policy",
+        "replay_safe": true,
+        "subject_id": "v3_7_graph_integrity_policy_default",
+        "summary": "the enforced policy requires evidence-source, continuity, provenance, explainability, and execution-boundary integrity"
+      },
+      {
+        "deterministic_order": 3,
+        "evidence_references": [
+          "v3_7_graph_planning_intelligence_aggregation_default"
+        ],
+        "explanation_id": "v3_7_graph_integrity_explanation_003_evidence_source",
+        "explanation_type": "evidence_source",
+        "replay_safe": true,
+        "subject_id": "v3_7_graph_planning_intelligence_aggregation_default",
+        "summary": "evidence source v3_7_graph_planning_intelligence_aggregation_default is included in integrity validation"
+      },
+      {
+        "deterministic_order": 4,
+        "evidence_references": [
+          "v3_7_intelligence_source_compatibility"
+        ],
+        "explanation_id": "v3_7_graph_integrity_explanation_004_evidence_source",
+        "explanation_type": "evidence_source",
+        "replay_safe": true,
+        "subject_id": "v3_7_intelligence_source_compatibility",
+        "summary": "evidence source v3_7_intelligence_source_compatibility is included in integrity validation"
+      },
+      {
+        "deterministic_order": 5,
+        "evidence_references": [
+          "v3_7_intelligence_source_evaluation"
+        ],
+        "explanation_id": "v3_7_graph_integrity_explanation_005_evidence_source",
+        "explanation_type": "evidence_source",
+        "replay_safe": true,
+        "subject_id": "v3_7_intelligence_source_evaluation",
+        "summary": "evidence source v3_7_intelligence_source_evaluation is included in integrity validation"
+      },
+      {
+        "deterministic_order": 6,
+        "evidence_references": [
+          "v3_7_intelligence_source_governance"
+        ],
+        "explanation_id": "v3_7_graph_integrity_explanation_006_evidence_source",
+        "explanation_type": "evidence_source",
+        "replay_safe": true,
+        "subject_id": "v3_7_intelligence_source_governance",
+        "summary": "evidence source v3_7_intelligence_source_governance is included in integrity validation"
+      },
+      {
+        "deterministic_order": 7,
+        "evidence_references": [
+          "v3_7_intelligence_source_graph_foundations"
+        ],
+        "explanation_id": "v3_7_graph_integrity_explanation_007_evidence_source",
+        "explanation_type": "evidence_source",
+        "replay_safe": true,
+        "subject_id": "v3_7_intelligence_source_graph_foundations",
+        "summary": "evidence source v3_7_intelligence_source_graph_foundations is included in integrity validation"
+      },
+      {
+        "deterministic_order": 8,
+        "evidence_references": [
+          "v3_7_intelligence_source_scenario"
+        ],
+        "explanation_id": "v3_7_graph_integrity_explanation_008_evidence_source",
+        "explanation_type": "evidence_source",
+        "replay_safe": true,
+        "subject_id": "v3_7_intelligence_source_scenario",
+        "summary": "evidence source v3_7_intelligence_source_scenario is included in integrity validation"
+      },
+      {
+        "deterministic_order": 9,
+        "evidence_references": [
+          "v3_7_intelligence_source_session"
+        ],
+        "explanation_id": "v3_7_graph_integrity_explanation_009_evidence_source",
+        "explanation_type": "evidence_source",
+        "replay_safe": true,
+        "subject_id": "v3_7_intelligence_source_session",
+        "summary": "evidence source v3_7_intelligence_source_session is included in integrity validation"
+      },
+      {
+        "deterministic_order": 10,
+        "evidence_references": [
+          "v3_7_graph_planning_intelligence_aggregation_default",
+          "v3_7_intelligence_source_compatibility",
+          "v3_7_intelligence_source_evaluation",
+          "v3_7_intelligence_source_governance",
+          "v3_7_intelligence_source_graph_foundations",
+          "v3_7_intelligence_source_scenario",
+          "v3_7_intelligence_source_session"
+        ],
+        "explanation_id": "v3_7_graph_integrity_explanation_010_finding",
+        "explanation_type": "finding",
+        "replay_safe": true,
+        "subject_id": "v3_7_graph_integrity_continuity_violation",
+        "summary": "continuity_violation remains fail-visible; active_violation=False"
+      },
+      {
+        "deterministic_order": 11,
+        "evidence_references": [
+          "v3_7_graph_planning_intelligence_aggregation_default",
+          "v3_7_intelligence_source_compatibility",
+          "v3_7_intelligence_source_evaluation",
+          "v3_7_intelligence_source_governance",
+          "v3_7_intelligence_source_graph_foundations",
+          "v3_7_intelligence_source_scenario",
+          "v3_7_intelligence_source_session"
+        ],
+        "explanation_id": "v3_7_graph_integrity_explanation_011_finding",
+        "explanation_type": "finding",
+        "replay_safe": true,
+        "subject_id": "v3_7_graph_integrity_execution_boundary_violation",
+        "summary": "execution_boundary_violation remains fail-visible; active_violation=False"
+      },
+      {
+        "deterministic_order": 12,
+        "evidence_references": [
+          "v3_7_graph_planning_intelligence_aggregation_default",
+          "v3_7_intelligence_source_compatibility",
+          "v3_7_intelligence_source_evaluation",
+          "v3_7_intelligence_source_governance",
+          "v3_7_intelligence_source_graph_foundations",
+          "v3_7_intelligence_source_scenario",
+          "v3_7_intelligence_source_session"
+        ],
+        "explanation_id": "v3_7_graph_integrity_explanation_012_finding",
+        "explanation_type": "finding",
+        "replay_safe": true,
+        "subject_id": "v3_7_graph_integrity_explainability_violation",
+        "summary": "explainability_violation remains fail-visible; active_violation=False"
+      },
+      {
+        "deterministic_order": 13,
+        "evidence_references": [
+          "v3_7_graph_planning_intelligence_aggregation_default",
+          "v3_7_intelligence_source_compatibility",
+          "v3_7_intelligence_source_evaluation",
+          "v3_7_intelligence_source_governance",
+          "v3_7_intelligence_source_graph_foundations",
+          "v3_7_intelligence_source_scenario",
+          "v3_7_intelligence_source_session"
+        ],
+        "explanation_id": "v3_7_graph_integrity_explanation_013_finding",
+        "explanation_type": "finding",
+        "replay_safe": true,
+        "subject_id": "v3_7_graph_integrity_hidden_prohibited_state",
+        "summary": "hidden_prohibited_state remains fail-visible; active_violation=False"
+      },
+      {
+        "deterministic_order": 14,
+        "evidence_references": [
+          "v3_7_graph_planning_intelligence_aggregation_default",
+          "v3_7_intelligence_source_compatibility",
+          "v3_7_intelligence_source_evaluation",
+          "v3_7_intelligence_source_governance",
+          "v3_7_intelligence_source_graph_foundations",
+          "v3_7_intelligence_source_scenario",
+          "v3_7_intelligence_source_session"
+        ],
+        "explanation_id": "v3_7_graph_integrity_explanation_014_finding",
+        "explanation_type": "finding",
+        "replay_safe": true,
+        "subject_id": "v3_7_graph_integrity_hidden_unknown_state",
+        "summary": "hidden_unknown_state remains fail-visible; active_violation=False"
+      },
+      {
+        "deterministic_order": 15,
+        "evidence_references": [
+          "v3_7_graph_planning_intelligence_aggregation_default",
+          "v3_7_intelligence_source_compatibility",
+          "v3_7_intelligence_source_evaluation",
+          "v3_7_intelligence_source_governance",
+          "v3_7_intelligence_source_graph_foundations",
+          "v3_7_intelligence_source_scenario",
+          "v3_7_intelligence_source_session"
+        ],
+        "explanation_id": "v3_7_graph_integrity_explanation_015_finding",
+        "explanation_type": "finding",
+        "replay_safe": true,
+        "subject_id": "v3_7_graph_integrity_hidden_unsupported_state",
+        "summary": "hidden_unsupported_state remains fail-visible; active_violation=False"
+      },
+      {
+        "deterministic_order": 16,
+        "evidence_references": [
+          "v3_7_graph_planning_intelligence_aggregation_default",
+          "v3_7_intelligence_source_compatibility",
+          "v3_7_intelligence_source_evaluation",
+          "v3_7_intelligence_source_governance",
+          "v3_7_intelligence_source_graph_foundations",
+          "v3_7_intelligence_source_scenario",
+          "v3_7_intelligence_source_session"
+        ],
+        "explanation_id": "v3_7_graph_integrity_explanation_016_finding",
+        "explanation_type": "finding",
+        "replay_safe": true,
+        "subject_id": "v3_7_graph_integrity_integrity_blocked",
+        "summary": "integrity_blocked remains fail-visible; active_violation=False"
+      },
+      {
+        "deterministic_order": 17,
+        "evidence_references": [
+          "v3_7_graph_planning_intelligence_aggregation_default",
+          "v3_7_intelligence_source_compatibility",
+          "v3_7_intelligence_source_evaluation",
+          "v3_7_intelligence_source_governance",
+          "v3_7_intelligence_source_graph_foundations",
+          "v3_7_intelligence_source_scenario",
+          "v3_7_intelligence_source_session"
+        ],
+        "explanation_id": "v3_7_graph_integrity_explanation_017_finding",
+        "explanation_type": "finding",
+        "replay_safe": true,
+        "subject_id": "v3_7_graph_integrity_integrity_invalid",
+        "summary": "integrity_invalid remains fail-visible; active_violation=False"
+      },
+      {
+        "deterministic_order": 18,
+        "evidence_references": [
+          "v3_7_graph_planning_intelligence_aggregation_default",
+          "v3_7_intelligence_source_compatibility",
+          "v3_7_intelligence_source_evaluation",
+          "v3_7_intelligence_source_governance",
+          "v3_7_intelligence_source_graph_foundations",
+          "v3_7_intelligence_source_scenario",
+          "v3_7_intelligence_source_session"
+        ],
+        "explanation_id": "v3_7_graph_integrity_explanation_018_finding",
+        "explanation_type": "finding",
+        "replay_safe": true,
+        "subject_id": "v3_7_graph_integrity_integrity_valid",
+        "summary": "integrity_valid remains fail-visible; active_violation=False"
+      },
+      {
+        "deterministic_order": 19,
+        "evidence_references": [
+          "v3_7_graph_planning_intelligence_aggregation_default",
+          "v3_7_intelligence_source_compatibility",
+          "v3_7_intelligence_source_evaluation",
+          "v3_7_intelligence_source_governance",
+          "v3_7_intelligence_source_graph_foundations",
+          "v3_7_intelligence_source_scenario",
+          "v3_7_intelligence_source_session"
+        ],
+        "explanation_id": "v3_7_graph_integrity_explanation_019_finding",
+        "explanation_type": "finding",
+        "replay_safe": true,
+        "subject_id": "v3_7_graph_integrity_integrity_warning",
+        "summary": "integrity_warning remains fail-visible; active_violation=False"
+      },
+      {
+        "deterministic_order": 20,
+        "evidence_references": [
+          "v3_7_graph_planning_intelligence_aggregation_default",
+          "v3_7_intelligence_source_compatibility",
+          "v3_7_intelligence_source_evaluation",
+          "v3_7_intelligence_source_governance",
+          "v3_7_intelligence_source_graph_foundations",
+          "v3_7_intelligence_source_scenario",
+          "v3_7_intelligence_source_session"
+        ],
+        "explanation_id": "v3_7_graph_integrity_explanation_020_finding",
+        "explanation_type": "finding",
+        "replay_safe": true,
+        "subject_id": "v3_7_graph_integrity_provenance_violation",
+        "summary": "provenance_violation remains fail-visible; active_violation=False"
+      },
+      {
+        "deterministic_order": 21,
+        "evidence_references": [
+          "v3_7_graph_planning_intelligence_aggregation_default",
+          "v3_7_intelligence_source_compatibility",
+          "v3_7_intelligence_source_evaluation",
+          "v3_7_intelligence_source_governance",
+          "v3_7_intelligence_source_graph_foundations",
+          "v3_7_intelligence_source_scenario",
+          "v3_7_intelligence_source_session"
+        ],
+        "explanation_id": "v3_7_graph_integrity_explanation_021_finding",
+        "explanation_type": "finding",
+        "replay_safe": true,
+        "subject_id": "v3_7_graph_integrity_replay_violation",
+        "summary": "replay_violation remains fail-visible; active_violation=False"
+      },
+      {
+        "deterministic_order": 22,
+        "evidence_references": [
+          "v3_7_graph_planning_intelligence_aggregation_default",
+          "v3_7_intelligence_source_compatibility",
+          "v3_7_intelligence_source_evaluation",
+          "v3_7_intelligence_source_governance",
+          "v3_7_intelligence_source_graph_foundations",
+          "v3_7_intelligence_source_scenario",
+          "v3_7_intelligence_source_session"
+        ],
+        "explanation_id": "v3_7_graph_integrity_explanation_022_finding",
+        "explanation_type": "finding",
+        "replay_safe": true,
+        "subject_id": "v3_7_graph_integrity_rollback_violation",
+        "summary": "rollback_violation remains fail-visible; active_violation=False"
+      },
+      {
+        "deterministic_order": 23,
+        "evidence_references": [
+          "v3_7_graph_integrity_integrity_warning"
+        ],
+        "explanation_id": "v3_7_graph_integrity_explanation_023_warning",
+        "explanation_type": "warning",
+        "replay_safe": true,
+        "subject_id": "v3_7_graph_integrity_enforcement_default",
+        "summary": "warning findings are visible planning validation evidence"
+      },
+      {
+        "deterministic_order": 24,
+        "evidence_references": [
+          "v3_7_graph_integrity_enforcement_default"
+        ],
+        "explanation_id": "v3_7_graph_integrity_explanation_024_blocked",
+        "explanation_type": "blocked",
+        "replay_safe": true,
+        "subject_id": "v3_7_graph_integrity_enforcement_default",
+        "summary": "blocked findings remain visible and would block integrity validation when active"
+      },
+      {
+        "deterministic_order": 25,
+        "evidence_references": [
+          "0797f2bdb22dacba6ea88c4d046550c2058a94a46466706cdc063edf42d9693c",
+          "0b8fd6de75b5d58790cefb054b18ae762089028b906a932800c6b00ce7e1b95e",
+          "30197b5afd37fa5e21de13c74a595db9125ea49ed2b1e0fa769c4f81dbfb8588",
+          "3d8f67e8de504c767ff3a6923b696b0c0b41c6a35e79c7967ddf888301ad8412",
+          "40346f9d255caa644b54ccf0e40e3d9313087a10b6b45784d6763eae475023df",
+          "4d75f9021078558dec7aec4e73a6b0d46e9924ddc12d5ed59f098b36c3a338eb",
+          "8c54298870f510627f69e00582e96f47c65f2a04f4da0b6ee08c2b663ef573cf",
+          "a154f02972eb862f83266f9cee67a635e423d78f79086e0e2898fced21dbf32b",
+          "a200adcd417767f0a00b6fa7549afd8fda94a2f272b13ac1dcadb36f7a2defe0",
+          "c486ab009cd251714d50b8dd737f4cbfa477276c2b487bffac40874073f40ac2",
+          "e6a6b5bb4221d1933f57e98cf9aebb06b3b57954d41c2e53a6a086cad2dd5570"
+        ],
+        "explanation_id": "v3_7_graph_integrity_explanation_025_continuity",
+        "explanation_type": "continuity",
+        "replay_safe": true,
+        "subject_id": "v3_7_graph_integrity_enforcement_default",
+        "summary": "continuity hashes preserve deterministic graph, governance, compatibility, evaluation, session, scenario, and aggregation evidence"
+      },
+      {
+        "deterministic_order": 26,
+        "evidence_references": [
+          "v3-7-provenance-v3_7_graph_integrity_enforcement_default",
+          "v3-7-provenance-v3_7_graph_integrity_policy_default"
+        ],
+        "explanation_id": "v3_7_graph_integrity_explanation_026_provenance",
+        "explanation_type": "provenance",
+        "replay_safe": true,
+        "subject_id": "v3_7_graph_integrity_enforcement_default",
+        "summary": "provenance references preserve replay-safe and rollback-safe integrity lineage"
+      },
+      {
+        "deterministic_order": 27,
+        "evidence_references": [
+          "v3_7_graph_planning_intelligence_aggregation_default",
+          "v3_7_intelligence_source_compatibility",
+          "v3_7_intelligence_source_evaluation",
+          "v3_7_intelligence_source_governance",
+          "v3_7_intelligence_source_graph_foundations",
+          "v3_7_intelligence_source_scenario",
+          "v3_7_intelligence_source_session"
+        ],
+        "explanation_id": "v3_7_graph_integrity_explanation_027_execution_boundary",
+        "explanation_type": "execution_boundary",
+        "replay_safe": true,
+        "subject_id": "v3_7_graph_integrity_enforcement_default",
+        "summary": "execution-boundary integrity is preserved when no execution, routing, scheduling, dispatch, traversal, path selection, scenario selection, optimization, or recommendation authorization is present"
+      },
+      {
+        "deterministic_order": 28,
+        "evidence_references": [
+          "v3_7_graph_integrity_enforcement_default"
+        ],
+        "explanation_id": "v3_7_graph_integrity_explanation_028_does_not_authorize",
+        "explanation_type": "does_not_authorize",
+        "replay_safe": true,
+        "subject_id": "v3_7_graph_integrity_enforcement_default",
+        "summary": "valid integrity remains planning validation only and does not authorize runtime orchestration"
+      }
+    ],
+    "finding_explanation_count": 13,
+    "policy_explanation_count": 1,
+    "provenance_explanation_count": 1,
+    "warning_explanation_count": 1
+  },
+  "explicit_limitations": [
+    "integrity enforcement is non-executable",
+    "integrity enforcement validates planning evidence only",
+    "valid integrity does not authorize execution",
+    "blocked integrity does not perform runtime blocking",
+    "enforcement outcomes are planning validation outcomes only",
+    "integrity enforcement does not route, schedule, dispatch, traverse, optimize, recommend, or execute"
+  ],
+  "finding_records": [
+    {
+      "active_violation": false,
+      "blocks_validation": false,
+      "dispatch_authorization": false,
+      "evidence_references": [
+        "v3_7_graph_planning_intelligence_aggregation_default",
+        "v3_7_intelligence_source_compatibility",
+        "v3_7_intelligence_source_evaluation",
+        "v3_7_intelligence_source_governance",
+        "v3_7_intelligence_source_graph_foundations",
+        "v3_7_intelligence_source_scenario",
+        "v3_7_intelligence_source_session"
+      ],
+      "execution_authorization": false,
+      "fail_visible": true,
+      "finding_classification": "continuity_violation",
+      "finding_id": "v3_7_graph_integrity_continuity_violation",
+      "hidden": false,
+      "routing_authorization": false,
+      "scheduling_authorization": false,
+      "severity": "blocked",
+      "subject_id": "continuity:0",
+      "subject_type": "continuity",
+      "summary": "continuity violations are blocked when active",
+      "traversal_authorization": false
+    },
+    {
+      "active_violation": false,
+      "blocks_validation": false,
+      "dispatch_authorization": false,
+      "evidence_references": [
+        "v3_7_graph_planning_intelligence_aggregation_default",
+        "v3_7_intelligence_source_compatibility",
+        "v3_7_intelligence_source_evaluation",
+        "v3_7_intelligence_source_governance",
+        "v3_7_intelligence_source_graph_foundations",
+        "v3_7_intelligence_source_scenario",
+        "v3_7_intelligence_source_session"
+      ],
+      "execution_authorization": false,
+      "fail_visible": true,
+      "finding_classification": "execution_boundary_violation",
+      "finding_id": "v3_7_graph_integrity_execution_boundary_violation",
+      "hidden": false,
+      "routing_authorization": false,
+      "scheduling_authorization": false,
+      "severity": "blocked",
+      "subject_id": "execution_boundary:0",
+      "subject_type": "execution_boundary",
+      "summary": "execution-boundary violations are blocked when active",
+      "traversal_authorization": false
+    },
+    {
+      "active_violation": false,
+      "blocks_validation": false,
+      "dispatch_authorization": false,
+      "evidence_references": [
+        "v3_7_graph_planning_intelligence_aggregation_default",
+        "v3_7_intelligence_source_compatibility",
+        "v3_7_intelligence_source_evaluation",
+        "v3_7_intelligence_source_governance",
+        "v3_7_intelligence_source_graph_foundations",
+        "v3_7_intelligence_source_scenario",
+        "v3_7_intelligence_source_session"
+      ],
+      "execution_authorization": false,
+      "fail_visible": true,
+      "finding_classification": "explainability_violation",
+      "finding_id": "v3_7_graph_integrity_explainability_violation",
+      "hidden": false,
+      "routing_authorization": false,
+      "scheduling_authorization": false,
+      "severity": "blocked",
+      "subject_id": "explainability:0",
+      "subject_type": "explainability",
+      "summary": "explainability violations are blocked when active",
+      "traversal_authorization": false
+    },
+    {
+      "active_violation": false,
+      "blocks_validation": false,
+      "dispatch_authorization": false,
+      "evidence_references": [
+        "v3_7_graph_planning_intelligence_aggregation_default",
+        "v3_7_intelligence_source_compatibility",
+        "v3_7_intelligence_source_evaluation",
+        "v3_7_intelligence_source_governance",
+        "v3_7_intelligence_source_graph_foundations",
+        "v3_7_intelligence_source_scenario",
+        "v3_7_intelligence_source_session"
+      ],
+      "execution_authorization": false,
+      "fail_visible": true,
+      "finding_classification": "hidden_prohibited_state",
+      "finding_id": "v3_7_graph_integrity_hidden_prohibited_state",
+      "hidden": false,
+      "routing_authorization": false,
+      "scheduling_authorization": false,
+      "severity": "blocked",
+      "subject_id": "prohibited:0",
+      "subject_type": "finding_visibility",
+      "summary": "hidden prohibited states are blocked when active",
+      "traversal_authorization": false
+    },
+    {
+      "active_violation": false,
+      "blocks_validation": false,
+      "dispatch_authorization": false,
+      "evidence_references": [
+        "v3_7_graph_planning_intelligence_aggregation_default",
+        "v3_7_intelligence_source_compatibility",
+        "v3_7_intelligence_source_evaluation",
+        "v3_7_intelligence_source_governance",
+        "v3_7_intelligence_source_graph_foundations",
+        "v3_7_intelligence_source_scenario",
+        "v3_7_intelligence_source_session"
+      ],
+      "execution_authorization": false,
+      "fail_visible": true,
+      "finding_classification": "hidden_unknown_state",
+      "finding_id": "v3_7_graph_integrity_hidden_unknown_state",
+      "hidden": false,
+      "routing_authorization": false,
+      "scheduling_authorization": false,
+      "severity": "blocked",
+      "subject_id": "unknown:0",
+      "subject_type": "finding_visibility",
+      "summary": "hidden unknown states are blocked when active",
+      "traversal_authorization": false
+    },
+    {
+      "active_violation": false,
+      "blocks_validation": false,
+      "dispatch_authorization": false,
+      "evidence_references": [
+        "v3_7_graph_planning_intelligence_aggregation_default",
+        "v3_7_intelligence_source_compatibility",
+        "v3_7_intelligence_source_evaluation",
+        "v3_7_intelligence_source_governance",
+        "v3_7_intelligence_source_graph_foundations",
+        "v3_7_intelligence_source_scenario",
+        "v3_7_intelligence_source_session"
+      ],
+      "execution_authorization": false,
+      "fail_visible": true,
+      "finding_classification": "hidden_unsupported_state",
+      "finding_id": "v3_7_graph_integrity_hidden_unsupported_state",
+      "hidden": false,
+      "routing_authorization": false,
+      "scheduling_authorization": false,
+      "severity": "blocked",
+      "subject_id": "unsupported:0",
+      "subject_type": "finding_visibility",
+      "summary": "hidden unsupported states are blocked when active",
+      "traversal_authorization": false
+    },
+    {
+      "active_violation": false,
+      "blocks_validation": false,
+      "dispatch_authorization": false,
+      "evidence_references": [
+        "v3_7_graph_planning_intelligence_aggregation_default",
+        "v3_7_intelligence_source_compatibility",
+        "v3_7_intelligence_source_evaluation",
+        "v3_7_intelligence_source_governance",
+        "v3_7_intelligence_source_graph_foundations",
+        "v3_7_intelligence_source_scenario",
+        "v3_7_intelligence_source_session"
+      ],
+      "execution_authorization": false,
+      "fail_visible": true,
+      "finding_classification": "integrity_blocked",
+      "finding_id": "v3_7_graph_integrity_integrity_blocked",
+      "hidden": false,
+      "routing_authorization": false,
+      "scheduling_authorization": false,
+      "severity": "visibility",
+      "subject_id": "blocked:0",
+      "subject_type": "integrity",
+      "summary": "blocked planning evidence remains fail-visible",
+      "traversal_authorization": false
+    },
+    {
+      "active_violation": false,
+      "blocks_validation": false,
+      "dispatch_authorization": false,
+      "evidence_references": [
+        "v3_7_graph_planning_intelligence_aggregation_default",
+        "v3_7_intelligence_source_compatibility",
+        "v3_7_intelligence_source_evaluation",
+        "v3_7_intelligence_source_governance",
+        "v3_7_intelligence_source_graph_foundations",
+        "v3_7_intelligence_source_scenario",
+        "v3_7_intelligence_source_session"
+      ],
+      "execution_authorization": false,
+      "fail_visible": true,
+      "finding_classification": "integrity_invalid",
+      "finding_id": "v3_7_graph_integrity_integrity_invalid",
+      "hidden": false,
+      "routing_authorization": false,
+      "scheduling_authorization": false,
+      "severity": "visibility",
+      "subject_id": "invalid:0",
+      "subject_type": "integrity",
+      "summary": "invalid integrity states remain fail-visible",
+      "traversal_authorization": false
+    },
+    {
+      "active_violation": false,
+      "blocks_validation": false,
+      "dispatch_authorization": false,
+      "evidence_references": [
+        "v3_7_graph_planning_intelligence_aggregation_default",
+        "v3_7_intelligence_source_compatibility",
+        "v3_7_intelligence_source_evaluation",
+        "v3_7_intelligence_source_governance",
+        "v3_7_intelligence_source_graph_foundations",
+        "v3_7_intelligence_source_scenario",
+        "v3_7_intelligence_source_session"
+      ],
+      "execution_authorization": false,
+      "fail_visible": true,
+      "finding_classification": "integrity_valid",
+      "finding_id": "v3_7_graph_integrity_integrity_valid",
+      "hidden": false,
+      "routing_authorization": false,
+      "scheduling_authorization": false,
+      "severity": "info",
+      "subject_id": "valid:0",
+      "subject_type": "integrity",
+      "summary": "integrity policy evaluation completed as deterministic planning validation",
+      "traversal_authorization": false
+    },
+    {
+      "active_violation": false,
+      "blocks_validation": false,
+      "dispatch_authorization": false,
+      "evidence_references": [
+        "v3_7_graph_planning_intelligence_aggregation_default",
+        "v3_7_intelligence_source_compatibility",
+        "v3_7_intelligence_source_evaluation",
+        "v3_7_intelligence_source_governance",
+        "v3_7_intelligence_source_graph_foundations",
+        "v3_7_intelligence_source_scenario",
+        "v3_7_intelligence_source_session"
+      ],
+      "execution_authorization": false,
+      "fail_visible": true,
+      "finding_classification": "integrity_warning",
+      "finding_id": "v3_7_graph_integrity_integrity_warning",
+      "hidden": false,
+      "routing_authorization": false,
+      "scheduling_authorization": false,
+      "severity": "warning",
+      "subject_id": "warning:0",
+      "subject_type": "integrity",
+      "summary": "warning planning evidence remains fail-visible",
+      "traversal_authorization": false
+    },
+    {
+      "active_violation": false,
+      "blocks_validation": false,
+      "dispatch_authorization": false,
+      "evidence_references": [
+        "v3_7_graph_planning_intelligence_aggregation_default",
+        "v3_7_intelligence_source_compatibility",
+        "v3_7_intelligence_source_evaluation",
+        "v3_7_intelligence_source_governance",
+        "v3_7_intelligence_source_graph_foundations",
+        "v3_7_intelligence_source_scenario",
+        "v3_7_intelligence_source_session"
+      ],
+      "execution_authorization": false,
+      "fail_visible": true,
+      "finding_classification": "provenance_violation",
+      "finding_id": "v3_7_graph_integrity_provenance_violation",
+      "hidden": false,
+      "routing_authorization": false,
+      "scheduling_authorization": false,
+      "severity": "blocked",
+      "subject_id": "provenance:0",
+      "subject_type": "provenance",
+      "summary": "provenance violations are blocked when active",
+      "traversal_authorization": false
+    },
+    {
+      "active_violation": false,
+      "blocks_validation": false,
+      "dispatch_authorization": false,
+      "evidence_references": [
+        "v3_7_graph_planning_intelligence_aggregation_default",
+        "v3_7_intelligence_source_compatibility",
+        "v3_7_intelligence_source_evaluation",
+        "v3_7_intelligence_source_governance",
+        "v3_7_intelligence_source_graph_foundations",
+        "v3_7_intelligence_source_scenario",
+        "v3_7_intelligence_source_session"
+      ],
+      "execution_authorization": false,
+      "fail_visible": true,
+      "finding_classification": "replay_violation",
+      "finding_id": "v3_7_graph_integrity_replay_violation",
+      "hidden": false,
+      "routing_authorization": false,
+      "scheduling_authorization": false,
+      "severity": "blocked",
+      "subject_id": "replay:0",
+      "subject_type": "replay",
+      "summary": "replay violations are blocked when active",
+      "traversal_authorization": false
+    },
+    {
+      "active_violation": false,
+      "blocks_validation": false,
+      "dispatch_authorization": false,
+      "evidence_references": [
+        "v3_7_graph_planning_intelligence_aggregation_default",
+        "v3_7_intelligence_source_compatibility",
+        "v3_7_intelligence_source_evaluation",
+        "v3_7_intelligence_source_governance",
+        "v3_7_intelligence_source_graph_foundations",
+        "v3_7_intelligence_source_scenario",
+        "v3_7_intelligence_source_session"
+      ],
+      "execution_authorization": false,
+      "fail_visible": true,
+      "finding_classification": "rollback_violation",
+      "finding_id": "v3_7_graph_integrity_rollback_violation",
+      "hidden": false,
+      "routing_authorization": false,
+      "scheduling_authorization": false,
+      "severity": "blocked",
+      "subject_id": "rollback:0",
+      "subject_type": "rollback",
+      "summary": "rollback violations are blocked when active",
+      "traversal_authorization": false
+    }
+  ],
+  "generated_at": "2026-05-16T00:00:00+00:00",
+  "graph_execution_enabled": false,
+  "integrity_driven_execution_enabled": false,
+  "integrity_enforcement_does_not_route_schedule_dispatch_traverse_optimize_recommend_or_execute": true,
+  "integrity_enforcement_is_non_executable": true,
+  "integrity_enforcement_record": {
+    "autonomous_orchestration_enabled": false,
+    "blocked_integrity_does_not_perform_runtime_blocking": true,
+    "callable_orchestration_flows_enabled": false,
+    "continuity_hash_references": [
+      "0797f2bdb22dacba6ea88c4d046550c2058a94a46466706cdc063edf42d9693c",
+      "0b8fd6de75b5d58790cefb054b18ae762089028b906a932800c6b00ce7e1b95e",
+      "30197b5afd37fa5e21de13c74a595db9125ea49ed2b1e0fa769c4f81dbfb8588",
+      "3d8f67e8de504c767ff3a6923b696b0c0b41c6a35e79c7967ddf888301ad8412",
+      "40346f9d255caa644b54ccf0e40e3d9313087a10b6b45784d6763eae475023df",
+      "4d75f9021078558dec7aec4e73a6b0d46e9924ddc12d5ed59f098b36c3a338eb",
+      "8c54298870f510627f69e00582e96f47c65f2a04f4da0b6ee08c2b663ef573cf",
+      "a154f02972eb862f83266f9cee67a635e423d78f79086e0e2898fced21dbf32b",
+      "a200adcd417767f0a00b6fa7549afd8fda94a2f272b13ac1dcadb36f7a2defe0",
+      "c486ab009cd251714d50b8dd737f4cbfa477276c2b487bffac40874073f40ac2",
+      "e6a6b5bb4221d1933f57e98cf9aebb06b3b57954d41c2e53a6a086cad2dd5570"
+    ],
+    "dispatch_enabled": false,
+    "enforcement_outcome": "valid",
+    "enforcement_outcomes_are_planning_validation_only": true,
+    "evidence_source_references": [
+      "v3_7_graph_planning_intelligence_aggregation_default",
+      "v3_7_intelligence_source_compatibility",
+      "v3_7_intelligence_source_evaluation",
+      "v3_7_intelligence_source_governance",
+      "v3_7_intelligence_source_graph_foundations",
+      "v3_7_intelligence_source_scenario",
+      "v3_7_intelligence_source_session"
+    ],
+    "evidence_source_types": [
+      "aggregation",
+      "compatibility",
+      "evaluation",
+      "governance",
+      "graph_foundations",
+      "scenario",
+      "session"
+    ],
+    "execution_gates_enabled": false,
+    "explainability_reference_ids": [
+      "v3_7_graph_integrity_explainability"
+    ],
+    "findings": [
+      {
+        "active_violation": false,
+        "blocks_validation": false,
+        "dispatch_authorization": false,
+        "evidence_references": [
+          "v3_7_graph_planning_intelligence_aggregation_default",
+          "v3_7_intelligence_source_compatibility",
+          "v3_7_intelligence_source_evaluation",
+          "v3_7_intelligence_source_governance",
+          "v3_7_intelligence_source_graph_foundations",
+          "v3_7_intelligence_source_scenario",
+          "v3_7_intelligence_source_session"
+        ],
+        "execution_authorization": false,
+        "fail_visible": true,
+        "finding_classification": "continuity_violation",
+        "finding_id": "v3_7_graph_integrity_continuity_violation",
+        "hidden": false,
+        "routing_authorization": false,
+        "scheduling_authorization": false,
+        "severity": "blocked",
+        "subject_id": "continuity:0",
+        "subject_type": "continuity",
+        "summary": "continuity violations are blocked when active",
+        "traversal_authorization": false
+      },
+      {
+        "active_violation": false,
+        "blocks_validation": false,
+        "dispatch_authorization": false,
+        "evidence_references": [
+          "v3_7_graph_planning_intelligence_aggregation_default",
+          "v3_7_intelligence_source_compatibility",
+          "v3_7_intelligence_source_evaluation",
+          "v3_7_intelligence_source_governance",
+          "v3_7_intelligence_source_graph_foundations",
+          "v3_7_intelligence_source_scenario",
+          "v3_7_intelligence_source_session"
+        ],
+        "execution_authorization": false,
+        "fail_visible": true,
+        "finding_classification": "execution_boundary_violation",
+        "finding_id": "v3_7_graph_integrity_execution_boundary_violation",
+        "hidden": false,
+        "routing_authorization": false,
+        "scheduling_authorization": false,
+        "severity": "blocked",
+        "subject_id": "execution_boundary:0",
+        "subject_type": "execution_boundary",
+        "summary": "execution-boundary violations are blocked when active",
+        "traversal_authorization": false
+      },
+      {
+        "active_violation": false,
+        "blocks_validation": false,
+        "dispatch_authorization": false,
+        "evidence_references": [
+          "v3_7_graph_planning_intelligence_aggregation_default",
+          "v3_7_intelligence_source_compatibility",
+          "v3_7_intelligence_source_evaluation",
+          "v3_7_intelligence_source_governance",
+          "v3_7_intelligence_source_graph_foundations",
+          "v3_7_intelligence_source_scenario",
+          "v3_7_intelligence_source_session"
+        ],
+        "execution_authorization": false,
+        "fail_visible": true,
+        "finding_classification": "explainability_violation",
+        "finding_id": "v3_7_graph_integrity_explainability_violation",
+        "hidden": false,
+        "routing_authorization": false,
+        "scheduling_authorization": false,
+        "severity": "blocked",
+        "subject_id": "explainability:0",
+        "subject_type": "explainability",
+        "summary": "explainability violations are blocked when active",
+        "traversal_authorization": false
+      },
+      {
+        "active_violation": false,
+        "blocks_validation": false,
+        "dispatch_authorization": false,
+        "evidence_references": [
+          "v3_7_graph_planning_intelligence_aggregation_default",
+          "v3_7_intelligence_source_compatibility",
+          "v3_7_intelligence_source_evaluation",
+          "v3_7_intelligence_source_governance",
+          "v3_7_intelligence_source_graph_foundations",
+          "v3_7_intelligence_source_scenario",
+          "v3_7_intelligence_source_session"
+        ],
+        "execution_authorization": false,
+        "fail_visible": true,
+        "finding_classification": "hidden_prohibited_state",
+        "finding_id": "v3_7_graph_integrity_hidden_prohibited_state",
+        "hidden": false,
+        "routing_authorization": false,
+        "scheduling_authorization": false,
+        "severity": "blocked",
+        "subject_id": "prohibited:0",
+        "subject_type": "finding_visibility",
+        "summary": "hidden prohibited states are blocked when active",
+        "traversal_authorization": false
+      },
+      {
+        "active_violation": false,
+        "blocks_validation": false,
+        "dispatch_authorization": false,
+        "evidence_references": [
+          "v3_7_graph_planning_intelligence_aggregation_default",
+          "v3_7_intelligence_source_compatibility",
+          "v3_7_intelligence_source_evaluation",
+          "v3_7_intelligence_source_governance",
+          "v3_7_intelligence_source_graph_foundations",
+          "v3_7_intelligence_source_scenario",
+          "v3_7_intelligence_source_session"
+        ],
+        "execution_authorization": false,
+        "fail_visible": true,
+        "finding_classification": "hidden_unknown_state",
+        "finding_id": "v3_7_graph_integrity_hidden_unknown_state",
+        "hidden": false,
+        "routing_authorization": false,
+        "scheduling_authorization": false,
+        "severity": "blocked",
+        "subject_id": "unknown:0",
+        "subject_type": "finding_visibility",
+        "summary": "hidden unknown states are blocked when active",
+        "traversal_authorization": false
+      },
+      {
+        "active_violation": false,
+        "blocks_validation": false,
+        "dispatch_authorization": false,
+        "evidence_references": [
+          "v3_7_graph_planning_intelligence_aggregation_default",
+          "v3_7_intelligence_source_compatibility",
+          "v3_7_intelligence_source_evaluation",
+          "v3_7_intelligence_source_governance",
+          "v3_7_intelligence_source_graph_foundations",
+          "v3_7_intelligence_source_scenario",
+          "v3_7_intelligence_source_session"
+        ],
+        "execution_authorization": false,
+        "fail_visible": true,
+        "finding_classification": "hidden_unsupported_state",
+        "finding_id": "v3_7_graph_integrity_hidden_unsupported_state",
+        "hidden": false,
+        "routing_authorization": false,
+        "scheduling_authorization": false,
+        "severity": "blocked",
+        "subject_id": "unsupported:0",
+        "subject_type": "finding_visibility",
+        "summary": "hidden unsupported states are blocked when active",
+        "traversal_authorization": false
+      },
+      {
+        "active_violation": false,
+        "blocks_validation": false,
+        "dispatch_authorization": false,
+        "evidence_references": [
+          "v3_7_graph_planning_intelligence_aggregation_default",
+          "v3_7_intelligence_source_compatibility",
+          "v3_7_intelligence_source_evaluation",
+          "v3_7_intelligence_source_governance",
+          "v3_7_intelligence_source_graph_foundations",
+          "v3_7_intelligence_source_scenario",
+          "v3_7_intelligence_source_session"
+        ],
+        "execution_authorization": false,
+        "fail_visible": true,
+        "finding_classification": "integrity_blocked",
+        "finding_id": "v3_7_graph_integrity_integrity_blocked",
+        "hidden": false,
+        "routing_authorization": false,
+        "scheduling_authorization": false,
+        "severity": "visibility",
+        "subject_id": "blocked:0",
+        "subject_type": "integrity",
+        "summary": "blocked planning evidence remains fail-visible",
+        "traversal_authorization": false
+      },
+      {
+        "active_violation": false,
+        "blocks_validation": false,
+        "dispatch_authorization": false,
+        "evidence_references": [
+          "v3_7_graph_planning_intelligence_aggregation_default",
+          "v3_7_intelligence_source_compatibility",
+          "v3_7_intelligence_source_evaluation",
+          "v3_7_intelligence_source_governance",
+          "v3_7_intelligence_source_graph_foundations",
+          "v3_7_intelligence_source_scenario",
+          "v3_7_intelligence_source_session"
+        ],
+        "execution_authorization": false,
+        "fail_visible": true,
+        "finding_classification": "integrity_invalid",
+        "finding_id": "v3_7_graph_integrity_integrity_invalid",
+        "hidden": false,
+        "routing_authorization": false,
+        "scheduling_authorization": false,
+        "severity": "visibility",
+        "subject_id": "invalid:0",
+        "subject_type": "integrity",
+        "summary": "invalid integrity states remain fail-visible",
+        "traversal_authorization": false
+      },
+      {
+        "active_violation": false,
+        "blocks_validation": false,
+        "dispatch_authorization": false,
+        "evidence_references": [
+          "v3_7_graph_planning_intelligence_aggregation_default",
+          "v3_7_intelligence_source_compatibility",
+          "v3_7_intelligence_source_evaluation",
+          "v3_7_intelligence_source_governance",
+          "v3_7_intelligence_source_graph_foundations",
+          "v3_7_intelligence_source_scenario",
+          "v3_7_intelligence_source_session"
+        ],
+        "execution_authorization": false,
+        "fail_visible": true,
+        "finding_classification": "integrity_valid",
+        "finding_id": "v3_7_graph_integrity_integrity_valid",
+        "hidden": false,
+        "routing_authorization": false,
+        "scheduling_authorization": false,
+        "severity": "info",
+        "subject_id": "valid:0",
+        "subject_type": "integrity",
+        "summary": "integrity policy evaluation completed as deterministic planning validation",
+        "traversal_authorization": false
+      },
+      {
+        "active_violation": false,
+        "blocks_validation": false,
+        "dispatch_authorization": false,
+        "evidence_references": [
+          "v3_7_graph_planning_intelligence_aggregation_default",
+          "v3_7_intelligence_source_compatibility",
+          "v3_7_intelligence_source_evaluation",
+          "v3_7_intelligence_source_governance",
+          "v3_7_intelligence_source_graph_foundations",
+          "v3_7_intelligence_source_scenario",
+          "v3_7_intelligence_source_session"
+        ],
+        "execution_authorization": false,
+        "fail_visible": true,
+        "finding_classification": "integrity_warning",
+        "finding_id": "v3_7_graph_integrity_integrity_warning",
+        "hidden": false,
+        "routing_authorization": false,
+        "scheduling_authorization": false,
+        "severity": "warning",
+        "subject_id": "warning:0",
+        "subject_type": "integrity",
+        "summary": "warning planning evidence remains fail-visible",
+        "traversal_authorization": false
+      },
+      {
+        "active_violation": false,
+        "blocks_validation": false,
+        "dispatch_authorization": false,
+        "evidence_references": [
+          "v3_7_graph_planning_intelligence_aggregation_default",
+          "v3_7_intelligence_source_compatibility",
+          "v3_7_intelligence_source_evaluation",
+          "v3_7_intelligence_source_governance",
+          "v3_7_intelligence_source_graph_foundations",
+          "v3_7_intelligence_source_scenario",
+          "v3_7_intelligence_source_session"
+        ],
+        "execution_authorization": false,
+        "fail_visible": true,
+        "finding_classification": "provenance_violation",
+        "finding_id": "v3_7_graph_integrity_provenance_violation",
+        "hidden": false,
+        "routing_authorization": false,
+        "scheduling_authorization": false,
+        "severity": "blocked",
+        "subject_id": "provenance:0",
+        "subject_type": "provenance",
+        "summary": "provenance violations are blocked when active",
+        "traversal_authorization": false
+      },
+      {
+        "active_violation": false,
+        "blocks_validation": false,
+        "dispatch_authorization": false,
+        "evidence_references": [
+          "v3_7_graph_planning_intelligence_aggregation_default",
+          "v3_7_intelligence_source_compatibility",
+          "v3_7_intelligence_source_evaluation",
+          "v3_7_intelligence_source_governance",
+          "v3_7_intelligence_source_graph_foundations",
+          "v3_7_intelligence_source_scenario",
+          "v3_7_intelligence_source_session"
+        ],
+        "execution_authorization": false,
+        "fail_visible": true,
+        "finding_classification": "replay_violation",
+        "finding_id": "v3_7_graph_integrity_replay_violation",
+        "hidden": false,
+        "routing_authorization": false,
+        "scheduling_authorization": false,
+        "severity": "blocked",
+        "subject_id": "replay:0",
+        "subject_type": "replay",
+        "summary": "replay violations are blocked when active",
+        "traversal_authorization": false
+      },
+      {
+        "active_violation": false,
+        "blocks_validation": false,
+        "dispatch_authorization": false,
+        "evidence_references": [
+          "v3_7_graph_planning_intelligence_aggregation_default",
+          "v3_7_intelligence_source_compatibility",
+          "v3_7_intelligence_source_evaluation",
+          "v3_7_intelligence_source_governance",
+          "v3_7_intelligence_source_graph_foundations",
+          "v3_7_intelligence_source_scenario",
+          "v3_7_intelligence_source_session"
+        ],
+        "execution_authorization": false,
+        "fail_visible": true,
+        "finding_classification": "rollback_violation",
+        "finding_id": "v3_7_graph_integrity_rollback_violation",
+        "hidden": false,
+        "routing_authorization": false,
+        "scheduling_authorization": false,
+        "severity": "blocked",
+        "subject_id": "rollback:0",
+        "subject_type": "rollback",
+        "summary": "rollback violations are blocked when active",
+        "traversal_authorization": false
+      }
+    ],
+    "graph_execution_enabled": false,
+    "identity": {
+      "aggregation_id": "v3_7_graph_planning_intelligence_aggregation_default",
+      "enforcement_id": "v3_7_graph_integrity_enforcement_default",
+      "enforcement_version": "v3.7",
+      "phase_id": "v3_7_graph_planning_integrity_enforcement",
+      "policy_id": "v3_7_graph_integrity_policy_default",
+      "stable_identity_key": "15fba1533df5c4396c0af65ad60e98c10acb4e4f4962ead955200645c7e50312"
+    },
+    "integrity_driven_execution_enabled": false,
+    "integrity_enforcement_does_not_route_schedule_dispatch_traverse_optimize_recommend_or_execute": true,
+    "integrity_enforcement_is_non_executable": true,
+    "integrity_enforcement_validates_planning_evidence_only": true,
+    "metadata": [
+      {
+        "metadata_key": "enforcement_semantics",
+        "metadata_value": "deterministic_planning_integrity_validation"
+      },
+      {
+        "metadata_key": "execution_boundary",
+        "metadata_value": "valid_integrity_does_not_authorize_execution"
+      },
+      {
+        "metadata_key": "runtime_capability",
+        "metadata_value": "none"
+      }
+    ],
+    "optimization_engine_enabled": false,
+    "orchestration_authorization_enabled": false,
+    "path_selection_enabled": false,
+    "persistent_runtime_writes_enabled": false,
+    "policy": {
+      "dispatch_authorization_enabled": false,
+      "enforcement_outcomes_are_planning_validation_only": true,
+      "execution_authorization_enabled": false,
+      "execution_boundary_requirements": [
+        "callable_execution_flow_reference",
+        "dispatch_authorization",
+        "execution_authorization",
+        "optimization_for_execution",
+        "recommendation_to_execute",
+        "routing_authorization",
+        "runtime_path_selection",
+        "scenario_execution_selection",
+        "scheduling_authorization",
+        "traversal_authorization"
+      ],
+      "execution_boundary_violations_blocked": true,
+      "identity": {
+        "phase_id": "v3_7_graph_planning_integrity_enforcement",
+        "policy_id": "v3_7_graph_integrity_policy_default",
+        "policy_version": "v3.7",
+        "stable_identity_key": "fee364c4d683c54c9dc038d988e716f33dff010f39e5e0345fab457abba27366"
+      },
+      "metadata": [
+        {
+          "metadata_key": "policy_semantics",
+          "metadata_value": "deterministic_planning_integrity_validation"
+        },
+        {
+          "metadata_key": "runtime_capability",
+          "metadata_value": "none"
+        },
+        {
+          "metadata_key": "validity_boundary",
+          "metadata_value": "valid_evidence_does_not_authorize_execution"
+        }
+      ],
+      "policy_is_non_executable": true,
+      "provenance": {
+        "compatibility_references": [
+          "v3_6_to_v3_7_graph_foundation_compatibility"
+        ],
+        "explainability_references": [
+          "v3_7_graph_explainability_evidence"
+        ],
+        "governance_references": [
+          "v3_7_non_execution_governance_boundary"
+        ],
+        "lineage_references": [
+          "v3_6_closeout_and_v3_7_readiness",
+          "v3_7_graph_integrity_policy_default"
+        ],
+        "provenance_id": "v3-7-provenance-v3_7_graph_integrity_policy_default",
+        "replay_lineage_references": [
+          "v3_6_replay_continuity",
+          "v3_7_graph_replay_continuity"
+        ],
+        "rollback_lineage_references": [
+          "v3_6_rollback_continuity",
+          "v3_7_graph_rollback_continuity"
+        ],
+        "source_artifact_id": "v3_7_graph_integrity_policy_default",
+        "source_kind": "graph_planning_integrity_policy",
+        "source_phase_id": "v3_7_graph_foundations"
+      },
+      "requirements": [
+        {
+          "description": "planning intelligence aggregation evidence must remain referenced",
+          "fail_visible": true,
+          "required_reference_type": "aggregation",
+          "requirement_id": "v3_7_integrity_requires_aggregation_evidence",
+          "requirement_type": "evidence_source"
+        },
+        {
+          "description": "compatibility reasoning evidence must remain referenced",
+          "fail_visible": true,
+          "required_reference_type": "compatibility",
+          "requirement_id": "v3_7_integrity_requires_compatibility_evidence",
+          "requirement_type": "evidence_source"
+        },
+        {
+          "description": "evaluation reasoning evidence must remain referenced",
+          "fail_visible": true,
+          "required_reference_type": "evaluation",
+          "requirement_id": "v3_7_integrity_requires_evaluation_evidence",
+          "requirement_type": "evidence_source"
+        },
+        {
+          "description": "integrity enforcement must block execution-boundary violations",
+          "fail_visible": true,
+          "required_reference_type": "non_executable",
+          "requirement_id": "v3_7_integrity_requires_execution_boundary",
+          "requirement_type": "execution_boundary"
+        },
+        {
+          "description": "explainability continuity must remain complete",
+          "fail_visible": true,
+          "required_reference_type": "explainability",
+          "requirement_id": "v3_7_integrity_requires_explainability_continuity",
+          "requirement_type": "explainability"
+        },
+        {
+          "description": "prohibited, unsupported, unknown, blocked, and warning evidence must remain visible",
+          "fail_visible": true,
+          "required_reference_type": "fail_visible",
+          "requirement_id": "v3_7_integrity_requires_fail_visible_findings",
+          "requirement_type": "finding_visibility"
+        },
+        {
+          "description": "governance boundary evidence must remain referenced",
+          "fail_visible": true,
+          "required_reference_type": "governance",
+          "requirement_id": "v3_7_integrity_requires_governance_evidence",
+          "requirement_type": "evidence_source"
+        },
+        {
+          "description": "graph foundation evidence must remain referenced",
+          "fail_visible": true,
+          "required_reference_type": "graph_foundations",
+          "requirement_id": "v3_7_integrity_requires_graph_evidence",
+          "requirement_type": "evidence_source"
+        },
+        {
+          "description": "provenance continuity must remain complete",
+          "fail_visible": true,
+          "required_reference_type": "provenance",
+          "requirement_id": "v3_7_integrity_requires_provenance_continuity",
+          "requirement_type": "provenance"
+        },
+        {
+          "description": "replay continuity evidence must remain non-executable and referenced",
+          "fail_visible": true,
+          "required_reference_type": "replay",
+          "requirement_id": "v3_7_integrity_requires_replay_continuity",
+          "requirement_type": "continuity"
+        },
+        {
+          "description": "rollback continuity evidence must remain referenced",
+          "fail_visible": true,
+          "required_reference_type": "rollback",
+          "requirement_id": "v3_7_integrity_requires_rollback_continuity",
+          "requirement_type": "continuity"
+        },
+        {
+          "description": "planning scenario evidence must remain referenced",
+          "fail_visible": true,
+          "required_reference_type": "scenario",
+          "requirement_id": "v3_7_integrity_requires_scenario_evidence",
+          "requirement_type": "evidence_source"
+        },
+        {
+          "description": "planning session evidence must remain referenced",
+          "fail_visible": true,
+          "required_reference_type": "session",
+          "requirement_id": "v3_7_integrity_requires_session_evidence",
+          "requirement_type": "evidence_source"
+        }
+      ],
+      "routing_authorization_enabled": false,
+      "scheduling_authorization_enabled": false,
+      "traversal_authorization_enabled": false,
+      "valid_integrity_does_not_authorize_execution": true,
+      "validates_planning_evidence_only": true
+    },
+    "provenance": {
+      "compatibility_references": [
+        "v3_6_to_v3_7_graph_foundation_compatibility"
+      ],
+      "explainability_references": [
+        "v3_7_graph_explainability_evidence"
+      ],
+      "governance_references": [
+        "v3_7_non_execution_governance_boundary"
+      ],
+      "lineage_references": [
+        "v3_6_closeout_and_v3_7_readiness",
+        "v3_7_graph_integrity_enforcement_default"
+      ],
+      "provenance_id": "v3-7-provenance-v3_7_graph_integrity_enforcement_default",
+      "replay_lineage_references": [
+        "v3_6_replay_continuity",
+        "v3_7_graph_replay_continuity"
+      ],
+      "rollback_lineage_references": [
+        "v3_6_rollback_continuity",
+        "v3_7_graph_rollback_continuity"
+      ],
+      "source_artifact_id": "v3_7_graph_integrity_enforcement_default",
+      "source_kind": "graph_planning_integrity_enforcement",
+      "source_phase_id": "v3_7_graph_foundations"
+    },
+    "recommendation_enabled": false,
+    "replay_evidence": [
+      {
+        "blocked_finding_references": [],
+        "continuity_hashes": [
+          "0797f2bdb22dacba6ea88c4d046550c2058a94a46466706cdc063edf42d9693c",
+          "0b8fd6de75b5d58790cefb054b18ae762089028b906a932800c6b00ce7e1b95e",
+          "30197b5afd37fa5e21de13c74a595db9125ea49ed2b1e0fa769c4f81dbfb8588",
+          "3d8f67e8de504c767ff3a6923b696b0c0b41c6a35e79c7967ddf888301ad8412",
+          "40346f9d255caa644b54ccf0e40e3d9313087a10b6b45784d6763eae475023df",
+          "4d75f9021078558dec7aec4e73a6b0d46e9924ddc12d5ed59f098b36c3a338eb",
+          "8c54298870f510627f69e00582e96f47c65f2a04f4da0b6ee08c2b663ef573cf",
+          "a154f02972eb862f83266f9cee67a635e423d78f79086e0e2898fced21dbf32b",
+          "a200adcd417767f0a00b6fa7549afd8fda94a2f272b13ac1dcadb36f7a2defe0",
+          "c486ab009cd251714d50b8dd737f4cbfa477276c2b487bffac40874073f40ac2",
+          "e6a6b5bb4221d1933f57e98cf9aebb06b3b57954d41c2e53a6a086cad2dd5570"
+        ],
+        "enforcement_id": "v3_7_graph_integrity_enforcement_default",
+        "evidence_source_references": [
+          "v3_7_graph_planning_intelligence_aggregation_default",
+          "v3_7_intelligence_source_compatibility",
+          "v3_7_intelligence_source_evaluation",
+          "v3_7_intelligence_source_governance",
+          "v3_7_intelligence_source_graph_foundations",
+          "v3_7_intelligence_source_scenario",
+          "v3_7_intelligence_source_session"
+        ],
+        "execution_authorization": false,
+        "explainability_references": [
+          "explain_evaluation_compatibility_restricted_v3_7_edge_provenance_continuity_to_explainability_continuity",
+          "explain_evaluation_finding_rule_compat_governance_to_structure",
+          "explain_evaluation_finding_rule_compat_graph_execution_prohibited",
+          "explain_evaluation_finding_rule_compat_legacy_incompatible",
+          "explain_evaluation_finding_rule_compat_runtime_dispatch_unsupported",
+          "explain_evaluation_finding_rule_compat_structure_to_experimental",
+          "explain_evaluation_finding_rule_compat_structure_to_structure",
+          "explain_evaluation_finding_rule_compat_unknown_external",
+          "explain_evaluation_structural_continuity_warning",
+          "v3_7_compatibility_explanation_v3_7_edge_governance_visibility_to_provenance_continuity_edge",
+          "v3_7_compatibility_explanation_v3_7_edge_governance_visibility_to_provenance_continuity_nodes",
+          "v3_7_compatibility_explanation_v3_7_edge_provenance_continuity_to_explainability_continuity_edge",
+          "v3_7_compatibility_explanation_v3_7_edge_provenance_continuity_to_explainability_continuity_nodes",
+          "v3_7_evidence_v3_7_edge_governance_visibility_to_provenance_continuity",
+          "v3_7_evidence_v3_7_edge_provenance_continuity_to_explainability_continuity",
+          "v3_7_evidence_v3_7_node_explainability_continuity",
+          "v3_7_evidence_v3_7_node_governance_boundary_visibility",
+          "v3_7_evidence_v3_7_node_provenance_continuity",
+          "v3_7_governance_explanation_v3_7_edge_governance_visibility_to_provenance_continuity",
+          "v3_7_governance_explanation_v3_7_edge_provenance_continuity_to_explainability_continuity",
+          "v3_7_governance_explanation_v3_7_node_explainability_continuity",
+          "v3_7_governance_explanation_v3_7_node_governance_boundary_visibility",
+          "v3_7_governance_explanation_v3_7_node_provenance_continuity",
+          "v3_7_graph_integrity_explainability",
+          "v3_7_graph_intelligence_explainability",
+          "v3_7_graph_planning_session_explainability",
+          "v3_7_graph_scenario_explainability"
+        ],
+        "integrity_finding_references": [
+          "v3_7_graph_integrity_continuity_violation",
+          "v3_7_graph_integrity_execution_boundary_violation",
+          "v3_7_graph_integrity_explainability_violation",
+          "v3_7_graph_integrity_hidden_prohibited_state",
+          "v3_7_graph_integrity_hidden_unknown_state",
+          "v3_7_graph_integrity_hidden_unsupported_state",
+          "v3_7_graph_integrity_integrity_blocked",
+          "v3_7_graph_integrity_integrity_invalid",
+          "v3_7_graph_integrity_integrity_valid",
+          "v3_7_graph_integrity_integrity_warning",
+          "v3_7_graph_integrity_provenance_violation",
+          "v3_7_graph_integrity_replay_violation",
+          "v3_7_graph_integrity_rollback_violation"
+        ],
+        "non_executable_replay_evidence": true,
+        "policy_id": "v3_7_graph_integrity_policy_default",
+        "provenance_references": [
+          "v3-7-provenance-compat_domain_graph_structure",
+          "v3-7-provenance-domain_graph_structure_modeling",
+          "v3-7-provenance-v3-7-deterministic-orchestration-planning-graph",
+          "v3-7-provenance-v3_7_graph_evaluation_reasoning_chain",
+          "v3-7-provenance-v3_7_graph_integrity_policy_default",
+          "v3-7-provenance-v3_7_graph_planning_intelligence_aggregation_default",
+          "v3-7-provenance-v3_7_graph_planning_scenario_default",
+          "v3-7-provenance-v3_7_graph_planning_session_default"
+        ],
+        "replay_evidence_id": "v3_7_graph_integrity_replay_evidence_default",
+        "runtime_replay": false
+      }
+    ],
+    "rollback_continuity_references": [
+      "v3_7_graph_evaluation_rollback_continuity"
+    ],
+    "routing_enabled": false,
+    "runtime_control_system_enabled": false,
+    "runtime_decision_making_enabled": false,
+    "runtime_mutation_enabled": false,
+    "scenario_selection_enabled": false,
+    "scheduling_enabled": false,
+    "traversal_logic_enabled": false,
+    "valid_integrity_does_not_authorize_execution": true
+  },
+  "integrity_enforcement_validates_planning_evidence_only": true,
+  "integrity_finding_totals": {
+    "finding_classification_counts": {
+      "continuity_violation": 1,
+      "execution_boundary_violation": 1,
+      "explainability_violation": 1,
+      "hidden_prohibited_state": 1,
+      "hidden_unknown_state": 1,
+      "hidden_unsupported_state": 1,
+      "integrity_blocked": 1,
+      "integrity_invalid": 1,
+      "integrity_valid": 1,
+      "integrity_warning": 1,
+      "provenance_violation": 1,
+      "replay_violation": 1,
+      "rollback_violation": 1
+    },
+    "integrity_finding_count": 13
+  },
+  "integrity_policy_counts": {
+    "execution_boundary_requirement_count": 10,
+    "policy_count": 1,
+    "policy_requirement_count": 13
+  },
+  "optimization_engine_enabled": false,
+  "orchestration_authorization_enabled": false,
+  "path_selection_enabled": false,
+  "persistent_runtime_writes_enabled": false,
+  "phase_name": "v3.7_graph_planning_integrity_enforcement",
+  "provenance_continuity_totals": {
+    "aggregation_provenance_preserved": true,
+    "compatibility_provenance_preserved": true,
+    "continuity_provenance_preserved": true,
+    "enforcement_provenance_preserved": true,
+    "evaluation_provenance_preserved": true,
+    "explainability_provenance_preserved": true,
+    "governance_provenance_preserved": true,
+    "graph_provenance_preserved": true,
+    "policy_provenance_preserved": true,
+    "provenance_record_count": 22,
+    "provenance_status": "v3_7_graph_integrity_provenance_preserved",
+    "replay_provenance_preserved": true,
+    "rollback_provenance_preserved": true,
+    "scenario_provenance_preserved": true,
+    "session_provenance_preserved": true
+  },
+  "provenance_result": {
+    "aggregation_provenance_preserved": true,
+    "compatibility_provenance_preserved": true,
+    "continuity_provenance_preserved": true,
+    "deterministic_provenance_hash": "84de304ec2230b15c9caa7a73c985a17ce5b7cafbb0e4890b87c576bb677a270",
+    "enforcement_provenance_preserved": true,
+    "evaluation_provenance_preserved": true,
+    "explainability_provenance_preserved": true,
+    "governance_provenance_preserved": true,
+    "graph_provenance_preserved": true,
+    "policy_provenance_preserved": true,
+    "provenance_record_count": 22,
+    "provenance_records": [
+      "0797f2bdb22dacba6ea88c4d046550c2058a94a46466706cdc063edf42d9693c",
+      "0b8fd6de75b5d58790cefb054b18ae762089028b906a932800c6b00ce7e1b95e",
+      "30197b5afd37fa5e21de13c74a595db9125ea49ed2b1e0fa769c4f81dbfb8588",
+      "3d8f67e8de504c767ff3a6923b696b0c0b41c6a35e79c7967ddf888301ad8412",
+      "40346f9d255caa644b54ccf0e40e3d9313087a10b6b45784d6763eae475023df",
+      "4d75f9021078558dec7aec4e73a6b0d46e9924ddc12d5ed59f098b36c3a338eb",
+      "8c54298870f510627f69e00582e96f47c65f2a04f4da0b6ee08c2b663ef573cf",
+      "a154f02972eb862f83266f9cee67a635e423d78f79086e0e2898fced21dbf32b",
+      "a200adcd417767f0a00b6fa7549afd8fda94a2f272b13ac1dcadb36f7a2defe0",
+      "c486ab009cd251714d50b8dd737f4cbfa477276c2b487bffac40874073f40ac2",
+      "e6a6b5bb4221d1933f57e98cf9aebb06b3b57954d41c2e53a6a086cad2dd5570",
+      "v3-7-provenance-compat_domain_graph_structure",
+      "v3-7-provenance-domain_graph_structure_modeling",
+      "v3-7-provenance-v3-7-deterministic-orchestration-planning-graph",
+      "v3-7-provenance-v3_7_graph_evaluation_reasoning_chain",
+      "v3-7-provenance-v3_7_graph_integrity_enforcement_default",
+      "v3-7-provenance-v3_7_graph_integrity_policy_default",
+      "v3-7-provenance-v3_7_graph_planning_intelligence_aggregation_default",
+      "v3-7-provenance-v3_7_graph_planning_scenario_default",
+      "v3-7-provenance-v3_7_graph_planning_session_default",
+      "v3_7_graph_evaluation_rollback_continuity",
+      "v3_7_graph_integrity_explainability"
+    ],
+    "provenance_status": "v3_7_graph_integrity_provenance_preserved",
+    "replay_provenance_preserved": true,
+    "rollback_provenance_preserved": true,
+    "scenario_provenance_preserved": true,
+    "session_provenance_preserved": true
+  },
+  "recommendation_enabled": false,
+  "replay_evidence_counts": {
+    "execution_authorization": false,
+    "non_executable_replay_evidence": true,
+    "replay_evidence_count": 1,
+    "runtime_replay": false
+  },
+  "replay_evidence_records": [
+    {
+      "blocked_finding_references": [],
+      "continuity_hashes": [
+        "0797f2bdb22dacba6ea88c4d046550c2058a94a46466706cdc063edf42d9693c",
+        "0b8fd6de75b5d58790cefb054b18ae762089028b906a932800c6b00ce7e1b95e",
+        "30197b5afd37fa5e21de13c74a595db9125ea49ed2b1e0fa769c4f81dbfb8588",
+        "3d8f67e8de504c767ff3a6923b696b0c0b41c6a35e79c7967ddf888301ad8412",
+        "40346f9d255caa644b54ccf0e40e3d9313087a10b6b45784d6763eae475023df",
+        "4d75f9021078558dec7aec4e73a6b0d46e9924ddc12d5ed59f098b36c3a338eb",
+        "8c54298870f510627f69e00582e96f47c65f2a04f4da0b6ee08c2b663ef573cf",
+        "a154f02972eb862f83266f9cee67a635e423d78f79086e0e2898fced21dbf32b",
+        "a200adcd417767f0a00b6fa7549afd8fda94a2f272b13ac1dcadb36f7a2defe0",
+        "c486ab009cd251714d50b8dd737f4cbfa477276c2b487bffac40874073f40ac2",
+        "e6a6b5bb4221d1933f57e98cf9aebb06b3b57954d41c2e53a6a086cad2dd5570"
+      ],
+      "enforcement_id": "v3_7_graph_integrity_enforcement_default",
+      "evidence_source_references": [
+        "v3_7_graph_planning_intelligence_aggregation_default",
+        "v3_7_intelligence_source_compatibility",
+        "v3_7_intelligence_source_evaluation",
+        "v3_7_intelligence_source_governance",
+        "v3_7_intelligence_source_graph_foundations",
+        "v3_7_intelligence_source_scenario",
+        "v3_7_intelligence_source_session"
+      ],
+      "execution_authorization": false,
+      "explainability_references": [
+        "explain_evaluation_compatibility_restricted_v3_7_edge_provenance_continuity_to_explainability_continuity",
+        "explain_evaluation_finding_rule_compat_governance_to_structure",
+        "explain_evaluation_finding_rule_compat_graph_execution_prohibited",
+        "explain_evaluation_finding_rule_compat_legacy_incompatible",
+        "explain_evaluation_finding_rule_compat_runtime_dispatch_unsupported",
+        "explain_evaluation_finding_rule_compat_structure_to_experimental",
+        "explain_evaluation_finding_rule_compat_structure_to_structure",
+        "explain_evaluation_finding_rule_compat_unknown_external",
+        "explain_evaluation_structural_continuity_warning",
+        "v3_7_compatibility_explanation_v3_7_edge_governance_visibility_to_provenance_continuity_edge",
+        "v3_7_compatibility_explanation_v3_7_edge_governance_visibility_to_provenance_continuity_nodes",
+        "v3_7_compatibility_explanation_v3_7_edge_provenance_continuity_to_explainability_continuity_edge",
+        "v3_7_compatibility_explanation_v3_7_edge_provenance_continuity_to_explainability_continuity_nodes",
+        "v3_7_evidence_v3_7_edge_governance_visibility_to_provenance_continuity",
+        "v3_7_evidence_v3_7_edge_provenance_continuity_to_explainability_continuity",
+        "v3_7_evidence_v3_7_node_explainability_continuity",
+        "v3_7_evidence_v3_7_node_governance_boundary_visibility",
+        "v3_7_evidence_v3_7_node_provenance_continuity",
+        "v3_7_governance_explanation_v3_7_edge_governance_visibility_to_provenance_continuity",
+        "v3_7_governance_explanation_v3_7_edge_provenance_continuity_to_explainability_continuity",
+        "v3_7_governance_explanation_v3_7_node_explainability_continuity",
+        "v3_7_governance_explanation_v3_7_node_governance_boundary_visibility",
+        "v3_7_governance_explanation_v3_7_node_provenance_continuity",
+        "v3_7_graph_integrity_explainability",
+        "v3_7_graph_intelligence_explainability",
+        "v3_7_graph_planning_session_explainability",
+        "v3_7_graph_scenario_explainability"
+      ],
+      "integrity_finding_references": [
+        "v3_7_graph_integrity_continuity_violation",
+        "v3_7_graph_integrity_execution_boundary_violation",
+        "v3_7_graph_integrity_explainability_violation",
+        "v3_7_graph_integrity_hidden_prohibited_state",
+        "v3_7_graph_integrity_hidden_unknown_state",
+        "v3_7_graph_integrity_hidden_unsupported_state",
+        "v3_7_graph_integrity_integrity_blocked",
+        "v3_7_graph_integrity_integrity_invalid",
+        "v3_7_graph_integrity_integrity_valid",
+        "v3_7_graph_integrity_integrity_warning",
+        "v3_7_graph_integrity_provenance_violation",
+        "v3_7_graph_integrity_replay_violation",
+        "v3_7_graph_integrity_rollback_violation"
+      ],
+      "non_executable_replay_evidence": true,
+      "policy_id": "v3_7_graph_integrity_policy_default",
+      "provenance_references": [
+        "v3-7-provenance-compat_domain_graph_structure",
+        "v3-7-provenance-domain_graph_structure_modeling",
+        "v3-7-provenance-v3-7-deterministic-orchestration-planning-graph",
+        "v3-7-provenance-v3_7_graph_evaluation_reasoning_chain",
+        "v3-7-provenance-v3_7_graph_integrity_policy_default",
+        "v3-7-provenance-v3_7_graph_planning_intelligence_aggregation_default",
+        "v3-7-provenance-v3_7_graph_planning_scenario_default",
+        "v3-7-provenance-v3_7_graph_planning_session_default"
+      ],
+      "replay_evidence_id": "v3_7_graph_integrity_replay_evidence_default",
+      "runtime_replay": false
+    }
+  ],
+  "repo_root": "D:\\Forge\\le-the-forge",
+  "rollback_continuity_counts": {
+    "rollback_continuity_preserved": true,
+    "rollback_reference_count": 1
+  },
+  "routing_enabled": false,
+  "runtime_control_system_enabled": false,
+  "runtime_decision_making_enabled": false,
+  "runtime_mutation_enabled": false,
+  "scenario_selection_enabled": false,
+  "scheduling_enabled": false,
+  "schema_version": "v3_7.graph_planning_integrity_enforcement_report.1",
+  "summary": {
+    "deterministic_hashing_verified": true,
+    "deterministic_serialization_verified": true,
+    "enforcement_outcome": "valid",
+    "execution_boundary_enforcement_verified": true,
+    "explainability_continuity_verified": true,
+    "no_execution_authorization_verified": true,
+    "non_executable_verified": true,
+    "provenance_continuity_verified": true,
+    "replay_continuity_verified": true,
+    "rollback_continuity_verified": true,
+    "validation_status": "v3_7_graph_integrity_validation_stable"
+  },
+  "traversal_logic_enabled": false,
+  "valid_integrity_does_not_authorize_execution": true,
+  "validation_result": {
+    "deterministic_hash_stable": true,
+    "deterministic_integrity_hash": "39c2526ae964dce0717a80e432f8950e61d51d55b77feb8445ec0c43a9a2b8c7",
+    "deterministic_serialization_stable": true,
+    "deterministic_validation_hash": "66eb73dca76eca1872e6189542d52cd4487fe0db06432b4909966f553c446c53",
+    "duplicate_enforcement_identity_count": 0,
+    "duplicate_policy_identity_count": 0,
+    "error_count": 0,
+    "execution_boundary_violation_count": 0,
+    "execution_boundary_violations_blocked": true,
+    "explainability_continuity_preserved": true,
+    "finding_count": 7,
+    "findings": [
+      {
+        "fail_visible": true,
+        "finding_id": "v3_7_graph_integrity_validation_visible_blocked:integrity_finding:v3_7_graph_integrity_continuity_violation",
+        "message": "continuity_violation remains fail-visible",
+        "severity": "visibility",
+        "status": "v3_7_graph_integrity_validation_visible_blocked",
+        "subject_id": "v3_7_graph_integrity_continuity_violation",
+        "subject_type": "integrity_finding"
+      },
+      {
+        "fail_visible": true,
+        "finding_id": "v3_7_graph_integrity_validation_visible_blocked:integrity_finding:v3_7_graph_integrity_explainability_violation",
+        "message": "explainability_violation remains fail-visible",
+        "severity": "visibility",
+        "status": "v3_7_graph_integrity_validation_visible_blocked",
+        "subject_id": "v3_7_graph_integrity_explainability_violation",
+        "subject_type": "integrity_finding"
+      },
+      {
+        "fail_visible": true,
+        "finding_id": "v3_7_graph_integrity_validation_visible_blocked:integrity_finding:v3_7_graph_integrity_provenance_violation",
+        "message": "provenance_violation remains fail-visible",
+        "severity": "visibility",
+        "status": "v3_7_graph_integrity_validation_visible_blocked",
+        "subject_id": "v3_7_graph_integrity_provenance_violation",
+        "subject_type": "integrity_finding"
+      },
+      {
+        "fail_visible": true,
+        "finding_id": "v3_7_graph_integrity_validation_visible_blocked:integrity_finding:v3_7_graph_integrity_replay_violation",
+        "message": "replay_violation remains fail-visible",
+        "severity": "visibility",
+        "status": "v3_7_graph_integrity_validation_visible_blocked",
+        "subject_id": "v3_7_graph_integrity_replay_violation",
+        "subject_type": "integrity_finding"
+      },
+      {
+        "fail_visible": true,
+        "finding_id": "v3_7_graph_integrity_validation_visible_blocked:integrity_finding:v3_7_graph_integrity_rollback_violation",
+        "message": "rollback_violation remains fail-visible",
+        "severity": "visibility",
+        "status": "v3_7_graph_integrity_validation_visible_blocked",
+        "subject_id": "v3_7_graph_integrity_rollback_violation",
+        "subject_type": "integrity_finding"
+      },
+      {
+        "fail_visible": true,
+        "finding_id": "v3_7_graph_integrity_validation_visible_execution_boundary:integrity_finding:v3_7_graph_integrity_execution_boundary_violation",
+        "message": "execution_boundary_violation remains fail-visible",
+        "severity": "visibility",
+        "status": "v3_7_graph_integrity_validation_visible_execution_boundary",
+        "subject_id": "v3_7_graph_integrity_execution_boundary_violation",
+        "subject_type": "integrity_finding"
+      },
+      {
+        "fail_visible": true,
+        "finding_id": "v3_7_graph_integrity_validation_visible_warning:integrity_finding:v3_7_graph_integrity_integrity_warning",
+        "message": "warning finding remains fail-visible",
+        "severity": "visibility",
+        "status": "v3_7_graph_integrity_validation_visible_warning",
+        "subject_id": "v3_7_graph_integrity_integrity_warning",
+        "subject_type": "integrity_finding"
+      }
+    ],
+    "hidden_prohibited_finding_count": 0,
+    "hidden_unknown_finding_count": 0,
+    "hidden_unsupported_finding_count": 0,
+    "integrity_enforcement_non_executable": true,
+    "invalid_evidence_source_reference_count": 0,
+    "missing_evidence_source_reference_count": 0,
+    "missing_explainability_evidence_count": 0,
+    "missing_provenance_evidence_count": 0,
+    "missing_replay_evidence_count": 0,
+    "missing_rollback_evidence_count": 0,
+    "provenance_continuity_preserved": true,
+    "replay_continuity_preserved": true,
+    "rollback_continuity_preserved": true,
+    "valid": true,
+    "valid_integrity_does_not_authorize_execution": true,
+    "validation_status": "v3_7_graph_integrity_validation_stable",
+    "visibility_finding_count": 7
+  },
+  "validation_totals": {
+    "duplicate_enforcement_identity_count": 0,
+    "duplicate_policy_identity_count": 0,
+    "error_count": 0,
+    "execution_boundary_violation_count": 0,
+    "execution_boundary_violations_blocked": true,
+    "finding_count": 7,
+    "hidden_prohibited_finding_count": 0,
+    "hidden_unknown_finding_count": 0,
+    "hidden_unsupported_finding_count": 0,
+    "integrity_enforcement_non_executable": true,
+    "valid": true,
+    "valid_integrity_does_not_authorize_execution": true,
+    "validation_status": "v3_7_graph_integrity_validation_stable",
+    "visibility_finding_count": 7
+  },
+  "warning_finding_totals": {
+    "warning_finding_count": 1
+  }
+}

--- a/docs/migration/V3_7_GRAPH_PLANNING_INTEGRITY_ENFORCEMENT.md
+++ b/docs/migration/V3_7_GRAPH_PLANNING_INTEGRITY_ENFORCEMENT.md
@@ -1,0 +1,58 @@
+# v3.7 Graph Planning Integrity Enforcement
+
+## Architectural Purpose
+
+v3.7 Phase 8 adds deterministic graph planning integrity enforcement.
+
+Integrity enforcement is NON-executable.
+
+Integrity enforcement validates planning evidence only.
+
+Valid integrity does NOT authorize execution.
+
+Blocked integrity does NOT perform runtime blocking.
+
+Enforcement outcomes are planning validation outcomes only.
+
+Integrity enforcement does NOT route, schedule, dispatch, traverse, optimize, recommend, or execute.
+
+Planning integrity enforcement checks deterministic planning evidence. Runtime orchestration control would control runtime behavior. This phase implements planning integrity enforcement only, not runtime orchestration control.
+
+## Deterministic Scope
+
+- Enforcement outcome: `valid`
+- Validation status: `v3_7_graph_integrity_validation_stable`
+- Integrity findings: `13`
+- Evidence sources: `7`
+- Execution-boundary violations: `0`
+- Serialization stable: `True`
+- Hash stable: `True`
+
+## Explicit Non-Execution Guarantees
+
+- Graph execution remains disabled.
+- Integrity-driven execution remains disabled.
+- Orchestration authorization remains disabled.
+- Routing remains disabled.
+- Scheduling remains disabled.
+- Dispatch remains disabled.
+- Traversal remains disabled.
+- Runtime path selection remains disabled.
+- Scenario execution selection remains disabled.
+- Optimization for execution remains disabled.
+- Recommendation to execute remains disabled.
+- Callable execution flow references remain prohibited.
+
+## Planning Integrity Enforcement vs Runtime Orchestration Control
+
+Planning integrity enforcement validates deterministic evidence continuity, provenance, explainability, replay, rollback, and execution-boundary preservation.
+
+Runtime orchestration control would authorize or direct runtime behavior. This phase does not implement runtime orchestration control.
+
+## Generated Evidence
+
+- Deterministic report hash: `4296e694eb12245d900ec0cb9582b0ae64609cab14d0a1e4cfb2b6dbdb3cf4a0`
+- Integrity hash: `39c2526ae964dce0717a80e432f8950e61d51d55b77feb8445ec0c43a9a2b8c7`
+- Policy hash: `af59d7bc53374ce02ac76cc00ca6a18bf2643992337549d751ea2e42004edfb7`
+- Validation hash: `66eb73dca76eca1872e6189542d52cd4487fe0db06432b4909966f553c446c53`
+- Audit hash: `07873830883750c0dd5648ea754d426abcb8fdd680c1f38f3c94cbcf38d87d7c`


### PR DESCRIPTION
Adds deterministic graph planning integrity enforcement for v3.7 orchestration planning intelligence.

Implements immutable integrity policies, enforcement results, fail-visible findings, execution-boundary checks, replay evidence, rollback continuity, provenance continuity, explainability, and audit support across graph, governance, compatibility, evaluation, session, scenario, and aggregation evidence.

Preserves NON-executable guarantees, deterministic integrity, and blocks execution-boundary violations without authorizing runtime orchestration.