### PR TITLE
v3.7: implement closeout and v3.8 readiness audit

### DIFF
--- a/backend/app/runtime_orchestration/v3_7_closeout_readiness_audit.py
+++ b/backend/app/runtime_orchestration/v3_7_closeout_readiness_audit.py
@@ -1,0 +1,467 @@
+"""Deterministic v3.7 closeout and v3.8 planning-readiness audit."""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import replace
+
+from .v3_7_closeout_readiness_models import (
+    V37_CLOSEOUT_FINDING_CLASSIFICATIONS,
+    V37_CLOSEOUT_FINDING_CLOSEOUT_BLOCKED,
+    V37_CLOSEOUT_FINDING_CLOSEOUT_READY,
+    V37_CLOSEOUT_FINDING_CONTINUITY_BROKEN,
+    V37_CLOSEOUT_FINDING_CONTINUITY_PRESERVED,
+    V37_CLOSEOUT_FINDING_DETERMINISTIC,
+    V37_CLOSEOUT_FINDING_EXECUTION_BOUNDARY_BROKEN,
+    V37_CLOSEOUT_FINDING_EXECUTION_BOUNDARY_PRESERVED,
+    V37_CLOSEOUT_FINDING_EXPLAINABILITY_SAFE,
+    V37_CLOSEOUT_FINDING_HIDDEN_RISK_DETECTED,
+    V37_CLOSEOUT_FINDING_NON_EXECUTABLE,
+    V37_CLOSEOUT_FINDING_PROVENANCE_SAFE,
+    V37_CLOSEOUT_FINDING_READINESS_BLOCKED,
+    V37_CLOSEOUT_FINDING_READINESS_CERTIFIED,
+    V37_CLOSEOUT_FINDING_REPLAY_SAFE,
+    V37_CLOSEOUT_FINDING_ROLLBACK_SAFE,
+    V3_7_CLOSED_OUT_READY_FOR_V3_8_PLANNING,
+    V3_7_CLOSEOUT_BLOCKED_FOR_V3_8_PLANNING,
+    V3_7_CLOSEOUT_PHASE_ID,
+    V37CloseoutPhaseEvidence,
+    V37CloseoutReadinessFinding,
+    V37CloseoutReadinessInput,
+    V37CloseoutReadinessResult,
+    export_v3_7_closeout_readiness_result,
+    hash_v3_7_closeout_readiness_result,
+)
+from .v3_7_graph_certification_audit import (
+    V37_GRAPH_CERTIFICATION_AUDIT_STABLE,
+    audit_v3_7_graph_certification,
+)
+from .v3_7_graph_certification_evidence import build_v3_7_graph_planning_continuity_certification
+from .v3_7_graph_certification_explainability import (
+    V37_GRAPH_CERTIFICATION_EXPLAINABILITY_STABLE,
+    explain_v3_7_graph_certification,
+)
+from .v3_7_graph_certification_models import (
+    V37GraphPlanningContinuityCertification,
+    hash_v3_7_graph_planning_continuity_certification,
+    validate_v3_7_graph_certification_hash_stability,
+    validate_v3_7_graph_certification_serialization_stability,
+)
+from .v3_7_graph_certification_provenance import (
+    V37_GRAPH_CERTIFICATION_PROVENANCE_PRESERVED,
+    audit_v3_7_graph_certification_provenance,
+)
+from .v3_7_graph_certification_replay import validate_v3_7_graph_certification_replay_evidence
+from .v3_7_graph_certification_validation import (
+    V37_GRAPH_CERTIFICATION_VALIDATION_STABLE,
+    validate_v3_7_graph_certification,
+)
+
+
+V37_CLOSEOUT_VALIDATION_STABLE = "v3_7_closeout_validation_stable"
+V37_CLOSEOUT_VALIDATION_BLOCKED = "v3_7_closeout_validation_blocked"
+
+PHASE_CHAIN: tuple[tuple[int, str, str, str], ...] = (
+    (1, "graph_foundations", "Graph Foundations", "graph_foundations"),
+    (2, "governance_boundaries", "Governance Boundary Intelligence", "governance"),
+    (3, "compatibility_reasoning", "Compatibility Reasoning", "compatibility"),
+    (4, "evaluation_reasoning", "Evaluation Reasoning", "evaluation"),
+    (5, "planning_sessions", "Planning Sessions", "session"),
+    (6, "planning_scenarios", "Planning Scenarios", "scenario"),
+    (7, "intelligence_aggregation", "Intelligence Aggregation", "aggregation"),
+    (8, "integrity_enforcement", "Integrity Enforcement", "integrity"),
+    (9, "continuity_certification", "Continuity Certification", "certification"),
+)
+
+
+def default_v3_7_closeout_readiness_input() -> V37CloseoutReadinessInput:
+    return V37CloseoutReadinessInput()
+
+
+def audit_v3_7_closeout_and_v3_8_readiness(
+    source: V37CloseoutReadinessInput | None = None,
+) -> V37CloseoutReadinessResult:
+    request = source or default_v3_7_closeout_readiness_input()
+    certification = request.certification or build_v3_7_graph_planning_continuity_certification()
+    assert isinstance(certification, V37GraphPlanningContinuityCertification)
+    certification_validation = validate_v3_7_graph_certification((certification,))
+    certification_audit = audit_v3_7_graph_certification(certification)
+    certification_provenance = audit_v3_7_graph_certification_provenance(certification)
+    certification_explainability = explain_v3_7_graph_certification(certification)
+    certification_replay = validate_v3_7_graph_certification_replay_evidence(certification)
+    certification_serialization = validate_v3_7_graph_certification_serialization_stability(certification)
+    certification_hashing = validate_v3_7_graph_certification_hash_stability(certification)
+    phase_evidence = _phase_evidence(certification, request.omitted_phase_ids)
+    missing_phase_ids = _missing_phase_ids(phase_evidence)
+    hidden_risk_detected = request.force_hidden_risk_detected or any(
+        (
+            certification_validation.hidden_prohibited_finding_count,
+            certification_validation.hidden_unsupported_finding_count,
+            certification_validation.hidden_unknown_finding_count,
+        )
+    )
+    replay_safe = certification_replay["replay_continuity_preserved"] and not request.force_missing_replay_evidence
+    rollback_safe = certification_replay["rollback_continuity_preserved"] and not request.force_missing_rollback_evidence
+    execution_boundary_preserved = _execution_boundary_preserved(certification) and not request.force_execution_boundary_violation
+    provenance_safe = certification_provenance.provenance_status == V37_GRAPH_CERTIFICATION_PROVENANCE_PRESERVED
+    explainability_safe = certification_explainability.explainability_status == V37_GRAPH_CERTIFICATION_EXPLAINABILITY_STABLE
+    deterministic = certification_serialization["stable"] and certification_hashing["stable"]
+    continuity_preserved = (
+        len(missing_phase_ids) == 0
+        and certification_validation.validation_status == V37_GRAPH_CERTIFICATION_VALIDATION_STABLE
+        and certification_audit.audit_status == V37_GRAPH_CERTIFICATION_AUDIT_STABLE
+        and all(evidence.continuity_preserved for evidence in phase_evidence)
+    )
+    closeout_ready = all(
+        (
+            continuity_preserved,
+            execution_boundary_preserved,
+            replay_safe,
+            rollback_safe,
+            provenance_safe,
+            explainability_safe,
+            deterministic,
+            not hidden_risk_detected,
+            not request.manual_blocker_reasons,
+        )
+    )
+    evidence_reference_ids = tuple(sorted(evidence.evidence_reference_id for evidence in phase_evidence))
+    findings = _build_findings(
+        closeout_ready=closeout_ready,
+        readiness_certified=closeout_ready,
+        continuity_preserved=continuity_preserved,
+        execution_boundary_preserved=execution_boundary_preserved,
+        replay_safe=replay_safe,
+        rollback_safe=rollback_safe,
+        provenance_safe=provenance_safe,
+        explainability_safe=explainability_safe,
+        deterministic=deterministic,
+        non_executable=certification.certification_is_non_executable,
+        hidden_risk_detected=hidden_risk_detected,
+        evidence_references=evidence_reference_ids,
+    )
+    execution_boundary_violations = _execution_boundary_violation_count(
+        certification,
+        request.force_execution_boundary_violation,
+    )
+    validation_totals = {
+        "validation_status": V37_CLOSEOUT_VALIDATION_STABLE if closeout_ready else V37_CLOSEOUT_VALIDATION_BLOCKED,
+        "valid": closeout_ready,
+        "finding_count": len(findings),
+        "error_count": sum(1 for finding in findings if finding.blocks_closeout),
+        "visibility_finding_count": sum(1 for finding in findings if finding.fail_visible and not finding.hidden),
+        "total_phases_audited": len(phase_evidence),
+        "missing_phase_continuity_count": len(missing_phase_ids),
+        "hidden_prohibited_state_count": 1 if hidden_risk_detected else 0,
+        "hidden_unsupported_state_count": 1 if hidden_risk_detected else 0,
+        "hidden_unknown_state_count": 1 if hidden_risk_detected else 0,
+        "missing_replay_evidence_count": 0 if replay_safe else 1,
+        "missing_rollback_evidence_count": 0 if rollback_safe else 1,
+        "execution_boundary_violation_count": execution_boundary_violations,
+        "manual_blocker_count": len(request.manual_blocker_reasons),
+    }
+    continuity_validation_totals = {
+        "deterministic_serialization_continuity": certification_serialization["stable"],
+        "deterministic_hashing_continuity": certification_hashing["stable"],
+        "governance_continuity": certification_audit.governance_continuity_preserved,
+        "compatibility_continuity": certification_audit.compatibility_continuity_preserved,
+        "evaluation_continuity": certification_audit.evaluation_continuity_preserved,
+        "planning_session_continuity": certification_audit.session_continuity_preserved,
+        "planning_scenario_continuity": certification_audit.scenario_continuity_preserved,
+        "aggregation_continuity": certification_audit.aggregation_continuity_preserved,
+        "integrity_continuity": certification_audit.integrity_continuity_preserved,
+        "certification_continuity": certification_audit.audit_status == V37_GRAPH_CERTIFICATION_AUDIT_STABLE,
+        "provenance_continuity": provenance_safe,
+        "explainability_continuity": explainability_safe,
+        "replay_continuity": replay_safe,
+        "rollback_continuity": rollback_safe,
+        "fail_visible_continuity": all(finding.fail_visible and not finding.hidden for finding in findings),
+        "execution_boundary_continuity": execution_boundary_preserved,
+    }
+    execution_boundary_audit_totals = {
+        "execution_authorization_absent": not certification.orchestration_authorization_enabled,
+        "orchestration_routing_absent": not certification.routing_enabled,
+        "orchestration_scheduling_absent": not certification.scheduling_enabled,
+        "orchestration_dispatch_absent": not certification.dispatch_enabled,
+        "traversal_authorization_absent": not certification.traversal_logic_enabled,
+        "runtime_path_selection_absent": not certification.path_selection_enabled,
+        "scenario_execution_selection_absent": not certification.scenario_selection_enabled,
+        "execution_recommendation_absent": not certification.recommendation_enabled,
+        "optimization_for_execution_absent": not certification.optimization_engine_enabled,
+        "callable_execution_flow_absent": not certification.executable_certification_gates_enabled,
+        "runtime_orchestration_engine_absent": not certification.runtime_control_system_enabled,
+        "execution_boundary_preserved": execution_boundary_preserved,
+        "execution_boundary_violation_count": execution_boundary_violations,
+    }
+    replay_rollback_totals = {
+        "replay_evidence_count": certification_replay["replay_evidence_count"],
+        "rollback_reference_count": certification_replay["rollback_reference_count"],
+        "replay_safe": replay_safe,
+        "rollback_safe": rollback_safe,
+        "runtime_replay_detected": certification_replay["runtime_replay"],
+        "runtime_readiness_certification_detected": certification_replay["runtime_readiness_certification"],
+    }
+    provenance_explainability_totals = {
+        "provenance_record_count": certification_provenance.provenance_record_count,
+        "explanation_count": certification_explainability.explanation_count,
+        "provenance_safe": provenance_safe,
+        "explainability_safe": explainability_safe,
+        "graph_provenance_preserved": certification_provenance.graph_provenance_preserved,
+        "governance_provenance_preserved": certification_provenance.governance_provenance_preserved,
+        "compatibility_provenance_preserved": certification_provenance.compatibility_provenance_preserved,
+        "evaluation_provenance_preserved": certification_provenance.evaluation_provenance_preserved,
+        "session_provenance_preserved": certification_provenance.session_provenance_preserved,
+        "scenario_provenance_preserved": certification_provenance.scenario_provenance_preserved,
+        "aggregation_provenance_preserved": certification_provenance.aggregation_provenance_preserved,
+        "integrity_provenance_preserved": certification_provenance.integrity_provenance_preserved,
+        "certification_provenance_preserved": certification_provenance.certification_provenance_preserved,
+    }
+    deterministic_guarantees = {
+        "certification_serialization_stable": certification_serialization["stable"],
+        "certification_hash_stable": certification_hashing["stable"],
+        "closeout_serialization_stable": True,
+        "closeout_hash_stable": True,
+        "certification_hash": hash_v3_7_graph_planning_continuity_certification(certification),
+        "certification_validation_hash": certification_validation.deterministic_validation_hash,
+        "certification_audit_hash": certification_audit.deterministic_audit_hash,
+        "certification_provenance_hash": certification_provenance.deterministic_provenance_hash,
+        "certification_explainability_hash": certification_explainability.deterministic_explainability_hash,
+    }
+    result = V37CloseoutReadinessResult(
+        closeout_status=V3_7_CLOSED_OUT_READY_FOR_V3_8_PLANNING
+        if closeout_ready
+        else V3_7_CLOSEOUT_BLOCKED_FOR_V3_8_PLANNING,
+        v3_8_readiness_classification=V3_7_CLOSED_OUT_READY_FOR_V3_8_PLANNING
+        if closeout_ready
+        else V3_7_CLOSEOUT_BLOCKED_FOR_V3_8_PLANNING,
+        phase_id=V3_7_CLOSEOUT_PHASE_ID,
+        total_phases_audited=len(phase_evidence),
+        phase_evidence=phase_evidence,
+        findings=findings,
+        validation_totals=validation_totals,
+        continuity_validation_totals=continuity_validation_totals,
+        execution_boundary_audit_totals=execution_boundary_audit_totals,
+        replay_rollback_totals=replay_rollback_totals,
+        provenance_explainability_totals=provenance_explainability_totals,
+        deterministic_guarantees=deterministic_guarantees,
+        hidden_risk_totals={
+            "hidden_risk_detected": hidden_risk_detected,
+            "hidden_prohibited_state_count": validation_totals["hidden_prohibited_state_count"],
+            "hidden_unsupported_state_count": validation_totals["hidden_unsupported_state_count"],
+            "hidden_unknown_state_count": validation_totals["hidden_unknown_state_count"],
+        },
+        explanation_summary=_explanation_summary(closeout_ready),
+        v3_8_allowed_expansion_summary=(
+            "v3.8 may expand deterministic planning intelligence evidence",
+            "v3.8 may expand structural governance, compatibility, evaluation, and continuity reasoning",
+            "v3.8 may add additional non-executable planning audit evidence",
+        ),
+        v3_8_prohibited_expansion_summary=(
+            "v3.8 may not enable runtime orchestration execution",
+            "v3.8 may not enable routing, scheduling, dispatch, or traversal",
+            "v3.8 may not authorize execution readiness",
+            "v3.8 may not add optimization-for-execution or recommendation-to-execute behavior",
+        ),
+        provenance_references=tuple(sorted({ref for evidence in phase_evidence for ref in evidence.provenance_references})),
+        explainability_references=tuple(sorted({ref for evidence in phase_evidence for ref in evidence.explainability_references})),
+        replay_references=tuple(sorted({ref for evidence in phase_evidence for ref in evidence.replay_references})),
+        rollback_references=tuple(sorted({ref for evidence in phase_evidence for ref in evidence.rollback_references})),
+        readiness_for_v3_8_planning=closeout_ready,
+        runtime_execution_readiness_certified=False,
+        execution_authorization_enabled=request.force_execution_boundary_violation,
+        orchestration_execution_enabled=False,
+        routing_enabled=False,
+        scheduling_enabled=False,
+        dispatch_enabled=False,
+        traversal_enabled=False,
+        runtime_path_selection_enabled=False,
+        scenario_execution_selection_enabled=False,
+        execution_recommendation_enabled=False,
+        optimization_for_execution_enabled=False,
+        callable_execution_flow_enabled=False,
+        runtime_orchestration_engine_enabled=False,
+        runtime_mutation_enabled=False,
+        persistent_runtime_writes_enabled=False,
+        autonomous_orchestration_enabled=False,
+    )
+    result = replace(result, deterministic_closeout_hash=hash_v3_7_closeout_readiness_result(result))
+    deterministic_guarantees = dict(result.deterministic_guarantees)
+    deterministic_guarantees["closeout_hash"] = result.deterministic_closeout_hash
+    return replace(result, deterministic_guarantees=deterministic_guarantees)
+
+
+def export_v3_7_closeout_and_v3_8_readiness_result(result: V37CloseoutReadinessResult) -> dict[str, object]:
+    return export_v3_7_closeout_readiness_result(result)
+
+
+def count_v3_7_closeout_findings_by_classification(
+    findings: tuple[V37CloseoutReadinessFinding, ...],
+) -> dict[str, int]:
+    counts = Counter(finding.finding_classification for finding in findings)
+    return {classification: counts.get(classification, 0) for classification in V37_CLOSEOUT_FINDING_CLASSIFICATIONS}
+
+
+def _phase_evidence(
+    certification: V37GraphPlanningContinuityCertification,
+    omitted_phase_ids: tuple[str, ...],
+) -> tuple[V37CloseoutPhaseEvidence, ...]:
+    refs_by_type = {reference.reference_type: reference for reference in certification.scope.references}
+    phase_records: list[V37CloseoutPhaseEvidence] = []
+    for phase_order, phase_id, phase_name, reference_type in PHASE_CHAIN:
+        if phase_id in omitted_phase_ids:
+            continue
+        if reference_type == "certification":
+            phase_records.append(
+                V37CloseoutPhaseEvidence(
+                    phase_order=phase_order,
+                    phase_id=phase_id,
+                    phase_name=phase_name,
+                    reference_type=reference_type,
+                    evidence_reference_id=certification.identity.certification_id,
+                    artifact_id=certification.identity.certification_id,
+                    artifact_hash=hash_v3_7_graph_planning_continuity_certification(certification),
+                    provenance_references=(certification.provenance.provenance_id,),
+                    explainability_references=certification.explainability_reference_ids,
+                    continuity_hashes=certification.continuity_hash_references,
+                    replay_references=tuple(item.replay_evidence_id for item in certification.replay_evidence),
+                    rollback_references=certification.rollback_continuity_references,
+                )
+            )
+            continue
+        reference = refs_by_type[reference_type]
+        phase_records.append(
+            V37CloseoutPhaseEvidence(
+                phase_order=phase_order,
+                phase_id=phase_id,
+                phase_name=phase_name,
+                reference_type=reference.reference_type,
+                evidence_reference_id=reference.reference_id,
+                artifact_id=reference.artifact_id,
+                artifact_hash=reference.artifact_hash,
+                provenance_references=reference.provenance_references,
+                explainability_references=reference.explainability_references,
+                continuity_hashes=reference.continuity_hashes,
+                replay_references=certification.evidence.replay_references,
+                rollback_references=certification.evidence.rollback_references,
+            )
+        )
+    return tuple(sorted(phase_records, key=lambda item: item.phase_order))
+
+
+def _missing_phase_ids(phase_evidence: tuple[V37CloseoutPhaseEvidence, ...]) -> tuple[str, ...]:
+    present = {evidence.phase_id for evidence in phase_evidence}
+    required = {phase_id for _, phase_id, _, _ in PHASE_CHAIN}
+    return tuple(sorted(required - present))
+
+
+def _build_findings(
+    *,
+    closeout_ready: bool,
+    readiness_certified: bool,
+    continuity_preserved: bool,
+    execution_boundary_preserved: bool,
+    replay_safe: bool,
+    rollback_safe: bool,
+    provenance_safe: bool,
+    explainability_safe: bool,
+    deterministic: bool,
+    non_executable: bool,
+    hidden_risk_detected: bool,
+    evidence_references: tuple[str, ...],
+) -> tuple[V37CloseoutReadinessFinding, ...]:
+    specs = (
+        (V37_CLOSEOUT_FINDING_CLOSEOUT_READY, closeout_ready, False, "v3.7 closeout is ready for v3.8 deterministic planning expansion"),
+        (V37_CLOSEOUT_FINDING_CLOSEOUT_BLOCKED, not closeout_ready, not closeout_ready, "closeout blockers remain fail-visible"),
+        (V37_CLOSEOUT_FINDING_READINESS_CERTIFIED, readiness_certified, False, "v3.8 planning readiness is certified for planning expansion only"),
+        (V37_CLOSEOUT_FINDING_READINESS_BLOCKED, not readiness_certified, not readiness_certified, "v3.8 planning readiness blockers remain fail-visible"),
+        (V37_CLOSEOUT_FINDING_CONTINUITY_PRESERVED, continuity_preserved, False, "v3.7 phase continuity is preserved"),
+        (V37_CLOSEOUT_FINDING_CONTINUITY_BROKEN, not continuity_preserved, not continuity_preserved, "broken continuity blocks closeout"),
+        (V37_CLOSEOUT_FINDING_EXECUTION_BOUNDARY_PRESERVED, execution_boundary_preserved, False, "execution boundaries remain preserved"),
+        (V37_CLOSEOUT_FINDING_EXECUTION_BOUNDARY_BROKEN, not execution_boundary_preserved, not execution_boundary_preserved, "execution-boundary failures block closeout"),
+        (V37_CLOSEOUT_FINDING_REPLAY_SAFE, replay_safe, not replay_safe, "replay continuity is planning evidence only"),
+        (V37_CLOSEOUT_FINDING_ROLLBACK_SAFE, rollback_safe, not rollback_safe, "rollback continuity is planning evidence only"),
+        (V37_CLOSEOUT_FINDING_PROVENANCE_SAFE, provenance_safe, not provenance_safe, "provenance continuity is preserved"),
+        (V37_CLOSEOUT_FINDING_EXPLAINABILITY_SAFE, explainability_safe, not explainability_safe, "explainability continuity is preserved"),
+        (V37_CLOSEOUT_FINDING_DETERMINISTIC, deterministic, not deterministic, "serialization and hashing remain deterministic"),
+        (V37_CLOSEOUT_FINDING_NON_EXECUTABLE, non_executable, not non_executable, "closeout evidence remains non-executable"),
+        (V37_CLOSEOUT_FINDING_HIDDEN_RISK_DETECTED, hidden_risk_detected, hidden_risk_detected, "hidden risk states block closeout"),
+    )
+    findings = []
+    for classification, active, blocks, summary in specs:
+        severity = "error" if blocks else ("info" if active else "visibility")
+        findings.append(
+            V37CloseoutReadinessFinding(
+                finding_id=f"v3_7_closeout_{classification}",
+                finding_classification=classification,
+                subject_type="v3_7_closeout",
+                subject_id=classification,
+                severity=severity,
+                summary=summary,
+                evidence_references=evidence_references,
+                active=active,
+                active_violation=blocks,
+                blocks_closeout=blocks,
+            )
+        )
+    return tuple(sorted(findings, key=lambda item: item.finding_id))
+
+
+def _execution_boundary_preserved(certification: V37GraphPlanningContinuityCertification) -> bool:
+    return all(
+        (
+            certification.certification_is_non_executable,
+            certification.certified_continuity_does_not_authorize_execution,
+            certification.certification_does_not_mark_runtime_execution_readiness,
+            certification.certification_does_not_route_schedule_dispatch_traverse_optimize_recommend_or_execute,
+            not certification.graph_execution_enabled,
+            not certification.certification_driven_execution_enabled,
+            not certification.orchestration_authorization_enabled,
+            not certification.execution_readiness_approval_enabled,
+            not certification.routing_enabled,
+            not certification.scheduling_enabled,
+            not certification.dispatch_enabled,
+            not certification.traversal_logic_enabled,
+            not certification.path_selection_enabled,
+            not certification.scenario_selection_enabled,
+            not certification.optimization_engine_enabled,
+            not certification.recommendation_enabled,
+            not certification.autonomous_orchestration_enabled,
+            not certification.runtime_mutation_enabled,
+            not certification.persistent_runtime_writes_enabled,
+            not certification.runtime_decision_making_enabled,
+            not certification.executable_certification_gates_enabled,
+            not certification.runtime_control_system_enabled,
+        )
+    )
+
+
+def _execution_boundary_violation_count(
+    certification: V37GraphPlanningContinuityCertification,
+    forced: bool,
+) -> int:
+    checks = (
+        certification.orchestration_authorization_enabled,
+        certification.routing_enabled,
+        certification.scheduling_enabled,
+        certification.dispatch_enabled,
+        certification.traversal_logic_enabled,
+        certification.path_selection_enabled,
+        certification.scenario_selection_enabled,
+        certification.recommendation_enabled,
+        certification.optimization_engine_enabled,
+        certification.executable_certification_gates_enabled,
+        certification.runtime_control_system_enabled,
+        forced,
+    )
+    return sum(1 for value in checks if value)
+
+
+def _explanation_summary(closeout_ready: bool) -> tuple[str, ...]:
+    status = "certified" if closeout_ready else "blocked"
+    return (
+        "v3.7 implemented deterministic orchestration planning intelligence across graph foundations, governance, compatibility, evaluation, sessions, scenarios, aggregation, integrity, and certification.",
+        "v3.7 preserved deterministic serialization, deterministic hashing, governance continuity, compatibility continuity, evaluation continuity, provenance continuity, explainability continuity, replay continuity, and rollback continuity.",
+        "v3.7 explicitly prohibited graph execution, orchestration execution, routing, scheduling, dispatch, traversal, runtime path selection, scenario execution selection, optimization for execution, recommendation to execute, callable flows, and runtime control systems.",
+        f"v3.7 closeout status is {status} for future deterministic planning expansion only.",
+        "v3.8 may expand planning intelligence evidence but may not enable runtime orchestration execution.",
+    )

