### PR TITLE
v4.1: implement refresh manifest foundations

### DIFF
--- a/backend/app/operational_refresh/__init__.py
+++ b/backend/app/operational_refresh/__init__.py
@@ -1,0 +1,65 @@
+"""Deterministic operational refresh governance foundations for v4.1."""
+
+from .refresh_manifest_diagnostics import (
+    build_refresh_manifest_diagnostics,
+    enabled_refresh_manifest_capability_flags,
+    refresh_manifest_capability_flags,
+)
+from .refresh_manifest_hashing import (
+    deterministic_refresh_manifest_hash,
+    hash_refresh_manifest,
+    hash_refresh_manifest_continuity,
+    hash_refresh_manifest_diagnostics,
+    hash_refresh_manifest_identity,
+)
+from .refresh_manifest_integrity import (
+    normalize_refresh_manifest_identity,
+    refresh_manifest_identities_equal,
+    refresh_manifest_identity_key,
+    refresh_manifest_identity_normalization_report,
+    refresh_manifest_payloads_equal,
+    refresh_manifests_equal,
+    validate_refresh_manifest_integrity,
+    validate_refresh_manifest_lineage_continuity,
+    validate_refresh_manifest_non_execution,
+    validate_refresh_manifest_provenance_continuity,
+)
+from .refresh_manifest_models import (
+    EXPLICIT_REFRESH_MANIFEST_LIMITATIONS,
+    EXPLICIT_REFRESH_MANIFEST_PROHIBITIONS,
+    PROHIBITED_REFRESH_DOMAINS,
+    REFRESH_MANIFEST_STATE_BLOCKED,
+    REFRESH_MANIFEST_STATE_PROHIBITED,
+    REFRESH_MANIFEST_STATE_STALE,
+    REFRESH_MANIFEST_STATE_SUPPORTED,
+    REFRESH_MANIFEST_STATE_UNKNOWN,
+    REFRESH_MANIFEST_STATE_UNSUPPORTED,
+    REFRESH_MANIFEST_STATES,
+    V4_1_REFRESH_MANIFEST_GENERATED_AT,
+    V4_1_REFRESH_MANIFEST_PHASE_ID,
+    V4_1_REFRESH_MANIFEST_PURPOSE,
+    V4_1_REFRESH_MANIFEST_REPORT_SCHEMA_VERSION,
+    V4_1_REFRESH_MANIFEST_SCHEMA_VERSION,
+    V4_1_REFRESH_MANIFEST_STATUS_BLOCKED,
+    V4_1_REFRESH_MANIFEST_STATUS_STABLE,
+    RefreshManifest,
+    RefreshManifestContinuityMetadata,
+    RefreshManifestDiagnosticsVisibility,
+    RefreshManifestIdentity,
+    RefreshManifestState,
+    default_refresh_manifest,
+    default_refresh_manifest_identity,
+    default_refresh_manifest_states,
+)
+from .refresh_manifest_serialization import (
+    export_refresh_manifest,
+    export_refresh_manifest_identity,
+    serialize_refresh_manifest,
+    serialize_refresh_manifest_identity,
+)
+from .refresh_manifest_visibility import (
+    count_refresh_manifest_states,
+    fail_visible_refresh_manifest_state_ids,
+    invalid_refresh_manifest_state_ids,
+    validate_refresh_manifest_visibility,
+)

--- a/backend/app/operational_refresh/refresh_manifest_diagnostics.py
+++ b/backend/app/operational_refresh/refresh_manifest_diagnostics.py
@@ -1,0 +1,133 @@
+"""Deterministic diagnostics visibility for v4.1 refresh manifest foundations."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .refresh_manifest_hashing import hash_refresh_manifest, hash_refresh_manifest_diagnostics
+from .refresh_manifest_models import RefreshManifest, default_refresh_manifest
+from .refresh_manifest_visibility import validate_refresh_manifest_visibility
+
+
+CAPABILITY_FLAG_NAMES: tuple[str, ...] = (
+    "execution_authorized",
+    "refresh_execution_enabled",
+    "orchestration_enabled",
+    "deployment_execution_enabled",
+    "automatic_refresh_enabled",
+    "automatic_migration_enabled",
+    "planner_integration_enabled",
+    "production_consumption_enabled",
+    "remediation_enabled",
+    "mutation_enabled",
+    "runtime_mutation_enabled",
+    "recommendation_enabled",
+    "ranking_enabled",
+    "scoring_enabled",
+    "selection_enabled",
+    "authorization_enabled",
+    "approval_enabled",
+    "automatic_rollback_enabled",
+    "automatic_recovery_enabled",
+    "hidden_operational_behavior_enabled",
+    "implicit_execution_pathway_enabled",
+    "silent_fallback_enabled",
+    "execution_enabled",
+    "extraction_execution_enabled",
+    "patch_execution_enabled",
+    "automatic_source_refresh_enabled",
+    "automatic_extraction_enabled",
+    "automatic_dependency_refresh_enabled",
+    "automatic_validation_execution_enabled",
+    "schema_migration_enabled",
+    "trust_inference_enabled",
+    "live_replay_enabled",
+    "runtime_execution_enabled",
+    "recovery_execution_enabled",
+)
+
+
+def refresh_manifest_capability_flags(manifest: RefreshManifest) -> dict[str, bool]:
+    flags: dict[str, bool] = {}
+    candidates: tuple[object, ...] = (
+        manifest,
+        manifest.identity,
+        manifest.continuity_metadata,
+        manifest.replay_metadata,
+        manifest.rollback_metadata,
+        manifest.governance_visibility,
+        *manifest.states,
+        *manifest.source_lineage,
+        *manifest.extraction_lineage,
+        *manifest.patch_lineage,
+        *manifest.schema_version_visibility,
+        *manifest.dependency_visibility,
+        *manifest.trust_visibility,
+        *manifest.validation_visibility,
+        *manifest.prohibited_domain_visibility,
+        *manifest.unsupported_state_visibility,
+        *manifest.diagnostics_visibility,
+    )
+    for index, candidate in enumerate(candidates):
+        candidate_name = candidate.__class__.__name__
+        for flag_name in CAPABILITY_FLAG_NAMES:
+            if hasattr(candidate, flag_name):
+                flags[f"{candidate_name}.{index}.{flag_name}"] = bool(getattr(candidate, flag_name))
+    return flags
+
+
+def enabled_refresh_manifest_capability_flags(manifest: RefreshManifest) -> dict[str, bool]:
+    return {key: value for key, value in refresh_manifest_capability_flags(manifest).items() if value}
+
+
+def build_refresh_manifest_diagnostics(manifest: RefreshManifest | None = None) -> dict[str, Any]:
+    source = manifest or default_refresh_manifest()
+    visibility = validate_refresh_manifest_visibility(source)
+    enabled_flags = enabled_refresh_manifest_capability_flags(source)
+    diagnostic_hashes = [
+        hash_refresh_manifest_diagnostics(record) for record in source.diagnostics_visibility
+    ]
+    unsupported_state_ids = tuple(
+        item for record in source.unsupported_state_visibility for item in record.unsupported_states
+    )
+    unknown_state_ids = tuple(item for record in source.unsupported_state_visibility for item in record.unknown_states)
+    blocked_state_ids = tuple(item for record in source.unsupported_state_visibility for item in record.blocked_states)
+    prohibited_state_ids = tuple(
+        item for record in source.unsupported_state_visibility for item in record.prohibited_states
+    )
+    stale_state_ids = tuple(item for record in source.unsupported_state_visibility for item in record.stale_states)
+    prohibited_domains = tuple(
+        item for record in source.prohibited_domain_visibility for item in record.prohibited_domains
+    )
+    return {
+        "manifest_hash": hash_refresh_manifest(source),
+        "diagnostics_hashes": diagnostic_hashes,
+        "visibility_validation": visibility,
+        "enabled_capability_count": len(enabled_flags),
+        "enabled_capability_flags": enabled_flags,
+        "unsupported_state_ids": sorted(unsupported_state_ids),
+        "unknown_state_ids": sorted(unknown_state_ids),
+        "blocked_state_ids": sorted(blocked_state_ids),
+        "prohibited_state_ids": sorted(prohibited_state_ids),
+        "stale_state_ids": sorted(stale_state_ids),
+        "prohibited_domains": sorted(prohibited_domains),
+        "warning_visibility": sorted(
+            item for record in source.diagnostics_visibility for item in record.warning_visibility
+        ),
+        "blocker_visibility": sorted(
+            item for record in source.diagnostics_visibility for item in record.blocker_visibility
+        ),
+        "fail_visible_warning_count": (
+            len(unsupported_state_ids)
+            + len(unknown_state_ids)
+            + len(blocked_state_ids)
+            + len(prohibited_state_ids)
+            + len(stale_state_ids)
+            + len(prohibited_domains)
+        ),
+        "diagnostics_visible": all(record.diagnostics_visible for record in source.diagnostics_visibility),
+        "diagnostics_are_descriptive_only": all(record.descriptive_only for record in source.diagnostics_visibility),
+        "remediation_absent": all(not record.remediation_enabled for record in source.diagnostics_visibility),
+        "silent_fallback_absent": all(not record.silent_fallback_enabled for record in source.diagnostics_visibility),
+        "automatic_recovery_absent": all(not record.automatic_recovery_enabled for record in source.diagnostics_visibility),
+    }

--- a/backend/app/operational_refresh/refresh_manifest_hashing.py
+++ b/backend/app/operational_refresh/refresh_manifest_hashing.py
@@ -1,0 +1,40 @@
+"""Stable hashing for v4.1 refresh manifest foundation evidence."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from operational_lifecycle.lifecycle_hashing import deterministic_lifecycle_hash
+
+from .refresh_manifest_models import (
+    RefreshManifest,
+    RefreshManifestContinuityMetadata,
+    RefreshManifestDiagnosticsVisibility,
+    RefreshManifestIdentity,
+)
+from .refresh_manifest_serialization import (
+    export_continuity_metadata,
+    export_diagnostics_visibility,
+    export_refresh_manifest,
+    export_refresh_manifest_identity,
+)
+
+
+def deterministic_refresh_manifest_hash(payload: Any) -> str:
+    return deterministic_lifecycle_hash(payload)
+
+
+def hash_refresh_manifest_identity(identity: RefreshManifestIdentity) -> str:
+    return deterministic_refresh_manifest_hash(export_refresh_manifest_identity(identity))
+
+
+def hash_refresh_manifest_continuity(metadata: RefreshManifestContinuityMetadata) -> str:
+    return deterministic_refresh_manifest_hash(export_continuity_metadata(metadata))
+
+
+def hash_refresh_manifest_diagnostics(record: RefreshManifestDiagnosticsVisibility) -> str:
+    return deterministic_refresh_manifest_hash(export_diagnostics_visibility(record))
+
+
+def hash_refresh_manifest(manifest: RefreshManifest) -> str:
+    return deterministic_refresh_manifest_hash(export_refresh_manifest(manifest))