--- a/backend/app/runtime_orchestration/v3_7_closeout_readiness_models.py
+++ b/backend/app/runtime_orchestration/v3_7_closeout_readiness_models.py
@@ -1,0 +1,268 @@
+"""Deterministic v3.7 closeout and v3.8 planning-readiness models.
+
+The closeout models are audit evidence only. They do not authorize runtime
+orchestration, route work, schedule work, dispatch work, traverse graphs,
+optimize execution, recommend execution, or create callable flows.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any, Iterable, Mapping
+
+from app.runtime_intelligence.classification_hashing import deterministic_hash, stable_serialize
+
+
+V3_7_CLOSEOUT_PHASE_ID = "v3_7_closeout_and_v3_8_readiness"
+V3_7_CLOSED_OUT_READY_FOR_V3_8_PLANNING = "v3_7_closed_out_ready_for_v3_8_planning"
+V3_7_CLOSEOUT_BLOCKED_FOR_V3_8_PLANNING = "v3_7_closeout_blocked_for_v3_8_planning"
+
+V37_CLOSEOUT_FINDING_CLOSEOUT_READY = "closeout_ready"
+V37_CLOSEOUT_FINDING_CLOSEOUT_BLOCKED = "closeout_blocked"
+V37_CLOSEOUT_FINDING_READINESS_CERTIFIED = "readiness_certified"
+V37_CLOSEOUT_FINDING_READINESS_BLOCKED = "readiness_blocked"
+V37_CLOSEOUT_FINDING_CONTINUITY_PRESERVED = "continuity_preserved"
+V37_CLOSEOUT_FINDING_CONTINUITY_BROKEN = "continuity_broken"
+V37_CLOSEOUT_FINDING_EXECUTION_BOUNDARY_PRESERVED = "execution_boundary_preserved"
+V37_CLOSEOUT_FINDING_EXECUTION_BOUNDARY_BROKEN = "execution_boundary_broken"
+V37_CLOSEOUT_FINDING_REPLAY_SAFE = "replay_safe"
+V37_CLOSEOUT_FINDING_ROLLBACK_SAFE = "rollback_safe"
+V37_CLOSEOUT_FINDING_PROVENANCE_SAFE = "provenance_safe"
+V37_CLOSEOUT_FINDING_EXPLAINABILITY_SAFE = "explainability_safe"
+V37_CLOSEOUT_FINDING_DETERMINISTIC = "deterministic"
+V37_CLOSEOUT_FINDING_NON_EXECUTABLE = "non_executable"
+V37_CLOSEOUT_FINDING_HIDDEN_RISK_DETECTED = "hidden_risk_detected"
+V37_CLOSEOUT_FINDING_CLASSIFICATIONS: tuple[str, ...] = (
+    V37_CLOSEOUT_FINDING_CLOSEOUT_READY,
+    V37_CLOSEOUT_FINDING_CLOSEOUT_BLOCKED,
+    V37_CLOSEOUT_FINDING_READINESS_CERTIFIED,
+    V37_CLOSEOUT_FINDING_READINESS_BLOCKED,
+    V37_CLOSEOUT_FINDING_CONTINUITY_PRESERVED,
+    V37_CLOSEOUT_FINDING_CONTINUITY_BROKEN,
+    V37_CLOSEOUT_FINDING_EXECUTION_BOUNDARY_PRESERVED,
+    V37_CLOSEOUT_FINDING_EXECUTION_BOUNDARY_BROKEN,
+    V37_CLOSEOUT_FINDING_REPLAY_SAFE,
+    V37_CLOSEOUT_FINDING_ROLLBACK_SAFE,
+    V37_CLOSEOUT_FINDING_PROVENANCE_SAFE,
+    V37_CLOSEOUT_FINDING_EXPLAINABILITY_SAFE,
+    V37_CLOSEOUT_FINDING_DETERMINISTIC,
+    V37_CLOSEOUT_FINDING_NON_EXECUTABLE,
+    V37_CLOSEOUT_FINDING_HIDDEN_RISK_DETECTED,
+)
+
+
+def _as_tuple(values: Iterable[str] | tuple[str, ...] | None) -> tuple[str, ...]:
+    return tuple(values or ())
+
+
+def _set_tuple_field(source: object, field_name: str) -> None:
+    object.__setattr__(source, field_name, _as_tuple(getattr(source, field_name)))
+
+
+@dataclass(frozen=True)
+class V37CloseoutReadinessInput:
+    certification: object | None = None
+    omitted_phase_ids: tuple[str, ...] = ()
+    manual_blocker_reasons: tuple[str, ...] = ()
+    force_hidden_risk_detected: bool = False
+    force_execution_boundary_violation: bool = False
+    force_missing_replay_evidence: bool = False
+    force_missing_rollback_evidence: bool = False
+
+    def __post_init__(self) -> None:
+        for field_name in ("omitted_phase_ids", "manual_blocker_reasons"):
+            _set_tuple_field(self, field_name)
+
+
+@dataclass(frozen=True)
+class V37CloseoutPhaseEvidence:
+    phase_order: int
+    phase_id: str
+    phase_name: str
+    reference_type: str
+    evidence_reference_id: str
+    artifact_id: str
+    artifact_hash: str
+    provenance_references: tuple[str, ...]
+    explainability_references: tuple[str, ...]
+    continuity_hashes: tuple[str, ...]
+    replay_references: tuple[str, ...]
+    rollback_references: tuple[str, ...]
+    continuity_preserved: bool = True
+    replay_safe: bool = True
+    rollback_safe: bool = True
+    provenance_safe: bool = True
+    explainability_safe: bool = True
+    deterministic_hash_present: bool = True
+    non_executable_evidence: bool = True
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "provenance_references",
+            "explainability_references",
+            "continuity_hashes",
+            "replay_references",
+            "rollback_references",
+        ):
+            _set_tuple_field(self, field_name)
+
+
+@dataclass(frozen=True)
+class V37CloseoutReadinessFinding:
+    finding_id: str
+    finding_classification: str
+    subject_type: str
+    subject_id: str
+    severity: str
+    summary: str
+    evidence_references: tuple[str, ...]
+    fail_visible: bool = True
+    hidden: bool = False
+    active: bool = True
+    active_violation: bool = False
+    blocks_closeout: bool = False
+
+    def __post_init__(self) -> None:
+        _set_tuple_field(self, "evidence_references")
+
+
+@dataclass(frozen=True)
+class V37CloseoutReadinessResult:
+    closeout_status: str
+    v3_8_readiness_classification: str
+    phase_id: str
+    total_phases_audited: int
+    phase_evidence: tuple[V37CloseoutPhaseEvidence, ...]
+    findings: tuple[V37CloseoutReadinessFinding, ...]
+    validation_totals: Mapping[str, int | bool | str]
+    continuity_validation_totals: Mapping[str, int | bool | str]
+    execution_boundary_audit_totals: Mapping[str, int | bool | str]
+    replay_rollback_totals: Mapping[str, int | bool | str]
+    provenance_explainability_totals: Mapping[str, int | bool | str]
+    deterministic_guarantees: Mapping[str, int | bool | str]
+    hidden_risk_totals: Mapping[str, int | bool | str]
+    explanation_summary: tuple[str, ...]
+    v3_8_allowed_expansion_summary: tuple[str, ...]
+    v3_8_prohibited_expansion_summary: tuple[str, ...]
+    provenance_references: tuple[str, ...]
+    explainability_references: tuple[str, ...]
+    replay_references: tuple[str, ...]
+    rollback_references: tuple[str, ...]
+    deterministic_closeout_hash: str = ""
+    closeout_is_non_executable: bool = True
+    closeout_certifies_planning_intelligence_continuity_only: bool = True
+    readiness_for_v3_8_planning: bool = True
+    runtime_execution_readiness_certified: bool = False
+    execution_authorization_enabled: bool = False
+    orchestration_execution_enabled: bool = False
+    routing_enabled: bool = False
+    scheduling_enabled: bool = False
+    dispatch_enabled: bool = False
+    traversal_enabled: bool = False
+    runtime_path_selection_enabled: bool = False
+    scenario_execution_selection_enabled: bool = False
+    execution_recommendation_enabled: bool = False
+    optimization_for_execution_enabled: bool = False
+    callable_execution_flow_enabled: bool = False
+    runtime_orchestration_engine_enabled: bool = False
+    runtime_mutation_enabled: bool = False
+    persistent_runtime_writes_enabled: bool = False
+    autonomous_orchestration_enabled: bool = False
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "phase_evidence",
+            "findings",
+            "explanation_summary",
+            "v3_8_allowed_expansion_summary",
+            "v3_8_prohibited_expansion_summary",
+            "provenance_references",
+            "explainability_references",
+            "replay_references",
+            "rollback_references",
+        ):
+            object.__setattr__(self, field_name, tuple(getattr(self, field_name) or ()))
+
+
+def export_v3_7_closeout_phase_evidence(evidence: V37CloseoutPhaseEvidence) -> dict[str, Any]:
+    data = asdict(evidence)
+    for field_name in (
+        "provenance_references",
+        "explainability_references",
+        "continuity_hashes",
+        "replay_references",
+        "rollback_references",
+    ):
+        data[field_name] = sorted(data[field_name])
+    return data
+
+
+def export_v3_7_closeout_readiness_finding(finding: V37CloseoutReadinessFinding) -> dict[str, Any]:
+    data = asdict(finding)
+    data["evidence_references"] = sorted(data["evidence_references"])
+    return data
+
+
+def export_v3_7_closeout_readiness_result(result: V37CloseoutReadinessResult) -> dict[str, Any]:
+    data = asdict(result)
+    data["phase_evidence"] = [
+        export_v3_7_closeout_phase_evidence(evidence)
+        for evidence in sorted(result.phase_evidence, key=lambda item: item.phase_order)
+    ]
+    data["findings"] = [
+        export_v3_7_closeout_readiness_finding(finding)
+        for finding in sorted(result.findings, key=lambda item: item.finding_id)
+    ]
+    for field_name in (
+        "validation_totals",
+        "continuity_validation_totals",
+        "execution_boundary_audit_totals",
+        "replay_rollback_totals",
+        "provenance_explainability_totals",
+        "deterministic_guarantees",
+        "hidden_risk_totals",
+    ):
+        data[field_name] = dict(sorted(data[field_name].items()))
+    for field_name in (
+        "explanation_summary",
+        "v3_8_allowed_expansion_summary",
+        "v3_8_prohibited_expansion_summary",
+        "provenance_references",
+        "explainability_references",
+        "replay_references",
+        "rollback_references",
+    ):
+        data[field_name] = sorted(data[field_name])
+    return data
+
+
+def serialize_v3_7_closeout_readiness_result(result: V37CloseoutReadinessResult) -> str:
+    return stable_serialize(export_v3_7_closeout_readiness_result(result))
+
+
+def hash_v3_7_closeout_readiness_result(result: V37CloseoutReadinessResult) -> str:
+    data = export_v3_7_closeout_readiness_result(result)
+    data.pop("deterministic_closeout_hash", None)
+    return deterministic_hash(data)
+
+
+def validate_v3_7_closeout_serialization_stability(result: V37CloseoutReadinessResult) -> dict[str, Any]:
+    first = serialize_v3_7_closeout_readiness_result(result)
+    second = serialize_v3_7_closeout_readiness_result(result)
+    return {
+        "stable": first == second,
+        "serializer": "json_sort_keys_stable_v3_7_closeout_readiness",
+        "first_length": len(first),
+        "second_length": len(second),
+    }
+
+
+def validate_v3_7_closeout_hash_stability(result: V37CloseoutReadinessResult) -> dict[str, Any]:
+    first = hash_v3_7_closeout_readiness_result(result)
+    second = hash_v3_7_closeout_readiness_result(result)
+    return {
+        "stable": first == second,
+        "first_hash": first,
+        "second_hash": second,
+        "hash_algorithm": "sha256_stable_json_v3_7_closeout_readiness",
+    }

--- a/backend/scripts/report_v3_7_closeout_and_v3_8_readiness.py
+++ b/backend/scripts/report_v3_7_closeout_and_v3_8_readiness.py
@@ -1,0 +1,215 @@
+"""Generate the v3.7 closeout and v3.8 planning-readiness report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.runtime_intelligence.classification_hashing import deterministic_hash  # noqa: E402
+from app.runtime_orchestration.v3_7_closeout_readiness_audit import (  # noqa: E402
+    audit_v3_7_closeout_and_v3_8_readiness,
+    count_v3_7_closeout_findings_by_classification,
+    export_v3_7_closeout_and_v3_8_readiness_result,
+)
+from app.runtime_orchestration.v3_7_closeout_readiness_models import (  # noqa: E402
+    validate_v3_7_closeout_hash_stability,
+    validate_v3_7_closeout_serialization_stability,
+)
+
+
+DETERMINISTIC_GENERATED_AT = "2026-05-16T00:00:00+00:00"
+
+
+def build_v3_7_closeout_and_v3_8_readiness_report(repo_root: Path | None = None) -> dict[str, Any]:
+    root = repo_root or Path(__file__).resolve().parents[2]
+    result = audit_v3_7_closeout_and_v3_8_readiness()
+    serialization = validate_v3_7_closeout_serialization_stability(result)
+    hashing = validate_v3_7_closeout_hash_stability(result)
+    report = {
+        "schema_version": "v3_7.closeout_and_v3_8_readiness_report.1",
+        "generated_at": DETERMINISTIC_GENERATED_AT,
+        "phase_name": "v3.7_closeout_and_v3.8_readiness",
+        "repo_root": str(root),
+        "architectural_purpose": "closeout certification and readiness auditing for deterministic orchestration planning intelligence",
+        "closeout_is_non_executable": result.closeout_is_non_executable,
+        "closeout_certifies_planning_intelligence_continuity_only": result.closeout_certifies_planning_intelligence_continuity_only,
+        "ready_for_future_deterministic_planning_expansion": result.readiness_for_v3_8_planning,
+        "runtime_execution_readiness_certified": result.runtime_execution_readiness_certified,
+        "execution_authorization_enabled": result.execution_authorization_enabled,
+        "orchestration_execution_enabled": result.orchestration_execution_enabled,
+        "routing_enabled": result.routing_enabled,
+        "scheduling_enabled": result.scheduling_enabled,
+        "dispatch_enabled": result.dispatch_enabled,
+        "traversal_enabled": result.traversal_enabled,
+        "runtime_path_selection_enabled": result.runtime_path_selection_enabled,
+        "scenario_execution_selection_enabled": result.scenario_execution_selection_enabled,
+        "execution_recommendation_enabled": result.execution_recommendation_enabled,
+        "optimization_for_execution_enabled": result.optimization_for_execution_enabled,
+        "callable_execution_flow_enabled": result.callable_execution_flow_enabled,
+        "runtime_orchestration_engine_enabled": result.runtime_orchestration_engine_enabled,
+        "runtime_mutation_enabled": result.runtime_mutation_enabled,
+        "persistent_runtime_writes_enabled": result.persistent_runtime_writes_enabled,
+        "autonomous_orchestration_enabled": result.autonomous_orchestration_enabled,
+        "total_phases_audited": result.total_phases_audited,
+        "continuity_validation_totals": dict(result.continuity_validation_totals),
+        "replay_rollback_totals": dict(result.replay_rollback_totals),
+        "provenance_explainability_totals": dict(result.provenance_explainability_totals),
+        "integrity_certification_totals": {
+            "integrity_continuity": result.continuity_validation_totals["integrity_continuity"],
+            "certification_continuity": result.continuity_validation_totals["certification_continuity"],
+        },
+        "execution_boundary_audit_totals": dict(result.execution_boundary_audit_totals),
+        "hidden_risk_totals": dict(result.hidden_risk_totals),
+        "validation_totals": dict(result.validation_totals),
+        "finding_totals": {
+            "finding_count": len(result.findings),
+            "finding_classification_counts": count_v3_7_closeout_findings_by_classification(result.findings),
+            "blocking_finding_count": sum(1 for finding in result.findings if finding.blocks_closeout),
+            "fail_visible_finding_count": sum(1 for finding in result.findings if finding.fail_visible and not finding.hidden),
+        },
+        "deterministic_guarantees": {
+            **dict(result.deterministic_guarantees),
+            "closeout_serialization_stable": serialization["stable"],
+            "closeout_hash_stable": hashing["stable"],
+            "closeout_hash": result.deterministic_closeout_hash,
+        },
+        "non_executable_confirmation": result.closeout_is_non_executable,
+        "no_execution_authorization_confirmation": not result.execution_authorization_enabled,
+        "readiness_for_v3_8_planning_confirmation": result.readiness_for_v3_8_planning,
+        "no_runtime_readiness_confirmation": not result.runtime_execution_readiness_certified,
+        "routing_scheduling_dispatch_traversal_prohibited_confirmation": not any(
+            (result.routing_enabled, result.scheduling_enabled, result.dispatch_enabled, result.traversal_enabled)
+        ),
+        "closeout_record": export_v3_7_closeout_and_v3_8_readiness_result(result),
+        "explicit_limitations": [
+            "v3.7 is non-executable",
+            "v3.7 does not enable orchestration execution",
+            "v3.7 does not enable routing, scheduling, dispatch, or traversal",
+            "v3.7 does not enable orchestration optimization",
+            "v3.7 does not enable execution authorization",
+            "v3.7 established deterministic orchestration planning intelligence only",
+            "v3.8 may expand planning intelligence but may not enable runtime orchestration execution",
+        ],
+        "summary": {
+            "closeout_status": result.closeout_status,
+            "v3_8_readiness_classification": result.v3_8_readiness_classification,
+            "total_phases_audited": result.total_phases_audited,
+            "validation_status": result.validation_totals["validation_status"],
+            "validation_error_count": result.validation_totals["error_count"],
+            "deterministic_serialization_verified": serialization["stable"],
+            "deterministic_hashing_verified": hashing["stable"],
+            "continuity_verified": result.continuity_validation_totals["certification_continuity"],
+            "execution_boundary_verified": result.execution_boundary_audit_totals["execution_boundary_preserved"],
+            "replay_verified": result.replay_rollback_totals["replay_safe"],
+            "rollback_verified": result.replay_rollback_totals["rollback_safe"],
+            "provenance_verified": result.provenance_explainability_totals["provenance_safe"],
+            "explainability_verified": result.provenance_explainability_totals["explainability_safe"],
+            "non_executable_verified": result.closeout_is_non_executable,
+            "no_execution_authorization_verified": not result.execution_authorization_enabled,
+            "no_runtime_readiness_verified": not result.runtime_execution_readiness_certified,
+        },
+    }
+    report["deterministic_report_hash"] = deterministic_hash(
+        {key: value for key, value in report.items() if key != "deterministic_report_hash"}
+    )
+    return report
+
+
+def write_markdown_report(report: dict[str, Any], output_path: Path) -> None:
+    lines = [
+        "# v3.7 Closeout and v3.8 Readiness",
+        "",
+        "## Architectural Purpose",
+        "",
+        "v3.7 closeout validates deterministic orchestration planning intelligence continuity across graph foundations, governance boundaries, compatibility reasoning, evaluation reasoning, planning sessions, planning scenarios, intelligence aggregation, integrity enforcement, and continuity certification.",
+        "",
+        "v3.7 is NON-executable.",
+        "",
+        "v3.7 does NOT enable orchestration execution.",
+        "",
+        "v3.7 does NOT enable routing, scheduling, dispatch, or traversal.",
+        "",
+        "v3.7 does NOT enable orchestration optimization.",
+        "",
+        "v3.7 does NOT enable execution authorization.",
+        "",
+        "v3.7 established deterministic orchestration planning intelligence ONLY.",
+        "",
+        "v3.8 may expand planning intelligence but may NOT enable runtime orchestration execution.",
+        "",
+        "## Planning Intelligence Maturity vs Runtime Orchestration Capability",
+        "",
+        "Planning intelligence maturity means deterministic, replay-safe, rollback-safe, provenance-safe, explainability-safe evidence that describes structural planning continuity.",
+        "",
+        "Runtime orchestration capability would mean executable behavior, runtime routing, scheduling, dispatch, traversal, path selection, optimization, recommendation, or callable control systems. This closeout does not create those capabilities.",
+        "",
+        "## Closeout Totals",
+        "",
+        f"- Closeout status: `{report['summary']['closeout_status']}`",
+        f"- v3.8 readiness classification: `{report['summary']['v3_8_readiness_classification']}`",
+        f"- Total phases audited: `{report['total_phases_audited']}`",
+        f"- Validation errors: `{report['validation_totals']['error_count']}`",
+        f"- Execution-boundary violations: `{report['execution_boundary_audit_totals']['execution_boundary_violation_count']}`",
+        f"- Hidden risk detected: `{report['hidden_risk_totals']['hidden_risk_detected']}`",
+        f"- Serialization stable: `{report['deterministic_guarantees']['closeout_serialization_stable']}`",
+        f"- Hash stable: `{report['deterministic_guarantees']['closeout_hash_stable']}`",
+        "",
+        "## Explicit Non-Execution Guarantees",
+        "",
+        "- Runtime execution readiness is not certified.",
+        "- Execution authorization remains disabled.",
+        "- Orchestration execution remains disabled.",
+        "- Routing remains disabled.",
+        "- Scheduling remains disabled.",
+        "- Dispatch remains disabled.",
+        "- Traversal remains disabled.",
+        "- Runtime path selection remains disabled.",
+        "- Scenario execution selection remains disabled.",
+        "- Optimization for execution remains disabled.",
+        "- Recommendation to execute remains disabled.",
+        "- Callable execution flows remain disabled.",
+        "- Runtime orchestration engines remain disabled.",
+        "",
+        "## Generated Evidence",
+        "",
+        f"- Deterministic report hash: `{report['deterministic_report_hash']}`",
+        f"- Deterministic closeout hash: `{report['deterministic_guarantees']['closeout_hash']}`",
+        f"- Certification hash: `{report['deterministic_guarantees']['certification_hash']}`",
+        f"- Certification validation hash: `{report['deterministic_guarantees']['certification_validation_hash']}`",
+        f"- Certification audit hash: `{report['deterministic_guarantees']['certification_audit_hash']}`",
+    ]
+    output_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=Path(__file__).resolve().parents[2])
+    parser.add_argument(
+        "--json-output",
+        type=Path,
+        default=Path(__file__).resolve().parents[2] / "docs" / "generated" / "v3_7_closeout_and_v3_8_readiness_report.json",
+    )
+    parser.add_argument(
+        "--markdown-output",
+        type=Path,
+        default=Path(__file__).resolve().parents[2] / "docs" / "migration" / "V3_7_CLOSEOUT_AND_V3_8_READINESS.md",
+    )
+    args = parser.parse_args(argv)
+    report = build_v3_7_closeout_and_v3_8_readiness_report(args.repo_root)
+    args.json_output.parent.mkdir(parents=True, exist_ok=True)
+    args.markdown_output.parent.mkdir(parents=True, exist_ok=True)
+    args.json_output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    write_markdown_report(report, args.markdown_output)
+    print(json.dumps(report["summary"], indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_v3_7_closeout_and_v3_8_readiness.py
+++ b/backend/tests/test_v3_7_closeout_and_v3_8_readiness.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from app.runtime_orchestration.v3_7_closeout_readiness_audit import (
+    V37_CLOSEOUT_VALIDATION_BLOCKED,
+    V37_CLOSEOUT_VALIDATION_STABLE,
+    audit_v3_7_closeout_and_v3_8_readiness,
+)
+from app.runtime_orchestration.v3_7_closeout_readiness_models import (
+    V37_CLOSEOUT_FINDING_EXECUTION_BOUNDARY_BROKEN,
+    V37_CLOSEOUT_FINDING_HIDDEN_RISK_DETECTED,
+    V37_CLOSEOUT_FINDING_NON_EXECUTABLE,
+    V3_7_CLOSED_OUT_READY_FOR_V3_8_PLANNING,
+    V3_7_CLOSEOUT_BLOCKED_FOR_V3_8_PLANNING,
+    V37CloseoutReadinessInput,
+    hash_v3_7_closeout_readiness_result,
+    serialize_v3_7_closeout_readiness_result,
+    validate_v3_7_closeout_hash_stability,
+    validate_v3_7_closeout_serialization_stability,
+)
+from scripts.report_v3_7_closeout_and_v3_8_readiness import (
+    build_v3_7_closeout_and_v3_8_readiness_report,
+)
+
+
+def test_v3_7_closeout_preserves_full_phase_continuity():
+    result = audit_v3_7_closeout_and_v3_8_readiness()
+
+    assert result.closeout_status == V3_7_CLOSED_OUT_READY_FOR_V3_8_PLANNING
+    assert result.v3_8_readiness_classification == V3_7_CLOSED_OUT_READY_FOR_V3_8_PLANNING
+    assert result.validation_totals["validation_status"] == V37_CLOSEOUT_VALIDATION_STABLE
+    assert result.total_phases_audited == 9
+    assert result.validation_totals["missing_phase_continuity_count"] == 0
+    assert result.continuity_validation_totals["governance_continuity"] is True
+    assert result.continuity_validation_totals["compatibility_continuity"] is True
+    assert result.continuity_validation_totals["evaluation_continuity"] is True
+    assert result.continuity_validation_totals["planning_session_continuity"] is True
+    assert result.continuity_validation_totals["planning_scenario_continuity"] is True
+    assert result.continuity_validation_totals["aggregation_continuity"] is True
+    assert result.continuity_validation_totals["integrity_continuity"] is True
+    assert result.continuity_validation_totals["certification_continuity"] is True
+
+
+def test_v3_7_closeout_serialization_and_hash_are_stable():
+    first = audit_v3_7_closeout_and_v3_8_readiness()
+    second = audit_v3_7_closeout_and_v3_8_readiness()
+
+    assert serialize_v3_7_closeout_readiness_result(first) == serialize_v3_7_closeout_readiness_result(second)
+    assert hash_v3_7_closeout_readiness_result(first) == hash_v3_7_closeout_readiness_result(second)
+    assert validate_v3_7_closeout_serialization_stability(first)["stable"] is True
+    assert validate_v3_7_closeout_hash_stability(first)["stable"] is True
+
+
+def test_v3_7_closeout_replay_rollback_provenance_and_explainability():
+    result = audit_v3_7_closeout_and_v3_8_readiness()
+
+    assert result.replay_rollback_totals["replay_safe"] is True
+    assert result.replay_rollback_totals["rollback_safe"] is True
+    assert result.provenance_explainability_totals["provenance_safe"] is True
+    assert result.provenance_explainability_totals["explainability_safe"] is True
+    assert all(evidence.replay_safe for evidence in result.phase_evidence)
+    assert all(evidence.rollback_safe for evidence in result.phase_evidence)
+    assert all(evidence.provenance_safe for evidence in result.phase_evidence)
+    assert all(evidence.explainability_safe for evidence in result.phase_evidence)
+
+
+def test_v3_7_closeout_execution_boundary_and_non_executable_guarantees():
+    result = audit_v3_7_closeout_and_v3_8_readiness()
+
+    assert result.closeout_is_non_executable is True
+    assert result.runtime_execution_readiness_certified is False
+    assert result.execution_authorization_enabled is False
+    assert result.orchestration_execution_enabled is False
+    assert result.routing_enabled is False
+    assert result.scheduling_enabled is False
+    assert result.dispatch_enabled is False
+    assert result.traversal_enabled is False
+    assert result.runtime_path_selection_enabled is False
+    assert result.scenario_execution_selection_enabled is False
+    assert result.execution_recommendation_enabled is False
+    assert result.optimization_for_execution_enabled is False
+    assert result.callable_execution_flow_enabled is False
+    assert result.runtime_orchestration_engine_enabled is False
+    assert result.execution_boundary_audit_totals["execution_boundary_preserved"] is True
+    assert any(finding.finding_classification == V37_CLOSEOUT_FINDING_NON_EXECUTABLE for finding in result.findings)
+
+
+def test_v3_7_closeout_missing_phase_is_fail_visible():
+    result = audit_v3_7_closeout_and_v3_8_readiness(
+        V37CloseoutReadinessInput(omitted_phase_ids=("planning_scenarios",))
+    )
+
+    assert result.closeout_status == V3_7_CLOSEOUT_BLOCKED_FOR_V3_8_PLANNING
+    assert result.validation_totals["validation_status"] == V37_CLOSEOUT_VALIDATION_BLOCKED
+    assert result.validation_totals["missing_phase_continuity_count"] == 1
+    assert any(finding.finding_classification == "continuity_broken" for finding in result.findings)
+
+
+def test_v3_7_closeout_hidden_risk_is_fail_visible():
+    result = audit_v3_7_closeout_and_v3_8_readiness(
+        V37CloseoutReadinessInput(force_hidden_risk_detected=True)
+    )
+
+    assert result.closeout_status == V3_7_CLOSEOUT_BLOCKED_FOR_V3_8_PLANNING
+    assert result.hidden_risk_totals["hidden_risk_detected"] is True
+    assert result.validation_totals["hidden_prohibited_state_count"] == 1
+    hidden_finding = next(
+        finding
+        for finding in result.findings
+        if finding.finding_classification == V37_CLOSEOUT_FINDING_HIDDEN_RISK_DETECTED
+    )
+    assert hidden_finding.blocks_closeout is True
+    assert hidden_finding.fail_visible is True
+
+
+def test_v3_7_closeout_execution_boundary_violation_blocks_closeout():
+    result = audit_v3_7_closeout_and_v3_8_readiness(
+        V37CloseoutReadinessInput(force_execution_boundary_violation=True)
+    )
+
+    assert result.closeout_status == V3_7_CLOSEOUT_BLOCKED_FOR_V3_8_PLANNING
+    assert result.validation_totals["execution_boundary_violation_count"] == 1
+    broken_finding = next(
+        finding
+        for finding in result.findings
+        if finding.finding_classification == V37_CLOSEOUT_FINDING_EXECUTION_BOUNDARY_BROKEN
+    )
+    assert broken_finding.blocks_closeout is True
+    assert broken_finding.fail_visible is True
+
+
+def test_v3_7_closeout_report_contains_required_totals_and_boundaries():
+    report = build_v3_7_closeout_and_v3_8_readiness_report()
+
+    assert report["summary"]["validation_status"] == V37_CLOSEOUT_VALIDATION_STABLE
+    assert report["total_phases_audited"] == 9
+    assert report["continuity_validation_totals"]["governance_continuity"] is True
+    assert report["execution_boundary_audit_totals"]["execution_boundary_violation_count"] == 0
+    assert report["non_executable_confirmation"] is True
+    assert report["no_execution_authorization_confirmation"] is True
+    assert report["no_runtime_readiness_confirmation"] is True
+    assert report["routing_scheduling_dispatch_traversal_prohibited_confirmation"] is True

--- a/docs/generated/v3_7_closeout_and_v3_8_readiness_report.json
+++ b/docs/generated/v3_7_closeout_and_v3_8_readiness_report.json
@@ -1,0 +1,1099 @@
+{
+  "architectural_purpose": "closeout certification and readiness auditing for deterministic orchestration planning intelligence",
+  "autonomous_orchestration_enabled": false,
+  "callable_execution_flow_enabled": false,
+  "closeout_certifies_planning_intelligence_continuity_only": true,
+  "closeout_is_non_executable": true,
+  "closeout_record": {
+    "autonomous_orchestration_enabled": false,
+    "callable_execution_flow_enabled": false,
+    "closeout_certifies_planning_intelligence_continuity_only": true,
+    "closeout_is_non_executable": true,
+    "closeout_status": "v3_7_closed_out_ready_for_v3_8_planning",
+    "continuity_validation_totals": {
+      "aggregation_continuity": true,
+      "certification_continuity": true,
+      "compatibility_continuity": true,
+      "deterministic_hashing_continuity": true,
+      "deterministic_serialization_continuity": true,
+      "evaluation_continuity": true,
+      "execution_boundary_continuity": true,
+      "explainability_continuity": true,
+      "fail_visible_continuity": true,
+      "governance_continuity": true,
+      "integrity_continuity": true,
+      "planning_scenario_continuity": true,
+      "planning_session_continuity": true,
+      "provenance_continuity": true,
+      "replay_continuity": true,
+      "rollback_continuity": true
+    },
+    "deterministic_closeout_hash": "d6ed1346c6adab8e44b1bf9a303a57a3ecd1c5ec6ee032d557bcdc7860a7db65",
+    "deterministic_guarantees": {
+      "certification_audit_hash": "afc7e288304a192d9f66886e1af4c3d739863b68c7b1dcc994a2186fa6891dbe",
+      "certification_explainability_hash": "bdae8a3ee7f9f1f680de2fac55fef8abd8d136d9210a6824ca9b8102f2b88502",
+      "certification_hash": "be8ee33cf57e8ea66bf85458c0f11ea6e2cbf51b928cbcc5e68728fe0dd8e25f",
+      "certification_hash_stable": true,
+      "certification_provenance_hash": "0ee425b51b8ba79c350da8fac83093ba8ba0b1380dd3ae7da24241f34ed99e2f",
+      "certification_serialization_stable": true,
+      "certification_validation_hash": "1d0ce18d4f7117d9f7f0dcc3db6102b07c7b79fbb1ff8918157a03c2fa833b39",
+      "closeout_hash": "d6ed1346c6adab8e44b1bf9a303a57a3ecd1c5ec6ee032d557bcdc7860a7db65",
+      "closeout_hash_stable": true,
+      "closeout_serialization_stable": true
+    },
+    "dispatch_enabled": false,
+    "execution_authorization_enabled": false,
+    "execution_boundary_audit_totals": {
+      "callable_execution_flow_absent": true,
+      "execution_authorization_absent": true,
+      "execution_boundary_preserved": true,
+      "execution_boundary_violation_count": 0,
+      "execution_recommendation_absent": true,
+      "optimization_for_execution_absent": true,
+      "orchestration_dispatch_absent": true,
+      "orchestration_routing_absent": true,
+      "orchestration_scheduling_absent": true,
+      "runtime_orchestration_engine_absent": true,
+      "runtime_path_selection_absent": true,
+      "scenario_execution_selection_absent": true,
+      "traversal_authorization_absent": true
+    },
+    "execution_recommendation_enabled": false,
+    "explainability_references": [
+      "explain_evaluation_compatibility_restricted_v3_7_edge_provenance_continuity_to_explainability_continuity",
+      "explain_evaluation_finding_rule_compat_governance_to_structure",
+      "explain_evaluation_finding_rule_compat_graph_execution_prohibited",
+      "explain_evaluation_finding_rule_compat_legacy_incompatible",
+      "explain_evaluation_finding_rule_compat_runtime_dispatch_unsupported",
+      "explain_evaluation_finding_rule_compat_structure_to_experimental",
+      "explain_evaluation_finding_rule_compat_structure_to_structure",
+      "explain_evaluation_finding_rule_compat_unknown_external",
+      "explain_evaluation_structural_continuity_warning",
+      "v3_7_compatibility_explanation_v3_7_edge_governance_visibility_to_provenance_continuity_edge",
+      "v3_7_compatibility_explanation_v3_7_edge_governance_visibility_to_provenance_continuity_nodes",
+      "v3_7_compatibility_explanation_v3_7_edge_provenance_continuity_to_explainability_continuity_edge",
+      "v3_7_compatibility_explanation_v3_7_edge_provenance_continuity_to_explainability_continuity_nodes",
+      "v3_7_evidence_v3_7_edge_governance_visibility_to_provenance_continuity",
+      "v3_7_evidence_v3_7_edge_provenance_continuity_to_explainability_continuity",
+      "v3_7_evidence_v3_7_node_explainability_continuity",
+      "v3_7_evidence_v3_7_node_governance_boundary_visibility",
+      "v3_7_evidence_v3_7_node_provenance_continuity",
+      "v3_7_governance_explanation_v3_7_edge_governance_visibility_to_provenance_continuity",
+      "v3_7_governance_explanation_v3_7_edge_provenance_continuity_to_explainability_continuity",
+      "v3_7_governance_explanation_v3_7_node_explainability_continuity",
+      "v3_7_governance_explanation_v3_7_node_governance_boundary_visibility",
+      "v3_7_governance_explanation_v3_7_node_provenance_continuity",
+      "v3_7_graph_certification_explainability",
+      "v3_7_graph_integrity_explainability",
+      "v3_7_graph_intelligence_explainability",
+      "v3_7_graph_planning_session_explainability",
+      "v3_7_graph_scenario_explainability"
+    ],
+    "explanation_summary": [
+      "v3.7 closeout status is certified for future deterministic planning expansion only.",
+      "v3.7 explicitly prohibited graph execution, orchestration execution, routing, scheduling, dispatch, traversal, runtime path selection, scenario execution selection, optimization for execution, recommendation to execute, callable flows, and runtime control systems.",
+      "v3.7 implemented deterministic orchestration planning intelligence across graph foundations, governance, compatibility, evaluation, sessions, scenarios, aggregation, integrity, and certification.",
+      "v3.7 preserved deterministic serialization, deterministic hashing, governance continuity, compatibility continuity, evaluation continuity, provenance continuity, explainability continuity, replay continuity, and rollback continuity.",
+      "v3.8 may expand planning intelligence evidence but may not enable runtime orchestration execution."
+    ],
+    "findings": [
+      {
+        "active": false,
+        "active_violation": false,
+        "blocks_closeout": false,
+        "evidence_references": [
+          "v3_7_certification_scope_aggregation",
+          "v3_7_certification_scope_compatibility",
+          "v3_7_certification_scope_evaluation",
+          "v3_7_certification_scope_governance",
+          "v3_7_certification_scope_graph_foundations",
+          "v3_7_certification_scope_integrity",
+          "v3_7_certification_scope_scenario",
+          "v3_7_certification_scope_session",
+          "v3_7_graph_planning_continuity_certification_default"
+        ],
+        "fail_visible": true,
+        "finding_classification": "closeout_blocked",
+        "finding_id": "v3_7_closeout_closeout_blocked",
+        "hidden": false,
+        "severity": "visibility",
+        "subject_id": "closeout_blocked",
+        "subject_type": "v3_7_closeout",
+        "summary": "closeout blockers remain fail-visible"
+      },
+      {
+        "active": true,
+        "active_violation": false,
+        "blocks_closeout": false,
+        "evidence_references": [
+          "v3_7_certification_scope_aggregation",
+          "v3_7_certification_scope_compatibility",
+          "v3_7_certification_scope_evaluation",
+          "v3_7_certification_scope_governance",
+          "v3_7_certification_scope_graph_foundations",
+          "v3_7_certification_scope_integrity",
+          "v3_7_certification_scope_scenario",
+          "v3_7_certification_scope_session",
+          "v3_7_graph_planning_continuity_certification_default"
+        ],
+        "fail_visible": true,
+        "finding_classification": "closeout_ready",
+        "finding_id": "v3_7_closeout_closeout_ready",
+        "hidden": false,
+        "severity": "info",
+        "subject_id": "closeout_ready",
+        "subject_type": "v3_7_closeout",
+        "summary": "v3.7 closeout is ready for v3.8 deterministic planning expansion"
+      },
+      {
+        "active": false,
+        "active_violation": false,
+        "blocks_closeout": false,
+        "evidence_references": [
+          "v3_7_certification_scope_aggregation",
+          "v3_7_certification_scope_compatibility",
+          "v3_7_certification_scope_evaluation",
+          "v3_7_certification_scope_governance",
+          "v3_7_certification_scope_graph_foundations",
+          "v3_7_certification_scope_integrity",
+          "v3_7_certification_scope_scenario",
+          "v3_7_certification_scope_session",
+          "v3_7_graph_planning_continuity_certification_default"
+        ],
+        "fail_visible": true,
+        "finding_classification": "continuity_broken",
+        "finding_id": "v3_7_closeout_continuity_broken",
+        "hidden": false,
+        "severity": "visibility",
+        "subject_id": "continuity_broken",
+        "subject_type": "v3_7_closeout",
+        "summary": "broken continuity blocks closeout"
+      },
+      {
+        "active": true,
+        "active_violation": false,
+        "blocks_closeout": false,
+        "evidence_references": [
+          "v3_7_certification_scope_aggregation",
+          "v3_7_certification_scope_compatibility",
+          "v3_7_certification_scope_evaluation",
+          "v3_7_certification_scope_governance",
+          "v3_7_certification_scope_graph_foundations",
+          "v3_7_certification_scope_integrity",
+          "v3_7_certification_scope_scenario",
+          "v3_7_certification_scope_session",
+          "v3_7_graph_planning_continuity_certification_default"
+        ],
+        "fail_visible": true,
+        "finding_classification": "continuity_preserved",
+        "finding_id": "v3_7_closeout_continuity_preserved",
+        "hidden": false,
+        "severity": "info",
+        "subject_id": "continuity_preserved",
+        "subject_type": "v3_7_closeout",
+        "summary": "v3.7 phase continuity is preserved"
+      },
+      {
+        "active": true,
+        "active_violation": false,
+        "blocks_closeout": false,
+        "evidence_references": [
+          "v3_7_certification_scope_aggregation",
+          "v3_7_certification_scope_compatibility",
+          "v3_7_certification_scope_evaluation",
+          "v3_7_certification_scope_governance",
+          "v3_7_certification_scope_graph_foundations",
+          "v3_7_certification_scope_integrity",
+          "v3_7_certification_scope_scenario",
+          "v3_7_certification_scope_session",
+          "v3_7_graph_planning_continuity_certification_default"
+        ],
+        "fail_visible": true,
+        "finding_classification": "deterministic",
+        "finding_id": "v3_7_closeout_deterministic",
+        "hidden": false,
+        "severity": "info",
+        "subject_id": "deterministic",
+        "subject_type": "v3_7_closeout",
+        "summary": "serialization and hashing remain deterministic"
+      },
+      {
+        "active": false,
+        "active_violation": false,
+        "blocks_closeout": false,
+        "evidence_references": [
+          "v3_7_certification_scope_aggregation",
+          "v3_7_certification_scope_compatibility",
+          "v3_7_certification_scope_evaluation",
+          "v3_7_certification_scope_governance",
+          "v3_7_certification_scope_graph_foundations",
+          "v3_7_certification_scope_integrity",
+          "v3_7_certification_scope_scenario",
+          "v3_7_certification_scope_session",
+          "v3_7_graph_planning_continuity_certification_default"
+        ],
+        "fail_visible": true,
+        "finding_classification": "execution_boundary_broken",
+        "finding_id": "v3_7_closeout_execution_boundary_broken",
+        "hidden": false,
+        "severity": "visibility",
+        "subject_id": "execution_boundary_broken",
+        "subject_type": "v3_7_closeout",
+        "summary": "execution-boundary failures block closeout"
+      },
+      {
+        "active": true,
+        "active_violation": false,
+        "blocks_closeout": false,
+        "evidence_references": [
+          "v3_7_certification_scope_aggregation",
+          "v3_7_certification_scope_compatibility",
+          "v3_7_certification_scope_evaluation",
+          "v3_7_certification_scope_governance",
+          "v3_7_certification_scope_graph_foundations",
+          "v3_7_certification_scope_integrity",
+          "v3_7_certification_scope_scenario",
+          "v3_7_certification_scope_session",
+          "v3_7_graph_planning_continuity_certification_default"
+        ],
+        "fail_visible": true,
+        "finding_classification": "execution_boundary_preserved",
+        "finding_id": "v3_7_closeout_execution_boundary_preserved",
+        "hidden": false,
+        "severity": "info",
+        "subject_id": "execution_boundary_preserved",
+        "subject_type": "v3_7_closeout",
+        "summary": "execution boundaries remain preserved"
+      },
+      {
+        "active": true,
+        "active_violation": false,
+        "blocks_closeout": false,
+        "evidence_references": [
+          "v3_7_certification_scope_aggregation",
+          "v3_7_certification_scope_compatibility",
+          "v3_7_certification_scope_evaluation",
+          "v3_7_certification_scope_governance",
+          "v3_7_certification_scope_graph_foundations",
+          "v3_7_certification_scope_integrity",
+          "v3_7_certification_scope_scenario",
+          "v3_7_certification_scope_session",
+          "v3_7_graph_planning_continuity_certification_default"
+        ],
+        "fail_visible": true,
+        "finding_classification": "explainability_safe",
+        "finding_id": "v3_7_closeout_explainability_safe",
+        "hidden": false,
+        "severity": "info",
+        "subject_id": "explainability_safe",
+        "subject_type": "v3_7_closeout",
+        "summary": "explainability continuity is preserved"
+      },
+      {
+        "active": false,
+        "active_violation": false,
+        "blocks_closeout": false,
+        "evidence_references": [
+          "v3_7_certification_scope_aggregation",
+          "v3_7_certification_scope_compatibility",
+          "v3_7_certification_scope_evaluation",
+          "v3_7_certification_scope_governance",
+          "v3_7_certification_scope_graph_foundations",
+          "v3_7_certification_scope_integrity",
+          "v3_7_certification_scope_scenario",
+          "v3_7_certification_scope_session",
+          "v3_7_graph_planning_continuity_certification_default"
+        ],
+        "fail_visible": true,
+        "finding_classification": "hidden_risk_detected",
+        "finding_id": "v3_7_closeout_hidden_risk_detected",
+        "hidden": false,
+        "severity": "visibility",
+        "subject_id": "hidden_risk_detected",
+        "subject_type": "v3_7_closeout",
+        "summary": "hidden risk states block closeout"
+      },
+      {
+        "active": true,
+        "active_violation": false,
+        "blocks_closeout": false,
+        "evidence_references": [
+          "v3_7_certification_scope_aggregation",
+          "v3_7_certification_scope_compatibility",
+          "v3_7_certification_scope_evaluation",
+          "v3_7_certification_scope_governance",
+          "v3_7_certification_scope_graph_foundations",
+          "v3_7_certification_scope_integrity",
+          "v3_7_certification_scope_scenario",
+          "v3_7_certification_scope_session",
+          "v3_7_graph_planning_continuity_certification_default"
+        ],
+        "fail_visible": true,
+        "finding_classification": "non_executable",
+        "finding_id": "v3_7_closeout_non_executable",
+        "hidden": false,
+        "severity": "info",
+        "subject_id": "non_executable",
+        "subject_type": "v3_7_closeout",
+        "summary": "closeout evidence remains non-executable"
+      },
+      {
+        "active": true,
+        "active_violation": false,
+        "blocks_closeout": false,
+        "evidence_references": [
+          "v3_7_certification_scope_aggregation",
+          "v3_7_certification_scope_compatibility",
+          "v3_7_certification_scope_evaluation",
+          "v3_7_certification_scope_governance",
+          "v3_7_certification_scope_graph_foundations",
+          "v3_7_certification_scope_integrity",
+          "v3_7_certification_scope_scenario",
+          "v3_7_certification_scope_session",
+          "v3_7_graph_planning_continuity_certification_default"
+        ],
+        "fail_visible": true,
+        "finding_classification": "provenance_safe",
+        "finding_id": "v3_7_closeout_provenance_safe",
+        "hidden": false,
+        "severity": "info",
+        "subject_id": "provenance_safe",
+        "subject_type": "v3_7_closeout",
+        "summary": "provenance continuity is preserved"
+      },
+      {
+        "active": false,
+        "active_violation": false,
+        "blocks_closeout": false,
+        "evidence_references": [
+          "v3_7_certification_scope_aggregation",
+          "v3_7_certification_scope_compatibility",
+          "v3_7_certification_scope_evaluation",
+          "v3_7_certification_scope_governance",
+          "v3_7_certification_scope_graph_foundations",
+          "v3_7_certification_scope_integrity",
+          "v3_7_certification_scope_scenario",
+          "v3_7_certification_scope_session",
+          "v3_7_graph_planning_continuity_certification_default"
+        ],
+        "fail_visible": true,
+        "finding_classification": "readiness_blocked",
+        "finding_id": "v3_7_closeout_readiness_blocked",
+        "hidden": false,
+        "severity": "visibility",
+        "subject_id": "readiness_blocked",
+        "subject_type": "v3_7_closeout",
+        "summary": "v3.8 planning readiness blockers remain fail-visible"
+      },
+      {
+        "active": true,
+        "active_violation": false,
+        "blocks_closeout": false,
+        "evidence_references": [
+          "v3_7_certification_scope_aggregation",
+          "v3_7_certification_scope_compatibility",
+          "v3_7_certification_scope_evaluation",
+          "v3_7_certification_scope_governance",
+          "v3_7_certification_scope_graph_foundations",
+          "v3_7_certification_scope_integrity",
+          "v3_7_certification_scope_scenario",
+          "v3_7_certification_scope_session",
+          "v3_7_graph_planning_continuity_certification_default"
+        ],
+        "fail_visible": true,
+        "finding_classification": "readiness_certified",
+        "finding_id": "v3_7_closeout_readiness_certified",
+        "hidden": false,
+        "severity": "info",
+        "subject_id": "readiness_certified",
+        "subject_type": "v3_7_closeout",
+        "summary": "v3.8 planning readiness is certified for planning expansion only"
+      },
+      {
+        "active": true,
+        "active_violation": false,
+        "blocks_closeout": false,
+        "evidence_references": [
+          "v3_7_certification_scope_aggregation",
+          "v3_7_certification_scope_compatibility",
+          "v3_7_certification_scope_evaluation",
+          "v3_7_certification_scope_governance",
+          "v3_7_certification_scope_graph_foundations",
+          "v3_7_certification_scope_integrity",
+          "v3_7_certification_scope_scenario",
+          "v3_7_certification_scope_session",
+          "v3_7_graph_planning_continuity_certification_default"
+        ],
+        "fail_visible": true,
+        "finding_classification": "replay_safe",
+        "finding_id": "v3_7_closeout_replay_safe",
+        "hidden": false,
+        "severity": "info",
+        "subject_id": "replay_safe",
+        "subject_type": "v3_7_closeout",
+        "summary": "replay continuity is planning evidence only"
+      },
+      {
+        "active": true,
+        "active_violation": false,
+        "blocks_closeout": false,
+        "evidence_references": [
+          "v3_7_certification_scope_aggregation",
+          "v3_7_certification_scope_compatibility",
+          "v3_7_certification_scope_evaluation",
+          "v3_7_certification_scope_governance",
+          "v3_7_certification_scope_graph_foundations",
+          "v3_7_certification_scope_integrity",
+          "v3_7_certification_scope_scenario",
+          "v3_7_certification_scope_session",
+          "v3_7_graph_planning_continuity_certification_default"
+        ],
+        "fail_visible": true,
+        "finding_classification": "rollback_safe",
+        "finding_id": "v3_7_closeout_rollback_safe",
+        "hidden": false,
+        "severity": "info",
+        "subject_id": "rollback_safe",
+        "subject_type": "v3_7_closeout",
+        "summary": "rollback continuity is planning evidence only"
+      }
+    ],
+    "hidden_risk_totals": {
+      "hidden_prohibited_state_count": 0,
+      "hidden_risk_detected": false,
+      "hidden_unknown_state_count": 0,
+      "hidden_unsupported_state_count": 0
+    },
+    "optimization_for_execution_enabled": false,
+    "orchestration_execution_enabled": false,
+    "persistent_runtime_writes_enabled": false,
+    "phase_evidence": [
+      {
+        "artifact_hash": "40346f9d255caa644b54ccf0e40e3d9313087a10b6b45784d6763eae475023df",
+        "artifact_id": "v3-7-deterministic-orchestration-planning-graph",
+        "continuity_hashes": [
+          "40346f9d255caa644b54ccf0e40e3d9313087a10b6b45784d6763eae475023df",
+          "v3_7_graph_continuity_evidence"
+        ],
+        "continuity_preserved": true,
+        "deterministic_hash_present": true,
+        "evidence_reference_id": "v3_7_certification_scope_graph_foundations",
+        "explainability_references": [
+          "v3_7_evidence_v3_7_edge_governance_visibility_to_provenance_continuity",
+          "v3_7_evidence_v3_7_edge_provenance_continuity_to_explainability_continuity",
+          "v3_7_evidence_v3_7_node_explainability_continuity",
+          "v3_7_evidence_v3_7_node_governance_boundary_visibility",
+          "v3_7_evidence_v3_7_node_provenance_continuity"
+        ],
+        "explainability_safe": true,
+        "non_executable_evidence": true,
+        "phase_id": "graph_foundations",
+        "phase_name": "Graph Foundations",
+        "phase_order": 1,
+        "provenance_references": [
+          "v3-7-provenance-v3-7-deterministic-orchestration-planning-graph"
+        ],
+        "provenance_safe": true,
+        "reference_type": "graph_foundations",
+        "replay_references": [
+          "v3_7_graph_integrity_replay_evidence_default"
+        ],
+        "replay_safe": true,
+        "rollback_references": [
+          "v3_7_graph_evaluation_rollback_continuity"
+        ],
+        "rollback_safe": true
+      },
+      {
+        "artifact_hash": "30197b5afd37fa5e21de13c74a595db9125ea49ed2b1e0fa769c4f81dbfb8588",
+        "artifact_id": "v3-7-deterministic-orchestration-planning-graph",
+        "continuity_hashes": [
+          "30197b5afd37fa5e21de13c74a595db9125ea49ed2b1e0fa769c4f81dbfb8588",
+          "v3_7_graph_governance_continuity_evidence"
+        ],
+        "continuity_preserved": true,
+        "deterministic_hash_present": true,
+        "evidence_reference_id": "v3_7_certification_scope_governance",
+        "explainability_references": [
+          "v3_7_governance_explanation_v3_7_edge_governance_visibility_to_provenance_continuity",
+          "v3_7_governance_explanation_v3_7_edge_provenance_continuity_to_explainability_continuity",
+          "v3_7_governance_explanation_v3_7_node_explainability_continuity",
+          "v3_7_governance_explanation_v3_7_node_governance_boundary_visibility",
+          "v3_7_governance_explanation_v3_7_node_provenance_continuity"
+        ],
+        "explainability_safe": true,
+        "non_executable_evidence": true,
+        "phase_id": "governance_boundaries",
+        "phase_name": "Governance Boundary Intelligence",
+        "phase_order": 2,
+        "provenance_references": [
+          "v3-7-provenance-domain_compatibility_boundary_visibility",
+          "v3-7-provenance-domain_governance_visibility",
+          "v3-7-provenance-domain_graph_execution",
+          "v3-7-provenance-domain_graph_governance_boundary_intelligence",
+          "v3-7-provenance-domain_graph_structure_modeling",
+          "v3-7-provenance-domain_optimization",
+          "v3-7-provenance-domain_routing_scheduling_dispatch",
+          "v3-7-provenance-domain_runtime_dispatch"
+        ],
+        "provenance_safe": true,
+        "reference_type": "governance",
+        "replay_references": [
+          "v3_7_graph_integrity_replay_evidence_default"
+        ],
+        "replay_safe": true,
+        "rollback_references": [
+          "v3_7_graph_evaluation_rollback_continuity"
+        ],
+        "rollback_safe": true
+      },
+      {
+        "artifact_hash": "e6a6b5bb4221d1933f57e98cf9aebb06b3b57954d41c2e53a6a086cad2dd5570",
+        "artifact_id": "v3-7-deterministic-orchestration-planning-graph",
+        "continuity_hashes": [
+          "e6a6b5bb4221d1933f57e98cf9aebb06b3b57954d41c2e53a6a086cad2dd5570",
+          "v3_7_graph_compatibility_continuity_evidence"
+        ],
+        "continuity_preserved": true,
+        "deterministic_hash_present": true,
+        "evidence_reference_id": "v3_7_certification_scope_compatibility",
+        "explainability_references": [
+          "v3_7_compatibility_explanation_v3_7_edge_governance_visibility_to_provenance_continuity_edge",
+          "v3_7_compatibility_explanation_v3_7_edge_governance_visibility_to_provenance_continuity_nodes",
+          "v3_7_compatibility_explanation_v3_7_edge_provenance_continuity_to_explainability_continuity_edge",
+          "v3_7_compatibility_explanation_v3_7_edge_provenance_continuity_to_explainability_continuity_nodes"
+        ],
+        "explainability_safe": true,
+        "non_executable_evidence": true,
+        "phase_id": "compatibility_reasoning",
+        "phase_name": "Compatibility Reasoning",
+        "phase_order": 3,
+        "provenance_references": [
+          "v3-7-provenance-compat_domain_compatibility_boundary",
+          "v3-7-provenance-compat_domain_experimental_governance",
+          "v3-7-provenance-compat_domain_governance_visibility",
+          "v3-7-provenance-compat_domain_graph_execution",
+          "v3-7-provenance-compat_domain_graph_structure",
+          "v3-7-provenance-compat_domain_legacy_structure",
+          "v3-7-provenance-compat_domain_runtime_dispatch",
+          "v3-7-provenance-compat_domain_unknown_external"
+        ],
+        "provenance_safe": true,
+        "reference_type": "compatibility",
+        "replay_references": [
+          "v3_7_graph_integrity_replay_evidence_default"
+        ],
+        "replay_safe": true,
+        "rollback_references": [
+          "v3_7_graph_evaluation_rollback_continuity"
+        ],
+        "rollback_safe": true
+      },
+      {
+        "artifact_hash": "0b8fd6de75b5d58790cefb054b18ae762089028b906a932800c6b00ce7e1b95e",
+        "artifact_id": "v3_7_graph_evaluation_reasoning_chain",
+        "continuity_hashes": [
+          "0b8fd6de75b5d58790cefb054b18ae762089028b906a932800c6b00ce7e1b95e",
+          "v3_7_graph_evaluation_continuity_evidence"
+        ],
+        "continuity_preserved": true,
+        "deterministic_hash_present": true,
+        "evidence_reference_id": "v3_7_certification_scope_evaluation",
+        "explainability_references": [
+          "explain_evaluation_compatibility_restricted_v3_7_edge_provenance_continuity_to_explainability_continuity",
+          "explain_evaluation_finding_rule_compat_governance_to_structure",
+          "explain_evaluation_finding_rule_compat_graph_execution_prohibited",
+          "explain_evaluation_finding_rule_compat_legacy_incompatible",
+          "explain_evaluation_finding_rule_compat_runtime_dispatch_unsupported",
+          "explain_evaluation_finding_rule_compat_structure_to_experimental",
+          "explain_evaluation_finding_rule_compat_structure_to_structure",
+          "explain_evaluation_finding_rule_compat_unknown_external",
+          "explain_evaluation_structural_continuity_warning"
+        ],
+        "explainability_safe": true,
+        "non_executable_evidence": true,
+        "phase_id": "evaluation_reasoning",
+        "phase_name": "Evaluation Reasoning",
+        "phase_order": 4,
+        "provenance_references": [
+          "v3-7-provenance-v3_7_graph_evaluation_reasoning_chain"
+        ],
+        "provenance_safe": true,
+        "reference_type": "evaluation",
+        "replay_references": [
+          "v3_7_graph_integrity_replay_evidence_default"
+        ],
+        "replay_safe": true,
+        "rollback_references": [
+          "v3_7_graph_evaluation_rollback_continuity"
+        ],
+        "rollback_safe": true
+      },
+      {
+        "artifact_hash": "c486ab009cd251714d50b8dd737f4cbfa477276c2b487bffac40874073f40ac2",
+        "artifact_id": "v3_7_graph_planning_session_default",
+        "continuity_hashes": [
+          "0b8fd6de75b5d58790cefb054b18ae762089028b906a932800c6b00ce7e1b95e",
+          "40346f9d255caa644b54ccf0e40e3d9313087a10b6b45784d6763eae475023df",
+          "c486ab009cd251714d50b8dd737f4cbfa477276c2b487bffac40874073f40ac2",
+          "c7ac7ce64e260e38f96c66dd371ce4484a859a3e9c5bea35eabe0cfe41b49b48"
+        ],
+        "continuity_preserved": true,
+        "deterministic_hash_present": true,
+        "evidence_reference_id": "v3_7_certification_scope_session",
+        "explainability_references": [
+          "v3_7_graph_planning_session_explainability"
+        ],
+        "explainability_safe": true,
+        "non_executable_evidence": true,
+        "phase_id": "planning_sessions",
+        "phase_name": "Planning Sessions",
+        "phase_order": 5,
+        "provenance_references": [
+          "v3-7-provenance-v3_7_graph_planning_session_default"
+        ],
+        "provenance_safe": true,
+        "reference_type": "session",
+        "replay_references": [
+          "v3_7_graph_integrity_replay_evidence_default"
+        ],
+        "replay_safe": true,
+        "rollback_references": [
+          "v3_7_graph_evaluation_rollback_continuity"
+        ],
+        "rollback_safe": true
+      },
+      {
+        "artifact_hash": "a200adcd417767f0a00b6fa7549afd8fda94a2f272b13ac1dcadb36f7a2defe0",
+        "artifact_id": "v3_7_graph_planning_scenario_default",
+        "continuity_hashes": [
+          "0b8fd6de75b5d58790cefb054b18ae762089028b906a932800c6b00ce7e1b95e",
+          "323aa30230c6622b7c26d8f70fe0867caf78821f748b274a946772b779e8dc21",
+          "40346f9d255caa644b54ccf0e40e3d9313087a10b6b45784d6763eae475023df",
+          "a200adcd417767f0a00b6fa7549afd8fda94a2f272b13ac1dcadb36f7a2defe0",
+          "c7ac7ce64e260e38f96c66dd371ce4484a859a3e9c5bea35eabe0cfe41b49b48"
+        ],
+        "continuity_preserved": true,
+        "deterministic_hash_present": true,
+        "evidence_reference_id": "v3_7_certification_scope_scenario",
+        "explainability_references": [
+          "v3_7_graph_scenario_explainability"
+        ],
+        "explainability_safe": true,
+        "non_executable_evidence": true,
+        "phase_id": "planning_scenarios",
+        "phase_name": "Planning Scenarios",
+        "phase_order": 6,
+        "provenance_references": [
+          "v3-7-provenance-v3_7_graph_planning_scenario_default"
+        ],
+        "provenance_safe": true,
+        "reference_type": "scenario",
+        "replay_references": [
+          "v3_7_graph_integrity_replay_evidence_default"
+        ],
+        "replay_safe": true,
+        "rollback_references": [
+          "v3_7_graph_evaluation_rollback_continuity"
+        ],
+        "rollback_safe": true
+      },
+      {
+        "artifact_hash": "8c54298870f510627f69e00582e96f47c65f2a04f4da0b6ee08c2b663ef573cf",
+        "artifact_id": "v3_7_graph_planning_intelligence_aggregation_default",
+        "continuity_hashes": [
+          "0b8fd6de75b5d58790cefb054b18ae762089028b906a932800c6b00ce7e1b95e",
+          "30197b5afd37fa5e21de13c74a595db9125ea49ed2b1e0fa769c4f81dbfb8588",
+          "40346f9d255caa644b54ccf0e40e3d9313087a10b6b45784d6763eae475023df",
+          "8c54298870f510627f69e00582e96f47c65f2a04f4da0b6ee08c2b663ef573cf",
+          "a200adcd417767f0a00b6fa7549afd8fda94a2f272b13ac1dcadb36f7a2defe0",
+          "c486ab009cd251714d50b8dd737f4cbfa477276c2b487bffac40874073f40ac2",
+          "e6a6b5bb4221d1933f57e98cf9aebb06b3b57954d41c2e53a6a086cad2dd5570"
+        ],
+        "continuity_preserved": true,
+        "deterministic_hash_present": true,
+        "evidence_reference_id": "v3_7_certification_scope_aggregation",
+        "explainability_references": [
+          "v3_7_graph_intelligence_explainability"
+        ],
+        "explainability_safe": true,
+        "non_executable_evidence": true,
+        "phase_id": "intelligence_aggregation",
+        "phase_name": "Intelligence Aggregation",
+        "phase_order": 7,
+        "provenance_references": [
+          "v3-7-provenance-v3_7_graph_planning_intelligence_aggregation_default"
+        ],
+        "provenance_safe": true,
+        "reference_type": "aggregation",
+        "replay_references": [
+          "v3_7_graph_integrity_replay_evidence_default"
+        ],
+        "replay_safe": true,
+        "rollback_references": [
+          "v3_7_graph_evaluation_rollback_continuity"
+        ],
+        "rollback_safe": true
+      },
+      {
+        "artifact_hash": "39c2526ae964dce0717a80e432f8950e61d51d55b77feb8445ec0c43a9a2b8c7",
+        "artifact_id": "v3_7_graph_integrity_enforcement_default",
+        "continuity_hashes": [
+          "0797f2bdb22dacba6ea88c4d046550c2058a94a46466706cdc063edf42d9693c",
+          "0b8fd6de75b5d58790cefb054b18ae762089028b906a932800c6b00ce7e1b95e",
+          "30197b5afd37fa5e21de13c74a595db9125ea49ed2b1e0fa769c4f81dbfb8588",
+          "39c2526ae964dce0717a80e432f8950e61d51d55b77feb8445ec0c43a9a2b8c7",
+          "3d8f67e8de504c767ff3a6923b696b0c0b41c6a35e79c7967ddf888301ad8412",
+          "40346f9d255caa644b54ccf0e40e3d9313087a10b6b45784d6763eae475023df",
+          "4d75f9021078558dec7aec4e73a6b0d46e9924ddc12d5ed59f098b36c3a338eb",
+          "8c54298870f510627f69e00582e96f47c65f2a04f4da0b6ee08c2b663ef573cf",
+          "a154f02972eb862f83266f9cee67a635e423d78f79086e0e2898fced21dbf32b",
+          "a200adcd417767f0a00b6fa7549afd8fda94a2f272b13ac1dcadb36f7a2defe0",
+          "c486ab009cd251714d50b8dd737f4cbfa477276c2b487bffac40874073f40ac2",
+          "e6a6b5bb4221d1933f57e98cf9aebb06b3b57954d41c2e53a6a086cad2dd5570"
+        ],
+        "continuity_preserved": true,
+        "deterministic_hash_present": true,
+        "evidence_reference_id": "v3_7_certification_scope_integrity",
+        "explainability_references": [
+          "v3_7_graph_integrity_explainability"
+        ],
+        "explainability_safe": true,
+        "non_executable_evidence": true,
+        "phase_id": "integrity_enforcement",
+        "phase_name": "Integrity Enforcement",
+        "phase_order": 8,
+        "provenance_references": [
+          "v3-7-provenance-v3_7_graph_integrity_enforcement_default",
+          "v3-7-provenance-v3_7_graph_integrity_policy_default"
+        ],
+        "provenance_safe": true,
+        "reference_type": "integrity",
+        "replay_references": [
+          "v3_7_graph_integrity_replay_evidence_default"
+        ],
+        "replay_safe": true,
+        "rollback_references": [
+          "v3_7_graph_evaluation_rollback_continuity"
+        ],
+        "rollback_safe": true
+      },
+      {
+        "artifact_hash": "be8ee33cf57e8ea66bf85458c0f11ea6e2cbf51b928cbcc5e68728fe0dd8e25f",
+        "artifact_id": "v3_7_graph_planning_continuity_certification_default",
+        "continuity_hashes": [
+          "07873830883750c0dd5648ea754d426abcb8fdd680c1f38f3c94cbcf38d87d7c",
+          "0797f2bdb22dacba6ea88c4d046550c2058a94a46466706cdc063edf42d9693c",
+          "0b8fd6de75b5d58790cefb054b18ae762089028b906a932800c6b00ce7e1b95e",
+          "30197b5afd37fa5e21de13c74a595db9125ea49ed2b1e0fa769c4f81dbfb8588",
+          "323aa30230c6622b7c26d8f70fe0867caf78821f748b274a946772b779e8dc21",
+          "39c2526ae964dce0717a80e432f8950e61d51d55b77feb8445ec0c43a9a2b8c7",
+          "3d8f67e8de504c767ff3a6923b696b0c0b41c6a35e79c7967ddf888301ad8412",
+          "40346f9d255caa644b54ccf0e40e3d9313087a10b6b45784d6763eae475023df",
+          "4d75f9021078558dec7aec4e73a6b0d46e9924ddc12d5ed59f098b36c3a338eb",
+          "66eb73dca76eca1872e6189542d52cd4487fe0db06432b4909966f553c446c53",
+          "84de304ec2230b15c9caa7a73c985a17ce5b7cafbb0e4890b87c576bb677a270",
+          "8c54298870f510627f69e00582e96f47c65f2a04f4da0b6ee08c2b663ef573cf",
+          "99de56359c83669667b972f2c509f9313dd54902ad11c14f3cff87e1916abe8e",
+          "a154f02972eb862f83266f9cee67a635e423d78f79086e0e2898fced21dbf32b",
+          "a200adcd417767f0a00b6fa7549afd8fda94a2f272b13ac1dcadb36f7a2defe0",
+          "c486ab009cd251714d50b8dd737f4cbfa477276c2b487bffac40874073f40ac2",
+          "c7ac7ce64e260e38f96c66dd371ce4484a859a3e9c5bea35eabe0cfe41b49b48",
+          "e6a6b5bb4221d1933f57e98cf9aebb06b3b57954d41c2e53a6a086cad2dd5570",
+          "v3_7_graph_compatibility_continuity_evidence",
+          "v3_7_graph_continuity_evidence",
+          "v3_7_graph_evaluation_continuity_evidence",
+          "v3_7_graph_governance_continuity_evidence"
+        ],
+        "continuity_preserved": true,
+        "deterministic_hash_present": true,
+        "evidence_reference_id": "v3_7_graph_planning_continuity_certification_default",
+        "explainability_references": [
+          "v3_7_graph_certification_explainability"
+        ],
+        "explainability_safe": true,
+        "non_executable_evidence": true,
+        "phase_id": "continuity_certification",
+        "phase_name": "Continuity Certification",
+        "phase_order": 9,
+        "provenance_references": [
+          "v3-7-provenance-v3_7_graph_planning_continuity_certification_default"
+        ],
+        "provenance_safe": true,
+        "reference_type": "certification",
+        "replay_references": [
+          "v3_7_graph_certification_replay_evidence_default"
+        ],
+        "replay_safe": true,
+        "rollback_references": [
+          "v3_7_graph_evaluation_rollback_continuity"
+        ],
+        "rollback_safe": true
+      }
+    ],
+    "phase_id": "v3_7_closeout_and_v3_8_readiness",
+    "provenance_explainability_totals": {
+      "aggregation_provenance_preserved": true,
+      "certification_provenance_preserved": true,
+      "compatibility_provenance_preserved": true,
+      "evaluation_provenance_preserved": true,
+      "explainability_safe": true,
+      "explanation_count": 17,
+      "governance_provenance_preserved": true,
+      "graph_provenance_preserved": true,
+      "integrity_provenance_preserved": true,
+      "provenance_record_count": 77,
+      "provenance_safe": true,
+      "scenario_provenance_preserved": true,
+      "session_provenance_preserved": true
+    },
+    "provenance_references": [
+      "v3-7-provenance-compat_domain_compatibility_boundary",
+      "v3-7-provenance-compat_domain_experimental_governance",
+      "v3-7-provenance-compat_domain_governance_visibility",
+      "v3-7-provenance-compat_domain_graph_execution",
+      "v3-7-provenance-compat_domain_graph_structure",
+      "v3-7-provenance-compat_domain_legacy_structure",
+      "v3-7-provenance-compat_domain_runtime_dispatch",
+      "v3-7-provenance-compat_domain_unknown_external",
+      "v3-7-provenance-domain_compatibility_boundary_visibility",
+      "v3-7-provenance-domain_governance_visibility",
+      "v3-7-provenance-domain_graph_execution",
+      "v3-7-provenance-domain_graph_governance_boundary_intelligence",
+      "v3-7-provenance-domain_graph_structure_modeling",
+      "v3-7-provenance-domain_optimization",
+      "v3-7-provenance-domain_routing_scheduling_dispatch",
+      "v3-7-provenance-domain_runtime_dispatch",
+      "v3-7-provenance-v3-7-deterministic-orchestration-planning-graph",
+      "v3-7-provenance-v3_7_graph_evaluation_reasoning_chain",
+      "v3-7-provenance-v3_7_graph_integrity_enforcement_default",
+      "v3-7-provenance-v3_7_graph_integrity_policy_default",
+      "v3-7-provenance-v3_7_graph_planning_continuity_certification_default",
+      "v3-7-provenance-v3_7_graph_planning_intelligence_aggregation_default",
+      "v3-7-provenance-v3_7_graph_planning_scenario_default",
+      "v3-7-provenance-v3_7_graph_planning_session_default"
+    ],
+    "readiness_for_v3_8_planning": true,
+    "replay_references": [
+      "v3_7_graph_certification_replay_evidence_default",
+      "v3_7_graph_integrity_replay_evidence_default"
+    ],
+    "replay_rollback_totals": {
+      "replay_evidence_count": 1,
+      "replay_safe": true,
+      "rollback_reference_count": 1,
+      "rollback_safe": true,
+      "runtime_readiness_certification_detected": false,
+      "runtime_replay_detected": false
+    },
+    "rollback_references": [
+      "v3_7_graph_evaluation_rollback_continuity"
+    ],
+    "routing_enabled": false,
+    "runtime_execution_readiness_certified": false,
+    "runtime_mutation_enabled": false,
+    "runtime_orchestration_engine_enabled": false,
+    "runtime_path_selection_enabled": false,
+    "scenario_execution_selection_enabled": false,
+    "scheduling_enabled": false,
+    "total_phases_audited": 9,
+    "traversal_enabled": false,
+    "v3_8_allowed_expansion_summary": [
+      "v3.8 may add additional non-executable planning audit evidence",
+      "v3.8 may expand deterministic planning intelligence evidence",
+      "v3.8 may expand structural governance, compatibility, evaluation, and continuity reasoning"
+    ],
+    "v3_8_prohibited_expansion_summary": [
+      "v3.8 may not add optimization-for-execution or recommendation-to-execute behavior",
+      "v3.8 may not authorize execution readiness",
+      "v3.8 may not enable routing, scheduling, dispatch, or traversal",
+      "v3.8 may not enable runtime orchestration execution"
+    ],
+    "v3_8_readiness_classification": "v3_7_closed_out_ready_for_v3_8_planning",
+    "validation_totals": {
+      "error_count": 0,
+      "execution_boundary_violation_count": 0,
+      "finding_count": 15,
+      "hidden_prohibited_state_count": 0,
+      "hidden_unknown_state_count": 0,
+      "hidden_unsupported_state_count": 0,
+      "manual_blocker_count": 0,
+      "missing_phase_continuity_count": 0,
+      "missing_replay_evidence_count": 0,
+      "missing_rollback_evidence_count": 0,
+      "total_phases_audited": 9,
+      "valid": true,
+      "validation_status": "v3_7_closeout_validation_stable",
+      "visibility_finding_count": 15
+    }
+  },
+  "continuity_validation_totals": {
+    "aggregation_continuity": true,
+    "certification_continuity": true,
+    "compatibility_continuity": true,
+    "deterministic_hashing_continuity": true,
+    "deterministic_serialization_continuity": true,
+    "evaluation_continuity": true,
+    "execution_boundary_continuity": true,
+    "explainability_continuity": true,
+    "fail_visible_continuity": true,
+    "governance_continuity": true,
+    "integrity_continuity": true,
+    "planning_scenario_continuity": true,
+    "planning_session_continuity": true,
+    "provenance_continuity": true,
+    "replay_continuity": true,
+    "rollback_continuity": true
+  },
+  "deterministic_guarantees": {
+    "certification_audit_hash": "afc7e288304a192d9f66886e1af4c3d739863b68c7b1dcc994a2186fa6891dbe",
+    "certification_explainability_hash": "bdae8a3ee7f9f1f680de2fac55fef8abd8d136d9210a6824ca9b8102f2b88502",
+    "certification_hash": "be8ee33cf57e8ea66bf85458c0f11ea6e2cbf51b928cbcc5e68728fe0dd8e25f",
+    "certification_hash_stable": true,
+    "certification_provenance_hash": "0ee425b51b8ba79c350da8fac83093ba8ba0b1380dd3ae7da24241f34ed99e2f",
+    "certification_serialization_stable": true,
+    "certification_validation_hash": "1d0ce18d4f7117d9f7f0dcc3db6102b07c7b79fbb1ff8918157a03c2fa833b39",
+    "closeout_hash": "d6ed1346c6adab8e44b1bf9a303a57a3ecd1c5ec6ee032d557bcdc7860a7db65",
+    "closeout_hash_stable": true,
+    "closeout_serialization_stable": true
+  },
+  "deterministic_report_hash": "ad85116ea7611f389a0862e9b8ae7d4327d960c284da184fd2b62bce8dbe972a",
+  "dispatch_enabled": false,
+  "execution_authorization_enabled": false,
+  "execution_boundary_audit_totals": {
+    "callable_execution_flow_absent": true,
+    "execution_authorization_absent": true,
+    "execution_boundary_preserved": true,
+    "execution_boundary_violation_count": 0,
+    "execution_recommendation_absent": true,
+    "optimization_for_execution_absent": true,
+    "orchestration_dispatch_absent": true,
+    "orchestration_routing_absent": true,
+    "orchestration_scheduling_absent": true,
+    "runtime_orchestration_engine_absent": true,
+    "runtime_path_selection_absent": true,
+    "scenario_execution_selection_absent": true,
+    "traversal_authorization_absent": true
+  },
+  "execution_recommendation_enabled": false,
+  "explicit_limitations": [
+    "v3.7 is non-executable",
+    "v3.7 does not enable orchestration execution",
+    "v3.7 does not enable routing, scheduling, dispatch, or traversal",
+    "v3.7 does not enable orchestration optimization",
+    "v3.7 does not enable execution authorization",
+    "v3.7 established deterministic orchestration planning intelligence only",
+    "v3.8 may expand planning intelligence but may not enable runtime orchestration execution"
+  ],
+  "finding_totals": {
+    "blocking_finding_count": 0,
+    "fail_visible_finding_count": 15,
+    "finding_classification_counts": {
+      "closeout_blocked": 1,
+      "closeout_ready": 1,
+      "continuity_broken": 1,
+      "continuity_preserved": 1,
+      "deterministic": 1,
+      "execution_boundary_broken": 1,
+      "execution_boundary_preserved": 1,
+      "explainability_safe": 1,
+      "hidden_risk_detected": 1,
+      "non_executable": 1,
+      "provenance_safe": 1,
+      "readiness_blocked": 1,
+      "readiness_certified": 1,
+      "replay_safe": 1,
+      "rollback_safe": 1
+    },
+    "finding_count": 15
+  },
+  "generated_at": "2026-05-16T00:00:00+00:00",
+  "hidden_risk_totals": {
+    "hidden_prohibited_state_count": 0,
+    "hidden_risk_detected": false,
+    "hidden_unknown_state_count": 0,
+    "hidden_unsupported_state_count": 0
+  },
+  "integrity_certification_totals": {
+    "certification_continuity": true,
+    "integrity_continuity": true
+  },
+  "no_execution_authorization_confirmation": true,
+  "no_runtime_readiness_confirmation": true,
+  "non_executable_confirmation": true,
+  "optimization_for_execution_enabled": false,
+  "orchestration_execution_enabled": false,
+  "persistent_runtime_writes_enabled": false,
+  "phase_name": "v3.7_closeout_and_v3.8_readiness",
+  "provenance_explainability_totals": {
+    "aggregation_provenance_preserved": true,
+    "certification_provenance_preserved": true,
+    "compatibility_provenance_preserved": true,
+    "evaluation_provenance_preserved": true,
+    "explainability_safe": true,
+    "explanation_count": 17,
+    "governance_provenance_preserved": true,
+    "graph_provenance_preserved": true,
+    "integrity_provenance_preserved": true,
+    "provenance_record_count": 77,
+    "provenance_safe": true,
+    "scenario_provenance_preserved": true,
+    "session_provenance_preserved": true
+  },
+  "readiness_for_v3_8_planning_confirmation": true,
+  "ready_for_future_deterministic_planning_expansion": true,
+  "replay_rollback_totals": {
+    "replay_evidence_count": 1,
+    "replay_safe": true,
+    "rollback_reference_count": 1,
+    "rollback_safe": true,
+    "runtime_readiness_certification_detected": false,
+    "runtime_replay_detected": false
+  },
+  "repo_root": "D:\\Forge\\le-the-forge",
+  "routing_enabled": false,
+  "routing_scheduling_dispatch_traversal_prohibited_confirmation": true,
+  "runtime_execution_readiness_certified": false,
+  "runtime_mutation_enabled": false,
+  "runtime_orchestration_engine_enabled": false,
+  "runtime_path_selection_enabled": false,
+  "scenario_execution_selection_enabled": false,
+  "scheduling_enabled": false,
+  "schema_version": "v3_7.closeout_and_v3_8_readiness_report.1",
+  "summary": {
+    "closeout_status": "v3_7_closed_out_ready_for_v3_8_planning",
+    "continuity_verified": true,
+    "deterministic_hashing_verified": true,
+    "deterministic_serialization_verified": true,
+    "execution_boundary_verified": true,
+    "explainability_verified": true,
+    "no_execution_authorization_verified": true,
+    "no_runtime_readiness_verified": true,
+    "non_executable_verified": true,
+    "provenance_verified": true,
+    "replay_verified": true,
+    "rollback_verified": true,
+    "total_phases_audited": 9,
+    "v3_8_readiness_classification": "v3_7_closed_out_ready_for_v3_8_planning",
+    "validation_error_count": 0,
+    "validation_status": "v3_7_closeout_validation_stable"
+  },
+  "total_phases_audited": 9,
+  "traversal_enabled": false,
+  "validation_totals": {
+    "error_count": 0,
+    "execution_boundary_violation_count": 0,
+    "finding_count": 15,
+    "hidden_prohibited_state_count": 0,
+    "hidden_unknown_state_count": 0,
+    "hidden_unsupported_state_count": 0,
+    "manual_blocker_count": 0,
+    "missing_phase_continuity_count": 0,
+    "missing_replay_evidence_count": 0,
+    "missing_rollback_evidence_count": 0,
+    "total_phases_audited": 9,
+    "valid": true,
+    "validation_status": "v3_7_closeout_validation_stable",
+    "visibility_finding_count": 15
+  }
+}

--- a/docs/migration/V3_7_CLOSEOUT_AND_V3_8_READINESS.md
+++ b/docs/migration/V3_7_CLOSEOUT_AND_V3_8_READINESS.md
@@ -1,0 +1,60 @@
+# v3.7 Closeout and v3.8 Readiness
+
+## Architectural Purpose
+
+v3.7 closeout validates deterministic orchestration planning intelligence continuity across graph foundations, governance boundaries, compatibility reasoning, evaluation reasoning, planning sessions, planning scenarios, intelligence aggregation, integrity enforcement, and continuity certification.
+
+v3.7 is NON-executable.
+
+v3.7 does NOT enable orchestration execution.
+
+v3.7 does NOT enable routing, scheduling, dispatch, or traversal.
+
+v3.7 does NOT enable orchestration optimization.
+
+v3.7 does NOT enable execution authorization.
+
+v3.7 established deterministic orchestration planning intelligence ONLY.
+
+v3.8 may expand planning intelligence but may NOT enable runtime orchestration execution.
+
+## Planning Intelligence Maturity vs Runtime Orchestration Capability
+
+Planning intelligence maturity means deterministic, replay-safe, rollback-safe, provenance-safe, explainability-safe evidence that describes structural planning continuity.
+
+Runtime orchestration capability would mean executable behavior, runtime routing, scheduling, dispatch, traversal, path selection, optimization, recommendation, or callable control systems. This closeout does not create those capabilities.
+
+## Closeout Totals
+
+- Closeout status: `v3_7_closed_out_ready_for_v3_8_planning`
+- v3.8 readiness classification: `v3_7_closed_out_ready_for_v3_8_planning`
+- Total phases audited: `9`
+- Validation errors: `0`
+- Execution-boundary violations: `0`
+- Hidden risk detected: `False`
+- Serialization stable: `True`
+- Hash stable: `True`
+
+## Explicit Non-Execution Guarantees
+
+- Runtime execution readiness is not certified.
+- Execution authorization remains disabled.
+- Orchestration execution remains disabled.
+- Routing remains disabled.
+- Scheduling remains disabled.
+- Dispatch remains disabled.
+- Traversal remains disabled.
+- Runtime path selection remains disabled.
+- Scenario execution selection remains disabled.
+- Optimization for execution remains disabled.
+- Recommendation to execute remains disabled.
+- Callable execution flows remain disabled.
+- Runtime orchestration engines remain disabled.
+
+## Generated Evidence
+
+- Deterministic report hash: `ad85116ea7611f389a0862e9b8ae7d4327d960c284da184fd2b62bce8dbe972a`
+- Deterministic closeout hash: `d6ed1346c6adab8e44b1bf9a303a57a3ecd1c5ec6ee032d557bcdc7860a7db65`
+- Certification hash: `be8ee33cf57e8ea66bf85458c0f11ea6e2cbf51b928cbcc5e68728fe0dd8e25f`
+- Certification validation hash: `1d0ce18d4f7117d9f7f0dcc3db6102b07c7b79fbb1ff8918157a03c2fa833b39`
+- Certification audit hash: `afc7e288304a192d9f66886e1af4c3d739863b68c7b1dcc994a2186fa6891dbe`


### PR DESCRIPTION
Adds end-to-end closeout and readiness auditing for the v3.7 deterministic orchestration planning intelligence stack.

Implements continuity auditing, execution-boundary auditing, provenance validation, explainability validation, replay/rollback validation, integrity validation, and readiness certification across graph, governance, compatibility, evaluation, session, scenario, aggregation, integrity, and certification systems.

Preserves NON-executable guarantees and confirms readiness for future deterministic planning expansion without enabling runtime orchestration execution.