--- a/backend/app/operational_refresh/refresh_manifest_integrity.py
+++ b/backend/app/operational_refresh/refresh_manifest_integrity.py
@@ -1,0 +1,197 @@
+"""Integrity, equality, and continuity helpers for v4.1 refresh manifests.
+
+Integrity checks are descriptive validation only. They do not remediate,
+authorize, execute, recover, roll back, or mutate refresh manifest evidence.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .refresh_manifest_diagnostics import enabled_refresh_manifest_capability_flags
+from .refresh_manifest_models import (
+    RefreshManifest,
+    RefreshManifestIdentity,
+    default_refresh_manifest,
+    default_refresh_manifest_identity,
+)
+from .refresh_manifest_serialization import (
+    export_refresh_manifest,
+    export_refresh_manifest_identity,
+    serialize_refresh_manifest,
+    serialize_refresh_manifest_identity,
+    stable_serialize,
+)
+from .refresh_manifest_visibility import validate_refresh_manifest_visibility
+
+
+def refresh_manifest_identity_key(identity: RefreshManifestIdentity) -> str:
+    return "|".join(
+        (
+            identity.schema_version,
+            identity.refresh_cycle_id,
+            identity.manifest_id,
+            identity.manifest_version,
+            identity.source_bundle_reference,
+            identity.provenance_reference,
+            identity.lineage_reference,
+        )
+    )
+
+
+def refresh_manifest_payloads_equal(left: Any, right: Any) -> bool:
+    return stable_serialize(left) == stable_serialize(right)
+
+
+def refresh_manifest_identities_equal(left: RefreshManifestIdentity, right: RefreshManifestIdentity) -> bool:
+    return serialize_refresh_manifest_identity(left) == serialize_refresh_manifest_identity(right)
+
+
+def refresh_manifests_equal(left: RefreshManifest, right: RefreshManifest) -> bool:
+    return serialize_refresh_manifest(left) == serialize_refresh_manifest(right)
+
+
+def normalize_refresh_manifest_identity(identity: RefreshManifestIdentity) -> RefreshManifestIdentity:
+    exported = export_refresh_manifest_identity(identity)
+    return RefreshManifestIdentity(**exported)
+
+
+def refresh_manifest_identity_normalization_report(identity: RefreshManifestIdentity) -> dict[str, object]:
+    normalized = normalize_refresh_manifest_identity(identity)
+    return {
+        "normalization_scope": "deterministic_field_representation_only",
+        "identity_key": refresh_manifest_identity_key(normalized),
+        "normalized_identity": export_refresh_manifest_identity(normalized),
+        "field_count": len(export_refresh_manifest_identity(normalized)),
+        "omitted_field_count": 0,
+        "silent_correction_enabled": False,
+        "hidden_fallback_enabled": normalized.hidden_fallback_enabled,
+        "runtime_mutation_enabled": normalized.runtime_mutation_enabled,
+        "refresh_execution_enabled": normalized.refresh_execution_enabled,
+    }
+
+
+def validate_refresh_manifest_provenance_continuity(manifest: RefreshManifest) -> dict[str, object]:
+    provenance_reference = manifest.identity.provenance_reference
+    source_refs = tuple(record.provenance_reference for record in manifest.source_lineage)
+    extraction_refs = tuple(record.provenance_reference for record in manifest.extraction_lineage)
+    patch_refs = tuple(record.provenance_reference for record in manifest.patch_lineage)
+    continuity_refs = manifest.continuity_metadata.provenance_continuity_references
+    provenance_visible = provenance_reference in source_refs + extraction_refs + patch_refs + continuity_refs
+    no_inferred_provenance = all(not record.inferred_source_allowed for record in manifest.source_lineage)
+    no_hidden_source_resolution = all(
+        not record.hidden_source_resolution_enabled for record in manifest.source_lineage
+    )
+    return {
+        "valid": (
+            provenance_visible
+            and no_inferred_provenance
+            and no_hidden_source_resolution
+            and manifest.continuity_metadata.provenance_continuity_preserved
+        ),
+        "provenance_reference": provenance_reference,
+        "source_provenance_reference_count": len(source_refs),
+        "extraction_provenance_reference_count": len(extraction_refs),
+        "patch_provenance_reference_count": len(patch_refs),
+        "provenance_continuity_reference_count": len(continuity_refs),
+        "provenance_visible": provenance_visible,
+        "provenance_continuity_preserved": manifest.continuity_metadata.provenance_continuity_preserved,
+        "no_inferred_provenance": no_inferred_provenance,
+        "hidden_source_resolution_absent": no_hidden_source_resolution,
+    }
+
+
+def validate_refresh_manifest_lineage_continuity(manifest: RefreshManifest) -> dict[str, object]:
+    lineage_reference = manifest.identity.lineage_reference
+    source_lineage_count = len(manifest.source_lineage)
+    extraction_lineage_count = len(manifest.extraction_lineage)
+    patch_lineage_count = len(manifest.patch_lineage)
+    lineage_continuity_refs = manifest.continuity_metadata.lineage_continuity_references
+    rollback_refs = manifest.continuity_metadata.rollback_references + manifest.rollback_metadata.rollback_evidence_references
+    replay_refs = manifest.continuity_metadata.replay_references + manifest.replay_metadata.replay_evidence_references
+    hidden_lineage_resolution_count = sum(
+        1
+        for record in (*manifest.source_lineage, *manifest.extraction_lineage, *manifest.patch_lineage)
+        if getattr(record, "hidden_source_resolution_enabled", False)
+        or getattr(record, "hidden_extraction_fallback_enabled", False)
+        or getattr(record, "hidden_patch_resolution_enabled", False)
+    )
+    return {
+        "valid": (
+            lineage_reference in lineage_continuity_refs
+            and source_lineage_count > 0
+            and extraction_lineage_count > 0
+            and patch_lineage_count > 0
+            and manifest.continuity_metadata.lineage_continuity_preserved
+            and manifest.continuity_metadata.replay_safe
+            and manifest.continuity_metadata.rollback_safe
+            and hidden_lineage_resolution_count == 0
+        ),
+        "lineage_reference": lineage_reference,
+        "source_lineage_count": source_lineage_count,
+        "extraction_lineage_count": extraction_lineage_count,
+        "patch_lineage_count": patch_lineage_count,
+        "lineage_continuity_reference_count": len(lineage_continuity_refs),
+        "rollback_reference_count": len(rollback_refs),
+        "replay_reference_count": len(replay_refs),
+        "lineage_continuity_preserved": manifest.continuity_metadata.lineage_continuity_preserved,
+        "replay_safe": manifest.continuity_metadata.replay_safe and manifest.replay_metadata.replay_safe,
+        "rollback_safe": manifest.continuity_metadata.rollback_safe and manifest.rollback_metadata.rollback_safe,
+        "hidden_lineage_resolution_count": hidden_lineage_resolution_count,
+    }
+
+
+def validate_refresh_manifest_non_execution(manifest: RefreshManifest) -> dict[str, object]:
+    enabled_flags = enabled_refresh_manifest_capability_flags(manifest)
+    return {
+        "valid": len(enabled_flags) == 0 and manifest.non_executable and manifest.descriptive_only,
+        "enabled_capability_count": len(enabled_flags),
+        "enabled_capability_flags": enabled_flags,
+        "non_executable": manifest.non_executable,
+        "descriptive_only": manifest.descriptive_only,
+        "refresh_execution_absent": not manifest.refresh_execution_enabled,
+        "orchestration_absent": not manifest.orchestration_enabled,
+        "deployment_execution_absent": not manifest.deployment_execution_enabled,
+        "automatic_refresh_absent": not manifest.automatic_refresh_enabled,
+        "automatic_migration_absent": not manifest.automatic_migration_enabled,
+        "planner_integration_absent": not manifest.planner_integration_enabled,
+        "production_consumption_absent": not manifest.production_consumption_enabled,
+        "remediation_absent": not manifest.remediation_enabled,
+        "runtime_mutation_absent": not manifest.runtime_mutation_enabled and not manifest.mutation_enabled,
+        "recommendation_absent": not manifest.recommendation_enabled,
+        "ranking_absent": not manifest.ranking_enabled,
+        "scoring_absent": not manifest.scoring_enabled,
+        "selection_absent": not manifest.selection_enabled,
+        "authorization_absent": not manifest.authorization_enabled,
+        "approval_absent": not manifest.approval_enabled,
+        "automatic_rollback_absent": not manifest.automatic_rollback_enabled,
+        "automatic_recovery_absent": not manifest.automatic_recovery_enabled,
+        "hidden_operational_behavior_absent": not manifest.hidden_operational_behavior_enabled,
+        "implicit_execution_pathway_absent": not manifest.implicit_execution_pathway_enabled,
+        "silent_fallback_absent": not manifest.silent_fallback_enabled,
+    }
+
+
+def validate_refresh_manifest_integrity(manifest: RefreshManifest | None = None) -> dict[str, object]:
+    source = manifest or default_refresh_manifest()
+    visibility = validate_refresh_manifest_visibility(source)
+    provenance = validate_refresh_manifest_provenance_continuity(source)
+    lineage = validate_refresh_manifest_lineage_continuity(source)
+    non_execution = validate_refresh_manifest_non_execution(source)
+    return {
+        "valid": visibility["valid"] and provenance["valid"] and lineage["valid"] and non_execution["valid"],
+        "visibility_valid": visibility["valid"],
+        "provenance_continuity_valid": provenance["valid"],
+        "lineage_continuity_valid": lineage["valid"],
+        "non_execution_valid": non_execution["valid"],
+        "visibility_validation": visibility,
+        "provenance_continuity_validation": provenance,
+        "lineage_continuity_validation": lineage,
+        "non_execution_validation": non_execution,
+        "identity_normalization": refresh_manifest_identity_normalization_report(source.identity),
+        "exported_field_count": len(export_refresh_manifest(source)),
+    }
+
+
+def build_default_refresh_manifest_identity() -> RefreshManifestIdentity:
+    return default_refresh_manifest_identity()

--- a/backend/app/operational_refresh/refresh_manifest_models.py
+++ b/backend/app/operational_refresh/refresh_manifest_models.py
@@ -1,0 +1,927 @@
+"""Deterministic v4.1 refresh manifest foundation models.
+
+Refresh manifests are descriptive governance evidence only. They do not
+execute refreshes, orchestrate work, migrate data, consume production bundles,
+integrate with planners, authorize behavior, remediate blockers, recover state,
+roll back state, or mutate runtime data.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+
+V4_1_REFRESH_MANIFEST_PHASE_ID = "v4_1_refresh_manifest_foundations"
+V4_1_REFRESH_MANIFEST_SCHEMA_VERSION = "v4_1.refresh_manifest_foundations.1"
+V4_1_REFRESH_MANIFEST_REPORT_SCHEMA_VERSION = "v4_1.refresh_manifest_foundations_report.1"
+V4_1_REFRESH_MANIFEST_DIAGNOSTICS_SCHEMA_VERSION = "v4_1.refresh_manifest_diagnostics_report.1"
+V4_1_REFRESH_MANIFEST_STATUS_STABLE = "v4_1_refresh_manifest_foundation_stable"
+V4_1_REFRESH_MANIFEST_STATUS_BLOCKED = "v4_1_refresh_manifest_foundation_blocked"
+V4_1_REFRESH_MANIFEST_GENERATED_AT = "2026-05-17T00:00:00+00:00"
+V4_1_REFRESH_MANIFEST_PURPOSE = "deterministic_operational_refresh_governance_intelligence_only"
+
+REFRESH_MANIFEST_IDENTITY_SCOPE = "refresh_manifest_identity_descriptive_only"
+REFRESH_MANIFEST_SOURCE_LINEAGE_SCOPE = "refresh_manifest_source_lineage_descriptive_only"
+REFRESH_MANIFEST_EXTRACTION_LINEAGE_SCOPE = "refresh_manifest_extraction_lineage_descriptive_only"
+REFRESH_MANIFEST_PATCH_LINEAGE_SCOPE = "refresh_manifest_patch_lineage_descriptive_only"
+REFRESH_MANIFEST_SCHEMA_VISIBILITY_SCOPE = "refresh_manifest_schema_version_visibility_descriptive_only"
+REFRESH_MANIFEST_DEPENDENCY_VISIBILITY_SCOPE = "refresh_manifest_dependency_visibility_descriptive_only"
+REFRESH_MANIFEST_TRUST_VISIBILITY_SCOPE = "refresh_manifest_trust_visibility_descriptive_only"
+REFRESH_MANIFEST_VALIDATION_VISIBILITY_SCOPE = "refresh_manifest_validation_visibility_descriptive_only"
+REFRESH_MANIFEST_PROHIBITED_DOMAIN_SCOPE = "refresh_manifest_prohibited_domain_visibility_descriptive_only"
+REFRESH_MANIFEST_UNSUPPORTED_STATE_SCOPE = "refresh_manifest_unsupported_state_visibility_descriptive_only"
+REFRESH_MANIFEST_CONTINUITY_SCOPE = "refresh_manifest_continuity_metadata_descriptive_only"
+REFRESH_MANIFEST_REPLAY_SCOPE = "refresh_manifest_replay_metadata_descriptive_only"
+REFRESH_MANIFEST_ROLLBACK_SCOPE = "refresh_manifest_rollback_metadata_descriptive_only"
+REFRESH_MANIFEST_DIAGNOSTICS_SCOPE = "refresh_manifest_diagnostics_visibility_descriptive_only"
+REFRESH_MANIFEST_GOVERNANCE_SCOPE = "refresh_manifest_governance_visibility_descriptive_only"
+
+REFRESH_MANIFEST_STATE_SUPPORTED = "supported"
+REFRESH_MANIFEST_STATE_UNSUPPORTED = "unsupported"
+REFRESH_MANIFEST_STATE_BLOCKED = "blocked"
+REFRESH_MANIFEST_STATE_UNKNOWN = "unknown"
+REFRESH_MANIFEST_STATE_PROHIBITED = "prohibited"
+REFRESH_MANIFEST_STATE_STALE = "stale"
+REFRESH_MANIFEST_STATES: tuple[str, ...] = (
+    REFRESH_MANIFEST_STATE_SUPPORTED,
+    REFRESH_MANIFEST_STATE_UNSUPPORTED,
+    REFRESH_MANIFEST_STATE_BLOCKED,
+    REFRESH_MANIFEST_STATE_UNKNOWN,
+    REFRESH_MANIFEST_STATE_PROHIBITED,
+    REFRESH_MANIFEST_STATE_STALE,
+)
+FAIL_VISIBLE_REFRESH_MANIFEST_STATES: tuple[str, ...] = (
+    REFRESH_MANIFEST_STATE_UNSUPPORTED,
+    REFRESH_MANIFEST_STATE_BLOCKED,
+    REFRESH_MANIFEST_STATE_UNKNOWN,
+    REFRESH_MANIFEST_STATE_PROHIBITED,
+    REFRESH_MANIFEST_STATE_STALE,
+)
+
+REFRESH_MANIFEST_VISIBILITY_VISIBLE = "visible"
+REFRESH_MANIFEST_VISIBILITY_FAIL_VISIBLE = "fail_visible"
+REFRESH_MANIFEST_SEVERITY_INFO = "info"
+REFRESH_MANIFEST_SEVERITY_WARNING = "warning"
+REFRESH_MANIFEST_SEVERITY_BLOCKED = "blocked"
+REFRESH_MANIFEST_SEVERITY_PROHIBITED = "prohibited"
+REFRESH_MANIFEST_SEVERITY_UNKNOWN = "unknown"
+
+PROHIBITED_REFRESH_DOMAINS: tuple[str, ...] = (
+    "refresh_execution",
+    "orchestration_execution",
+    "deployment_execution",
+    "automatic_refresh_behavior",
+    "automatic_migration_behavior",
+    "planner_integration",
+    "production_bundle_consumption",
+    "remediation_systems",
+    "recommendation_ranking_scoring_selection",
+    "authorization_approval_systems",
+    "runtime_mutation",
+    "automatic_rollback",
+    "automatic_recovery",
+    "hidden_operational_behavior",
+)
+
+EXPLICIT_REFRESH_MANIFEST_LIMITATIONS: tuple[str, ...] = (
+    "v4.1 Phase 1 creates deterministic refresh manifest governance metadata only.",
+    "v4.1 Phase 1 does not enable refresh execution.",
+    "v4.1 Phase 1 does not enable orchestration.",
+    "v4.1 Phase 1 does not enable deployment execution.",
+    "v4.1 Phase 1 does not enable automatic refresh behavior.",
+    "v4.1 Phase 1 does not enable automatic migration behavior.",
+    "v4.1 Phase 1 does not enable planner integration.",
+    "v4.1 Phase 1 does not enable production consumption.",
+    "v4.1 Phase 1 does not enable remediation.",
+    "v4.1 Phase 1 does not enable runtime mutation.",
+)
+
+EXPLICIT_REFRESH_MANIFEST_PROHIBITIONS: tuple[str, ...] = (
+    "No execution behavior exists.",
+    "No orchestration exists.",
+    "No planner integration exists.",
+    "No production consumption exists.",
+    "No remediation exists.",
+    "No mutation behavior exists.",
+    "No recommendation, ranking, scoring, or selection behavior exists.",
+    "No approval or authorization behavior exists.",
+    "No automatic rollback or automatic recovery behavior exists.",
+    "No silent fallback behavior exists.",
+)
+
+
+def _as_tuple(values: Iterable[str] | tuple[str, ...] | None) -> tuple[str, ...]:
+    return tuple(values or ())
+
+
+def _set_tuple_field(source: object, field_name: str) -> None:
+    object.__setattr__(source, field_name, _as_tuple(getattr(source, field_name)))
+
+
+@dataclass(frozen=True)
+class RefreshManifestIdentity:
+    manifest_id: str
+    refresh_cycle_id: str
+    manifest_version: str
+    source_bundle_reference: str
+    extraction_reference: str
+    patch_reference: str
+    schema_version: str
+    generated_at: str
+    provenance_reference: str
+    lineage_reference: str
+    trust_reference: str
+    validation_reference: str
+    diagnostics_reference: str
+    governance_reference: str
+    identity_scope: str = REFRESH_MANIFEST_IDENTITY_SCOPE
+    governance_purpose: str = V4_1_REFRESH_MANIFEST_PURPOSE
+    non_executable: bool = True
+    descriptive_only: bool = True
+    refresh_execution_enabled: bool = False
+    runtime_mutation_enabled: bool = False
+    hidden_fallback_enabled: bool = False
+
+
+@dataclass(frozen=True)
+class RefreshManifestState:
+    state_id: str
+    state: str
+    reason: str
+    provenance_reference: str
+    lineage_reference: str
+    visibility_reference: str
+    deterministic_order: int
+    visibility_status: str = REFRESH_MANIFEST_VISIBILITY_VISIBLE
+    severity: str = REFRESH_MANIFEST_SEVERITY_INFO
+    descriptive_only: bool = True
+    fail_visible: bool = False
+    hidden: bool = False
+    executable: bool = False
+    automatic_resolution_enabled: bool = False
+    silent_fallback_enabled: bool = False
+    remediation_enabled: bool = False
+    runtime_mutation_enabled: bool = False
+
+
+@dataclass(frozen=True)
+class RefreshManifestSourceLineage:
+    source_lineage_id: str
+    source_system_reference: str
+    source_bundle_reference: str
+    source_evidence_references: tuple[str, ...]
+    prior_manifest_references: tuple[str, ...]
+    unsupported_source_visibility: tuple[str, ...]
+    provenance_reference: str
+    deterministic_hash_reference: str
+    deterministic_order: int
+    source_lineage_scope: str = REFRESH_MANIFEST_SOURCE_LINEAGE_SCOPE
+    source_lineage_preserved: bool = True
+    provenance_preserved: bool = True
+    inferred_source_allowed: bool = False
+    fail_visible: bool = True
+    descriptive_only: bool = True
+    execution_enabled: bool = False
+    automatic_source_refresh_enabled: bool = False
+    hidden_source_resolution_enabled: bool = False
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "source_evidence_references",
+            "prior_manifest_references",
+            "unsupported_source_visibility",
+        ):
+            _set_tuple_field(self, field_name)
+
+
+@dataclass(frozen=True)
+class RefreshManifestExtractionLineage:
+    extraction_lineage_id: str
+    extractor_reference: str
+    extraction_snapshot_reference: str
+    extraction_evidence_references: tuple[str, ...]
+    unsupported_extraction_states: tuple[str, ...]
+    provenance_reference: str
+    deterministic_hash_reference: str
+    deterministic_order: int
+    extraction_lineage_scope: str = REFRESH_MANIFEST_EXTRACTION_LINEAGE_SCOPE
+    extraction_lineage_preserved: bool = True
+    no_implicit_extraction: bool = True
+    fail_visible: bool = True
+    descriptive_only: bool = True
+    extraction_execution_enabled: bool = False
+    automatic_extraction_enabled: bool = False
+    hidden_extraction_fallback_enabled: bool = False
+
+    def __post_init__(self) -> None:
+        for field_name in ("extraction_evidence_references", "unsupported_extraction_states"):
+            _set_tuple_field(self, field_name)
+
+
+@dataclass(frozen=True)
+class RefreshManifestPatchLineage:
+    patch_lineage_id: str
+    patch_reference: str
+    patch_evidence_references: tuple[str, ...]
+    prior_patch_references: tuple[str, ...]
+    rollback_references: tuple[str, ...]
+    provenance_reference: str
+    deterministic_hash_reference: str
+    deterministic_order: int
+    patch_lineage_scope: str = REFRESH_MANIFEST_PATCH_LINEAGE_SCOPE
+    patch_lineage_preserved: bool = True
+    rollback_safe: bool = True
+    fail_visible: bool = True
+    descriptive_only: bool = True
+    patch_execution_enabled: bool = False
+    automatic_migration_enabled: bool = False
+    hidden_patch_resolution_enabled: bool = False
+
+    def __post_init__(self) -> None:
+        for field_name in ("patch_evidence_references", "prior_patch_references", "rollback_references"):
+            _set_tuple_field(self, field_name)
+
+
+@dataclass(frozen=True)
+class RefreshManifestSchemaVersionVisibility:
+    schema_visibility_id: str
+    manifest_schema_version: str
+    source_schema_version: str
+    extraction_schema_version: str
+    patch_schema_version: str
+    visible_schema_constraints: tuple[str, ...]
+    unsupported_schema_versions: tuple[str, ...]
+    deterministic_order: int
+    schema_visibility_scope: str = REFRESH_MANIFEST_SCHEMA_VISIBILITY_SCOPE
+    schema_version_visible: bool = True
+    fail_visible: bool = True
+    descriptive_only: bool = True
+    schema_migration_enabled: bool = False
+    hidden_schema_inference_enabled: bool = False
+
+    def __post_init__(self) -> None:
+        for field_name in ("visible_schema_constraints", "unsupported_schema_versions"):
+            _set_tuple_field(self, field_name)
+
+
+@dataclass(frozen=True)
+class RefreshManifestDependencyVisibility:
+    dependency_visibility_id: str
+    dependency_references: tuple[str, ...]
+    missing_dependency_visibility: tuple[str, ...]
+    stale_dependency_visibility: tuple[str, ...]
+    prohibited_dependency_visibility: tuple[str, ...]
+    deterministic_order: int
+    dependency_visibility_scope: str = REFRESH_MANIFEST_DEPENDENCY_VISIBILITY_SCOPE
+    dependencies_visible: bool = True
+    fail_visible: bool = True
+    descriptive_only: bool = True
+    automatic_dependency_refresh_enabled: bool = False
+    hidden_dependency_resolution_enabled: bool = False
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "dependency_references",
+            "missing_dependency_visibility",
+            "stale_dependency_visibility",
+            "prohibited_dependency_visibility",
+        ):
+            _set_tuple_field(self, field_name)
+
+
+@dataclass(frozen=True)
+class RefreshManifestTrustVisibility:
+    trust_visibility_id: str
+    trusted_source_references: tuple[str, ...]
+    untrusted_source_visibility: tuple[str, ...]
+    ambiguous_trust_visibility: tuple[str, ...]
+    deterministic_order: int
+    trust_visibility_scope: str = REFRESH_MANIFEST_TRUST_VISIBILITY_SCOPE
+    trust_visible: bool = True
+    fail_visible: bool = True
+    descriptive_only: bool = True
+    trust_inference_enabled: bool = False
+    authorization_enabled: bool = False
+    approval_enabled: bool = False
+
+    def __post_init__(self) -> None:
+        for field_name in ("trusted_source_references", "untrusted_source_visibility", "ambiguous_trust_visibility"):
+            _set_tuple_field(self, field_name)
+
+
+@dataclass(frozen=True)
+class RefreshManifestValidationVisibility:
+    validation_visibility_id: str
+    validation_references: tuple[str, ...]
+    validation_warning_visibility: tuple[str, ...]
+    validation_blocker_visibility: tuple[str, ...]
+    unsupported_validation_visibility: tuple[str, ...]
+    deterministic_order: int
+    validation_visibility_scope: str = REFRESH_MANIFEST_VALIDATION_VISIBILITY_SCOPE
+    validation_visible: bool = True
+    fail_visible: bool = True
+    descriptive_only: bool = True
+    automatic_validation_execution_enabled: bool = False
+    remediation_enabled: bool = False
+    silent_validation_fallback_enabled: bool = False
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "validation_references",
+            "validation_warning_visibility",
+            "validation_blocker_visibility",
+            "unsupported_validation_visibility",
+        ):
+            _set_tuple_field(self, field_name)
+
+
+@dataclass(frozen=True)
+class RefreshManifestProhibitedDomainVisibility:
+    prohibited_domain_visibility_id: str
+    prohibited_domains: tuple[str, ...]
+    visible_blocked_reasons: tuple[str, ...]
+    deterministic_order: int
+    prohibited_domain_scope: str = REFRESH_MANIFEST_PROHIBITED_DOMAIN_SCOPE
+    fail_visible: bool = True
+    descriptive_only: bool = True
+    hidden_operational_behavior_enabled: bool = False
+    implicit_execution_pathway_enabled: bool = False
+
+    def __post_init__(self) -> None:
+        for field_name in ("prohibited_domains", "visible_blocked_reasons"):
+            _set_tuple_field(self, field_name)
+
+
+@dataclass(frozen=True)
+class RefreshManifestUnsupportedStateVisibility:
+    unsupported_state_visibility_id: str
+    unsupported_states: tuple[str, ...]
+    unknown_states: tuple[str, ...]
+    blocked_states: tuple[str, ...]
+    prohibited_states: tuple[str, ...]
+    stale_states: tuple[str, ...]
+    deterministic_order: int
+    unsupported_state_scope: str = REFRESH_MANIFEST_UNSUPPORTED_STATE_SCOPE
+    fail_visible: bool = True
+    descriptive_only: bool = True
+    automatic_recovery_enabled: bool = False
+    remediation_enabled: bool = False
+    hidden_unsupported_state_resolution_enabled: bool = False
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "unsupported_states",
+            "unknown_states",
+            "blocked_states",
+            "prohibited_states",
+            "stale_states",
+        ):
+            _set_tuple_field(self, field_name)
+
+
+@dataclass(frozen=True)
+class RefreshManifestContinuityMetadata:
+    continuity_metadata_id: str
+    provenance_continuity_references: tuple[str, ...]
+    lineage_continuity_references: tuple[str, ...]
+    replay_references: tuple[str, ...]
+    rollback_references: tuple[str, ...]
+    diagnostics_references: tuple[str, ...]
+    deterministic_hash_reference: str
+    deterministic_order: int
+    continuity_scope: str = REFRESH_MANIFEST_CONTINUITY_SCOPE
+    continuity_preserved: bool = True
+    replay_safe: bool = True
+    rollback_safe: bool = True
+    provenance_continuity_preserved: bool = True
+    lineage_continuity_preserved: bool = True
+    fail_visible: bool = True
+    descriptive_only: bool = True
+    automatic_rollback_enabled: bool = False
+    automatic_recovery_enabled: bool = False
+    execution_enabled: bool = False
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "provenance_continuity_references",
+            "lineage_continuity_references",
+            "replay_references",
+            "rollback_references",
+            "diagnostics_references",
+        ):
+            _set_tuple_field(self, field_name)
+
+
+@dataclass(frozen=True)
+class RefreshManifestReplayMetadata:
+    replay_metadata_id: str
+    replay_reference: str
+    replay_evidence_references: tuple[str, ...]
+    deterministic_hash_reference: str
+    deterministic_order: int
+    replay_scope: str = REFRESH_MANIFEST_REPLAY_SCOPE
+    replay_safe: bool = True
+    descriptive_only: bool = True
+    live_replay_enabled: bool = False
+    runtime_execution_enabled: bool = False
+
+    def __post_init__(self) -> None:
+        _set_tuple_field(self, "replay_evidence_references")
+
+
+@dataclass(frozen=True)
+class RefreshManifestRollbackMetadata:
+    rollback_metadata_id: str
+    rollback_reference: str
+    rollback_evidence_references: tuple[str, ...]
+    deterministic_hash_reference: str
+    deterministic_order: int
+    rollback_scope: str = REFRESH_MANIFEST_ROLLBACK_SCOPE
+    rollback_safe: bool = True
+    descriptive_only: bool = True
+    automatic_rollback_enabled: bool = False
+    recovery_execution_enabled: bool = False
+
+    def __post_init__(self) -> None:
+        _set_tuple_field(self, "rollback_evidence_references")
+
+
+@dataclass(frozen=True)
+class RefreshManifestDiagnosticsVisibility:
+    diagnostics_visibility_id: str
+    diagnostic_references: tuple[str, ...]
+    warning_visibility: tuple[str, ...]
+    blocker_visibility: tuple[str, ...]
+    unsupported_state_visibility: tuple[str, ...]
+    prohibited_domain_visibility: tuple[str, ...]
+    deterministic_order: int
+    diagnostics_scope: str = REFRESH_MANIFEST_DIAGNOSTICS_SCOPE
+    diagnostics_visible: bool = True
+    fail_visible: bool = True
+    descriptive_only: bool = True
+    remediation_enabled: bool = False
+    silent_fallback_enabled: bool = False
+    automatic_recovery_enabled: bool = False
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "diagnostic_references",
+            "warning_visibility",
+            "blocker_visibility",
+            "unsupported_state_visibility",
+            "prohibited_domain_visibility",
+        ):
+            _set_tuple_field(self, field_name)
+
+
+@dataclass(frozen=True)
+class RefreshManifestGovernanceVisibility:
+    governance_visibility_id: str
+    governance_references: tuple[str, ...]
+    explicit_limitations: tuple[str, ...]
+    explicit_prohibitions: tuple[str, ...]
+    deterministic_order: int
+    governance_scope: str = REFRESH_MANIFEST_GOVERNANCE_SCOPE
+    governance_visible: bool = True
+    descriptive_only: bool = True
+    execution_authorized: bool = False
+    refresh_execution_enabled: bool = False
+    orchestration_enabled: bool = False
+    planner_integration_enabled: bool = False
+    production_consumption_enabled: bool = False
+    remediation_enabled: bool = False
+    mutation_enabled: bool = False
+    authorization_enabled: bool = False
+    approval_enabled: bool = False
+    recommendation_enabled: bool = False
+    ranking_enabled: bool = False
+    scoring_enabled: bool = False
+    selection_enabled: bool = False
+
+    def __post_init__(self) -> None:
+        for field_name in ("governance_references", "explicit_limitations", "explicit_prohibitions"):
+            _set_tuple_field(self, field_name)
+
+
+@dataclass(frozen=True)
+class RefreshManifest:
+    identity: RefreshManifestIdentity
+    states: tuple[RefreshManifestState, ...]
+    source_lineage: tuple[RefreshManifestSourceLineage, ...]
+    extraction_lineage: tuple[RefreshManifestExtractionLineage, ...]
+    patch_lineage: tuple[RefreshManifestPatchLineage, ...]
+    schema_version_visibility: tuple[RefreshManifestSchemaVersionVisibility, ...]
+    dependency_visibility: tuple[RefreshManifestDependencyVisibility, ...]
+    trust_visibility: tuple[RefreshManifestTrustVisibility, ...]
+    validation_visibility: tuple[RefreshManifestValidationVisibility, ...]
+    prohibited_domain_visibility: tuple[RefreshManifestProhibitedDomainVisibility, ...]
+    unsupported_state_visibility: tuple[RefreshManifestUnsupportedStateVisibility, ...]
+    continuity_metadata: RefreshManifestContinuityMetadata
+    replay_metadata: RefreshManifestReplayMetadata
+    rollback_metadata: RefreshManifestRollbackMetadata
+    diagnostics_visibility: tuple[RefreshManifestDiagnosticsVisibility, ...]
+    governance_visibility: RefreshManifestGovernanceVisibility
+    manifest_scope: str = V4_1_REFRESH_MANIFEST_PURPOSE
+    non_executable: bool = True
+    descriptive_only: bool = True
+    refresh_execution_enabled: bool = False
+    orchestration_enabled: bool = False
+    deployment_execution_enabled: bool = False
+    automatic_refresh_enabled: bool = False
+    automatic_migration_enabled: bool = False
+    planner_integration_enabled: bool = False
+    production_consumption_enabled: bool = False
+    remediation_enabled: bool = False
+    mutation_enabled: bool = False
+    runtime_mutation_enabled: bool = False
+    recommendation_enabled: bool = False
+    ranking_enabled: bool = False
+    scoring_enabled: bool = False
+    selection_enabled: bool = False
+    authorization_enabled: bool = False
+    approval_enabled: bool = False
+    automatic_rollback_enabled: bool = False
+    automatic_recovery_enabled: bool = False
+    hidden_operational_behavior_enabled: bool = False
+    implicit_execution_pathway_enabled: bool = False
+    silent_fallback_enabled: bool = False
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "states",
+            "source_lineage",
+            "extraction_lineage",
+            "patch_lineage",
+            "schema_version_visibility",
+            "dependency_visibility",
+            "trust_visibility",
+            "validation_visibility",
+            "prohibited_domain_visibility",
+            "unsupported_state_visibility",
+            "diagnostics_visibility",
+        ):
+            object.__setattr__(self, field_name, tuple(getattr(self, field_name) or ()))
+
+
+def default_refresh_manifest_identity() -> RefreshManifestIdentity:
+    return RefreshManifestIdentity(
+        manifest_id="v4_1_refresh_manifest_primary",
+        refresh_cycle_id="v4_1_phase_1_refresh_manifest_foundations",
+        manifest_version="v4.1.0-foundation",
+        source_bundle_reference="v4_0_closeout_and_v4_1_readiness_report",
+        extraction_reference="v4_1_refresh_manifest_extraction_primary",
+        patch_reference="v4_1_refresh_manifest_patch_lineage_primary",
+        schema_version=V4_1_REFRESH_MANIFEST_SCHEMA_VERSION,
+        generated_at=V4_1_REFRESH_MANIFEST_GENERATED_AT,
+        provenance_reference="v4_1_refresh_manifest_provenance_primary",
+        lineage_reference="v4_1_refresh_manifest_lineage_primary",
+        trust_reference="v4_1_refresh_manifest_trust_visibility_primary",
+        validation_reference="v4_1_refresh_manifest_validation_visibility_primary",
+        diagnostics_reference="v4_1_refresh_manifest_diagnostics_primary",
+        governance_reference="v4_1_refresh_manifest_governance_primary",
+    )
+
+
+def default_refresh_manifest_states(
+    identity: RefreshManifestIdentity | None = None,
+) -> tuple[RefreshManifestState, ...]:
+    source = identity or default_refresh_manifest_identity()
+    visibility = "v4_1_refresh_manifest_unsupported_state_visibility_primary"
+    return (
+        RefreshManifestState(
+            state_id="v4_1_refresh_manifest_state_supported_identity",
+            state=REFRESH_MANIFEST_STATE_SUPPORTED,
+            reason="refresh manifest identity is deterministic and descriptive",
+            provenance_reference=source.provenance_reference,
+            lineage_reference=source.lineage_reference,
+            visibility_reference=visibility,
+            deterministic_order=1,
+        ),
+        RefreshManifestState(
+            state_id="v4_1_refresh_manifest_state_unsupported_source_provider",
+            state=REFRESH_MANIFEST_STATE_UNSUPPORTED,
+            reason="unsupported refresh source providers remain visible and blocked from execution",
+            provenance_reference=source.provenance_reference,
+            lineage_reference=source.lineage_reference,
+            visibility_reference=visibility,
+            deterministic_order=2,
+            visibility_status=REFRESH_MANIFEST_VISIBILITY_FAIL_VISIBLE,
+            severity=REFRESH_MANIFEST_SEVERITY_WARNING,
+            fail_visible=True,
+        ),
+        RefreshManifestState(
+            state_id="v4_1_refresh_manifest_state_blocked_dependency_gap",
+            state=REFRESH_MANIFEST_STATE_BLOCKED,
+            reason="missing refresh dependencies remain blocked evidence until a future phase supplies them",
+            provenance_reference=source.provenance_reference,
+            lineage_reference=source.lineage_reference,
+            visibility_reference=visibility,
+            deterministic_order=3,
+            visibility_status=REFRESH_MANIFEST_VISIBILITY_FAIL_VISIBLE,
+            severity=REFRESH_MANIFEST_SEVERITY_BLOCKED,
+            fail_visible=True,
+        ),
+        RefreshManifestState(
+            state_id="v4_1_refresh_manifest_state_unknown_future_source",
+            state=REFRESH_MANIFEST_STATE_UNKNOWN,
+            reason="future refresh source state is explicitly unknown and not inferred",
+            provenance_reference=source.provenance_reference,
+            lineage_reference=source.lineage_reference,
+            visibility_reference=visibility,
+            deterministic_order=4,
+            visibility_status=REFRESH_MANIFEST_VISIBILITY_FAIL_VISIBLE,
+            severity=REFRESH_MANIFEST_SEVERITY_UNKNOWN,
+            fail_visible=True,
+        ),
+        RefreshManifestState(
+            state_id="v4_1_refresh_manifest_state_stale_lifecycle_dependency",
+            state=REFRESH_MANIFEST_STATE_STALE,
+            reason="v4.0 lifecycle dependency context remains visible as a read-only stale reference",
+            provenance_reference=source.provenance_reference,
+            lineage_reference=source.lineage_reference,
+            visibility_reference=visibility,
+            deterministic_order=5,
+            visibility_status=REFRESH_MANIFEST_VISIBILITY_FAIL_VISIBLE,
+            severity=REFRESH_MANIFEST_SEVERITY_WARNING,
+            fail_visible=True,
+        ),
+        RefreshManifestState(
+            state_id="v4_1_refresh_manifest_state_prohibited_execution_domain",
+            state=REFRESH_MANIFEST_STATE_PROHIBITED,
+            reason="execution-capable refresh behavior is prohibited",
+            provenance_reference=source.provenance_reference,
+            lineage_reference=source.lineage_reference,
+            visibility_reference=visibility,
+            deterministic_order=6,
+            visibility_status=REFRESH_MANIFEST_VISIBILITY_FAIL_VISIBLE,
+            severity=REFRESH_MANIFEST_SEVERITY_PROHIBITED,
+            fail_visible=True,
+        ),
+    )
+
+
+def default_refresh_manifest_source_lineage(
+    identity: RefreshManifestIdentity | None = None,
+) -> RefreshManifestSourceLineage:
+    source = identity or default_refresh_manifest_identity()
+    return RefreshManifestSourceLineage(
+        source_lineage_id="v4_1_refresh_manifest_source_lineage_primary",
+        source_system_reference="epochforge_v4_0_closeout_governance_evidence",
+        source_bundle_reference=source.source_bundle_reference,
+        source_evidence_references=(
+            "docs/generated/v4_0_closeout_and_v4_1_readiness_report.json",
+            "docs/generated/v4_0_patch_lifecycle_foundations_report.json",
+            "docs/migration/V4_0_CLOSEOUT_AND_V4_1_READINESS.md",
+        ),
+        prior_manifest_references=(
+            "v4_0_closeout_and_v4_1_readiness",
+            "v4_0_patch_lifecycle_foundations",
+        ),
+        unsupported_source_visibility=("v4_1_future_refresh_source_provider_not_declared",),
+        provenance_reference=source.provenance_reference,
+        deterministic_hash_reference="v4_1_refresh_manifest_source_lineage_hash",
+        deterministic_order=1,
+    )
+
+
+def default_refresh_manifest_extraction_lineage(
+    identity: RefreshManifestIdentity | None = None,
+) -> RefreshManifestExtractionLineage:
+    source = identity or default_refresh_manifest_identity()
+    return RefreshManifestExtractionLineage(
+        extraction_lineage_id=source.extraction_reference,
+        extractor_reference="v4_1_refresh_manifest_foundation_extractor_descriptive_only",
+        extraction_snapshot_reference="v4_1_refresh_manifest_foundation_snapshot",
+        extraction_evidence_references=(
+            "v4_1_refresh_manifest_identity_fields",
+            "v4_1_refresh_manifest_lineage_fields",
+            "v4_1_refresh_manifest_governance_visibility_fields",
+        ),
+        unsupported_extraction_states=("v4_1_live_refresh_extraction_not_supported",),
+        provenance_reference=source.provenance_reference,
+        deterministic_hash_reference="v4_1_refresh_manifest_extraction_lineage_hash",
+        deterministic_order=1,
+    )
+
+
+def default_refresh_manifest_patch_lineage(
+    identity: RefreshManifestIdentity | None = None,
+) -> RefreshManifestPatchLineage:
+    source = identity or default_refresh_manifest_identity()
+    return RefreshManifestPatchLineage(
+        patch_lineage_id=source.patch_reference,
+        patch_reference="v4_1_refresh_manifest_foundation_patch_reference",
+        patch_evidence_references=(
+            "v4_0_closeout_and_v4_1_readiness_report_hash",
+            "v4_1_refresh_manifest_foundation_model_hash",
+        ),
+        prior_patch_references=(
+            "v4_0_patch_lifecycle_foundations",
+            "v4_0_closeout_and_v4_1_readiness",
+        ),
+        rollback_references=("v4_0_closeout_and_v4_1_readiness_report",),
+        provenance_reference=source.provenance_reference,
+        deterministic_hash_reference="v4_1_refresh_manifest_patch_lineage_hash",
+        deterministic_order=1,
+    )
+
+
+def default_schema_version_visibility(
+    identity: RefreshManifestIdentity | None = None,
+) -> RefreshManifestSchemaVersionVisibility:
+    source = identity or default_refresh_manifest_identity()
+    return RefreshManifestSchemaVersionVisibility(
+        schema_visibility_id="v4_1_refresh_manifest_schema_visibility_primary",
+        manifest_schema_version=source.schema_version,
+        source_schema_version="v4_0.closeout_and_v4_1_readiness_report.1",
+        extraction_schema_version="v4_1.refresh_manifest_extraction_lineage.1",
+        patch_schema_version="v4_1.refresh_manifest_patch_lineage.1",
+        visible_schema_constraints=(
+            "deterministic_serialization_required",
+            "deterministic_hashing_required",
+            "unsupported_states_must_be_fail_visible",
+            "execution_semantics_must_remain_disabled",
+        ),
+        unsupported_schema_versions=("future_refresh_manifest_schema_not_declared",),
+        deterministic_order=1,
+    )
+
+
+def default_dependency_visibility() -> RefreshManifestDependencyVisibility:
+    return RefreshManifestDependencyVisibility(
+        dependency_visibility_id="v4_1_refresh_manifest_dependency_visibility_primary",
+        dependency_references=(
+            "v4_0_closeout_and_v4_1_readiness_report",
+            "v4_0_patch_lifecycle_foundations_report",
+            "v4_1_refresh_manifest_schema_visibility_primary",
+        ),
+        missing_dependency_visibility=("future_refresh_provider_contract_not_declared",),
+        stale_dependency_visibility=("v4_0_lifecycle_dependency_snapshot_read_only",),
+        prohibited_dependency_visibility=("production_runtime_bundle_dependency",),
+        deterministic_order=1,
+    )
+
+
+def default_trust_visibility() -> RefreshManifestTrustVisibility:
+    return RefreshManifestTrustVisibility(
+        trust_visibility_id="v4_1_refresh_manifest_trust_visibility_primary",
+        trusted_source_references=(
+            "v4_0_closeout_and_v4_1_readiness_report",
+            "v4_0_patch_lifecycle_foundations_report",
+        ),
+        untrusted_source_visibility=("live_production_bundle_source_not_trusted",),
+        ambiguous_trust_visibility=("future_refresh_provider_trust_unknown",),
+        deterministic_order=1,
+    )
+
+
+def default_validation_visibility() -> RefreshManifestValidationVisibility:
+    return RefreshManifestValidationVisibility(
+        validation_visibility_id="v4_1_refresh_manifest_validation_visibility_primary",
+        validation_references=(
+            "deterministic_serialization_validation",
+            "deterministic_hashing_validation",
+            "deterministic_equality_validation",
+            "non_execution_boundary_validation",
+            "planner_integration_disabled_validation",
+            "production_consumption_disabled_validation",
+        ),
+        validation_warning_visibility=("future_refresh_provider_contract_not_declared",),
+        validation_blocker_visibility=("production_runtime_bundle_dependency",),
+        unsupported_validation_visibility=("live_refresh_execution_validation_not_supported",),
+        deterministic_order=1,
+    )
+
+
+def default_prohibited_domain_visibility() -> RefreshManifestProhibitedDomainVisibility:
+    return RefreshManifestProhibitedDomainVisibility(
+        prohibited_domain_visibility_id="v4_1_refresh_manifest_prohibited_domain_visibility_primary",
+        prohibited_domains=PROHIBITED_REFRESH_DOMAINS,
+        visible_blocked_reasons=tuple(f"v4_1_prohibited_domain_{domain}" for domain in PROHIBITED_REFRESH_DOMAINS),
+        deterministic_order=1,
+    )
+
+
+def default_unsupported_state_visibility(
+    states: tuple[RefreshManifestState, ...] | None = None,
+) -> RefreshManifestUnsupportedStateVisibility:
+    manifest_states = states or default_refresh_manifest_states()
+    return RefreshManifestUnsupportedStateVisibility(
+        unsupported_state_visibility_id="v4_1_refresh_manifest_unsupported_state_visibility_primary",
+        unsupported_states=tuple(
+            state.state_id for state in manifest_states if state.state == REFRESH_MANIFEST_STATE_UNSUPPORTED
+        ),
+        unknown_states=tuple(state.state_id for state in manifest_states if state.state == REFRESH_MANIFEST_STATE_UNKNOWN),
+        blocked_states=tuple(state.state_id for state in manifest_states if state.state == REFRESH_MANIFEST_STATE_BLOCKED),
+        prohibited_states=tuple(
+            state.state_id for state in manifest_states if state.state == REFRESH_MANIFEST_STATE_PROHIBITED
+        ),
+        stale_states=tuple(state.state_id for state in manifest_states if state.state == REFRESH_MANIFEST_STATE_STALE),
+        deterministic_order=1,
+    )
+
+
+def default_continuity_metadata(identity: RefreshManifestIdentity | None = None) -> RefreshManifestContinuityMetadata:
+    source = identity or default_refresh_manifest_identity()
+    return RefreshManifestContinuityMetadata(
+        continuity_metadata_id="v4_1_refresh_manifest_continuity_primary",
+        provenance_continuity_references=(
+            source.provenance_reference,
+            "v4_0_closeout_and_v4_1_readiness_provenance_safe",
+        ),
+        lineage_continuity_references=(
+            source.lineage_reference,
+            "v4_0_closeout_and_v4_1_readiness_lineage_safe",
+        ),
+        replay_references=("v4_1_refresh_manifest_replay_primary",),
+        rollback_references=("v4_1_refresh_manifest_rollback_primary",),
+        diagnostics_references=(source.diagnostics_reference,),
+        deterministic_hash_reference="v4_1_refresh_manifest_continuity_hash",
+        deterministic_order=1,
+    )
+
+
+def default_replay_metadata() -> RefreshManifestReplayMetadata:
+    return RefreshManifestReplayMetadata(
+        replay_metadata_id="v4_1_refresh_manifest_replay_primary",
+        replay_reference="v4_1_refresh_manifest_replay_safe_descriptive_reference",
+        replay_evidence_references=(
+            "v4_1_refresh_manifest_serialization_snapshot",
+            "v4_1_refresh_manifest_hash_snapshot",
+        ),
+        deterministic_hash_reference="v4_1_refresh_manifest_replay_hash",
+        deterministic_order=1,
+    )
+
+
+def default_rollback_metadata() -> RefreshManifestRollbackMetadata:
+    return RefreshManifestRollbackMetadata(
+        rollback_metadata_id="v4_1_refresh_manifest_rollback_primary",
+        rollback_reference="v4_0_closeout_and_v4_1_readiness_report",
+        rollback_evidence_references=(
+            "docs/generated/v4_0_closeout_and_v4_1_readiness_report.json",
+            "docs/migration/V4_0_CLOSEOUT_AND_V4_1_READINESS.md",
+        ),
+        deterministic_hash_reference="v4_1_refresh_manifest_rollback_hash",
+        deterministic_order=1,
+    )
+
+
+def default_diagnostics_visibility(
+    unsupported: RefreshManifestUnsupportedStateVisibility | None = None,
+    prohibited: RefreshManifestProhibitedDomainVisibility | None = None,
+) -> RefreshManifestDiagnosticsVisibility:
+    unsupported_visibility = unsupported or default_unsupported_state_visibility()
+    prohibited_visibility = prohibited or default_prohibited_domain_visibility()
+    return RefreshManifestDiagnosticsVisibility(
+        diagnostics_visibility_id="v4_1_refresh_manifest_diagnostics_primary",
+        diagnostic_references=(
+            "v4_1_refresh_manifest_visibility_validation",
+            "v4_1_refresh_manifest_integrity_validation",
+            "v4_1_refresh_manifest_non_execution_validation",
+        ),
+        warning_visibility=unsupported_visibility.unsupported_states + unsupported_visibility.stale_states,
+        blocker_visibility=unsupported_visibility.blocked_states,
+        unsupported_state_visibility=unsupported_visibility.unsupported_states + unsupported_visibility.unknown_states,
+        prohibited_domain_visibility=prohibited_visibility.prohibited_domains,
+        deterministic_order=1,
+    )
+
+
+def default_governance_visibility() -> RefreshManifestGovernanceVisibility:
+    return RefreshManifestGovernanceVisibility(
+        governance_visibility_id="v4_1_refresh_manifest_governance_primary",
+        governance_references=(
+            "v4_0_closeout_and_v4_1_readiness_governance_chain",
+            "v4_1_refresh_manifest_foundation_governance_boundary",
+        ),
+        explicit_limitations=EXPLICIT_REFRESH_MANIFEST_LIMITATIONS,
+        explicit_prohibitions=EXPLICIT_REFRESH_MANIFEST_PROHIBITIONS,
+        deterministic_order=1,
+    )
+
+
+def default_refresh_manifest() -> RefreshManifest:
+    identity = default_refresh_manifest_identity()
+    states = default_refresh_manifest_states(identity)
+    prohibited = default_prohibited_domain_visibility()
+    unsupported = default_unsupported_state_visibility(states)
+    return RefreshManifest(
+        identity=identity,
+        states=states,
+        source_lineage=(default_refresh_manifest_source_lineage(identity),),
+        extraction_lineage=(default_refresh_manifest_extraction_lineage(identity),),
+        patch_lineage=(default_refresh_manifest_patch_lineage(identity),),
+        schema_version_visibility=(default_schema_version_visibility(identity),),
+        dependency_visibility=(default_dependency_visibility(),),
+        trust_visibility=(default_trust_visibility(),),
+        validation_visibility=(default_validation_visibility(),),
+        prohibited_domain_visibility=(prohibited,),
+        unsupported_state_visibility=(unsupported,),
+        continuity_metadata=default_continuity_metadata(identity),
+        replay_metadata=default_replay_metadata(),
+        rollback_metadata=default_rollback_metadata(),
+        diagnostics_visibility=(default_diagnostics_visibility(unsupported, prohibited),),
+        governance_visibility=default_governance_visibility(),
+    )

--- a/backend/app/operational_refresh/refresh_manifest_serialization.py
+++ b/backend/app/operational_refresh/refresh_manifest_serialization.py
@@ -1,0 +1,286 @@
+"""Deterministic serialization for v4.1 refresh manifest foundations.
+
+Serialization preserves unsupported, prohibited, unknown, stale, blocker, and
+warning evidence. It does not correct, omit, authorize, execute, or mutate
+refresh manifest state.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import Any, Iterable
+
+from operational_lifecycle.lifecycle_serialization import stable_serialize
+
+from .refresh_manifest_models import (
+    RefreshManifest,
+    RefreshManifestContinuityMetadata,
+    RefreshManifestDependencyVisibility,
+    RefreshManifestDiagnosticsVisibility,
+    RefreshManifestExtractionLineage,
+    RefreshManifestGovernanceVisibility,
+    RefreshManifestIdentity,
+    RefreshManifestPatchLineage,
+    RefreshManifestProhibitedDomainVisibility,
+    RefreshManifestReplayMetadata,
+    RefreshManifestRollbackMetadata,
+    RefreshManifestSchemaVersionVisibility,
+    RefreshManifestSourceLineage,
+    RefreshManifestState,
+    RefreshManifestTrustVisibility,
+    RefreshManifestUnsupportedStateVisibility,
+    RefreshManifestValidationVisibility,
+)
+
+
+def sorted_entries(values: Iterable[str] | tuple[str, ...] | list[str]) -> list[str]:
+    return sorted(tuple(values or ()))
+
+
+def _disable_execution_fields(data: dict[str, Any]) -> dict[str, Any]:
+    for field_name in (
+        "execution_authorized",
+        "refresh_execution_enabled",
+        "orchestration_enabled",
+        "deployment_execution_enabled",
+        "automatic_refresh_enabled",
+        "automatic_migration_enabled",
+        "planner_integration_enabled",
+        "production_consumption_enabled",
+        "remediation_enabled",
+        "mutation_enabled",
+        "runtime_mutation_enabled",
+        "recommendation_enabled",
+        "ranking_enabled",
+        "scoring_enabled",
+        "selection_enabled",
+        "authorization_enabled",
+        "approval_enabled",
+        "automatic_rollback_enabled",
+        "automatic_recovery_enabled",
+        "hidden_operational_behavior_enabled",
+        "implicit_execution_pathway_enabled",
+        "silent_fallback_enabled",
+        "execution_enabled",
+        "extraction_execution_enabled",
+        "patch_execution_enabled",
+        "automatic_extraction_enabled",
+        "automatic_source_refresh_enabled",
+        "automatic_dependency_refresh_enabled",
+        "automatic_validation_execution_enabled",
+        "live_replay_enabled",
+        "runtime_execution_enabled",
+        "recovery_execution_enabled",
+    ):
+        if field_name in data:
+            data[field_name] = False
+    return data
+
+
+def export_refresh_manifest_identity(identity: RefreshManifestIdentity) -> dict[str, Any]:
+    return _disable_execution_fields(asdict(identity))
+
+
+def export_refresh_manifest_state(state: RefreshManifestState) -> dict[str, Any]:
+    return _disable_execution_fields(asdict(state))
+
+
+def export_source_lineage(record: RefreshManifestSourceLineage) -> dict[str, Any]:
+    data = _disable_execution_fields(asdict(record))
+    for field_name in ("source_evidence_references", "prior_manifest_references", "unsupported_source_visibility"):
+        data[field_name] = sorted_entries(data[field_name])
+    return data
+
+
+def export_extraction_lineage(record: RefreshManifestExtractionLineage) -> dict[str, Any]:
+    data = _disable_execution_fields(asdict(record))
+    for field_name in ("extraction_evidence_references", "unsupported_extraction_states"):
+        data[field_name] = sorted_entries(data[field_name])
+    return data
+
+
+def export_patch_lineage(record: RefreshManifestPatchLineage) -> dict[str, Any]:
+    data = _disable_execution_fields(asdict(record))
+    for field_name in ("patch_evidence_references", "prior_patch_references", "rollback_references"):
+        data[field_name] = sorted_entries(data[field_name])
+    return data
+
+
+def export_schema_version_visibility(record: RefreshManifestSchemaVersionVisibility) -> dict[str, Any]:
+    data = _disable_execution_fields(asdict(record))
+    for field_name in ("visible_schema_constraints", "unsupported_schema_versions"):
+        data[field_name] = sorted_entries(data[field_name])
+    return data
+
+
+def export_dependency_visibility(record: RefreshManifestDependencyVisibility) -> dict[str, Any]:
+    data = _disable_execution_fields(asdict(record))
+    for field_name in (
+        "dependency_references",
+        "missing_dependency_visibility",
+        "stale_dependency_visibility",
+        "prohibited_dependency_visibility",
+    ):
+        data[field_name] = sorted_entries(data[field_name])
+    return data
+
+
+def export_trust_visibility(record: RefreshManifestTrustVisibility) -> dict[str, Any]:
+    data = _disable_execution_fields(asdict(record))
+    for field_name in ("trusted_source_references", "untrusted_source_visibility", "ambiguous_trust_visibility"):
+        data[field_name] = sorted_entries(data[field_name])
+    return data
+
+
+def export_validation_visibility(record: RefreshManifestValidationVisibility) -> dict[str, Any]:
+    data = _disable_execution_fields(asdict(record))
+    for field_name in (
+        "validation_references",
+        "validation_warning_visibility",
+        "validation_blocker_visibility",
+        "unsupported_validation_visibility",
+    ):
+        data[field_name] = sorted_entries(data[field_name])
+    return data
+
+
+def export_prohibited_domain_visibility(record: RefreshManifestProhibitedDomainVisibility) -> dict[str, Any]:
+    data = _disable_execution_fields(asdict(record))
+    for field_name in ("prohibited_domains", "visible_blocked_reasons"):
+        data[field_name] = sorted_entries(data[field_name])
+    return data
+
+
+def export_unsupported_state_visibility(record: RefreshManifestUnsupportedStateVisibility) -> dict[str, Any]:
+    data = _disable_execution_fields(asdict(record))
+    for field_name in ("unsupported_states", "unknown_states", "blocked_states", "prohibited_states", "stale_states"):
+        data[field_name] = sorted_entries(data[field_name])
+    return data
+
+
+def export_continuity_metadata(metadata: RefreshManifestContinuityMetadata) -> dict[str, Any]:
+    data = _disable_execution_fields(asdict(metadata))
+    for field_name in (
+        "provenance_continuity_references",
+        "lineage_continuity_references",
+        "replay_references",
+        "rollback_references",
+        "diagnostics_references",
+    ):
+        data[field_name] = sorted_entries(data[field_name])
+    return data
+
+
+def export_replay_metadata(metadata: RefreshManifestReplayMetadata) -> dict[str, Any]:
+    data = _disable_execution_fields(asdict(metadata))
+    data["replay_evidence_references"] = sorted_entries(data["replay_evidence_references"])
+    return data
+
+
+def export_rollback_metadata(metadata: RefreshManifestRollbackMetadata) -> dict[str, Any]:
+    data = _disable_execution_fields(asdict(metadata))
+    data["rollback_evidence_references"] = sorted_entries(data["rollback_evidence_references"])
+    return data
+
+
+def export_diagnostics_visibility(record: RefreshManifestDiagnosticsVisibility) -> dict[str, Any]:
+    data = _disable_execution_fields(asdict(record))
+    for field_name in (
+        "diagnostic_references",
+        "warning_visibility",
+        "blocker_visibility",
+        "unsupported_state_visibility",
+        "prohibited_domain_visibility",
+    ):
+        data[field_name] = sorted_entries(data[field_name])
+    return data
+
+
+def export_governance_visibility(record: RefreshManifestGovernanceVisibility) -> dict[str, Any]:
+    data = _disable_execution_fields(asdict(record))
+    for field_name in ("governance_references", "explicit_limitations", "explicit_prohibitions"):
+        data[field_name] = sorted_entries(data[field_name])
+    return data
+
+
+def export_refresh_manifest(manifest: RefreshManifest) -> dict[str, Any]:
+    data = _disable_execution_fields(asdict(manifest))
+    data["identity"] = export_refresh_manifest_identity(manifest.identity)
+    data["states"] = [
+        export_refresh_manifest_state(state)
+        for state in sorted(manifest.states, key=lambda item: (item.deterministic_order, item.state_id))
+    ]
+    data["source_lineage"] = [
+        export_source_lineage(record)
+        for record in sorted(manifest.source_lineage, key=lambda item: (item.deterministic_order, item.source_lineage_id))
+    ]
+    data["extraction_lineage"] = [
+        export_extraction_lineage(record)
+        for record in sorted(
+            manifest.extraction_lineage,
+            key=lambda item: (item.deterministic_order, item.extraction_lineage_id),
+        )
+    ]
+    data["patch_lineage"] = [
+        export_patch_lineage(record)
+        for record in sorted(manifest.patch_lineage, key=lambda item: (item.deterministic_order, item.patch_lineage_id))
+    ]
+    data["schema_version_visibility"] = [
+        export_schema_version_visibility(record)
+        for record in sorted(
+            manifest.schema_version_visibility,
+            key=lambda item: (item.deterministic_order, item.schema_visibility_id),
+        )
+    ]
+    data["dependency_visibility"] = [
+        export_dependency_visibility(record)
+        for record in sorted(
+            manifest.dependency_visibility,
+            key=lambda item: (item.deterministic_order, item.dependency_visibility_id),
+        )
+    ]
+    data["trust_visibility"] = [
+        export_trust_visibility(record)
+        for record in sorted(manifest.trust_visibility, key=lambda item: (item.deterministic_order, item.trust_visibility_id))
+    ]
+    data["validation_visibility"] = [
+        export_validation_visibility(record)
+        for record in sorted(
+            manifest.validation_visibility,
+            key=lambda item: (item.deterministic_order, item.validation_visibility_id),
+        )
+    ]
+    data["prohibited_domain_visibility"] = [
+        export_prohibited_domain_visibility(record)
+        for record in sorted(
+            manifest.prohibited_domain_visibility,
+            key=lambda item: (item.deterministic_order, item.prohibited_domain_visibility_id),
+        )
+    ]
+    data["unsupported_state_visibility"] = [
+        export_unsupported_state_visibility(record)
+        for record in sorted(
+            manifest.unsupported_state_visibility,
+            key=lambda item: (item.deterministic_order, item.unsupported_state_visibility_id),
+        )
+    ]
+    data["continuity_metadata"] = export_continuity_metadata(manifest.continuity_metadata)
+    data["replay_metadata"] = export_replay_metadata(manifest.replay_metadata)
+    data["rollback_metadata"] = export_rollback_metadata(manifest.rollback_metadata)
+    data["diagnostics_visibility"] = [
+        export_diagnostics_visibility(record)
+        for record in sorted(
+            manifest.diagnostics_visibility,
+            key=lambda item: (item.deterministic_order, item.diagnostics_visibility_id),
+        )
+    ]
+    data["governance_visibility"] = export_governance_visibility(manifest.governance_visibility)
+    return data
+
+
+def serialize_refresh_manifest_identity(identity: RefreshManifestIdentity) -> str:
+    return stable_serialize(export_refresh_manifest_identity(identity))
+
+
+def serialize_refresh_manifest(manifest: RefreshManifest) -> str:
+    return stable_serialize(export_refresh_manifest(manifest))

--- a/backend/app/operational_refresh/refresh_manifest_visibility.py
+++ b/backend/app/operational_refresh/refresh_manifest_visibility.py
@@ -1,0 +1,196 @@
+"""Fail-visible visibility helpers for v4.1 refresh manifest foundations."""
+
+from __future__ import annotations
+
+from .refresh_manifest_models import (
+    FAIL_VISIBLE_REFRESH_MANIFEST_STATES,
+    REFRESH_MANIFEST_STATE_BLOCKED,
+    REFRESH_MANIFEST_STATE_PROHIBITED,
+    REFRESH_MANIFEST_STATE_STALE,
+    REFRESH_MANIFEST_STATE_UNKNOWN,
+    REFRESH_MANIFEST_STATE_UNSUPPORTED,
+    REFRESH_MANIFEST_STATES,
+    RefreshManifest,
+    RefreshManifestState,
+    default_refresh_manifest,
+    default_refresh_manifest_states,
+)
+
+
+def count_refresh_manifest_states(states: tuple[RefreshManifestState, ...] | list[RefreshManifestState]) -> dict[str, int]:
+    counts = {state: 0 for state in REFRESH_MANIFEST_STATES}
+    counts["invalid"] = 0
+    for state in states:
+        if state.state in counts:
+            counts[state.state] += 1
+        else:
+            counts["invalid"] += 1
+    return counts
+
+
+def invalid_refresh_manifest_state_ids(
+    states: tuple[RefreshManifestState, ...] | list[RefreshManifestState],
+) -> tuple[str, ...]:
+    return tuple(state.state_id for state in states if state.state not in REFRESH_MANIFEST_STATES)
+
+
+def fail_visible_refresh_manifest_state_ids(
+    states: tuple[RefreshManifestState, ...] | list[RefreshManifestState],
+) -> tuple[str, ...]:
+    return tuple(state.state_id for state in states if state.state in FAIL_VISIBLE_REFRESH_MANIFEST_STATES and state.fail_visible)
+
+
+def validate_refresh_manifest_visibility(manifest: RefreshManifest) -> dict[str, object]:
+    states = manifest.states
+    unsupported_ids = tuple(state.state_id for state in states if state.state == REFRESH_MANIFEST_STATE_UNSUPPORTED)
+    unknown_ids = tuple(state.state_id for state in states if state.state == REFRESH_MANIFEST_STATE_UNKNOWN)
+    blocked_ids = tuple(state.state_id for state in states if state.state == REFRESH_MANIFEST_STATE_BLOCKED)
+    prohibited_ids = tuple(state.state_id for state in states if state.state == REFRESH_MANIFEST_STATE_PROHIBITED)
+    stale_ids = tuple(state.state_id for state in states if state.state == REFRESH_MANIFEST_STATE_STALE)
+    visibility_unsupported = tuple(
+        item for record in manifest.unsupported_state_visibility for item in record.unsupported_states
+    )
+    visibility_unknown = tuple(item for record in manifest.unsupported_state_visibility for item in record.unknown_states)
+    visibility_blocked = tuple(item for record in manifest.unsupported_state_visibility for item in record.blocked_states)
+    visibility_prohibited = tuple(item for record in manifest.unsupported_state_visibility for item in record.prohibited_states)
+    visibility_stale = tuple(item for record in manifest.unsupported_state_visibility for item in record.stale_states)
+    prohibited_domains = tuple(
+        domain for record in manifest.prohibited_domain_visibility for domain in record.prohibited_domains
+    )
+    visible_blocked_reasons = tuple(
+        reason for record in manifest.prohibited_domain_visibility for reason in record.visible_blocked_reasons
+    )
+    hidden_state_count = sum(1 for state in states if state.hidden)
+    invalid_state_ids = invalid_refresh_manifest_state_ids(states)
+    corrective_state_count = sum(
+        1
+        for state in states
+        if state.automatic_resolution_enabled
+        or state.silent_fallback_enabled
+        or state.remediation_enabled
+        or state.runtime_mutation_enabled
+    )
+    state_execution_count = sum(1 for state in states if state.executable)
+    hidden_visibility_count = sum(
+        1
+        for record in (
+            *manifest.source_lineage,
+            *manifest.extraction_lineage,
+            *manifest.patch_lineage,
+            *manifest.schema_version_visibility,
+            *manifest.dependency_visibility,
+            *manifest.validation_visibility,
+            *manifest.prohibited_domain_visibility,
+            *manifest.unsupported_state_visibility,
+            *manifest.diagnostics_visibility,
+        )
+        if getattr(record, "hidden_source_resolution_enabled", False)
+        or getattr(record, "hidden_extraction_fallback_enabled", False)
+        or getattr(record, "hidden_patch_resolution_enabled", False)
+        or getattr(record, "hidden_schema_inference_enabled", False)
+        or getattr(record, "hidden_dependency_resolution_enabled", False)
+        or getattr(record, "silent_validation_fallback_enabled", False)
+        or getattr(record, "hidden_operational_behavior_enabled", False)
+        or getattr(record, "hidden_unsupported_state_resolution_enabled", False)
+        or getattr(record, "silent_fallback_enabled", False)
+    )
+    corrective_visibility_count = sum(
+        1
+        for record in (
+            *manifest.validation_visibility,
+            *manifest.unsupported_state_visibility,
+            *manifest.diagnostics_visibility,
+        )
+        if getattr(record, "remediation_enabled", False)
+        or getattr(record, "automatic_recovery_enabled", False)
+        or getattr(record, "automatic_validation_execution_enabled", False)
+    )
+    visibility_failures = [
+        bool(set(unsupported_ids) - set(visibility_unsupported)),
+        bool(set(unknown_ids) - set(visibility_unknown)),
+        bool(set(blocked_ids) - set(visibility_blocked)),
+        bool(set(prohibited_ids) - set(visibility_prohibited)),
+        bool(set(stale_ids) - set(visibility_stale)),
+    ]
+    return {
+        "state_counts": count_refresh_manifest_states(states),
+        "fail_visible_refresh_manifest_state_count": len(fail_visible_refresh_manifest_state_ids(states)),
+        "unsupported_state_visibility_count": len(visibility_unsupported),
+        "unknown_state_visibility_count": len(visibility_unknown),
+        "blocked_state_visibility_count": len(visibility_blocked),
+        "prohibited_state_visibility_count": len(visibility_prohibited),
+        "stale_state_visibility_count": len(visibility_stale),
+        "prohibited_domain_visibility_count": len(prohibited_domains),
+        "visible_blocked_reason_count": len(visible_blocked_reasons),
+        "dependency_warning_visibility_count": sum(
+            len(record.missing_dependency_visibility)
+            + len(record.stale_dependency_visibility)
+            + len(record.prohibited_dependency_visibility)
+            for record in manifest.dependency_visibility
+        ),
+        "trust_warning_visibility_count": sum(
+            len(record.untrusted_source_visibility) + len(record.ambiguous_trust_visibility)
+            for record in manifest.trust_visibility
+        ),
+        "validation_warning_visibility_count": sum(
+            len(record.validation_warning_visibility)
+            + len(record.validation_blocker_visibility)
+            + len(record.unsupported_validation_visibility)
+            for record in manifest.validation_visibility
+        ),
+        "diagnostics_warning_visibility_count": sum(
+            len(record.warning_visibility)
+            + len(record.blocker_visibility)
+            + len(record.unsupported_state_visibility)
+            + len(record.prohibited_domain_visibility)
+            for record in manifest.diagnostics_visibility
+        ),
+        "governance_limitation_count": len(manifest.governance_visibility.explicit_limitations),
+        "governance_prohibition_count": len(manifest.governance_visibility.explicit_prohibitions),
+        "hidden_state_count": hidden_state_count,
+        "invalid_refresh_manifest_state_count": len(invalid_state_ids),
+        "corrective_state_count": corrective_state_count,
+        "state_execution_semantics_count": state_execution_count,
+        "hidden_visibility_count": hidden_visibility_count,
+        "corrective_visibility_count": corrective_visibility_count,
+        "unsupported_states_visible": not bool(set(unsupported_ids) - set(visibility_unsupported)),
+        "unknown_states_visible": not bool(set(unknown_ids) - set(visibility_unknown)),
+        "blocked_states_visible": not bool(set(blocked_ids) - set(visibility_blocked)),
+        "prohibited_states_visible": not bool(set(prohibited_ids) - set(visibility_prohibited)),
+        "stale_states_visible": not bool(set(stale_ids) - set(visibility_stale)),
+        "prohibited_domains_visible": len(prohibited_domains) == len(visible_blocked_reasons),
+        "visibility_is_descriptive_only": all(
+            getattr(record, "descriptive_only", False)
+            for record in (
+                *manifest.source_lineage,
+                *manifest.extraction_lineage,
+                *manifest.patch_lineage,
+                *manifest.schema_version_visibility,
+                *manifest.dependency_visibility,
+                *manifest.trust_visibility,
+                *manifest.validation_visibility,
+                *manifest.prohibited_domain_visibility,
+                *manifest.unsupported_state_visibility,
+                *manifest.diagnostics_visibility,
+                manifest.governance_visibility,
+            )
+        ),
+        "valid": (
+            not any(visibility_failures)
+            and hidden_state_count == 0
+            and len(invalid_state_ids) == 0
+            and corrective_state_count == 0
+            and state_execution_count == 0
+            and hidden_visibility_count == 0
+            and corrective_visibility_count == 0
+            and len(prohibited_domains) == len(visible_blocked_reasons)
+        ),
+    }
+
+
+def build_default_refresh_manifest_states() -> tuple[RefreshManifestState, ...]:
+    return default_refresh_manifest_states()
+
+
+def build_default_refresh_manifest() -> RefreshManifest:
+    return default_refresh_manifest()

--- a/backend/scripts/report_v4_1_refresh_manifest_foundations.py
+++ b/backend/scripts/report_v4_1_refresh_manifest_foundations.py
@@ -1,0 +1,318 @@
+"""Generate deterministic v4.1 refresh manifest foundation evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+APP_ROOT = BACKEND_ROOT / "app"
+if str(APP_ROOT) not in sys.path:
+    sys.path.insert(0, str(APP_ROOT))
+
+from operational_refresh.refresh_manifest_diagnostics import (  # noqa: E402
+    build_refresh_manifest_diagnostics,
+)
+from operational_refresh.refresh_manifest_hashing import (  # noqa: E402
+    deterministic_refresh_manifest_hash,
+    hash_refresh_manifest,
+    hash_refresh_manifest_continuity,
+    hash_refresh_manifest_diagnostics,
+    hash_refresh_manifest_identity,
+)
+from operational_refresh.refresh_manifest_integrity import (  # noqa: E402
+    refresh_manifest_identity_normalization_report,
+    refresh_manifests_equal,
+    validate_refresh_manifest_integrity,
+    validate_refresh_manifest_lineage_continuity,
+    validate_refresh_manifest_non_execution,
+    validate_refresh_manifest_provenance_continuity,
+)
+from operational_refresh.refresh_manifest_models import (  # noqa: E402
+    V4_1_REFRESH_MANIFEST_DIAGNOSTICS_SCHEMA_VERSION,
+    V4_1_REFRESH_MANIFEST_GENERATED_AT,
+    V4_1_REFRESH_MANIFEST_PHASE_ID,
+    V4_1_REFRESH_MANIFEST_PURPOSE,
+    V4_1_REFRESH_MANIFEST_REPORT_SCHEMA_VERSION,
+    V4_1_REFRESH_MANIFEST_STATUS_BLOCKED,
+    V4_1_REFRESH_MANIFEST_STATUS_STABLE,
+    default_refresh_manifest,
+)
+from operational_refresh.refresh_manifest_serialization import (  # noqa: E402
+    export_refresh_manifest,
+    serialize_refresh_manifest,
+)
+from operational_refresh.refresh_manifest_visibility import (  # noqa: E402
+    count_refresh_manifest_states,
+    validate_refresh_manifest_visibility,
+)
+
+
+REPORT_PATH = Path("docs/generated/v4_1_refresh_manifest_foundations_report.json")
+DIAGNOSTICS_REPORT_PATH = Path("docs/generated/v4_1_refresh_manifest_diagnostics_report.json")
+
+
+def _reordered_refresh_manifest():
+    manifest = default_refresh_manifest()
+    return replace(
+        manifest,
+        states=tuple(reversed(manifest.states)),
+        source_lineage=tuple(reversed(manifest.source_lineage)),
+        extraction_lineage=tuple(reversed(manifest.extraction_lineage)),
+        patch_lineage=tuple(reversed(manifest.patch_lineage)),
+        schema_version_visibility=tuple(reversed(manifest.schema_version_visibility)),
+        dependency_visibility=tuple(reversed(manifest.dependency_visibility)),
+        trust_visibility=tuple(reversed(manifest.trust_visibility)),
+        validation_visibility=tuple(reversed(manifest.validation_visibility)),
+        prohibited_domain_visibility=tuple(reversed(manifest.prohibited_domain_visibility)),
+        unsupported_state_visibility=tuple(reversed(manifest.unsupported_state_visibility)),
+        diagnostics_visibility=tuple(reversed(manifest.diagnostics_visibility)),
+    )
+
+
+def build_v4_1_refresh_manifest_foundations_report(repo_root: Path | None = None) -> dict[str, Any]:
+    root = repo_root or Path(__file__).resolve().parents[2]
+    manifest = default_refresh_manifest()
+    repeated_manifest = default_refresh_manifest()
+    reordered_manifest = _reordered_refresh_manifest()
+    exported = export_refresh_manifest(manifest)
+    visibility = validate_refresh_manifest_visibility(manifest)
+    provenance_validation = validate_refresh_manifest_provenance_continuity(manifest)
+    lineage_validation = validate_refresh_manifest_lineage_continuity(manifest)
+    non_execution = validate_refresh_manifest_non_execution(manifest)
+    integrity = validate_refresh_manifest_integrity(manifest)
+    diagnostics = build_refresh_manifest_diagnostics(manifest)
+    serialization_first = serialize_refresh_manifest(manifest)
+    serialization_second = serialize_refresh_manifest(repeated_manifest)
+    serialization_reordered = serialize_refresh_manifest(reordered_manifest)
+    manifest_hash = hash_refresh_manifest(manifest)
+    repeated_hash = hash_refresh_manifest(repeated_manifest)
+    reordered_hash = hash_refresh_manifest(reordered_manifest)
+    validation_error_count = sum(
+        [
+            0 if visibility["valid"] else 1,
+            0 if provenance_validation["valid"] else 1,
+            0 if lineage_validation["valid"] else 1,
+            0 if non_execution["valid"] else 1,
+            0 if integrity["valid"] else 1,
+            0 if serialization_first == serialization_second == serialization_reordered else 1,
+            0 if manifest_hash == repeated_hash == reordered_hash else 1,
+            0 if refresh_manifests_equal(manifest, repeated_manifest) else 1,
+        ]
+    )
+    status = (
+        V4_1_REFRESH_MANIFEST_STATUS_STABLE
+        if validation_error_count == 0
+        else V4_1_REFRESH_MANIFEST_STATUS_BLOCKED
+    )
+    state_counts = count_refresh_manifest_states(manifest.states)
+    exported_state_order = [item["state_id"] for item in exported["states"]]
+    expected_state_order = [
+        item["state_id"] for item in sorted(exported["states"], key=lambda item: (item["deterministic_order"], item["state_id"]))
+    ]
+    report = {
+        "schema_version": V4_1_REFRESH_MANIFEST_REPORT_SCHEMA_VERSION,
+        "generated_at": V4_1_REFRESH_MANIFEST_GENERATED_AT,
+        "phase_id": V4_1_REFRESH_MANIFEST_PHASE_ID,
+        "phase_name": "v4.1_phase_1_refresh_manifest_foundations",
+        "repo_root": str(root),
+        "architectural_purpose": "deterministic operational refresh governance intelligence foundations without execution behavior",
+        "refresh_governance_mode": "descriptive_only",
+        "foundation_status": status,
+        "manifest_model_counts": {
+            "identity_count": 1,
+            "state_count": len(manifest.states),
+            "source_lineage_count": len(manifest.source_lineage),
+            "extraction_lineage_count": len(manifest.extraction_lineage),
+            "patch_lineage_count": len(manifest.patch_lineage),
+            "schema_version_visibility_count": len(manifest.schema_version_visibility),
+            "dependency_visibility_count": len(manifest.dependency_visibility),
+            "trust_visibility_count": len(manifest.trust_visibility),
+            "validation_visibility_count": len(manifest.validation_visibility),
+            "prohibited_domain_visibility_count": len(manifest.prohibited_domain_visibility),
+            "unsupported_state_visibility_count": len(manifest.unsupported_state_visibility),
+            "diagnostics_visibility_count": len(manifest.diagnostics_visibility),
+            "state_counts": state_counts,
+        },
+        "lineage_continuity_visibility": lineage_validation,
+        "provenance_continuity_visibility": provenance_validation,
+        "fail_visible_visibility": {
+            "fail_visible_refresh_manifest_state_count": visibility["fail_visible_refresh_manifest_state_count"],
+            "unsupported_state_visibility_count": visibility["unsupported_state_visibility_count"],
+            "unknown_state_visibility_count": visibility["unknown_state_visibility_count"],
+            "blocked_state_visibility_count": visibility["blocked_state_visibility_count"],
+            "prohibited_state_visibility_count": visibility["prohibited_state_visibility_count"],
+            "stale_state_visibility_count": visibility["stale_state_visibility_count"],
+            "prohibited_domain_visibility_count": visibility["prohibited_domain_visibility_count"],
+            "visible_blocked_reason_count": visibility["visible_blocked_reason_count"],
+            "dependency_warning_visibility_count": visibility["dependency_warning_visibility_count"],
+            "trust_warning_visibility_count": visibility["trust_warning_visibility_count"],
+            "validation_warning_visibility_count": visibility["validation_warning_visibility_count"],
+            "diagnostics_warning_visibility_count": visibility["diagnostics_warning_visibility_count"],
+            "unsupported_states_visible": visibility["unsupported_states_visible"],
+            "unknown_states_visible": visibility["unknown_states_visible"],
+            "blocked_states_visible": visibility["blocked_states_visible"],
+            "prohibited_states_visible": visibility["prohibited_states_visible"],
+            "stale_states_visible": visibility["stale_states_visible"],
+            "prohibited_domains_visible": visibility["prohibited_domains_visible"],
+            "visibility_is_descriptive_only": visibility["visibility_is_descriptive_only"],
+        },
+        "deterministic_serialization_verification": {
+            "stable": serialization_first == serialization_second == serialization_reordered,
+            "serializer": "json_sort_keys_stable_v4_1_refresh_manifest_foundations",
+            "payload_length": len(serialization_first),
+            "deterministic_order_preserved": exported_state_order == expected_state_order,
+            "unsupported_states_preserved": visibility["unsupported_state_visibility_count"] > 0,
+            "prohibited_states_preserved": visibility["prohibited_state_visibility_count"] > 0,
+            "unknown_states_preserved": visibility["unknown_state_visibility_count"] > 0,
+            "blocked_states_preserved": visibility["blocked_state_visibility_count"] > 0,
+            "stale_states_preserved": visibility["stale_state_visibility_count"] > 0,
+            "hidden_omission_enabled": False,
+        },
+        "deterministic_hashing_verification": {
+            "stable": manifest_hash == repeated_hash == reordered_hash,
+            "hash_algorithm": "sha256_stable_json_v4_1_refresh_manifest_foundations",
+            "manifest_hash": manifest_hash,
+            "identity_hash": hash_refresh_manifest_identity(manifest.identity),
+            "continuity_hash": hash_refresh_manifest_continuity(manifest.continuity_metadata),
+            "diagnostics_hashes": [
+                hash_refresh_manifest_diagnostics(record) for record in manifest.diagnostics_visibility
+            ],
+        },
+        "deterministic_equality_verification": {
+            "dataclass_equality_stable": manifest == repeated_manifest,
+            "dataclass_hash_stable": hash(manifest) == hash(repeated_manifest),
+            "serialized_equality_stable": refresh_manifests_equal(manifest, repeated_manifest),
+            "reordered_serialized_equality_stable": refresh_manifests_equal(manifest, reordered_manifest),
+        },
+        "refresh_manifest_identity_normalization": refresh_manifest_identity_normalization_report(manifest.identity),
+        "diagnostics_visibility": diagnostics,
+        "integrity_validation": integrity,
+        "non_execution_guarantees": non_execution,
+        "summary": {
+            "foundation_status": status,
+            "validation_error_count": validation_error_count,
+            "enabled_capability_count": diagnostics["enabled_capability_count"],
+            "deterministic_serialization_verified": serialization_first == serialization_second == serialization_reordered,
+            "deterministic_hashing_verified": manifest_hash == repeated_hash == reordered_hash,
+            "deterministic_equality_verified": refresh_manifests_equal(manifest, repeated_manifest),
+            "deterministic_visibility_verified": visibility["valid"],
+            "lineage_continuity_verified": lineage_validation["valid"],
+            "provenance_continuity_verified": provenance_validation["valid"],
+            "replay_continuity_verified": lineage_validation["replay_safe"],
+            "rollback_continuity_verified": lineage_validation["rollback_safe"],
+            "fail_visible_unsupported_state_validation": visibility["unsupported_states_visible"],
+            "non_execution_enforcement_validated": non_execution["valid"],
+            "production_consumption_disabled_validated": non_execution["production_consumption_absent"],
+            "planner_integration_disabled_validated": non_execution["planner_integration_absent"],
+            "descriptive_only_verified": manifest.descriptive_only and manifest.non_executable,
+        },
+        "refresh_manifest": exported,
+        "explicit_limitations": list(manifest.governance_visibility.explicit_limitations),
+        "explicit_prohibitions": list(manifest.governance_visibility.explicit_prohibitions),
+    }
+    report["deterministic_report_hash"] = _hash_report(report)
+    return report
+
+
+def build_v4_1_refresh_manifest_diagnostics_report(repo_root: Path | None = None) -> dict[str, Any]:
+    root = repo_root or Path(__file__).resolve().parents[2]
+    manifest = default_refresh_manifest()
+    diagnostics = build_refresh_manifest_diagnostics(manifest)
+    non_execution = validate_refresh_manifest_non_execution(manifest)
+    status = (
+        V4_1_REFRESH_MANIFEST_STATUS_STABLE
+        if diagnostics["visibility_validation"]["valid"] and diagnostics["enabled_capability_count"] == 0
+        else V4_1_REFRESH_MANIFEST_STATUS_BLOCKED
+    )
+    report = {
+        "schema_version": V4_1_REFRESH_MANIFEST_DIAGNOSTICS_SCHEMA_VERSION,
+        "generated_at": V4_1_REFRESH_MANIFEST_GENERATED_AT,
+        "phase_id": V4_1_REFRESH_MANIFEST_PHASE_ID,
+        "phase_name": "v4.1_phase_1_refresh_manifest_diagnostics",
+        "repo_root": str(root),
+        "architectural_purpose": "deterministic refresh manifest diagnostics visibility without remediation or execution",
+        "diagnostics_mode": "fail_visible_descriptive_only",
+        "foundation_status": status,
+        "manifest_hash": diagnostics["manifest_hash"],
+        "diagnostics_hashes": diagnostics["diagnostics_hashes"],
+        "visibility_validation": diagnostics["visibility_validation"],
+        "enabled_capability_count": diagnostics["enabled_capability_count"],
+        "enabled_capability_flags": diagnostics["enabled_capability_flags"],
+        "unsupported_state_ids": diagnostics["unsupported_state_ids"],
+        "unknown_state_ids": diagnostics["unknown_state_ids"],
+        "blocked_state_ids": diagnostics["blocked_state_ids"],
+        "prohibited_state_ids": diagnostics["prohibited_state_ids"],
+        "stale_state_ids": diagnostics["stale_state_ids"],
+        "prohibited_domains": diagnostics["prohibited_domains"],
+        "warning_visibility": diagnostics["warning_visibility"],
+        "blocker_visibility": diagnostics["blocker_visibility"],
+        "fail_visible_warning_count": diagnostics["fail_visible_warning_count"],
+        "non_execution_guarantees": non_execution,
+        "summary": {
+            "foundation_status": status,
+            "diagnostics_visible": diagnostics["diagnostics_visible"],
+            "diagnostics_are_descriptive_only": diagnostics["diagnostics_are_descriptive_only"],
+            "remediation_absent": diagnostics["remediation_absent"],
+            "silent_fallback_absent": diagnostics["silent_fallback_absent"],
+            "automatic_recovery_absent": diagnostics["automatic_recovery_absent"],
+            "enabled_capability_count": diagnostics["enabled_capability_count"],
+            "non_execution_enforcement_validated": non_execution["valid"],
+            "production_consumption_disabled_validated": non_execution["production_consumption_absent"],
+            "planner_integration_disabled_validated": non_execution["planner_integration_absent"],
+        },
+        "explicit_limitations": list(manifest.governance_visibility.explicit_limitations),
+        "explicit_prohibitions": list(manifest.governance_visibility.explicit_prohibitions),
+    }
+    report["deterministic_report_hash"] = _hash_report(report)
+    return report
+
+
+def _hash_report(report: dict[str, Any]) -> str:
+    payload = dict(report)
+    payload.pop("deterministic_report_hash", None)
+    return deterministic_refresh_manifest_hash(payload)
+
+
+def write_report(report: dict[str, Any], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", default=str(REPORT_PATH), help="Refresh manifest JSON report output path")
+    parser.add_argument(
+        "--diagnostics-output",
+        default=str(DIAGNOSTICS_REPORT_PATH),
+        help="Refresh manifest diagnostics JSON report output path",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    output_path = Path(args.output)
+    diagnostics_output_path = Path(args.diagnostics_output)
+    report = build_v4_1_refresh_manifest_foundations_report()
+    diagnostics_report = build_v4_1_refresh_manifest_diagnostics_report()
+    write_report(report, output_path)
+    write_report(diagnostics_report, diagnostics_output_path)
+    print(f"wrote {output_path}")
+    print(f"wrote {diagnostics_output_path}")
+    print(f"foundation_status={report['foundation_status']}")
+    print(f"diagnostics_status={diagnostics_report['foundation_status']}")
+    print(f"deterministic_report_hash={report['deterministic_report_hash']}")
+    print(f"deterministic_diagnostics_report_hash={diagnostics_report['deterministic_report_hash']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_v4_1_refresh_manifest_foundations.py
+++ b/backend/tests/test_v4_1_refresh_manifest_foundations.py
@@ -1,0 +1,298 @@
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import FrozenInstanceError, replace
+from pathlib import Path
+
+import pytest
+
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+APP_ROOT = BACKEND_ROOT / "app"
+if str(APP_ROOT) not in sys.path:
+    sys.path.insert(0, str(APP_ROOT))
+
+from operational_refresh.refresh_manifest_diagnostics import (  # noqa: E402
+    build_refresh_manifest_diagnostics,
+)
+from operational_refresh.refresh_manifest_hashing import (  # noqa: E402
+    hash_refresh_manifest,
+    hash_refresh_manifest_identity,
+)
+from operational_refresh.refresh_manifest_integrity import (  # noqa: E402
+    refresh_manifest_identities_equal,
+    refresh_manifest_identity_key,
+    refresh_manifests_equal,
+    validate_refresh_manifest_integrity,
+    validate_refresh_manifest_lineage_continuity,
+    validate_refresh_manifest_non_execution,
+    validate_refresh_manifest_provenance_continuity,
+)
+from operational_refresh.refresh_manifest_models import (  # noqa: E402
+    PROHIBITED_REFRESH_DOMAINS,
+    REFRESH_MANIFEST_STATE_BLOCKED,
+    REFRESH_MANIFEST_STATE_PROHIBITED,
+    REFRESH_MANIFEST_STATE_STALE,
+    REFRESH_MANIFEST_STATE_SUPPORTED,
+    REFRESH_MANIFEST_STATE_UNKNOWN,
+    REFRESH_MANIFEST_STATE_UNSUPPORTED,
+    V4_1_REFRESH_MANIFEST_SCHEMA_VERSION,
+    V4_1_REFRESH_MANIFEST_STATUS_STABLE,
+    default_refresh_manifest,
+)
+from operational_refresh.refresh_manifest_serialization import (  # noqa: E402
+    export_refresh_manifest,
+    serialize_refresh_manifest,
+)
+from operational_refresh.refresh_manifest_visibility import (  # noqa: E402
+    count_refresh_manifest_states,
+    validate_refresh_manifest_visibility,
+)
+from scripts.report_v4_1_refresh_manifest_foundations import (  # noqa: E402
+    build_v4_1_refresh_manifest_diagnostics_report,
+    build_v4_1_refresh_manifest_foundations_report,
+)
+
+
+def test_v4_1_refresh_manifest_models_are_immutable_and_non_executable():
+    manifest = default_refresh_manifest()
+
+    with pytest.raises(FrozenInstanceError):
+        manifest.refresh_execution_enabled = True
+
+    assert manifest.identity.schema_version == V4_1_REFRESH_MANIFEST_SCHEMA_VERSION
+    assert manifest.non_executable is True
+    assert manifest.descriptive_only is True
+    assert manifest.refresh_execution_enabled is False
+    assert manifest.orchestration_enabled is False
+    assert manifest.deployment_execution_enabled is False
+    assert manifest.automatic_refresh_enabled is False
+    assert manifest.automatic_migration_enabled is False
+    assert manifest.planner_integration_enabled is False
+    assert manifest.production_consumption_enabled is False
+    assert manifest.remediation_enabled is False
+    assert manifest.mutation_enabled is False
+    assert manifest.runtime_mutation_enabled is False
+    assert manifest.recommendation_enabled is False
+    assert manifest.ranking_enabled is False
+    assert manifest.scoring_enabled is False
+    assert manifest.selection_enabled is False
+    assert manifest.authorization_enabled is False
+    assert manifest.approval_enabled is False
+    assert manifest.automatic_rollback_enabled is False
+    assert manifest.automatic_recovery_enabled is False
+    assert manifest.hidden_operational_behavior_enabled is False
+    assert manifest.implicit_execution_pathway_enabled is False
+    assert manifest.silent_fallback_enabled is False
+    assert all(not state.executable for state in manifest.states)
+    assert all(not state.automatic_resolution_enabled for state in manifest.states)
+    assert all(not record.execution_enabled for record in manifest.source_lineage)
+    assert all(not record.extraction_execution_enabled for record in manifest.extraction_lineage)
+    assert all(not record.patch_execution_enabled for record in manifest.patch_lineage)
+    assert manifest.governance_visibility.production_consumption_enabled is False
+    assert manifest.governance_visibility.planner_integration_enabled is False
+
+
+def test_v4_1_refresh_manifest_identity_key_is_stable():
+    manifest = default_refresh_manifest()
+
+    assert refresh_manifest_identity_key(manifest.identity) == (
+        "v4_1.refresh_manifest_foundations.1"
+        "|v4_1_phase_1_refresh_manifest_foundations"
+        "|v4_1_refresh_manifest_primary|v4.1.0-foundation"
+        "|v4_0_closeout_and_v4_1_readiness_report"
+        "|v4_1_refresh_manifest_provenance_primary"
+        "|v4_1_refresh_manifest_lineage_primary"
+    )
+
+
+def test_v4_1_deterministic_serialization_hashing_and_equality_are_stable():
+    first = default_refresh_manifest()
+    second = default_refresh_manifest()
+
+    assert first == second
+    assert hash(first) == hash(second)
+    assert refresh_manifests_equal(first, second)
+    assert refresh_manifest_identities_equal(first.identity, second.identity)
+    assert serialize_refresh_manifest(first) == serialize_refresh_manifest(second)
+    assert hash_refresh_manifest(first) == hash_refresh_manifest(second)
+    assert hash_refresh_manifest_identity(first.identity) == hash_refresh_manifest_identity(second.identity)
+    assert json.loads(serialize_refresh_manifest(first))["non_executable"] is True
+
+
+def test_v4_1_serialization_preserves_order_and_fail_visible_states():
+    manifest = default_refresh_manifest()
+    reordered = replace(
+        manifest,
+        states=tuple(reversed(manifest.states)),
+        source_lineage=tuple(reversed(manifest.source_lineage)),
+        extraction_lineage=tuple(reversed(manifest.extraction_lineage)),
+        patch_lineage=tuple(reversed(manifest.patch_lineage)),
+        schema_version_visibility=tuple(reversed(manifest.schema_version_visibility)),
+        dependency_visibility=tuple(reversed(manifest.dependency_visibility)),
+        trust_visibility=tuple(reversed(manifest.trust_visibility)),
+        validation_visibility=tuple(reversed(manifest.validation_visibility)),
+        prohibited_domain_visibility=tuple(reversed(manifest.prohibited_domain_visibility)),
+        unsupported_state_visibility=tuple(reversed(manifest.unsupported_state_visibility)),
+        diagnostics_visibility=tuple(reversed(manifest.diagnostics_visibility)),
+    )
+
+    assert serialize_refresh_manifest(manifest) == serialize_refresh_manifest(reordered)
+    assert hash_refresh_manifest(manifest) == hash_refresh_manifest(reordered)
+    exported = export_refresh_manifest(reordered)
+    assert [item["state"] for item in exported["states"]] == [
+        REFRESH_MANIFEST_STATE_SUPPORTED,
+        REFRESH_MANIFEST_STATE_UNSUPPORTED,
+        REFRESH_MANIFEST_STATE_BLOCKED,
+        REFRESH_MANIFEST_STATE_UNKNOWN,
+        REFRESH_MANIFEST_STATE_STALE,
+        REFRESH_MANIFEST_STATE_PROHIBITED,
+    ]
+    visibility = exported["unsupported_state_visibility"][0]
+    assert visibility["unsupported_states"] == ["v4_1_refresh_manifest_state_unsupported_source_provider"]
+    assert visibility["unknown_states"] == ["v4_1_refresh_manifest_state_unknown_future_source"]
+    assert visibility["blocked_states"] == ["v4_1_refresh_manifest_state_blocked_dependency_gap"]
+    assert visibility["stale_states"] == ["v4_1_refresh_manifest_state_stale_lifecycle_dependency"]
+    assert visibility["prohibited_states"] == ["v4_1_refresh_manifest_state_prohibited_execution_domain"]
+
+
+def test_v4_1_visibility_preserves_unsupported_prohibited_and_diagnostics_state():
+    manifest = default_refresh_manifest()
+    validation = validate_refresh_manifest_visibility(manifest)
+    counts = count_refresh_manifest_states(manifest.states)
+
+    assert counts[REFRESH_MANIFEST_STATE_SUPPORTED] == 1
+    assert counts[REFRESH_MANIFEST_STATE_UNSUPPORTED] == 1
+    assert counts[REFRESH_MANIFEST_STATE_BLOCKED] == 1
+    assert counts[REFRESH_MANIFEST_STATE_UNKNOWN] == 1
+    assert counts[REFRESH_MANIFEST_STATE_STALE] == 1
+    assert counts[REFRESH_MANIFEST_STATE_PROHIBITED] == 1
+    assert counts["invalid"] == 0
+    assert validation["valid"] is True
+    assert validation["unsupported_states_visible"] is True
+    assert validation["unknown_states_visible"] is True
+    assert validation["blocked_states_visible"] is True
+    assert validation["prohibited_states_visible"] is True
+    assert validation["stale_states_visible"] is True
+    assert validation["prohibited_domains_visible"] is True
+    assert validation["prohibited_domain_visibility_count"] == len(PROHIBITED_REFRESH_DOMAINS)
+    assert validation["hidden_state_count"] == 0
+    assert validation["corrective_state_count"] == 0
+    assert validation["state_execution_semantics_count"] == 0
+    assert validation["hidden_visibility_count"] == 0
+    assert validation["corrective_visibility_count"] == 0
+
+
+def test_v4_1_provenance_lineage_replay_and_rollback_continuity_are_preserved():
+    manifest = default_refresh_manifest()
+    provenance = validate_refresh_manifest_provenance_continuity(manifest)
+    lineage = validate_refresh_manifest_lineage_continuity(manifest)
+
+    with pytest.raises(FrozenInstanceError):
+        manifest.source_lineage[0].inferred_source_allowed = True
+
+    assert provenance["valid"] is True
+    assert provenance["provenance_visible"] is True
+    assert provenance["provenance_continuity_preserved"] is True
+    assert provenance["no_inferred_provenance"] is True
+    assert provenance["hidden_source_resolution_absent"] is True
+    assert lineage["valid"] is True
+    assert lineage["lineage_continuity_preserved"] is True
+    assert lineage["replay_safe"] is True
+    assert lineage["rollback_safe"] is True
+    assert lineage["source_lineage_count"] == 1
+    assert lineage["extraction_lineage_count"] == 1
+    assert lineage["patch_lineage_count"] == 1
+    assert lineage["rollback_reference_count"] == 3
+    assert lineage["replay_reference_count"] == 3
+
+
+def test_v4_1_non_execution_validation_blocks_execution_production_and_planner_flags():
+    manifest = default_refresh_manifest()
+    contaminated = replace(
+        manifest,
+        refresh_execution_enabled=True,
+        production_consumption_enabled=True,
+        planner_integration_enabled=True,
+    )
+    validation = validate_refresh_manifest_non_execution(contaminated)
+
+    assert validate_refresh_manifest_non_execution(manifest)["valid"] is True
+    assert validation["valid"] is False
+    assert validation["enabled_capability_count"] == 3
+    assert validation["refresh_execution_absent"] is False
+    assert validation["production_consumption_absent"] is False
+    assert validation["planner_integration_absent"] is False
+
+
+def test_v4_1_integrity_validation_blocks_hidden_correction_and_execution_semantics():
+    manifest = default_refresh_manifest()
+    hidden_state = replace(
+        manifest.states[1],
+        hidden=True,
+        fail_visible=False,
+        executable=True,
+        automatic_resolution_enabled=True,
+    )
+    corrective_diagnostics = replace(
+        manifest.diagnostics_visibility[0],
+        remediation_enabled=True,
+        silent_fallback_enabled=True,
+    )
+    contaminated = replace(
+        manifest,
+        states=(manifest.states[0], hidden_state, *manifest.states[2:]),
+        diagnostics_visibility=(corrective_diagnostics,),
+    )
+    validation = validate_refresh_manifest_integrity(contaminated)
+
+    assert validate_refresh_manifest_integrity(manifest)["valid"] is True
+    assert validation["valid"] is False
+    assert validation["visibility_validation"]["hidden_state_count"] == 1
+    assert validation["visibility_validation"]["corrective_state_count"] == 1
+    assert validation["visibility_validation"]["state_execution_semantics_count"] == 1
+    assert validation["visibility_validation"]["corrective_visibility_count"] == 1
+
+
+def test_v4_1_refresh_manifest_diagnostics_are_fail_visible_and_descriptive_only():
+    diagnostics = build_refresh_manifest_diagnostics()
+
+    assert diagnostics["visibility_validation"]["valid"] is True
+    assert diagnostics["enabled_capability_count"] == 0
+    assert diagnostics["fail_visible_warning_count"] >= len(PROHIBITED_REFRESH_DOMAINS)
+    assert diagnostics["diagnostics_visible"] is True
+    assert diagnostics["diagnostics_are_descriptive_only"] is True
+    assert diagnostics["remediation_absent"] is True
+    assert diagnostics["silent_fallback_absent"] is True
+    assert diagnostics["automatic_recovery_absent"] is True
+
+
+def test_v4_1_refresh_manifest_reports_contain_required_evidence_and_boundaries():
+    report = build_v4_1_refresh_manifest_foundations_report()
+    diagnostics_report = build_v4_1_refresh_manifest_diagnostics_report()
+
+    assert report["foundation_status"] == V4_1_REFRESH_MANIFEST_STATUS_STABLE
+    assert report["refresh_governance_mode"] == "descriptive_only"
+    assert report["summary"]["validation_error_count"] == 0
+    assert report["summary"]["enabled_capability_count"] == 0
+    assert report["summary"]["deterministic_serialization_verified"] is True
+    assert report["summary"]["deterministic_hashing_verified"] is True
+    assert report["summary"]["deterministic_equality_verified"] is True
+    assert report["summary"]["deterministic_visibility_verified"] is True
+    assert report["summary"]["lineage_continuity_verified"] is True
+    assert report["summary"]["provenance_continuity_verified"] is True
+    assert report["summary"]["replay_continuity_verified"] is True
+    assert report["summary"]["rollback_continuity_verified"] is True
+    assert report["summary"]["non_execution_enforcement_validated"] is True
+    assert report["summary"]["production_consumption_disabled_validated"] is True
+    assert report["summary"]["planner_integration_disabled_validated"] is True
+    assert diagnostics_report["summary"]["enabled_capability_count"] == 0
+    assert "No execution behavior exists." in report["explicit_prohibitions"]
+    assert "No orchestration exists." in report["explicit_prohibitions"]
+    assert "No planner integration exists." in report["explicit_prohibitions"]
+    assert "No production consumption exists." in report["explicit_prohibitions"]
+    assert "No remediation exists." in report["explicit_prohibitions"]
+    assert "No mutation behavior exists." in report["explicit_prohibitions"]

--- a/docs/generated/v4_1_refresh_manifest_diagnostics_report.json
+++ b/docs/generated/v4_1_refresh_manifest_diagnostics_report.json
@@ -1,0 +1,158 @@
+{
+  "architectural_purpose": "deterministic refresh manifest diagnostics visibility without remediation or execution",
+  "blocked_state_ids": [
+    "v4_1_refresh_manifest_state_blocked_dependency_gap"
+  ],
+  "blocker_visibility": [
+    "v4_1_refresh_manifest_state_blocked_dependency_gap"
+  ],
+  "deterministic_report_hash": "877ab817fa31669262f790547d241dcb8c52208b48ec9ab8c83e7a1bc431c063",
+  "diagnostics_hashes": [
+    "e1565d871c2d105f0e2098a8f18ef09bd268efabed414746f519fba223d3a86c"
+  ],
+  "diagnostics_mode": "fail_visible_descriptive_only",
+  "enabled_capability_count": 0,
+  "enabled_capability_flags": {},
+  "explicit_limitations": [
+    "v4.1 Phase 1 creates deterministic refresh manifest governance metadata only.",
+    "v4.1 Phase 1 does not enable refresh execution.",
+    "v4.1 Phase 1 does not enable orchestration.",
+    "v4.1 Phase 1 does not enable deployment execution.",
+    "v4.1 Phase 1 does not enable automatic refresh behavior.",
+    "v4.1 Phase 1 does not enable automatic migration behavior.",
+    "v4.1 Phase 1 does not enable planner integration.",
+    "v4.1 Phase 1 does not enable production consumption.",
+    "v4.1 Phase 1 does not enable remediation.",
+    "v4.1 Phase 1 does not enable runtime mutation."
+  ],
+  "explicit_prohibitions": [
+    "No execution behavior exists.",
+    "No orchestration exists.",
+    "No planner integration exists.",
+    "No production consumption exists.",
+    "No remediation exists.",
+    "No mutation behavior exists.",
+    "No recommendation, ranking, scoring, or selection behavior exists.",
+    "No approval or authorization behavior exists.",
+    "No automatic rollback or automatic recovery behavior exists.",
+    "No silent fallback behavior exists."
+  ],
+  "fail_visible_warning_count": 19,
+  "foundation_status": "v4_1_refresh_manifest_foundation_stable",
+  "generated_at": "2026-05-17T00:00:00+00:00",
+  "manifest_hash": "9f80efd07620a61c592f10c3042f04ce1a5e477dd8312fb241548ac518a5df5d",
+  "non_execution_guarantees": {
+    "approval_absent": true,
+    "authorization_absent": true,
+    "automatic_migration_absent": true,
+    "automatic_recovery_absent": true,
+    "automatic_refresh_absent": true,
+    "automatic_rollback_absent": true,
+    "deployment_execution_absent": true,
+    "descriptive_only": true,
+    "enabled_capability_count": 0,
+    "enabled_capability_flags": {},
+    "hidden_operational_behavior_absent": true,
+    "implicit_execution_pathway_absent": true,
+    "non_executable": true,
+    "orchestration_absent": true,
+    "planner_integration_absent": true,
+    "production_consumption_absent": true,
+    "ranking_absent": true,
+    "recommendation_absent": true,
+    "refresh_execution_absent": true,
+    "remediation_absent": true,
+    "runtime_mutation_absent": true,
+    "scoring_absent": true,
+    "selection_absent": true,
+    "silent_fallback_absent": true,
+    "valid": true
+  },
+  "phase_id": "v4_1_refresh_manifest_foundations",
+  "phase_name": "v4.1_phase_1_refresh_manifest_diagnostics",
+  "prohibited_domains": [
+    "authorization_approval_systems",
+    "automatic_migration_behavior",
+    "automatic_recovery",
+    "automatic_refresh_behavior",
+    "automatic_rollback",
+    "deployment_execution",
+    "hidden_operational_behavior",
+    "orchestration_execution",
+    "planner_integration",
+    "production_bundle_consumption",
+    "recommendation_ranking_scoring_selection",
+    "refresh_execution",
+    "remediation_systems",
+    "runtime_mutation"
+  ],
+  "prohibited_state_ids": [
+    "v4_1_refresh_manifest_state_prohibited_execution_domain"
+  ],
+  "repo_root": "D:\\Forge\\le-the-forge",
+  "schema_version": "v4_1.refresh_manifest_diagnostics_report.1",
+  "stale_state_ids": [
+    "v4_1_refresh_manifest_state_stale_lifecycle_dependency"
+  ],
+  "summary": {
+    "automatic_recovery_absent": true,
+    "diagnostics_are_descriptive_only": true,
+    "diagnostics_visible": true,
+    "enabled_capability_count": 0,
+    "foundation_status": "v4_1_refresh_manifest_foundation_stable",
+    "non_execution_enforcement_validated": true,
+    "planner_integration_disabled_validated": true,
+    "production_consumption_disabled_validated": true,
+    "remediation_absent": true,
+    "silent_fallback_absent": true
+  },
+  "unknown_state_ids": [
+    "v4_1_refresh_manifest_state_unknown_future_source"
+  ],
+  "unsupported_state_ids": [
+    "v4_1_refresh_manifest_state_unsupported_source_provider"
+  ],
+  "visibility_validation": {
+    "blocked_state_visibility_count": 1,
+    "blocked_states_visible": true,
+    "corrective_state_count": 0,
+    "corrective_visibility_count": 0,
+    "dependency_warning_visibility_count": 3,
+    "diagnostics_warning_visibility_count": 19,
+    "fail_visible_refresh_manifest_state_count": 5,
+    "governance_limitation_count": 10,
+    "governance_prohibition_count": 10,
+    "hidden_state_count": 0,
+    "hidden_visibility_count": 0,
+    "invalid_refresh_manifest_state_count": 0,
+    "prohibited_domain_visibility_count": 14,
+    "prohibited_domains_visible": true,
+    "prohibited_state_visibility_count": 1,
+    "prohibited_states_visible": true,
+    "stale_state_visibility_count": 1,
+    "stale_states_visible": true,
+    "state_counts": {
+      "blocked": 1,
+      "invalid": 0,
+      "prohibited": 1,
+      "stale": 1,
+      "supported": 1,
+      "unknown": 1,
+      "unsupported": 1
+    },
+    "state_execution_semantics_count": 0,
+    "trust_warning_visibility_count": 2,
+    "unknown_state_visibility_count": 1,
+    "unknown_states_visible": true,
+    "unsupported_state_visibility_count": 1,
+    "unsupported_states_visible": true,
+    "valid": true,
+    "validation_warning_visibility_count": 3,
+    "visibility_is_descriptive_only": true,
+    "visible_blocked_reason_count": 14
+  },
+  "warning_visibility": [
+    "v4_1_refresh_manifest_state_stale_lifecycle_dependency",
+    "v4_1_refresh_manifest_state_unsupported_source_provider"
+  ]
+}

--- a/docs/generated/v4_1_refresh_manifest_foundations_report.json
+++ b/docs/generated/v4_1_refresh_manifest_foundations_report.json
@@ -1,0 +1,1015 @@
+{
+  "architectural_purpose": "deterministic operational refresh governance intelligence foundations without execution behavior",
+  "deterministic_equality_verification": {
+    "dataclass_equality_stable": true,
+    "dataclass_hash_stable": true,
+    "reordered_serialized_equality_stable": true,
+    "serialized_equality_stable": true
+  },
+  "deterministic_hashing_verification": {
+    "continuity_hash": "709ce9156b351790857865c81cab43f8c49fdffcfac72968aca1bc16c3a6c88e",
+    "diagnostics_hashes": [
+      "e1565d871c2d105f0e2098a8f18ef09bd268efabed414746f519fba223d3a86c"
+    ],
+    "hash_algorithm": "sha256_stable_json_v4_1_refresh_manifest_foundations",
+    "identity_hash": "016d6e4938f94fa11a224fc0a8e850129b2636d06180b93583023d231b2693cd",
+    "manifest_hash": "9f80efd07620a61c592f10c3042f04ce1a5e477dd8312fb241548ac518a5df5d",
+    "stable": true
+  },
+  "deterministic_report_hash": "e91e3469fe5bab2b12d4caac2fe0de2bffa769e1c32a2c3c7307bb25d5939a47",
+  "deterministic_serialization_verification": {
+    "blocked_states_preserved": true,
+    "deterministic_order_preserved": true,
+    "hidden_omission_enabled": false,
+    "payload_length": 19572,
+    "prohibited_states_preserved": true,
+    "serializer": "json_sort_keys_stable_v4_1_refresh_manifest_foundations",
+    "stable": true,
+    "stale_states_preserved": true,
+    "unknown_states_preserved": true,
+    "unsupported_states_preserved": true
+  },
+  "diagnostics_visibility": {
+    "automatic_recovery_absent": true,
+    "blocked_state_ids": [
+      "v4_1_refresh_manifest_state_blocked_dependency_gap"
+    ],
+    "blocker_visibility": [
+      "v4_1_refresh_manifest_state_blocked_dependency_gap"
+    ],
+    "diagnostics_are_descriptive_only": true,
+    "diagnostics_hashes": [
+      "e1565d871c2d105f0e2098a8f18ef09bd268efabed414746f519fba223d3a86c"
+    ],
+    "diagnostics_visible": true,
+    "enabled_capability_count": 0,
+    "enabled_capability_flags": {},
+    "fail_visible_warning_count": 19,
+    "manifest_hash": "9f80efd07620a61c592f10c3042f04ce1a5e477dd8312fb241548ac518a5df5d",
+    "prohibited_domains": [
+      "authorization_approval_systems",
+      "automatic_migration_behavior",
+      "automatic_recovery",
+      "automatic_refresh_behavior",
+      "automatic_rollback",
+      "deployment_execution",
+      "hidden_operational_behavior",
+      "orchestration_execution",
+      "planner_integration",
+      "production_bundle_consumption",
+      "recommendation_ranking_scoring_selection",
+      "refresh_execution",
+      "remediation_systems",
+      "runtime_mutation"
+    ],
+    "prohibited_state_ids": [
+      "v4_1_refresh_manifest_state_prohibited_execution_domain"
+    ],
+    "remediation_absent": true,
+    "silent_fallback_absent": true,
+    "stale_state_ids": [
+      "v4_1_refresh_manifest_state_stale_lifecycle_dependency"
+    ],
+    "unknown_state_ids": [
+      "v4_1_refresh_manifest_state_unknown_future_source"
+    ],
+    "unsupported_state_ids": [
+      "v4_1_refresh_manifest_state_unsupported_source_provider"
+    ],
+    "visibility_validation": {
+      "blocked_state_visibility_count": 1,
+      "blocked_states_visible": true,
+      "corrective_state_count": 0,
+      "corrective_visibility_count": 0,
+      "dependency_warning_visibility_count": 3,
+      "diagnostics_warning_visibility_count": 19,
+      "fail_visible_refresh_manifest_state_count": 5,
+      "governance_limitation_count": 10,
+      "governance_prohibition_count": 10,
+      "hidden_state_count": 0,
+      "hidden_visibility_count": 0,
+      "invalid_refresh_manifest_state_count": 0,
+      "prohibited_domain_visibility_count": 14,
+      "prohibited_domains_visible": true,
+      "prohibited_state_visibility_count": 1,
+      "prohibited_states_visible": true,
+      "stale_state_visibility_count": 1,
+      "stale_states_visible": true,
+      "state_counts": {
+        "blocked": 1,
+        "invalid": 0,
+        "prohibited": 1,
+        "stale": 1,
+        "supported": 1,
+        "unknown": 1,
+        "unsupported": 1
+      },
+      "state_execution_semantics_count": 0,
+      "trust_warning_visibility_count": 2,
+      "unknown_state_visibility_count": 1,
+      "unknown_states_visible": true,
+      "unsupported_state_visibility_count": 1,
+      "unsupported_states_visible": true,
+      "valid": true,
+      "validation_warning_visibility_count": 3,
+      "visibility_is_descriptive_only": true,
+      "visible_blocked_reason_count": 14
+    },
+    "warning_visibility": [
+      "v4_1_refresh_manifest_state_stale_lifecycle_dependency",
+      "v4_1_refresh_manifest_state_unsupported_source_provider"
+    ]
+  },
+  "explicit_limitations": [
+    "v4.1 Phase 1 creates deterministic refresh manifest governance metadata only.",
+    "v4.1 Phase 1 does not enable refresh execution.",
+    "v4.1 Phase 1 does not enable orchestration.",
+    "v4.1 Phase 1 does not enable deployment execution.",
+    "v4.1 Phase 1 does not enable automatic refresh behavior.",
+    "v4.1 Phase 1 does not enable automatic migration behavior.",
+    "v4.1 Phase 1 does not enable planner integration.",
+    "v4.1 Phase 1 does not enable production consumption.",
+    "v4.1 Phase 1 does not enable remediation.",
+    "v4.1 Phase 1 does not enable runtime mutation."
+  ],
+  "explicit_prohibitions": [
+    "No execution behavior exists.",
+    "No orchestration exists.",
+    "No planner integration exists.",
+    "No production consumption exists.",
+    "No remediation exists.",
+    "No mutation behavior exists.",
+    "No recommendation, ranking, scoring, or selection behavior exists.",
+    "No approval or authorization behavior exists.",
+    "No automatic rollback or automatic recovery behavior exists.",
+    "No silent fallback behavior exists."
+  ],
+  "fail_visible_visibility": {
+    "blocked_state_visibility_count": 1,
+    "blocked_states_visible": true,
+    "dependency_warning_visibility_count": 3,
+    "diagnostics_warning_visibility_count": 19,
+    "fail_visible_refresh_manifest_state_count": 5,
+    "prohibited_domain_visibility_count": 14,
+    "prohibited_domains_visible": true,
+    "prohibited_state_visibility_count": 1,
+    "prohibited_states_visible": true,
+    "stale_state_visibility_count": 1,
+    "stale_states_visible": true,
+    "trust_warning_visibility_count": 2,
+    "unknown_state_visibility_count": 1,
+    "unknown_states_visible": true,
+    "unsupported_state_visibility_count": 1,
+    "unsupported_states_visible": true,
+    "validation_warning_visibility_count": 3,
+    "visibility_is_descriptive_only": true,
+    "visible_blocked_reason_count": 14
+  },
+  "foundation_status": "v4_1_refresh_manifest_foundation_stable",
+  "generated_at": "2026-05-17T00:00:00+00:00",
+  "integrity_validation": {
+    "exported_field_count": 40,
+    "identity_normalization": {
+      "field_count": 21,
+      "hidden_fallback_enabled": false,
+      "identity_key": "v4_1.refresh_manifest_foundations.1|v4_1_phase_1_refresh_manifest_foundations|v4_1_refresh_manifest_primary|v4.1.0-foundation|v4_0_closeout_and_v4_1_readiness_report|v4_1_refresh_manifest_provenance_primary|v4_1_refresh_manifest_lineage_primary",
+      "normalization_scope": "deterministic_field_representation_only",
+      "normalized_identity": {
+        "descriptive_only": true,
+        "diagnostics_reference": "v4_1_refresh_manifest_diagnostics_primary",
+        "extraction_reference": "v4_1_refresh_manifest_extraction_primary",
+        "generated_at": "2026-05-17T00:00:00+00:00",
+        "governance_purpose": "deterministic_operational_refresh_governance_intelligence_only",
+        "governance_reference": "v4_1_refresh_manifest_governance_primary",
+        "hidden_fallback_enabled": false,
+        "identity_scope": "refresh_manifest_identity_descriptive_only",
+        "lineage_reference": "v4_1_refresh_manifest_lineage_primary",
+        "manifest_id": "v4_1_refresh_manifest_primary",
+        "manifest_version": "v4.1.0-foundation",
+        "non_executable": true,
+        "patch_reference": "v4_1_refresh_manifest_patch_lineage_primary",
+        "provenance_reference": "v4_1_refresh_manifest_provenance_primary",
+        "refresh_cycle_id": "v4_1_phase_1_refresh_manifest_foundations",
+        "refresh_execution_enabled": false,
+        "runtime_mutation_enabled": false,
+        "schema_version": "v4_1.refresh_manifest_foundations.1",
+        "source_bundle_reference": "v4_0_closeout_and_v4_1_readiness_report",
+        "trust_reference": "v4_1_refresh_manifest_trust_visibility_primary",
+        "validation_reference": "v4_1_refresh_manifest_validation_visibility_primary"
+      },
+      "omitted_field_count": 0,
+      "refresh_execution_enabled": false,
+      "runtime_mutation_enabled": false,
+      "silent_correction_enabled": false
+    },
+    "lineage_continuity_valid": true,
+    "lineage_continuity_validation": {
+      "extraction_lineage_count": 1,
+      "hidden_lineage_resolution_count": 0,
+      "lineage_continuity_preserved": true,
+      "lineage_continuity_reference_count": 2,
+      "lineage_reference": "v4_1_refresh_manifest_lineage_primary",
+      "patch_lineage_count": 1,
+      "replay_reference_count": 3,
+      "replay_safe": true,
+      "rollback_reference_count": 3,
+      "rollback_safe": true,
+      "source_lineage_count": 1,
+      "valid": true
+    },
+    "non_execution_valid": true,
+    "non_execution_validation": {
+      "approval_absent": true,
+      "authorization_absent": true,
+      "automatic_migration_absent": true,
+      "automatic_recovery_absent": true,
+      "automatic_refresh_absent": true,
+      "automatic_rollback_absent": true,
+      "deployment_execution_absent": true,
+      "descriptive_only": true,
+      "enabled_capability_count": 0,
+      "enabled_capability_flags": {},
+      "hidden_operational_behavior_absent": true,
+      "implicit_execution_pathway_absent": true,
+      "non_executable": true,
+      "orchestration_absent": true,
+      "planner_integration_absent": true,
+      "production_consumption_absent": true,
+      "ranking_absent": true,
+      "recommendation_absent": true,
+      "refresh_execution_absent": true,
+      "remediation_absent": true,
+      "runtime_mutation_absent": true,
+      "scoring_absent": true,
+      "selection_absent": true,
+      "silent_fallback_absent": true,
+      "valid": true
+    },
+    "provenance_continuity_valid": true,
+    "provenance_continuity_validation": {
+      "extraction_provenance_reference_count": 1,
+      "hidden_source_resolution_absent": true,
+      "no_inferred_provenance": true,
+      "patch_provenance_reference_count": 1,
+      "provenance_continuity_preserved": true,
+      "provenance_continuity_reference_count": 2,
+      "provenance_reference": "v4_1_refresh_manifest_provenance_primary",
+      "provenance_visible": true,
+      "source_provenance_reference_count": 1,
+      "valid": true
+    },
+    "valid": true,
+    "visibility_valid": true,
+    "visibility_validation": {
+      "blocked_state_visibility_count": 1,
+      "blocked_states_visible": true,
+      "corrective_state_count": 0,
+      "corrective_visibility_count": 0,
+      "dependency_warning_visibility_count": 3,
+      "diagnostics_warning_visibility_count": 19,
+      "fail_visible_refresh_manifest_state_count": 5,
+      "governance_limitation_count": 10,
+      "governance_prohibition_count": 10,
+      "hidden_state_count": 0,
+      "hidden_visibility_count": 0,
+      "invalid_refresh_manifest_state_count": 0,
+      "prohibited_domain_visibility_count": 14,
+      "prohibited_domains_visible": true,
+      "prohibited_state_visibility_count": 1,
+      "prohibited_states_visible": true,
+      "stale_state_visibility_count": 1,
+      "stale_states_visible": true,
+      "state_counts": {
+        "blocked": 1,
+        "invalid": 0,
+        "prohibited": 1,
+        "stale": 1,
+        "supported": 1,
+        "unknown": 1,
+        "unsupported": 1
+      },
+      "state_execution_semantics_count": 0,
+      "trust_warning_visibility_count": 2,
+      "unknown_state_visibility_count": 1,
+      "unknown_states_visible": true,
+      "unsupported_state_visibility_count": 1,
+      "unsupported_states_visible": true,
+      "valid": true,
+      "validation_warning_visibility_count": 3,
+      "visibility_is_descriptive_only": true,
+      "visible_blocked_reason_count": 14
+    }
+  },
+  "lineage_continuity_visibility": {
+    "extraction_lineage_count": 1,
+    "hidden_lineage_resolution_count": 0,
+    "lineage_continuity_preserved": true,
+    "lineage_continuity_reference_count": 2,
+    "lineage_reference": "v4_1_refresh_manifest_lineage_primary",
+    "patch_lineage_count": 1,
+    "replay_reference_count": 3,
+    "replay_safe": true,
+    "rollback_reference_count": 3,
+    "rollback_safe": true,
+    "source_lineage_count": 1,
+    "valid": true
+  },
+  "manifest_model_counts": {
+    "dependency_visibility_count": 1,
+    "diagnostics_visibility_count": 1,
+    "extraction_lineage_count": 1,
+    "identity_count": 1,
+    "patch_lineage_count": 1,
+    "prohibited_domain_visibility_count": 1,
+    "schema_version_visibility_count": 1,
+    "source_lineage_count": 1,
+    "state_count": 6,
+    "state_counts": {
+      "blocked": 1,
+      "invalid": 0,
+      "prohibited": 1,
+      "stale": 1,
+      "supported": 1,
+      "unknown": 1,
+      "unsupported": 1
+    },
+    "trust_visibility_count": 1,
+    "unsupported_state_visibility_count": 1,
+    "validation_visibility_count": 1
+  },
+  "non_execution_guarantees": {
+    "approval_absent": true,
+    "authorization_absent": true,
+    "automatic_migration_absent": true,
+    "automatic_recovery_absent": true,
+    "automatic_refresh_absent": true,
+    "automatic_rollback_absent": true,
+    "deployment_execution_absent": true,
+    "descriptive_only": true,
+    "enabled_capability_count": 0,
+    "enabled_capability_flags": {},
+    "hidden_operational_behavior_absent": true,
+    "implicit_execution_pathway_absent": true,
+    "non_executable": true,
+    "orchestration_absent": true,
+    "planner_integration_absent": true,
+    "production_consumption_absent": true,
+    "ranking_absent": true,
+    "recommendation_absent": true,
+    "refresh_execution_absent": true,
+    "remediation_absent": true,
+    "runtime_mutation_absent": true,
+    "scoring_absent": true,
+    "selection_absent": true,
+    "silent_fallback_absent": true,
+    "valid": true
+  },
+  "phase_id": "v4_1_refresh_manifest_foundations",
+  "phase_name": "v4.1_phase_1_refresh_manifest_foundations",
+  "provenance_continuity_visibility": {
+    "extraction_provenance_reference_count": 1,
+    "hidden_source_resolution_absent": true,
+    "no_inferred_provenance": true,
+    "patch_provenance_reference_count": 1,
+    "provenance_continuity_preserved": true,
+    "provenance_continuity_reference_count": 2,
+    "provenance_reference": "v4_1_refresh_manifest_provenance_primary",
+    "provenance_visible": true,
+    "source_provenance_reference_count": 1,
+    "valid": true
+  },
+  "refresh_governance_mode": "descriptive_only",
+  "refresh_manifest": {
+    "approval_enabled": false,
+    "authorization_enabled": false,
+    "automatic_migration_enabled": false,
+    "automatic_recovery_enabled": false,
+    "automatic_refresh_enabled": false,
+    "automatic_rollback_enabled": false,
+    "continuity_metadata": {
+      "automatic_recovery_enabled": false,
+      "automatic_rollback_enabled": false,
+      "continuity_metadata_id": "v4_1_refresh_manifest_continuity_primary",
+      "continuity_preserved": true,
+      "continuity_scope": "refresh_manifest_continuity_metadata_descriptive_only",
+      "descriptive_only": true,
+      "deterministic_hash_reference": "v4_1_refresh_manifest_continuity_hash",
+      "deterministic_order": 1,
+      "diagnostics_references": [
+        "v4_1_refresh_manifest_diagnostics_primary"
+      ],
+      "execution_enabled": false,
+      "fail_visible": true,
+      "lineage_continuity_preserved": true,
+      "lineage_continuity_references": [
+        "v4_0_closeout_and_v4_1_readiness_lineage_safe",
+        "v4_1_refresh_manifest_lineage_primary"
+      ],
+      "provenance_continuity_preserved": true,
+      "provenance_continuity_references": [
+        "v4_0_closeout_and_v4_1_readiness_provenance_safe",
+        "v4_1_refresh_manifest_provenance_primary"
+      ],
+      "replay_references": [
+        "v4_1_refresh_manifest_replay_primary"
+      ],
+      "replay_safe": true,
+      "rollback_references": [
+        "v4_1_refresh_manifest_rollback_primary"
+      ],
+      "rollback_safe": true
+    },
+    "dependency_visibility": [
+      {
+        "automatic_dependency_refresh_enabled": false,
+        "dependencies_visible": true,
+        "dependency_references": [
+          "v4_0_closeout_and_v4_1_readiness_report",
+          "v4_0_patch_lifecycle_foundations_report",
+          "v4_1_refresh_manifest_schema_visibility_primary"
+        ],
+        "dependency_visibility_id": "v4_1_refresh_manifest_dependency_visibility_primary",
+        "dependency_visibility_scope": "refresh_manifest_dependency_visibility_descriptive_only",
+        "descriptive_only": true,
+        "deterministic_order": 1,
+        "fail_visible": true,
+        "hidden_dependency_resolution_enabled": false,
+        "missing_dependency_visibility": [
+          "future_refresh_provider_contract_not_declared"
+        ],
+        "prohibited_dependency_visibility": [
+          "production_runtime_bundle_dependency"
+        ],
+        "stale_dependency_visibility": [
+          "v4_0_lifecycle_dependency_snapshot_read_only"
+        ]
+      }
+    ],
+    "deployment_execution_enabled": false,
+    "descriptive_only": true,
+    "diagnostics_visibility": [
+      {
+        "automatic_recovery_enabled": false,
+        "blocker_visibility": [
+          "v4_1_refresh_manifest_state_blocked_dependency_gap"
+        ],
+        "descriptive_only": true,
+        "deterministic_order": 1,
+        "diagnostic_references": [
+          "v4_1_refresh_manifest_integrity_validation",
+          "v4_1_refresh_manifest_non_execution_validation",
+          "v4_1_refresh_manifest_visibility_validation"
+        ],
+        "diagnostics_scope": "refresh_manifest_diagnostics_visibility_descriptive_only",
+        "diagnostics_visibility_id": "v4_1_refresh_manifest_diagnostics_primary",
+        "diagnostics_visible": true,
+        "fail_visible": true,
+        "prohibited_domain_visibility": [
+          "authorization_approval_systems",
+          "automatic_migration_behavior",
+          "automatic_recovery",
+          "automatic_refresh_behavior",
+          "automatic_rollback",
+          "deployment_execution",
+          "hidden_operational_behavior",
+          "orchestration_execution",
+          "planner_integration",
+          "production_bundle_consumption",
+          "recommendation_ranking_scoring_selection",
+          "refresh_execution",
+          "remediation_systems",
+          "runtime_mutation"
+        ],
+        "remediation_enabled": false,
+        "silent_fallback_enabled": false,
+        "unsupported_state_visibility": [
+          "v4_1_refresh_manifest_state_unknown_future_source",
+          "v4_1_refresh_manifest_state_unsupported_source_provider"
+        ],
+        "warning_visibility": [
+          "v4_1_refresh_manifest_state_stale_lifecycle_dependency",
+          "v4_1_refresh_manifest_state_unsupported_source_provider"
+        ]
+      }
+    ],
+    "extraction_lineage": [
+      {
+        "automatic_extraction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_hash_reference": "v4_1_refresh_manifest_extraction_lineage_hash",
+        "deterministic_order": 1,
+        "extraction_evidence_references": [
+          "v4_1_refresh_manifest_governance_visibility_fields",
+          "v4_1_refresh_manifest_identity_fields",
+          "v4_1_refresh_manifest_lineage_fields"
+        ],
+        "extraction_execution_enabled": false,
+        "extraction_lineage_id": "v4_1_refresh_manifest_extraction_primary",
+        "extraction_lineage_preserved": true,
+        "extraction_lineage_scope": "refresh_manifest_extraction_lineage_descriptive_only",
+        "extraction_snapshot_reference": "v4_1_refresh_manifest_foundation_snapshot",
+        "extractor_reference": "v4_1_refresh_manifest_foundation_extractor_descriptive_only",
+        "fail_visible": true,
+        "hidden_extraction_fallback_enabled": false,
+        "no_implicit_extraction": true,
+        "provenance_reference": "v4_1_refresh_manifest_provenance_primary",
+        "unsupported_extraction_states": [
+          "v4_1_live_refresh_extraction_not_supported"
+        ]
+      }
+    ],
+    "governance_visibility": {
+      "approval_enabled": false,
+      "authorization_enabled": false,
+      "descriptive_only": true,
+      "deterministic_order": 1,
+      "execution_authorized": false,
+      "explicit_limitations": [
+        "v4.1 Phase 1 creates deterministic refresh manifest governance metadata only.",
+        "v4.1 Phase 1 does not enable automatic migration behavior.",
+        "v4.1 Phase 1 does not enable automatic refresh behavior.",
+        "v4.1 Phase 1 does not enable deployment execution.",
+        "v4.1 Phase 1 does not enable orchestration.",
+        "v4.1 Phase 1 does not enable planner integration.",
+        "v4.1 Phase 1 does not enable production consumption.",
+        "v4.1 Phase 1 does not enable refresh execution.",
+        "v4.1 Phase 1 does not enable remediation.",
+        "v4.1 Phase 1 does not enable runtime mutation."
+      ],
+      "explicit_prohibitions": [
+        "No approval or authorization behavior exists.",
+        "No automatic rollback or automatic recovery behavior exists.",
+        "No execution behavior exists.",
+        "No mutation behavior exists.",
+        "No orchestration exists.",
+        "No planner integration exists.",
+        "No production consumption exists.",
+        "No recommendation, ranking, scoring, or selection behavior exists.",
+        "No remediation exists.",
+        "No silent fallback behavior exists."
+      ],
+      "governance_references": [
+        "v4_0_closeout_and_v4_1_readiness_governance_chain",
+        "v4_1_refresh_manifest_foundation_governance_boundary"
+      ],
+      "governance_scope": "refresh_manifest_governance_visibility_descriptive_only",
+      "governance_visibility_id": "v4_1_refresh_manifest_governance_primary",
+      "governance_visible": true,
+      "mutation_enabled": false,
+      "orchestration_enabled": false,
+      "planner_integration_enabled": false,
+      "production_consumption_enabled": false,
+      "ranking_enabled": false,
+      "recommendation_enabled": false,
+      "refresh_execution_enabled": false,
+      "remediation_enabled": false,
+      "scoring_enabled": false,
+      "selection_enabled": false
+    },
+    "hidden_operational_behavior_enabled": false,
+    "identity": {
+      "descriptive_only": true,
+      "diagnostics_reference": "v4_1_refresh_manifest_diagnostics_primary",
+      "extraction_reference": "v4_1_refresh_manifest_extraction_primary",
+      "generated_at": "2026-05-17T00:00:00+00:00",
+      "governance_purpose": "deterministic_operational_refresh_governance_intelligence_only",
+      "governance_reference": "v4_1_refresh_manifest_governance_primary",
+      "hidden_fallback_enabled": false,
+      "identity_scope": "refresh_manifest_identity_descriptive_only",
+      "lineage_reference": "v4_1_refresh_manifest_lineage_primary",
+      "manifest_id": "v4_1_refresh_manifest_primary",
+      "manifest_version": "v4.1.0-foundation",
+      "non_executable": true,
+      "patch_reference": "v4_1_refresh_manifest_patch_lineage_primary",
+      "provenance_reference": "v4_1_refresh_manifest_provenance_primary",
+      "refresh_cycle_id": "v4_1_phase_1_refresh_manifest_foundations",
+      "refresh_execution_enabled": false,
+      "runtime_mutation_enabled": false,
+      "schema_version": "v4_1.refresh_manifest_foundations.1",
+      "source_bundle_reference": "v4_0_closeout_and_v4_1_readiness_report",
+      "trust_reference": "v4_1_refresh_manifest_trust_visibility_primary",
+      "validation_reference": "v4_1_refresh_manifest_validation_visibility_primary"
+    },
+    "implicit_execution_pathway_enabled": false,
+    "manifest_scope": "deterministic_operational_refresh_governance_intelligence_only",
+    "mutation_enabled": false,
+    "non_executable": true,
+    "orchestration_enabled": false,
+    "patch_lineage": [
+      {
+        "automatic_migration_enabled": false,
+        "descriptive_only": true,
+        "deterministic_hash_reference": "v4_1_refresh_manifest_patch_lineage_hash",
+        "deterministic_order": 1,
+        "fail_visible": true,
+        "hidden_patch_resolution_enabled": false,
+        "patch_evidence_references": [
+          "v4_0_closeout_and_v4_1_readiness_report_hash",
+          "v4_1_refresh_manifest_foundation_model_hash"
+        ],
+        "patch_execution_enabled": false,
+        "patch_lineage_id": "v4_1_refresh_manifest_patch_lineage_primary",
+        "patch_lineage_preserved": true,
+        "patch_lineage_scope": "refresh_manifest_patch_lineage_descriptive_only",
+        "patch_reference": "v4_1_refresh_manifest_foundation_patch_reference",
+        "prior_patch_references": [
+          "v4_0_closeout_and_v4_1_readiness",
+          "v4_0_patch_lifecycle_foundations"
+        ],
+        "provenance_reference": "v4_1_refresh_manifest_provenance_primary",
+        "rollback_references": [
+          "v4_0_closeout_and_v4_1_readiness_report"
+        ],
+        "rollback_safe": true
+      }
+    ],
+    "planner_integration_enabled": false,
+    "production_consumption_enabled": false,
+    "prohibited_domain_visibility": [
+      {
+        "descriptive_only": true,
+        "deterministic_order": 1,
+        "fail_visible": true,
+        "hidden_operational_behavior_enabled": false,
+        "implicit_execution_pathway_enabled": false,
+        "prohibited_domain_scope": "refresh_manifest_prohibited_domain_visibility_descriptive_only",
+        "prohibited_domain_visibility_id": "v4_1_refresh_manifest_prohibited_domain_visibility_primary",
+        "prohibited_domains": [
+          "authorization_approval_systems",
+          "automatic_migration_behavior",
+          "automatic_recovery",
+          "automatic_refresh_behavior",
+          "automatic_rollback",
+          "deployment_execution",
+          "hidden_operational_behavior",
+          "orchestration_execution",
+          "planner_integration",
+          "production_bundle_consumption",
+          "recommendation_ranking_scoring_selection",
+          "refresh_execution",
+          "remediation_systems",
+          "runtime_mutation"
+        ],
+        "visible_blocked_reasons": [
+          "v4_1_prohibited_domain_authorization_approval_systems",
+          "v4_1_prohibited_domain_automatic_migration_behavior",
+          "v4_1_prohibited_domain_automatic_recovery",
+          "v4_1_prohibited_domain_automatic_refresh_behavior",
+          "v4_1_prohibited_domain_automatic_rollback",
+          "v4_1_prohibited_domain_deployment_execution",
+          "v4_1_prohibited_domain_hidden_operational_behavior",
+          "v4_1_prohibited_domain_orchestration_execution",
+          "v4_1_prohibited_domain_planner_integration",
+          "v4_1_prohibited_domain_production_bundle_consumption",
+          "v4_1_prohibited_domain_recommendation_ranking_scoring_selection",
+          "v4_1_prohibited_domain_refresh_execution",
+          "v4_1_prohibited_domain_remediation_systems",
+          "v4_1_prohibited_domain_runtime_mutation"
+        ]
+      }
+    ],
+    "ranking_enabled": false,
+    "recommendation_enabled": false,
+    "refresh_execution_enabled": false,
+    "remediation_enabled": false,
+    "replay_metadata": {
+      "descriptive_only": true,
+      "deterministic_hash_reference": "v4_1_refresh_manifest_replay_hash",
+      "deterministic_order": 1,
+      "live_replay_enabled": false,
+      "replay_evidence_references": [
+        "v4_1_refresh_manifest_hash_snapshot",
+        "v4_1_refresh_manifest_serialization_snapshot"
+      ],
+      "replay_metadata_id": "v4_1_refresh_manifest_replay_primary",
+      "replay_reference": "v4_1_refresh_manifest_replay_safe_descriptive_reference",
+      "replay_safe": true,
+      "replay_scope": "refresh_manifest_replay_metadata_descriptive_only",
+      "runtime_execution_enabled": false
+    },
+    "rollback_metadata": {
+      "automatic_rollback_enabled": false,
+      "descriptive_only": true,
+      "deterministic_hash_reference": "v4_1_refresh_manifest_rollback_hash",
+      "deterministic_order": 1,
+      "recovery_execution_enabled": false,
+      "rollback_evidence_references": [
+        "docs/generated/v4_0_closeout_and_v4_1_readiness_report.json",
+        "docs/migration/V4_0_CLOSEOUT_AND_V4_1_READINESS.md"
+      ],
+      "rollback_metadata_id": "v4_1_refresh_manifest_rollback_primary",
+      "rollback_reference": "v4_0_closeout_and_v4_1_readiness_report",
+      "rollback_safe": true,
+      "rollback_scope": "refresh_manifest_rollback_metadata_descriptive_only"
+    },
+    "runtime_mutation_enabled": false,
+    "schema_version_visibility": [
+      {
+        "descriptive_only": true,
+        "deterministic_order": 1,
+        "extraction_schema_version": "v4_1.refresh_manifest_extraction_lineage.1",
+        "fail_visible": true,
+        "hidden_schema_inference_enabled": false,
+        "manifest_schema_version": "v4_1.refresh_manifest_foundations.1",
+        "patch_schema_version": "v4_1.refresh_manifest_patch_lineage.1",
+        "schema_migration_enabled": false,
+        "schema_version_visible": true,
+        "schema_visibility_id": "v4_1_refresh_manifest_schema_visibility_primary",
+        "schema_visibility_scope": "refresh_manifest_schema_version_visibility_descriptive_only",
+        "source_schema_version": "v4_0.closeout_and_v4_1_readiness_report.1",
+        "unsupported_schema_versions": [
+          "future_refresh_manifest_schema_not_declared"
+        ],
+        "visible_schema_constraints": [
+          "deterministic_hashing_required",
+          "deterministic_serialization_required",
+          "execution_semantics_must_remain_disabled",
+          "unsupported_states_must_be_fail_visible"
+        ]
+      }
+    ],
+    "scoring_enabled": false,
+    "selection_enabled": false,
+    "silent_fallback_enabled": false,
+    "source_lineage": [
+      {
+        "automatic_source_refresh_enabled": false,
+        "descriptive_only": true,
+        "deterministic_hash_reference": "v4_1_refresh_manifest_source_lineage_hash",
+        "deterministic_order": 1,
+        "execution_enabled": false,
+        "fail_visible": true,
+        "hidden_source_resolution_enabled": false,
+        "inferred_source_allowed": false,
+        "prior_manifest_references": [
+          "v4_0_closeout_and_v4_1_readiness",
+          "v4_0_patch_lifecycle_foundations"
+        ],
+        "provenance_preserved": true,
+        "provenance_reference": "v4_1_refresh_manifest_provenance_primary",
+        "source_bundle_reference": "v4_0_closeout_and_v4_1_readiness_report",
+        "source_evidence_references": [
+          "docs/generated/v4_0_closeout_and_v4_1_readiness_report.json",
+          "docs/generated/v4_0_patch_lifecycle_foundations_report.json",
+          "docs/migration/V4_0_CLOSEOUT_AND_V4_1_READINESS.md"
+        ],
+        "source_lineage_id": "v4_1_refresh_manifest_source_lineage_primary",
+        "source_lineage_preserved": true,
+        "source_lineage_scope": "refresh_manifest_source_lineage_descriptive_only",
+        "source_system_reference": "epochforge_v4_0_closeout_governance_evidence",
+        "unsupported_source_visibility": [
+          "v4_1_future_refresh_source_provider_not_declared"
+        ]
+      }
+    ],
+    "states": [
+      {
+        "automatic_resolution_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 1,
+        "executable": false,
+        "fail_visible": false,
+        "hidden": false,
+        "lineage_reference": "v4_1_refresh_manifest_lineage_primary",
+        "provenance_reference": "v4_1_refresh_manifest_provenance_primary",
+        "reason": "refresh manifest identity is deterministic and descriptive",
+        "remediation_enabled": false,
+        "runtime_mutation_enabled": false,
+        "severity": "info",
+        "silent_fallback_enabled": false,
+        "state": "supported",
+        "state_id": "v4_1_refresh_manifest_state_supported_identity",
+        "visibility_reference": "v4_1_refresh_manifest_unsupported_state_visibility_primary",
+        "visibility_status": "visible"
+      },
+      {
+        "automatic_resolution_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 2,
+        "executable": false,
+        "fail_visible": true,
+        "hidden": false,
+        "lineage_reference": "v4_1_refresh_manifest_lineage_primary",
+        "provenance_reference": "v4_1_refresh_manifest_provenance_primary",
+        "reason": "unsupported refresh source providers remain visible and blocked from execution",
+        "remediation_enabled": false,
+        "runtime_mutation_enabled": false,
+        "severity": "warning",
+        "silent_fallback_enabled": false,
+        "state": "unsupported",
+        "state_id": "v4_1_refresh_manifest_state_unsupported_source_provider",
+        "visibility_reference": "v4_1_refresh_manifest_unsupported_state_visibility_primary",
+        "visibility_status": "fail_visible"
+      },
+      {
+        "automatic_resolution_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 3,
+        "executable": false,
+        "fail_visible": true,
+        "hidden": false,
+        "lineage_reference": "v4_1_refresh_manifest_lineage_primary",
+        "provenance_reference": "v4_1_refresh_manifest_provenance_primary",
+        "reason": "missing refresh dependencies remain blocked evidence until a future phase supplies them",
+        "remediation_enabled": false,
+        "runtime_mutation_enabled": false,
+        "severity": "blocked",
+        "silent_fallback_enabled": false,
+        "state": "blocked",
+        "state_id": "v4_1_refresh_manifest_state_blocked_dependency_gap",
+        "visibility_reference": "v4_1_refresh_manifest_unsupported_state_visibility_primary",
+        "visibility_status": "fail_visible"
+      },
+      {
+        "automatic_resolution_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 4,
+        "executable": false,
+        "fail_visible": true,
+        "hidden": false,
+        "lineage_reference": "v4_1_refresh_manifest_lineage_primary",
+        "provenance_reference": "v4_1_refresh_manifest_provenance_primary",
+        "reason": "future refresh source state is explicitly unknown and not inferred",
+        "remediation_enabled": false,
+        "runtime_mutation_enabled": false,
+        "severity": "unknown",
+        "silent_fallback_enabled": false,
+        "state": "unknown",
+        "state_id": "v4_1_refresh_manifest_state_unknown_future_source",
+        "visibility_reference": "v4_1_refresh_manifest_unsupported_state_visibility_primary",
+        "visibility_status": "fail_visible"
+      },
+      {
+        "automatic_resolution_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 5,
+        "executable": false,
+        "fail_visible": true,
+        "hidden": false,
+        "lineage_reference": "v4_1_refresh_manifest_lineage_primary",
+        "provenance_reference": "v4_1_refresh_manifest_provenance_primary",
+        "reason": "v4.0 lifecycle dependency context remains visible as a read-only stale reference",
+        "remediation_enabled": false,
+        "runtime_mutation_enabled": false,
+        "severity": "warning",
+        "silent_fallback_enabled": false,
+        "state": "stale",
+        "state_id": "v4_1_refresh_manifest_state_stale_lifecycle_dependency",
+        "visibility_reference": "v4_1_refresh_manifest_unsupported_state_visibility_primary",
+        "visibility_status": "fail_visible"
+      },
+      {
+        "automatic_resolution_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 6,
+        "executable": false,
+        "fail_visible": true,
+        "hidden": false,
+        "lineage_reference": "v4_1_refresh_manifest_lineage_primary",
+        "provenance_reference": "v4_1_refresh_manifest_provenance_primary",
+        "reason": "execution-capable refresh behavior is prohibited",
+        "remediation_enabled": false,
+        "runtime_mutation_enabled": false,
+        "severity": "prohibited",
+        "silent_fallback_enabled": false,
+        "state": "prohibited",
+        "state_id": "v4_1_refresh_manifest_state_prohibited_execution_domain",
+        "visibility_reference": "v4_1_refresh_manifest_unsupported_state_visibility_primary",
+        "visibility_status": "fail_visible"
+      }
+    ],
+    "trust_visibility": [
+      {
+        "ambiguous_trust_visibility": [
+          "future_refresh_provider_trust_unknown"
+        ],
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 1,
+        "fail_visible": true,
+        "trust_inference_enabled": false,
+        "trust_visibility_id": "v4_1_refresh_manifest_trust_visibility_primary",
+        "trust_visibility_scope": "refresh_manifest_trust_visibility_descriptive_only",
+        "trust_visible": true,
+        "trusted_source_references": [
+          "v4_0_closeout_and_v4_1_readiness_report",
+          "v4_0_patch_lifecycle_foundations_report"
+        ],
+        "untrusted_source_visibility": [
+          "live_production_bundle_source_not_trusted"
+        ]
+      }
+    ],
+    "unsupported_state_visibility": [
+      {
+        "automatic_recovery_enabled": false,
+        "blocked_states": [
+          "v4_1_refresh_manifest_state_blocked_dependency_gap"
+        ],
+        "descriptive_only": true,
+        "deterministic_order": 1,
+        "fail_visible": true,
+        "hidden_unsupported_state_resolution_enabled": false,
+        "prohibited_states": [
+          "v4_1_refresh_manifest_state_prohibited_execution_domain"
+        ],
+        "remediation_enabled": false,
+        "stale_states": [
+          "v4_1_refresh_manifest_state_stale_lifecycle_dependency"
+        ],
+        "unknown_states": [
+          "v4_1_refresh_manifest_state_unknown_future_source"
+        ],
+        "unsupported_state_scope": "refresh_manifest_unsupported_state_visibility_descriptive_only",
+        "unsupported_state_visibility_id": "v4_1_refresh_manifest_unsupported_state_visibility_primary",
+        "unsupported_states": [
+          "v4_1_refresh_manifest_state_unsupported_source_provider"
+        ]
+      }
+    ],
+    "validation_visibility": [
+      {
+        "automatic_validation_execution_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 1,
+        "fail_visible": true,
+        "remediation_enabled": false,
+        "silent_validation_fallback_enabled": false,
+        "unsupported_validation_visibility": [
+          "live_refresh_execution_validation_not_supported"
+        ],
+        "validation_blocker_visibility": [
+          "production_runtime_bundle_dependency"
+        ],
+        "validation_references": [
+          "deterministic_equality_validation",
+          "deterministic_hashing_validation",
+          "deterministic_serialization_validation",
+          "non_execution_boundary_validation",
+          "planner_integration_disabled_validation",
+          "production_consumption_disabled_validation"
+        ],
+        "validation_visibility_id": "v4_1_refresh_manifest_validation_visibility_primary",
+        "validation_visibility_scope": "refresh_manifest_validation_visibility_descriptive_only",
+        "validation_visible": true,
+        "validation_warning_visibility": [
+          "future_refresh_provider_contract_not_declared"
+        ]
+      }
+    ]
+  },
+  "refresh_manifest_identity_normalization": {
+    "field_count": 21,
+    "hidden_fallback_enabled": false,
+    "identity_key": "v4_1.refresh_manifest_foundations.1|v4_1_phase_1_refresh_manifest_foundations|v4_1_refresh_manifest_primary|v4.1.0-foundation|v4_0_closeout_and_v4_1_readiness_report|v4_1_refresh_manifest_provenance_primary|v4_1_refresh_manifest_lineage_primary",
+    "normalization_scope": "deterministic_field_representation_only",
+    "normalized_identity": {
+      "descriptive_only": true,
+      "diagnostics_reference": "v4_1_refresh_manifest_diagnostics_primary",
+      "extraction_reference": "v4_1_refresh_manifest_extraction_primary",
+      "generated_at": "2026-05-17T00:00:00+00:00",
+      "governance_purpose": "deterministic_operational_refresh_governance_intelligence_only",
+      "governance_reference": "v4_1_refresh_manifest_governance_primary",
+      "hidden_fallback_enabled": false,
+      "identity_scope": "refresh_manifest_identity_descriptive_only",
+      "lineage_reference": "v4_1_refresh_manifest_lineage_primary",
+      "manifest_id": "v4_1_refresh_manifest_primary",
+      "manifest_version": "v4.1.0-foundation",
+      "non_executable": true,
+      "patch_reference": "v4_1_refresh_manifest_patch_lineage_primary",
+      "provenance_reference": "v4_1_refresh_manifest_provenance_primary",
+      "refresh_cycle_id": "v4_1_phase_1_refresh_manifest_foundations",
+      "refresh_execution_enabled": false,
+      "runtime_mutation_enabled": false,
+      "schema_version": "v4_1.refresh_manifest_foundations.1",
+      "source_bundle_reference": "v4_0_closeout_and_v4_1_readiness_report",
+      "trust_reference": "v4_1_refresh_manifest_trust_visibility_primary",
+      "validation_reference": "v4_1_refresh_manifest_validation_visibility_primary"
+    },
+    "omitted_field_count": 0,
+    "refresh_execution_enabled": false,
+    "runtime_mutation_enabled": false,
+    "silent_correction_enabled": false
+  },
+  "repo_root": "D:\\Forge\\le-the-forge",
+  "schema_version": "v4_1.refresh_manifest_foundations_report.1",
+  "summary": {
+    "descriptive_only_verified": true,
+    "deterministic_equality_verified": true,
+    "deterministic_hashing_verified": true,
+    "deterministic_serialization_verified": true,
+    "deterministic_visibility_verified": true,
+    "enabled_capability_count": 0,
+    "fail_visible_unsupported_state_validation": true,
+    "foundation_status": "v4_1_refresh_manifest_foundation_stable",
+    "lineage_continuity_verified": true,
+    "non_execution_enforcement_validated": true,
+    "planner_integration_disabled_validated": true,
+    "production_consumption_disabled_validated": true,
+    "provenance_continuity_verified": true,
+    "replay_continuity_verified": true,
+    "rollback_continuity_verified": true,
+    "validation_error_count": 0
+  }
+}

--- a/docs/migration/V4_1_REFRESH_MANIFEST_FOUNDATIONS.md
+++ b/docs/migration/V4_1_REFRESH_MANIFEST_FOUNDATIONS.md
@@ -1,0 +1,101 @@
+# v4.1 Refresh Manifest Foundations
+
+## Architectural Purpose
+
+v4.1 Phase 1 begins the transition from deterministic operational lifecycle governance intelligence into deterministic operational refresh governance intelligence.
+
+This phase establishes deterministic refresh manifest identity, serialization, hashing, equality, lineage visibility, provenance continuity, diagnostics visibility, governance visibility, continuity metadata, replay metadata, rollback metadata, and fail-visible unsupported state visibility.
+
+The refresh manifest layer is descriptive-only infrastructure. It creates governance evidence for future refresh work without introducing execution-capable architecture.
+
+## Scope
+
+The phase creates deterministic refresh manifest models under `backend/app/operational_refresh/`, a deterministic report generator, focused validation tests, a generated JSON report, and a generated diagnostics JSON report.
+
+The phase does not alter planner behavior, production bundle loading, crafting behavior, stat resolution, simulation, routing, dispatch, scheduling, remediation, recovery, rollback, or runtime state.
+
+## Deterministic Manifest Guarantees
+
+Refresh manifest models are frozen dataclasses with explicit identity, source lineage, extraction lineage, patch lineage, schema version visibility, dependency visibility, trust visibility, validation visibility, prohibited domain visibility, unsupported state visibility, continuity metadata, replay metadata, rollback metadata, diagnostics visibility, and governance visibility.
+
+Serialization uses stable sorted JSON-compatible output. Unsupported, unknown, blocked, stale, and prohibited states remain visible. Prohibited domains remain visible. Lineage and provenance references remain explicit.
+
+Hashing uses stable SHA-256 hashing over deterministic serialization. Repeated manifest construction and reordered manifest collections produce the same serialized equality result and the same hash.
+
+## Lineage And Provenance Continuity
+
+Source lineage links v4.1 refresh manifest foundations back to v4.0 closeout and v4.1 readiness evidence.
+
+Extraction lineage identifies the descriptive foundation extraction snapshot without enabling live extraction.
+
+Patch lineage preserves rollback references to v4.0 closeout evidence and does not enable patch execution or migration.
+
+Provenance continuity and lineage continuity are validated as evidence properties. They do not authorize refresh execution or production activation.
+
+## Diagnostics Visibility
+
+Diagnostics are fail-visible and descriptive-only. Unsupported source providers, unknown future sources, blocked dependency gaps, stale lifecycle dependencies, prohibited execution domains, and prohibited refresh domains remain visible in generated evidence.
+
+Diagnostics do not remediate, repair, recover, roll back, approve, authorize, or execute.
+
+## Explicit Limitation Visibility
+
+v4.1 Phase 1 creates deterministic refresh manifest governance metadata only.
+
+v4.1 Phase 1 does not enable refresh execution.
+
+v4.1 Phase 1 does not enable orchestration.
+
+v4.1 Phase 1 does not enable deployment execution.
+
+v4.1 Phase 1 does not enable automatic refresh behavior.
+
+v4.1 Phase 1 does not enable automatic migration behavior.
+
+v4.1 Phase 1 does not enable planner integration.
+
+v4.1 Phase 1 does not enable production consumption.
+
+v4.1 Phase 1 does not enable remediation.
+
+v4.1 Phase 1 does not enable runtime mutation.
+
+## Explicit Prohibition Visibility
+
+No execution behavior exists.
+
+No orchestration exists.
+
+No planner integration exists.
+
+No production consumption exists.
+
+No remediation exists.
+
+No mutation behavior exists.
+
+No recommendation, ranking, scoring, or selection behavior exists.
+
+No approval or authorization behavior exists.
+
+No automatic rollback or automatic recovery behavior exists.
+
+No silent fallback behavior exists.
+
+## Non-Execution Preservation
+
+Refresh manifests remain non-executable. The models expose disabled flags for refresh execution, orchestration, deployment execution, automatic refresh, automatic migration, planner integration, production consumption, remediation, mutation, recommendation, ranking, scoring, selection, authorization, approval, automatic rollback, automatic recovery, hidden operational behavior, implicit execution pathways, and silent fallback.
+
+The validation report treats any enabled capability flag as a blocker.
+
+## Generated Evidence
+
+Generated report:
+
+`docs/generated/v4_1_refresh_manifest_foundations_report.json`
+
+Generated diagnostics report:
+
+`docs/generated/v4_1_refresh_manifest_diagnostics_report.json`
+
+Both reports include deterministic hashes, visibility validation, lineage continuity validation, provenance continuity validation, non-execution validation, explicit limitations, and explicit prohibitions.


### PR DESCRIPTION
Establish deterministic refresh manifest governance foundations for v4.1 including serialization, hashing, lineage visibility, provenance continuity, diagnostics visibility, and fail-visible governance-safe refresh manifest infrastructure without enabling execution behavior.