### PR TITLE
v4.5B.1: implement trust visibility foundations

### DIFF
--- a/backend/app/public_trust_visibility/__init__.py
+++ b/backend/app/public_trust_visibility/__init__.py
@@ -1,0 +1,1 @@
+"""Deterministic public trust visibility package."""

--- a/backend/app/public_trust_visibility/v4_5b_1_trust_visibility_foundation_audit.py
+++ b/backend/app/public_trust_visibility/v4_5b_1_trust_visibility_foundation_audit.py
@@ -1,0 +1,1000 @@
+"""Audit for deterministic v4.5B.1 public trust visibility foundations.
+
+The audit validates descriptive public trust visibility only. It does not
+authorize, approve, execute, dispatch, route, traverse, schedule, sequence,
+decide, recommend, rank, remediate, repair, mitigate, correct, integrate
+planners, consume production paths, or mutate runtime or operational state.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import is_dataclass, replace
+from pathlib import Path
+from typing import Any, Iterable
+
+from .v4_5b_1_trust_visibility_foundation_hashing import (
+    deterministic_v4_5b_1_trust_visibility_foundation_hash,
+    hash_governance_transparency_visibility,
+    hash_public_explainability_visibility,
+    hash_public_integrity_visibility,
+    hash_public_trust_diagnostic_record,
+    hash_public_trust_evidence_visibility,
+    hash_trust_summary_record,
+    hash_trust_visibility_identity,
+    hash_trust_visibility_record,
+    hash_unsupported_public_trust_visibility,
+    hash_unsupported_state_visibility,
+    hash_v4_5b_1_trust_visibility_foundation,
+)
+from .v4_5b_1_trust_visibility_foundation_models import (
+    GOVERNANCE_TRANSPARENCY_VISIBILITY_TYPES,
+    PUBLIC_EXPLAINABILITY_VISIBILITY_TYPES,
+    PUBLIC_INTEGRITY_VISIBILITY_TYPES,
+    PUBLIC_TRUST_DIAGNOSTIC_TYPES,
+    PUBLIC_TRUST_EVIDENCE_VISIBILITY_TYPES,
+    PUBLIC_TRUST_VISIBILITY_NON_AUTHORITY_STATEMENT,
+    PUBLIC_TRUST_VISIBILITY_STATEMENT,
+    TRUST_SUMMARY_TYPES,
+    UNSUPPORTED_PUBLIC_TRUST_OPERATIONAL_STATES,
+    UNSUPPORTED_STATE_VISIBILITY_TYPES,
+    V4_5B_1_TRUST_VISIBILITY_FOUNDATION_DISABLED_COUNTER_NAMES,
+    V4_5B_1_TRUST_VISIBILITY_FOUNDATION_GENERATED_AT,
+    V4_5B_1_TRUST_VISIBILITY_FOUNDATION_PHASE_ID,
+    V4_5B_1_TRUST_VISIBILITY_FOUNDATION_PURPOSE,
+    V4_5B_1_TRUST_VISIBILITY_FOUNDATION_REPORT_SCHEMA_VERSION,
+    V4_5B_1_TRUST_VISIBILITY_FOUNDATION_STATUS_BLOCKED,
+    V4_5B_1_TRUST_VISIBILITY_FOUNDATION_STATUS_STABLE,
+    TrustVisibilityFoundationIntelligence,
+    default_v4_5b_1_trust_visibility_foundation,
+)
+from .v4_5b_1_trust_visibility_foundation_serialization import (
+    export_v4_5b_1_trust_visibility_foundation,
+    serialize_v4_5b_1_trust_visibility_foundation,
+)
+from .v4_5b_1_trust_visibility_foundation_visibility import (
+    descriptive_only_public_trust_summary,
+    diagnostics_summary,
+    evidence_visibility_summary,
+    explainability_summary,
+    governance_transparency_summary,
+    integrity_summary,
+    trust_summary_visibility,
+    trust_visibility_summary,
+    unsupported_public_trust_summary,
+    unsupported_state_summary,
+    validate_required_trust_visibility_foundation,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+CAPABILITY_COUNTER_FIELD_MAP: dict[str, tuple[str, ...]] = {
+    "enabled_runtime_execution_count": (
+        "runtime_execution_enabled",
+        "orchestration_execution_enabled",
+        "planner_execution_enabled",
+        "execution_enabled",
+        "execution_enablement_enabled",
+    ),
+    "enabled_orchestration_authorization_count": (
+        "orchestration_authorization_enabled",
+        "authorization_enabled",
+    ),
+    "enabled_orchestration_approval_count": (
+        "orchestration_approval_enabled",
+        "approval_enabled",
+    ),
+    "enabled_orchestration_dispatch_count": (
+        "orchestration_dispatch_enabled",
+        "dispatch_enabled",
+    ),
+    "enabled_orchestration_routing_count": (
+        "orchestration_routing_enabled",
+        "routing_enabled",
+    ),
+    "enabled_orchestration_traversal_count": (
+        "orchestration_traversal_enabled",
+        "traversal_enabled",
+    ),
+    "enabled_orchestration_scheduling_count": (
+        "orchestration_scheduling_enabled",
+        "scheduling_enabled",
+    ),
+    "enabled_orchestration_sequencing_count": (
+        "orchestration_sequencing_enabled",
+        "sequencing_enabled",
+    ),
+    "enabled_orchestration_decision_count": (
+        "orchestration_decision_enabled",
+        "decision_enabled",
+    ),
+    "enabled_orchestration_recommendation_count": (
+        "orchestration_recommendation_enabled",
+        "orchestration_response_enabled",
+    ),
+    "enabled_trust_authorization_count": (
+        "trust_authorization_enabled",
+        "trust_authority_enabled",
+        "authorization_enabled",
+    ),
+    "enabled_trust_approval_count": (
+        "trust_approval_enabled",
+        "approval_enabled",
+        "operational_approval_enabled",
+    ),
+    "enabled_trust_ranking_count": (
+        "trust_ranking_enabled",
+        "ranking_enabled",
+        "scoring_enabled",
+    ),
+    "enabled_trust_recommendation_count": (
+        "trust_recommendation_enabled",
+        "recommendation_enabled",
+    ),
+    "enabled_remediation_count": ("remediation_enabled",),
+    "enabled_repair_count": ("repair_enabled",),
+    "enabled_mitigation_count": ("mitigation_enabled",),
+    "enabled_auto_correction_count": (
+        "auto_correction_enabled",
+        "automated_correction_enabled",
+    ),
+    "enabled_planner_integration_count": ("planner_integration_enabled",),
+    "enabled_production_consumption_count": (
+        "production_consumption_enabled",
+        "production_enablement_enabled",
+    ),
+    "enabled_runtime_mutation_count": (
+        "runtime_mutation_enabled",
+        "runtime_enablement_enabled",
+    ),
+    "enabled_operational_mutation_count": (
+        "operational_mutation_enabled",
+        "operational_behavior_enabled",
+        "operational_semantics_enabled",
+        "operational_enabled",
+    ),
+}
+
+PROHIBITED_BOOLEAN_FIELD_NAMES: tuple[str, ...] = tuple(
+    sorted({field for fields in CAPABILITY_COUNTER_FIELD_MAP.values() for field in fields})
+)
+
+
+def build_v4_5b_1_trust_visibility_foundation() -> (
+    TrustVisibilityFoundationIntelligence
+):
+    return default_v4_5b_1_trust_visibility_foundation()
+
+
+def _iter_dataclass_objects(value: Any) -> Iterable[Any]:
+    if is_dataclass(value) and not isinstance(value, type):
+        yield value
+        for item in value.__dict__.values():
+            yield from _iter_dataclass_objects(item)
+    elif isinstance(value, dict):
+        for item in value.values():
+            yield from _iter_dataclass_objects(item)
+    elif isinstance(value, tuple | list | set):
+        for item in value:
+            yield from _iter_dataclass_objects(item)
+
+
+def _relative_path_exists(reference: str) -> bool:
+    return (REPO_ROOT / reference).exists()
+
+
+def _report_hash_matches(reference: str, expected_hash: str) -> bool:
+    path = REPO_ROOT / reference
+    if not path.exists():
+        return False
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return False
+    return payload.get("deterministic_report_hash") == expected_hash
+
+
+def enabled_trust_visibility_capability_flags(
+    intelligence: TrustVisibilityFoundationIntelligence,
+) -> dict[str, list[str]]:
+    enabled: dict[str, list[str]] = {}
+    for item in _iter_dataclass_objects(intelligence):
+        item_id = (
+            getattr(item, "trust_record_id", None)
+            or getattr(item, "evidence_visibility_id", None)
+            or getattr(item, "unsupported_visibility_id", None)
+            or getattr(item, "transparency_visibility_id", None)
+            or getattr(item, "trust_summary_record_id", None)
+            or getattr(item, "explainability_visibility_id", None)
+            or getattr(item, "integrity_visibility_id", None)
+            or getattr(item, "diagnostic_id", None)
+            or getattr(item, "state_id", None)
+            or getattr(item, "trust_visibility_id", item.__class__.__name__)
+        )
+        for field_name in PROHIBITED_BOOLEAN_FIELD_NAMES:
+            if bool(getattr(item, field_name, False)):
+                enabled.setdefault(str(item_id), []).append(field_name)
+    return {key: sorted(values) for key, values in sorted(enabled.items())}
+
+
+def trust_visibility_capability_counter_values(
+    intelligence: TrustVisibilityFoundationIntelligence,
+) -> dict[str, int]:
+    objects = tuple(_iter_dataclass_objects(intelligence))
+    counters: dict[str, int] = {}
+    for counter_name, field_names in CAPABILITY_COUNTER_FIELD_MAP.items():
+        counters[counter_name] = sum(
+            1
+            for item in objects
+            for field_name in field_names
+            if bool(getattr(item, field_name, False))
+        )
+    return counters
+
+
+def trust_visibility_foundation_equal(
+    left: TrustVisibilityFoundationIntelligence,
+    right: TrustVisibilityFoundationIntelligence,
+) -> bool:
+    return serialize_v4_5b_1_trust_visibility_foundation(
+        left
+    ) == serialize_v4_5b_1_trust_visibility_foundation(right)
+
+
+def validate_trust_visibility_ordering_stability(
+    intelligence: TrustVisibilityFoundationIntelligence,
+) -> dict[str, Any]:
+    order_groups = {
+        "trust_visibility_records": tuple(
+            record.deterministic_order
+            for record in intelligence.trust_visibility_records
+        ),
+        "evidence_visibility": tuple(
+            record.deterministic_order for record in intelligence.evidence_visibility
+        ),
+        "unsupported_state_visibility": tuple(
+            record.deterministic_order
+            for record in intelligence.unsupported_state_visibility
+        ),
+        "governance_transparency_visibility": tuple(
+            record.deterministic_order
+            for record in intelligence.governance_transparency_visibility
+        ),
+        "trust_summaries": tuple(
+            record.deterministic_order for record in intelligence.trust_summaries
+        ),
+        "explainability_visibility": tuple(
+            record.deterministic_order
+            for record in intelligence.explainability_visibility
+        ),
+        "integrity_visibility": tuple(
+            record.deterministic_order for record in intelligence.integrity_visibility
+        ),
+        "public_trust_diagnostics": tuple(
+            record.deterministic_order
+            for record in intelligence.public_trust_diagnostics
+        ),
+        "unsupported_public_trust_visibility": tuple(
+            record.deterministic_order
+            for record in intelligence.unsupported_public_trust_visibility
+        ),
+    }
+    unordered_groups = sorted(
+        key for key, values in order_groups.items() if tuple(sorted(values)) != values
+    )
+    return {
+        "valid": not unordered_groups,
+        "order_groups": {key: list(values) for key, values in order_groups.items()},
+        "unordered_groups": unordered_groups,
+    }
+
+
+def validate_trust_visibility_identity_integrity(
+    intelligence: TrustVisibilityFoundationIntelligence,
+) -> dict[str, Any]:
+    identity = intelligence.trust_identity
+    required_values = {
+        "trust_visibility_id": identity.trust_visibility_id,
+        "trust_summary_id": identity.trust_summary_id,
+        "transparency_reference_id": identity.transparency_reference_id,
+        "evidence_reference_id": identity.evidence_reference_id,
+        "continuity_reference_id": identity.continuity_reference_id,
+        "explainability_reference_id": identity.explainability_reference_id,
+        "integrity_reference_id": identity.integrity_reference_id,
+        "diagnostics_reference_id": identity.diagnostics_reference_id,
+        "unsupported_state_reference_id": identity.unsupported_state_reference_id,
+        "lineage_reference_id": identity.lineage_reference_id,
+        "provenance_reference_id": identity.provenance_reference_id,
+    }
+    missing_fields = sorted(key for key, value in required_values.items() if not value)
+    source_report_present = _relative_path_exists(
+        identity.source_readiness_closeout_report_reference
+    )
+    source_report_hash_matches = _report_hash_matches(
+        identity.source_readiness_closeout_report_reference,
+        identity.source_readiness_closeout_hash_reference,
+    )
+    return {
+        "valid": not missing_fields
+        and identity.phase_id == V4_5B_1_TRUST_VISIBILITY_FOUNDATION_PHASE_ID
+        and source_report_present
+        and source_report_hash_matches,
+        "missing_identity_fields": missing_fields,
+        "phase_id": identity.phase_id,
+        "schema_version": identity.schema_version,
+        "source_report_present": source_report_present,
+        "source_report_hash_matches": source_report_hash_matches,
+    }
+
+
+def validate_public_trust_evidence_visibility(
+    intelligence: TrustVisibilityFoundationIntelligence,
+) -> dict[str, Any]:
+    records = intelligence.evidence_visibility
+    present = {record.evidence_visibility_type for record in records}
+    missing_types = sorted(set(PUBLIC_TRUST_EVIDENCE_VISIBILITY_TYPES) - present)
+    unsafe_ids = sorted(
+        record.evidence_visibility_id
+        for record in records
+        if (
+            not record.visibility_preserved
+            or not record.descriptive_only
+            or not record.replay_safe
+            or not record.provenance_safe
+            or record.authorization_enabled
+            or record.approval_enabled
+            or record.scoring_enabled
+        )
+    )
+    return {
+        "valid": not (missing_types or unsafe_ids),
+        "evidence_visibility_count": len(records),
+        "missing_evidence_visibility_types": missing_types,
+        "unsafe_evidence_visibility_ids": unsafe_ids,
+    }
+
+
+def validate_unsupported_state_visibility_preservation(
+    intelligence: TrustVisibilityFoundationIntelligence,
+) -> dict[str, Any]:
+    records = intelligence.unsupported_state_visibility
+    present = {record.unsupported_state_type for record in records}
+    missing_types = sorted(set(UNSUPPORTED_STATE_VISIBILITY_TYPES) - present)
+    unsafe_ids = sorted(
+        record.unsupported_visibility_id
+        for record in records
+        if (
+            not record.visibility_preserved
+            or not record.descriptive_only
+            or not record.fail_visible
+            or record.suppression_enabled
+            or record.hidden_fallback_enabled
+            or record.authorization_enabled
+            or record.approval_enabled
+            or record.remediation_enabled
+        )
+    )
+    return {
+        "valid": not (missing_types or unsafe_ids),
+        "unsupported_state_visibility_count": len(records),
+        "missing_unsupported_state_types": missing_types,
+        "unsafe_unsupported_state_ids": unsafe_ids,
+    }
+
+
+def validate_governance_transparency_visibility_preservation(
+    intelligence: TrustVisibilityFoundationIntelligence,
+) -> dict[str, Any]:
+    records = intelligence.governance_transparency_visibility
+    present = {record.transparency_type for record in records}
+    missing_types = sorted(set(GOVERNANCE_TRANSPARENCY_VISIBILITY_TYPES) - present)
+    unsafe_ids = sorted(
+        record.transparency_visibility_id
+        for record in records
+        if (
+            not record.visibility_preserved
+            or not record.descriptive_only
+            or not record.public_visibility
+            or record.operational_approval_enabled
+            or record.authorization_enabled
+            or record.approval_enabled
+        )
+    )
+    return {
+        "valid": not (missing_types or unsafe_ids),
+        "transparency_visibility_count": len(records),
+        "missing_transparency_types": missing_types,
+        "unsafe_transparency_ids": unsafe_ids,
+    }
+
+
+def validate_trust_summary_stability(
+    intelligence: TrustVisibilityFoundationIntelligence,
+) -> dict[str, Any]:
+    records = intelligence.trust_summaries
+    present = {record.summary_type for record in records}
+    missing_types = sorted(set(TRUST_SUMMARY_TYPES) - present)
+    unsafe_ids = sorted(
+        record.trust_summary_record_id
+        for record in records
+        if (
+            not record.descriptive_only
+            or record.authorization_enabled
+            or record.approval_enabled
+            or record.ranking_enabled
+            or record.recommendation_enabled
+            or record.execution_enablement_enabled
+            or record.production_enablement_enabled
+        )
+    )
+    return {
+        "valid": not (missing_types or unsafe_ids),
+        "trust_summary_count": len(records),
+        "missing_summary_types": missing_types,
+        "unsafe_summary_ids": unsafe_ids,
+    }
+
+
+def validate_public_explainability_visibility(
+    intelligence: TrustVisibilityFoundationIntelligence,
+) -> dict[str, Any]:
+    records = intelligence.explainability_visibility
+    present = {record.explainability_visibility_type for record in records}
+    missing_types = sorted(set(PUBLIC_EXPLAINABILITY_VISIBILITY_TYPES) - present)
+    unsafe_ids = sorted(
+        record.explainability_visibility_id
+        for record in records
+        if (
+            not record.visibility_preserved
+            or not record.descriptive_only
+            or record.recommendation_enabled
+            or record.decision_enabled
+            or record.authorization_enabled
+        )
+    )
+    return {
+        "valid": not (missing_types or unsafe_ids),
+        "explainability_visibility_count": len(records),
+        "missing_explainability_types": missing_types,
+        "unsafe_explainability_ids": unsafe_ids,
+    }
+
+
+def validate_public_integrity_visibility(
+    intelligence: TrustVisibilityFoundationIntelligence,
+) -> dict[str, Any]:
+    records = intelligence.integrity_visibility
+    present = {record.integrity_visibility_type for record in records}
+    missing_types = sorted(set(PUBLIC_INTEGRITY_VISIBILITY_TYPES) - present)
+    unsafe_ids = sorted(
+        record.integrity_visibility_id
+        for record in records
+        if (
+            not record.visibility_preserved
+            or not record.descriptive_only
+            or record.operational_semantics_enabled
+            or record.approval_enabled
+            or record.authorization_enabled
+        )
+    )
+    return {
+        "valid": not (missing_types or unsafe_ids),
+        "integrity_visibility_count": len(records),
+        "missing_integrity_types": missing_types,
+        "unsafe_integrity_ids": unsafe_ids,
+    }
+
+
+def validate_lineage_and_provenance_preservation(
+    intelligence: TrustVisibilityFoundationIntelligence,
+) -> dict[str, Any]:
+    identity = intelligence.trust_identity
+    missing_lineage = not bool(identity.lineage_reference_id)
+    missing_provenance = not bool(identity.provenance_reference_id)
+    missing_continuity = not bool(identity.continuity_reference_id)
+    missing_evidence = sorted(
+        str(
+            getattr(item, "evidence_visibility_id", None)
+            or getattr(item, "unsupported_visibility_id", None)
+            or getattr(item, "transparency_visibility_id", None)
+            or getattr(item, "trust_summary_record_id", None)
+            or getattr(item, "explainability_visibility_id", None)
+            or getattr(item, "integrity_visibility_id", None)
+            or getattr(item, "diagnostic_id", None)
+            or getattr(item, "state_id", "")
+        )
+        for item in _iter_dataclass_objects(intelligence)
+        if hasattr(item, "evidence_reference_ids")
+        and not tuple(getattr(item, "evidence_reference_ids"))
+    )
+    return {
+        "valid": not (
+            missing_lineage
+            or missing_provenance
+            or missing_continuity
+            or missing_evidence
+        ),
+        "lineage_continuity_preserved": not missing_lineage,
+        "provenance_continuity_preserved": not missing_provenance,
+        "continuity_reference_preserved": not missing_continuity,
+        "evidence_continuity_preserved": not missing_evidence,
+        "missing_evidence_reference_ids": missing_evidence,
+    }
+
+
+def validate_trust_visibility_serialization_and_hashing(
+    intelligence: TrustVisibilityFoundationIntelligence,
+) -> dict[str, Any]:
+    first_serialization = serialize_v4_5b_1_trust_visibility_foundation(intelligence)
+    second_serialization = serialize_v4_5b_1_trust_visibility_foundation(intelligence)
+    first_hash = hash_v4_5b_1_trust_visibility_foundation(intelligence)
+    second_hash = hash_v4_5b_1_trust_visibility_foundation(intelligence)
+    rebuilt_hash = hash_v4_5b_1_trust_visibility_foundation(
+        build_v4_5b_1_trust_visibility_foundation()
+    )
+    return {
+        "valid": (
+            first_serialization == second_serialization
+            and first_hash == second_hash
+            and first_hash == rebuilt_hash
+        ),
+        "serialization_stable": first_serialization == second_serialization,
+        "hashing_stable": first_hash == second_hash == rebuilt_hash,
+        "trust_visibility_hash": first_hash,
+        "rebuilt_trust_visibility_hash": rebuilt_hash,
+        "serialization_length": len(first_serialization),
+    }
+
+
+def validate_fail_visible_public_trust_diagnostics(
+    intelligence: TrustVisibilityFoundationIntelligence,
+) -> dict[str, Any]:
+    diagnostics = intelligence.public_trust_diagnostics
+    unsupported = intelligence.unsupported_public_trust_visibility
+    missing_diagnostic_types = sorted(
+        set(PUBLIC_TRUST_DIAGNOSTIC_TYPES)
+        - {record.diagnostic_type for record in diagnostics}
+    )
+    missing_unsupported_states = sorted(
+        set(UNSUPPORTED_PUBLIC_TRUST_OPERATIONAL_STATES)
+        - {record.unsupported_state for record in unsupported}
+    )
+    unsafe_diagnostic_ids = sorted(
+        record.diagnostic_id
+        for record in diagnostics
+        if (
+            not record.fail_visible
+            or not record.descriptive_only
+            or record.silent_fallback_enabled
+            or record.hidden_fallback_enabled
+            or record.authorization_enabled
+            or record.approval_enabled
+            or record.remediation_enabled
+            or record.repair_enabled
+            or record.mitigation_enabled
+            or record.auto_correction_enabled
+            or record.ranking_enabled
+            or record.recommendation_enabled
+            or record.orchestration_response_enabled
+        )
+    )
+    unsafe_unsupported_ids = sorted(
+        record.state_id
+        for record in unsupported
+        if (
+            not record.fail_visible
+            or not record.descriptive_only
+            or record.authorization_enabled
+            or record.approval_enabled
+            or record.operational_enabled
+            or record.remediation_enabled
+            or record.repair_enabled
+            or record.mitigation_enabled
+            or record.automated_correction_enabled
+            or record.ranking_enabled
+            or record.recommendation_enabled
+            or record.suppression_enabled
+        )
+    )
+    return {
+        "valid": not (
+            missing_diagnostic_types
+            or missing_unsupported_states
+            or unsafe_diagnostic_ids
+            or unsafe_unsupported_ids
+        ),
+        "public_trust_diagnostic_count": len(diagnostics),
+        "unsupported_public_trust_state_count": len(unsupported),
+        "missing_diagnostic_types": missing_diagnostic_types,
+        "missing_unsupported_states": missing_unsupported_states,
+        "unsafe_diagnostic_ids": unsafe_diagnostic_ids,
+        "unsafe_unsupported_ids": unsafe_unsupported_ids,
+        "fail_visible": all(record.fail_visible for record in diagnostics)
+        and all(record.fail_visible for record in unsupported),
+        "silent_fallback_enabled_count": sum(
+            1 for record in diagnostics if record.silent_fallback_enabled
+        ),
+        "hidden_fallback_enabled_count": sum(
+            1 for record in diagnostics if record.hidden_fallback_enabled
+        ),
+        "authorization_enabled_count": sum(
+            1 for record in diagnostics if record.authorization_enabled
+        )
+        + sum(1 for record in unsupported if record.authorization_enabled),
+        "approval_enabled_count": sum(
+            1 for record in diagnostics if record.approval_enabled
+        )
+        + sum(1 for record in unsupported if record.approval_enabled),
+        "ranking_enabled_count": sum(
+            1 for record in diagnostics if record.ranking_enabled
+        )
+        + sum(1 for record in unsupported if record.ranking_enabled),
+        "recommendation_enabled_count": sum(
+            1 for record in diagnostics if record.recommendation_enabled
+        )
+        + sum(1 for record in unsupported if record.recommendation_enabled),
+    }
+
+
+def validate_descriptive_only_public_trust_guarantees(
+    intelligence: TrustVisibilityFoundationIntelligence,
+) -> dict[str, Any]:
+    counters = trust_visibility_capability_counter_values(intelligence)
+    enabled_flags = enabled_trust_visibility_capability_flags(intelligence)
+    descriptive_failures = sorted(
+        str(
+            getattr(item, "trust_record_id", None)
+            or getattr(item, "evidence_visibility_id", None)
+            or getattr(item, "unsupported_visibility_id", None)
+            or getattr(item, "transparency_visibility_id", None)
+            or getattr(item, "trust_summary_record_id", None)
+            or getattr(item, "diagnostic_id", None)
+            or getattr(item, "state_id", None)
+            or getattr(item, "trust_visibility_id", item.__class__.__name__)
+        )
+        for item in _iter_dataclass_objects(intelligence)
+        if hasattr(item, "descriptive_only") and not getattr(item, "descriptive_only")
+    )
+    missing_disabled_counters = sorted(
+        set(V4_5B_1_TRUST_VISIBILITY_FOUNDATION_DISABLED_COUNTER_NAMES)
+        - set(counters)
+    )
+    required_repository_states = {
+        "NON-operational": intelligence.non_operational,
+        "NON-authorizing": intelligence.non_authorizing,
+        "NON-approving": intelligence.non_approving,
+        "NON-executing": intelligence.non_executing,
+        "NON-remediating": intelligence.non_remediating,
+        "NON-runtime-mutating": intelligence.non_runtime_mutating,
+        "NON-ranking": intelligence.non_ranking,
+        "NON-recommending": intelligence.non_recommending,
+    }
+    statement_valid = (
+        intelligence.public_trust_visibility_statement
+        == PUBLIC_TRUST_VISIBILITY_STATEMENT
+        and intelligence.trust_visibility_non_authority_statement
+        == PUBLIC_TRUST_VISIBILITY_NON_AUTHORITY_STATEMENT
+    )
+    return {
+        "valid": (
+            not enabled_flags
+            and all(value == 0 for value in counters.values())
+            and not descriptive_failures
+            and not missing_disabled_counters
+            and all(required_repository_states.values())
+            and intelligence.publicly_transparent
+            and statement_valid
+        ),
+        "enabled_flags": enabled_flags,
+        "counters": counters,
+        "descriptive_failures": descriptive_failures,
+        "missing_disabled_counters": missing_disabled_counters,
+        "repository_remains": required_repository_states,
+        "publicly_transparent": intelligence.publicly_transparent,
+        "public_trust_visibility_statement": (
+            intelligence.public_trust_visibility_statement
+        ),
+        "trust_visibility_non_authority_statement": (
+            intelligence.trust_visibility_non_authority_statement
+        ),
+        "statement_valid": statement_valid,
+        "inherited_prohibition_count": len(intelligence.inherited_prohibitions),
+        "inherited_constraint_count": len(intelligence.inherited_constraints),
+        "explicit_limitation_count": len(intelligence.explicit_limitations),
+    }
+
+
+def validate_v4_5b_1_trust_visibility_foundation(
+    intelligence: TrustVisibilityFoundationIntelligence | None = None,
+) -> dict[str, Any]:
+    if intelligence is None:
+        intelligence = build_v4_5b_1_trust_visibility_foundation()
+    validations = {
+        "required_visibility": validate_required_trust_visibility_foundation(
+            intelligence
+        ),
+        "ordering_stability": validate_trust_visibility_ordering_stability(
+            intelligence
+        ),
+        "identity_integrity": validate_trust_visibility_identity_integrity(
+            intelligence
+        ),
+        "evidence_visibility": validate_public_trust_evidence_visibility(
+            intelligence
+        ),
+        "unsupported_state_visibility": (
+            validate_unsupported_state_visibility_preservation(intelligence)
+        ),
+        "governance_transparency": (
+            validate_governance_transparency_visibility_preservation(intelligence)
+        ),
+        "trust_summary": validate_trust_summary_stability(intelligence),
+        "explainability_visibility": validate_public_explainability_visibility(
+            intelligence
+        ),
+        "integrity_visibility": validate_public_integrity_visibility(intelligence),
+        "lineage_and_provenance": validate_lineage_and_provenance_preservation(
+            intelligence
+        ),
+        "serialization_hashing": validate_trust_visibility_serialization_and_hashing(
+            intelligence
+        ),
+        "fail_visible_public_trust": validate_fail_visible_public_trust_diagnostics(
+            intelligence
+        ),
+        "descriptive_only_guarantees": (
+            validate_descriptive_only_public_trust_guarantees(intelligence)
+        ),
+    }
+    failed_validations = sorted(
+        name for name, result in validations.items() if not result["valid"]
+    )
+    return {
+        "valid": not failed_validations,
+        "foundation_status": (
+            V4_5B_1_TRUST_VISIBILITY_FOUNDATION_STATUS_STABLE
+            if not failed_validations
+            else V4_5B_1_TRUST_VISIBILITY_FOUNDATION_STATUS_BLOCKED
+        ),
+        "validation_error_count": len(failed_validations),
+        "failed_validations": failed_validations,
+        "validations": validations,
+    }
+
+
+def build_v4_5b_1_trust_visibility_foundation_report() -> dict[str, Any]:
+    intelligence = build_v4_5b_1_trust_visibility_foundation()
+    exported = export_v4_5b_1_trust_visibility_foundation(intelligence)
+    validation = validate_v4_5b_1_trust_visibility_foundation(intelligence)
+    required_visibility = validation["validations"]["required_visibility"]
+    serialization_hashing = validation["validations"]["serialization_hashing"]
+    evidence = validation["validations"]["evidence_visibility"]
+    unsupported = validation["validations"]["unsupported_state_visibility"]
+    transparency = validation["validations"]["governance_transparency"]
+    trust_summary = validation["validations"]["trust_summary"]
+    explainability = validation["validations"]["explainability_visibility"]
+    integrity = validation["validations"]["integrity_visibility"]
+    lineage_provenance = validation["validations"]["lineage_and_provenance"]
+    fail_visible = validation["validations"]["fail_visible_public_trust"]
+    descriptive_only = validation["validations"]["descriptive_only_guarantees"]
+    counters = descriptive_only["counters"]
+
+    deterministic_hash_evidence = {
+        "trust_identity_hash": hash_trust_visibility_identity(
+            intelligence.trust_identity
+        ),
+        "trust_visibility_foundation_hash": hash_v4_5b_1_trust_visibility_foundation(
+            intelligence
+        ),
+        "trust_visibility_record_hashes": {
+            record.trust_record_id: hash_trust_visibility_record(record)
+            for record in sorted(
+                intelligence.trust_visibility_records,
+                key=lambda item: (item.deterministic_order, item.trust_record_id),
+            )
+        },
+        "evidence_visibility_hashes": {
+            record.evidence_visibility_id: hash_public_trust_evidence_visibility(record)
+            for record in sorted(
+                intelligence.evidence_visibility,
+                key=lambda item: (item.deterministic_order, item.evidence_visibility_id),
+            )
+        },
+        "unsupported_state_visibility_hashes": {
+            record.unsupported_visibility_id: hash_unsupported_state_visibility(record)
+            for record in sorted(
+                intelligence.unsupported_state_visibility,
+                key=lambda item: (
+                    item.deterministic_order,
+                    item.unsupported_visibility_id,
+                ),
+            )
+        },
+        "governance_transparency_hashes": {
+            record.transparency_visibility_id: (
+                hash_governance_transparency_visibility(record)
+            )
+            for record in sorted(
+                intelligence.governance_transparency_visibility,
+                key=lambda item: (
+                    item.deterministic_order,
+                    item.transparency_visibility_id,
+                ),
+            )
+        },
+        "trust_summary_hashes": {
+            record.trust_summary_record_id: hash_trust_summary_record(record)
+            for record in sorted(
+                intelligence.trust_summaries,
+                key=lambda item: (item.deterministic_order, item.trust_summary_record_id),
+            )
+        },
+        "explainability_visibility_hashes": {
+            record.explainability_visibility_id: (
+                hash_public_explainability_visibility(record)
+            )
+            for record in sorted(
+                intelligence.explainability_visibility,
+                key=lambda item: (
+                    item.deterministic_order,
+                    item.explainability_visibility_id,
+                ),
+            )
+        },
+        "integrity_visibility_hashes": {
+            record.integrity_visibility_id: hash_public_integrity_visibility(record)
+            for record in sorted(
+                intelligence.integrity_visibility,
+                key=lambda item: (item.deterministic_order, item.integrity_visibility_id),
+            )
+        },
+        "public_trust_diagnostic_hashes": {
+            record.diagnostic_id: hash_public_trust_diagnostic_record(record)
+            for record in sorted(
+                intelligence.public_trust_diagnostics,
+                key=lambda item: (item.deterministic_order, item.diagnostic_id),
+            )
+        },
+        "unsupported_public_trust_hashes": {
+            record.state_id: hash_unsupported_public_trust_visibility(record)
+            for record in sorted(
+                intelligence.unsupported_public_trust_visibility,
+                key=lambda item: (item.deterministic_order, item.state_id),
+            )
+        },
+    }
+    summary = {
+        "trust_visibility_record_count": len(intelligence.trust_visibility_records),
+        "evidence_visibility_count": len(intelligence.evidence_visibility),
+        "unsupported_state_visibility_count": len(
+            intelligence.unsupported_state_visibility
+        ),
+        "governance_transparency_visibility_count": len(
+            intelligence.governance_transparency_visibility
+        ),
+        "trust_summary_count": len(intelligence.trust_summaries),
+        "explainability_visibility_count": len(intelligence.explainability_visibility),
+        "integrity_visibility_count": len(intelligence.integrity_visibility),
+        "public_trust_diagnostic_count": len(intelligence.public_trust_diagnostics),
+        "unsupported_public_trust_state_count": len(
+            intelligence.unsupported_public_trust_visibility
+        ),
+        "evidence_counts": required_visibility["evidence_counts"],
+        "unsupported_counts": required_visibility["unsupported_counts"],
+        "transparency_counts": required_visibility["transparency_counts"],
+        "summary_counts": required_visibility["summary_counts"],
+        "explainability_counts": required_visibility["explainability_counts"],
+        "integrity_counts": required_visibility["integrity_counts"],
+        "diagnostic_counts": required_visibility["diagnostic_counts"],
+        "unsupported_operational_counts": required_visibility[
+            "unsupported_operational_counts"
+        ],
+        "deterministic_serialization_verified": serialization_hashing[
+            "serialization_stable"
+        ],
+        "deterministic_hashing_verified": serialization_hashing["hashing_stable"],
+        "evidence_visibility_stable": evidence["valid"],
+        "unsupported_state_visibility_preserved": unsupported["valid"],
+        "governance_transparency_visibility_preserved": transparency["valid"],
+        "trust_summary_stable": trust_summary["valid"],
+        "explainability_visibility_stable": explainability["valid"],
+        "integrity_visibility_stable": integrity["valid"],
+        "lineage_continuity_preserved": lineage_provenance[
+            "lineage_continuity_preserved"
+        ],
+        "provenance_continuity_preserved": lineage_provenance[
+            "provenance_continuity_preserved"
+        ],
+        "evidence_continuity_preserved": lineage_provenance[
+            "evidence_continuity_preserved"
+        ],
+        "fail_visible_public_trust_diagnostics_verified": fail_visible["valid"],
+        "descriptive_only_guarantees_verified": descriptive_only["valid"],
+        "publicly_transparent": descriptive_only["publicly_transparent"],
+        "public_trust_visibility_statement": (
+            descriptive_only["public_trust_visibility_statement"]
+        ),
+        "trust_visibility_non_authority_statement": (
+            descriptive_only["trust_visibility_non_authority_statement"]
+        ),
+        "inherited_prohibition_count": descriptive_only[
+            "inherited_prohibition_count"
+        ],
+        "inherited_constraint_count": descriptive_only["inherited_constraint_count"],
+        "explicit_limitation_count": descriptive_only["explicit_limitation_count"],
+        "validation_error_count": validation["validation_error_count"],
+        "repository_remains": [
+            "NON-operational",
+            "NON-authorizing",
+            "NON-approving",
+            "NON-executing",
+            "NON-remediating",
+            "NON-runtime-mutating",
+            "NON-ranking",
+            "NON-recommending",
+        ],
+    }
+    summary.update(counters)
+    report = {
+        "phase_id": V4_5B_1_TRUST_VISIBILITY_FOUNDATION_PHASE_ID,
+        "schema_version": V4_5B_1_TRUST_VISIBILITY_FOUNDATION_REPORT_SCHEMA_VERSION,
+        "generated_at": V4_5B_1_TRUST_VISIBILITY_FOUNDATION_GENERATED_AT,
+        "purpose": V4_5B_1_TRUST_VISIBILITY_FOUNDATION_PURPOSE,
+        "foundation_status": validation["foundation_status"],
+        "summary": summary,
+        "visibility": {
+            "trust_visibility": trust_visibility_summary(
+                intelligence.trust_visibility_records
+            ),
+            "public_trust_evidence": evidence_visibility_summary(
+                intelligence.evidence_visibility
+            ),
+            "unsupported_states": unsupported_state_summary(
+                intelligence.unsupported_state_visibility
+            ),
+            "governance_transparency": governance_transparency_summary(
+                intelligence.governance_transparency_visibility
+            ),
+            "trust_summaries": trust_summary_visibility(
+                intelligence.trust_summaries
+            ),
+            "explainability": explainability_summary(
+                intelligence.explainability_visibility
+            ),
+            "integrity": integrity_summary(intelligence.integrity_visibility),
+            "diagnostics": diagnostics_summary(
+                intelligence.public_trust_diagnostics
+            ),
+            "unsupported_public_trust": unsupported_public_trust_summary(
+                intelligence.unsupported_public_trust_visibility
+            ),
+            "descriptive_only": descriptive_only_public_trust_summary(
+                intelligence
+            ),
+        },
+        "deterministic_hash_evidence": deterministic_hash_evidence,
+        "validation": validation,
+        "exported_intelligence": exported,
+    }
+    report["deterministic_report_hash"] = (
+        deterministic_v4_5b_1_trust_visibility_foundation_hash(report)
+    )
+    return report
+
+
+def contaminate_v4_5b_1_trust_visibility_foundation_for_non_operational_validation(
+    intelligence: TrustVisibilityFoundationIntelligence | None = None,
+) -> TrustVisibilityFoundationIntelligence:
+    if intelligence is None:
+        intelligence = build_v4_5b_1_trust_visibility_foundation()
+    return replace(
+        intelligence,
+        runtime_execution_enabled=True,
+        trust_authorization_enabled=True,
+        trust_approval_enabled=True,
+        trust_ranking_enabled=True,
+        trust_recommendation_enabled=True,
+        remediation_enabled=True,
+        planner_integration_enabled=True,
+    )

--- a/backend/app/public_trust_visibility/v4_5b_1_trust_visibility_foundation_hashing.py
+++ b/backend/app/public_trust_visibility/v4_5b_1_trust_visibility_foundation_hashing.py
@@ -1,0 +1,118 @@
+"""Deterministic hashing for v4.5B.1 trust visibility foundations."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+from .v4_5b_1_trust_visibility_foundation_models import (
+    GovernanceTransparencyVisibility,
+    PublicExplainabilityVisibility,
+    PublicIntegrityVisibility,
+    PublicTrustDiagnosticRecord,
+    PublicTrustEvidenceVisibility,
+    TrustSummaryRecord,
+    TrustVisibilityFoundationIntelligence,
+    TrustVisibilityIdentity,
+    TrustVisibilityRecord,
+    UnsupportedPublicTrustVisibility,
+    UnsupportedStateVisibility,
+)
+from .v4_5b_1_trust_visibility_foundation_serialization import (
+    export_governance_transparency_visibility,
+    export_public_explainability_visibility,
+    export_public_integrity_visibility,
+    export_public_trust_diagnostic_record,
+    export_public_trust_evidence_visibility,
+    export_trust_summary_record,
+    export_trust_visibility_identity,
+    export_trust_visibility_record,
+    export_unsupported_public_trust_visibility,
+    export_unsupported_state_visibility,
+    export_v4_5b_1_trust_visibility_foundation,
+    stable_serialize_v4_5b_1_trust_visibility_foundation,
+)
+
+
+def deterministic_v4_5b_1_trust_visibility_foundation_hash(payload: Any) -> str:
+    return hashlib.sha256(
+        stable_serialize_v4_5b_1_trust_visibility_foundation(payload).encode("utf-8")
+    ).hexdigest()
+
+
+def hash_trust_visibility_identity(identity: TrustVisibilityIdentity) -> str:
+    return deterministic_v4_5b_1_trust_visibility_foundation_hash(
+        export_trust_visibility_identity(identity)
+    )
+
+
+def hash_trust_visibility_record(record: TrustVisibilityRecord) -> str:
+    return deterministic_v4_5b_1_trust_visibility_foundation_hash(
+        export_trust_visibility_record(record)
+    )
+
+
+def hash_public_trust_evidence_visibility(
+    record: PublicTrustEvidenceVisibility,
+) -> str:
+    return deterministic_v4_5b_1_trust_visibility_foundation_hash(
+        export_public_trust_evidence_visibility(record)
+    )
+
+
+def hash_unsupported_state_visibility(record: UnsupportedStateVisibility) -> str:
+    return deterministic_v4_5b_1_trust_visibility_foundation_hash(
+        export_unsupported_state_visibility(record)
+    )
+
+
+def hash_governance_transparency_visibility(
+    record: GovernanceTransparencyVisibility,
+) -> str:
+    return deterministic_v4_5b_1_trust_visibility_foundation_hash(
+        export_governance_transparency_visibility(record)
+    )
+
+
+def hash_trust_summary_record(record: TrustSummaryRecord) -> str:
+    return deterministic_v4_5b_1_trust_visibility_foundation_hash(
+        export_trust_summary_record(record)
+    )
+
+
+def hash_public_explainability_visibility(
+    record: PublicExplainabilityVisibility,
+) -> str:
+    return deterministic_v4_5b_1_trust_visibility_foundation_hash(
+        export_public_explainability_visibility(record)
+    )
+
+
+def hash_public_integrity_visibility(record: PublicIntegrityVisibility) -> str:
+    return deterministic_v4_5b_1_trust_visibility_foundation_hash(
+        export_public_integrity_visibility(record)
+    )
+
+
+def hash_public_trust_diagnostic_record(
+    record: PublicTrustDiagnosticRecord,
+) -> str:
+    return deterministic_v4_5b_1_trust_visibility_foundation_hash(
+        export_public_trust_diagnostic_record(record)
+    )
+
+
+def hash_unsupported_public_trust_visibility(
+    record: UnsupportedPublicTrustVisibility,
+) -> str:
+    return deterministic_v4_5b_1_trust_visibility_foundation_hash(
+        export_unsupported_public_trust_visibility(record)
+    )
+
+
+def hash_v4_5b_1_trust_visibility_foundation(
+    intelligence: TrustVisibilityFoundationIntelligence,
+) -> str:
+    return deterministic_v4_5b_1_trust_visibility_foundation_hash(
+        export_v4_5b_1_trust_visibility_foundation(intelligence)
+    )

--- a/backend/app/public_trust_visibility/v4_5b_1_trust_visibility_foundation_models.py
+++ b/backend/app/public_trust_visibility/v4_5b_1_trust_visibility_foundation_models.py
@@ -1,0 +1,760 @@
+"""Deterministic v4.5B.1 public trust visibility foundation models.
+
+The v4.5B.1 Track B layer establishes public-facing trust visibility without
+enabling trust authority, approval, authorization, ranking, recommendation,
+execution, remediation, runtime mutation, planner integration, production
+consumption, or operational behavior.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+V4_5B_1_TRUST_VISIBILITY_FOUNDATION_PHASE_ID = (
+    "v4_5b_1_trust_visibility_foundations"
+)
+V4_5B_1_TRUST_VISIBILITY_FOUNDATION_SCHEMA_VERSION = (
+    "v4_5b_1.trust_visibility_foundations.1"
+)
+V4_5B_1_TRUST_VISIBILITY_FOUNDATION_REPORT_SCHEMA_VERSION = (
+    "v4_5b_1.trust_visibility_foundations_report.1"
+)
+V4_5B_1_TRUST_VISIBILITY_FOUNDATION_GENERATED_AT = (
+    "2026-05-18T00:00:00+00:00"
+)
+V4_5B_1_TRUST_VISIBILITY_FOUNDATION_STATUS_STABLE = (
+    "v4_5b_1_trust_visibility_foundations_stable"
+)
+V4_5B_1_TRUST_VISIBILITY_FOUNDATION_STATUS_BLOCKED = (
+    "v4_5b_1_trust_visibility_foundations_blocked"
+)
+V4_5B_1_TRUST_VISIBILITY_FOUNDATION_PURPOSE = (
+    "deterministic_public_trust_visibility_foundations_descriptive_only"
+)
+V4_5B_1_TRUST_VISIBILITY_FOUNDATION_CLASSIFICATION = (
+    "governance_safe_public_trust_visibility_descriptive_only"
+)
+
+V4_5A_8_READINESS_CLOSEOUT_REPORT_REFERENCE = (
+    "docs/generated/v4_5a_8_readiness_closeout_report.json"
+)
+V4_5A_8_READINESS_CLOSEOUT_REPORT_HASH_REFERENCE = (
+    "efa3eb2730857cd4916ba21fb7678eb25077dd912eee9db1c14045d24286744c"
+)
+
+PUBLIC_TRUST_VISIBILITY_STATEMENT = "Public trust visibility is descriptive-only."
+PUBLIC_TRUST_VISIBILITY_NON_AUTHORITY_STATEMENT = (
+    "Trust visibility does NOT imply authorization, approval, operational readiness, "
+    "or production enablement."
+)
+
+PUBLIC_TRUST_EVIDENCE_VISIBILITY_TYPES: tuple[str, ...] = (
+    "deterministic_evidence_visibility",
+    "replay_safe_evidence_visibility",
+    "provenance_visibility",
+    "lineage_visibility",
+    "continuity_visibility",
+    "integrity_visibility",
+    "explainability_visibility",
+    "diagnostics_visibility",
+)
+
+UNSUPPORTED_STATE_VISIBILITY_TYPES: tuple[str, ...] = (
+    "unsupported_drift_states",
+    "unsupported_propagation_states",
+    "unsupported_degradation_states",
+    "unsupported_explainability_states",
+    "unsupported_continuity_states",
+    "unsupported_operational_states",
+)
+
+GOVERNANCE_TRANSPARENCY_VISIBILITY_TYPES: tuple[str, ...] = (
+    "inherited_prohibitions",
+    "inherited_constraints",
+    "governance_safe_limitations",
+    "descriptive_only_guarantees",
+    "fail_visible_limitations",
+    "continuity_guarantees",
+    "explainability_guarantees",
+    "deterministic_guarantees",
+)
+
+TRUST_SUMMARY_TYPES: tuple[str, ...] = (
+    "evidence_continuity_visibility",
+    "integrity_continuity_visibility",
+    "explainability_continuity_visibility",
+    "unsupported_state_visibility",
+    "fail_visible_diagnostics_visibility",
+    "governance_transparency_visibility",
+)
+
+PUBLIC_EXPLAINABILITY_VISIBILITY_TYPES: tuple[str, ...] = (
+    "explanation_chain_visibility",
+    "evidence_to_explanation_visibility",
+    "continuity_explanation_visibility",
+    "integrity_explanation_visibility",
+    "fail_visible_explanation_diagnostics",
+)
+
+PUBLIC_INTEGRITY_VISIBILITY_TYPES: tuple[str, ...] = (
+    "integrity_continuity_visibility",
+    "degradation_visibility",
+    "diagnostics_visibility",
+    "fail_visible_integrity_summaries",
+    "unsupported_integrity_states",
+)
+
+PUBLIC_TRUST_DIAGNOSTIC_TYPES: tuple[str, ...] = (
+    "missing_evidence_visibility",
+    "incomplete_continuity_visibility",
+    "unsupported_public_trust_states",
+    "unsupported_operational_states",
+    "incomplete_explainability_visibility",
+    "incomplete_integrity_visibility",
+    "inherited_limitation_visibility_gaps",
+    "inherited_prohibition_visibility_gaps",
+)
+
+UNSUPPORTED_PUBLIC_TRUST_OPERATIONAL_STATES: tuple[str, ...] = (
+    "orchestration_execution",
+    "orchestration_authorization",
+    "orchestration_approval",
+    "orchestration_dispatch",
+    "orchestration_routing",
+    "orchestration_traversal",
+    "orchestration_scheduling",
+    "orchestration_sequencing",
+    "orchestration_decisions",
+    "orchestration_recommendations",
+    "trust_based_authorization",
+    "trust_based_approval",
+    "trust_based_ranking",
+    "trust_based_recommendation",
+    "automated_remediation",
+    "automated_repair",
+    "automated_mitigation",
+    "automated_correction",
+    "planner_integration",
+    "production_consumption",
+    "runtime_mutation",
+    "operational_mutation",
+    "implicit_operational_behavior",
+)
+
+V4_5B_1_TRUST_VISIBILITY_FOUNDATION_DISABLED_COUNTER_NAMES: tuple[str, ...] = (
+    "enabled_runtime_execution_count",
+    "enabled_orchestration_authorization_count",
+    "enabled_orchestration_approval_count",
+    "enabled_orchestration_dispatch_count",
+    "enabled_orchestration_routing_count",
+    "enabled_orchestration_traversal_count",
+    "enabled_orchestration_scheduling_count",
+    "enabled_orchestration_sequencing_count",
+    "enabled_orchestration_decision_count",
+    "enabled_orchestration_recommendation_count",
+    "enabled_trust_authorization_count",
+    "enabled_trust_approval_count",
+    "enabled_trust_ranking_count",
+    "enabled_trust_recommendation_count",
+    "enabled_remediation_count",
+    "enabled_repair_count",
+    "enabled_mitigation_count",
+    "enabled_auto_correction_count",
+    "enabled_planner_integration_count",
+    "enabled_production_consumption_count",
+    "enabled_runtime_mutation_count",
+    "enabled_operational_mutation_count",
+)
+
+V4_5B_1_TRUST_VISIBILITY_FOUNDATION_DETERMINISTIC_GUARANTEES: tuple[str, ...] = (
+    "deterministic_trust_visibility_identity",
+    "deterministic_public_trust_evidence_visibility",
+    "deterministic_unsupported_state_visibility",
+    "deterministic_governance_transparency_visibility",
+    "deterministic_trust_summary_visibility",
+    "deterministic_public_explainability_visibility",
+    "deterministic_public_integrity_visibility",
+    "stable_replay_safe_serialization",
+    "stable_replay_safe_hashing",
+    "lineage_continuity_preserved",
+    "provenance_continuity_preserved",
+    "publicly_transparent_descriptive_only_visibility",
+)
+
+V4_5B_1_TRUST_VISIBILITY_FOUNDATION_INHERITED_PROHIBITIONS: tuple[str, ...] = (
+    "orchestration_execution_prohibited",
+    "orchestration_authorization_prohibited",
+    "orchestration_approval_prohibited",
+    "orchestration_dispatch_prohibited",
+    "orchestration_routing_prohibited",
+    "orchestration_traversal_prohibited",
+    "orchestration_scheduling_prohibited",
+    "orchestration_sequencing_prohibited",
+    "orchestration_decisions_prohibited",
+    "orchestration_recommendations_prohibited",
+    "trust_based_authorization_prohibited",
+    "trust_based_approval_prohibited",
+    "trust_based_ranking_prohibited",
+    "trust_based_recommendation_prohibited",
+    "automated_remediation_prohibited",
+    "automated_repair_prohibited",
+    "automated_mitigation_prohibited",
+    "automated_correction_prohibited",
+    "planner_integration_prohibited",
+    "production_consumption_prohibited",
+    "runtime_mutation_prohibited",
+    "operational_mutation_prohibited",
+    "implicit_operational_behavior_prohibited",
+)
+
+V4_5B_1_TRUST_VISIBILITY_FOUNDATION_INHERITED_CONSTRAINTS: tuple[str, ...] = (
+    "deterministic",
+    "governance-safe",
+    "replay-safe",
+    "rollback-safe",
+    "lineage-safe",
+    "provenance-safe",
+    "integrity-safe",
+    "explainability-first",
+    "fail-visible",
+    "descriptive-only",
+    "publicly transparent",
+    "NON-operational",
+    "NON-authorizing",
+    "NON-approving",
+    "NON-executing",
+    "NON-remediating",
+    "NON-runtime-mutating",
+    "NON-ranking",
+    "NON-recommending",
+)
+
+V4_5B_1_TRUST_VISIBILITY_FOUNDATION_EXPLICIT_LIMITATIONS: tuple[str, ...] = (
+    "trust_visibility_does_not_authorize",
+    "trust_visibility_does_not_approve",
+    "trust_visibility_does_not_rank",
+    "trust_visibility_does_not_recommend",
+    "trust_visibility_does_not_execute",
+    "trust_visibility_does_not_enable_production",
+    "trust_visibility_does_not_imply_correctness_guarantees",
+    "trust_visibility_does_not_remediate_or_repair",
+    "trust_visibility_does_not_mitigate_or_correct",
+    "trust_visibility_does_not_integrate_planners",
+    "trust_visibility_does_not_mutate_runtime_state",
+)
+
+
+def _set_tuple_field(instance: object, field_name: str) -> None:
+    object.__setattr__(instance, field_name, tuple(getattr(instance, field_name)))
+
+
+@dataclass(frozen=True)
+class TrustVisibilityIdentity:
+    trust_visibility_id: str
+    trust_summary_id: str
+    transparency_reference_id: str
+    evidence_reference_id: str
+    continuity_reference_id: str
+    explainability_reference_id: str
+    integrity_reference_id: str
+    diagnostics_reference_id: str
+    unsupported_state_reference_id: str
+    lineage_reference_id: str
+    provenance_reference_id: str
+    phase_id: str
+    schema_version: str
+    generated_at: str
+    classification: str
+    source_readiness_closeout_report_reference: str
+    source_readiness_closeout_hash_reference: str
+
+
+@dataclass(frozen=True)
+class TrustVisibilityRecord:
+    trust_record_id: str
+    trust_visibility_id: str
+    trust_summary_id: str
+    transparency_reference_id: str
+    evidence_reference_id: str
+    continuity_reference_id: str
+    explainability_reference_id: str
+    integrity_reference_id: str
+    diagnostics_reference_id: str
+    unsupported_state_reference_id: str
+    lineage_reference_id: str
+    provenance_reference_id: str
+    visibility_state: str
+    deterministic_order: int
+    descriptive_only: bool = True
+    publicly_transparent: bool = True
+    fail_visible: bool = True
+    non_authorizing: bool = True
+    non_approving: bool = True
+    trust_authority_enabled: bool = False
+    authorization_enabled: bool = False
+    approval_enabled: bool = False
+    ranking_enabled: bool = False
+    recommendation_enabled: bool = False
+    execution_enabled: bool = False
+    production_enablement_enabled: bool = False
+
+
+@dataclass(frozen=True)
+class PublicTrustEvidenceVisibility:
+    evidence_visibility_id: str
+    evidence_visibility_type: str
+    evidence_reference_ids: tuple[str, ...]
+    visibility_preserved: bool
+    visibility_state: str
+    deterministic_order: int
+    descriptive_only: bool = True
+    replay_safe: bool = True
+    provenance_safe: bool = True
+    authorization_enabled: bool = False
+    approval_enabled: bool = False
+    scoring_enabled: bool = False
+
+    def __post_init__(self) -> None:
+        _set_tuple_field(self, "evidence_reference_ids")
+
+
+@dataclass(frozen=True)
+class UnsupportedStateVisibility:
+    unsupported_visibility_id: str
+    unsupported_state_type: str
+    evidence_reference_ids: tuple[str, ...]
+    visibility_preserved: bool
+    visibility_state: str
+    deterministic_order: int
+    descriptive_only: bool = True
+    fail_visible: bool = True
+    suppression_enabled: bool = False
+    hidden_fallback_enabled: bool = False
+    authorization_enabled: bool = False
+    approval_enabled: bool = False
+    remediation_enabled: bool = False
+
+    def __post_init__(self) -> None:
+        _set_tuple_field(self, "evidence_reference_ids")
+
+
+@dataclass(frozen=True)
+class GovernanceTransparencyVisibility:
+    transparency_visibility_id: str
+    transparency_type: str
+    evidence_reference_ids: tuple[str, ...]
+    visibility_preserved: bool
+    visibility_state: str
+    deterministic_order: int
+    descriptive_only: bool = True
+    public_visibility: bool = True
+    operational_approval_enabled: bool = False
+    authorization_enabled: bool = False
+    approval_enabled: bool = False
+
+    def __post_init__(self) -> None:
+        _set_tuple_field(self, "evidence_reference_ids")
+
+
+@dataclass(frozen=True)
+class TrustSummaryRecord:
+    trust_summary_record_id: str
+    trust_summary_id: str
+    summary_type: str
+    evidence_reference_ids: tuple[str, ...]
+    summary_state: str
+    deterministic_order: int
+    descriptive_only: bool = True
+    authorization_enabled: bool = False
+    approval_enabled: bool = False
+    ranking_enabled: bool = False
+    recommendation_enabled: bool = False
+    execution_enablement_enabled: bool = False
+    production_enablement_enabled: bool = False
+
+    def __post_init__(self) -> None:
+        _set_tuple_field(self, "evidence_reference_ids")
+
+
+@dataclass(frozen=True)
+class PublicExplainabilityVisibility:
+    explainability_visibility_id: str
+    explainability_visibility_type: str
+    evidence_reference_ids: tuple[str, ...]
+    visibility_preserved: bool
+    visibility_state: str
+    deterministic_order: int
+    descriptive_only: bool = True
+    recommendation_enabled: bool = False
+    decision_enabled: bool = False
+    authorization_enabled: bool = False
+
+    def __post_init__(self) -> None:
+        _set_tuple_field(self, "evidence_reference_ids")
+
+
+@dataclass(frozen=True)
+class PublicIntegrityVisibility:
+    integrity_visibility_id: str
+    integrity_visibility_type: str
+    evidence_reference_ids: tuple[str, ...]
+    visibility_preserved: bool
+    visibility_state: str
+    deterministic_order: int
+    descriptive_only: bool = True
+    operational_semantics_enabled: bool = False
+    approval_enabled: bool = False
+    authorization_enabled: bool = False
+
+    def __post_init__(self) -> None:
+        _set_tuple_field(self, "evidence_reference_ids")
+
+
+@dataclass(frozen=True)
+class PublicTrustDiagnosticRecord:
+    diagnostic_id: str
+    diagnostic_type: str
+    evidence_reference_ids: tuple[str, ...]
+    message: str
+    visibility_state: str
+    deterministic_order: int
+    fail_visible: bool = True
+    descriptive_only: bool = True
+    silent_fallback_enabled: bool = False
+    hidden_fallback_enabled: bool = False
+    authorization_enabled: bool = False
+    approval_enabled: bool = False
+    remediation_enabled: bool = False
+    repair_enabled: bool = False
+    mitigation_enabled: bool = False
+    auto_correction_enabled: bool = False
+    ranking_enabled: bool = False
+    recommendation_enabled: bool = False
+    orchestration_response_enabled: bool = False
+
+    def __post_init__(self) -> None:
+        _set_tuple_field(self, "evidence_reference_ids")
+
+
+@dataclass(frozen=True)
+class UnsupportedPublicTrustVisibility:
+    state_id: str
+    unsupported_state: str
+    explicit_reason: str
+    evidence_reference_ids: tuple[str, ...]
+    visibility_state: str
+    deterministic_order: int
+    fail_visible: bool = True
+    descriptive_only: bool = True
+    authorization_enabled: bool = False
+    approval_enabled: bool = False
+    operational_enabled: bool = False
+    remediation_enabled: bool = False
+    repair_enabled: bool = False
+    mitigation_enabled: bool = False
+    automated_correction_enabled: bool = False
+    ranking_enabled: bool = False
+    recommendation_enabled: bool = False
+    suppression_enabled: bool = False
+
+    def __post_init__(self) -> None:
+        _set_tuple_field(self, "evidence_reference_ids")
+
+
+@dataclass(frozen=True)
+class TrustVisibilityFoundationIntelligence:
+    trust_identity: TrustVisibilityIdentity
+    trust_visibility_records: tuple[TrustVisibilityRecord, ...]
+    evidence_visibility: tuple[PublicTrustEvidenceVisibility, ...]
+    unsupported_state_visibility: tuple[UnsupportedStateVisibility, ...]
+    governance_transparency_visibility: tuple[GovernanceTransparencyVisibility, ...]
+    trust_summaries: tuple[TrustSummaryRecord, ...]
+    explainability_visibility: tuple[PublicExplainabilityVisibility, ...]
+    integrity_visibility: tuple[PublicIntegrityVisibility, ...]
+    public_trust_diagnostics: tuple[PublicTrustDiagnosticRecord, ...]
+    unsupported_public_trust_visibility: tuple[UnsupportedPublicTrustVisibility, ...]
+    deterministic_guarantees: tuple[str, ...]
+    inherited_prohibitions: tuple[str, ...]
+    inherited_constraints: tuple[str, ...]
+    explicit_limitations: tuple[str, ...]
+    public_trust_visibility_statement: str = PUBLIC_TRUST_VISIBILITY_STATEMENT
+    trust_visibility_non_authority_statement: str = (
+        PUBLIC_TRUST_VISIBILITY_NON_AUTHORITY_STATEMENT
+    )
+    descriptive_only: bool = True
+    publicly_transparent: bool = True
+    non_operational: bool = True
+    non_authorizing: bool = True
+    non_approving: bool = True
+    non_executing: bool = True
+    non_remediating: bool = True
+    non_runtime_mutating: bool = True
+    non_ranking: bool = True
+    non_recommending: bool = True
+    runtime_execution_enabled: bool = False
+    orchestration_execution_enabled: bool = False
+    orchestration_authorization_enabled: bool = False
+    orchestration_approval_enabled: bool = False
+    orchestration_dispatch_enabled: bool = False
+    orchestration_routing_enabled: bool = False
+    orchestration_traversal_enabled: bool = False
+    orchestration_scheduling_enabled: bool = False
+    orchestration_sequencing_enabled: bool = False
+    orchestration_decision_enabled: bool = False
+    orchestration_recommendation_enabled: bool = False
+    trust_authorization_enabled: bool = False
+    trust_approval_enabled: bool = False
+    trust_ranking_enabled: bool = False
+    trust_recommendation_enabled: bool = False
+    remediation_enabled: bool = False
+    repair_enabled: bool = False
+    mitigation_enabled: bool = False
+    auto_correction_enabled: bool = False
+    ranking_enabled: bool = False
+    recommendation_enabled: bool = False
+    planner_integration_enabled: bool = False
+    planner_execution_enabled: bool = False
+    production_consumption_enabled: bool = False
+    runtime_mutation_enabled: bool = False
+    operational_mutation_enabled: bool = False
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "trust_visibility_records",
+            "evidence_visibility",
+            "unsupported_state_visibility",
+            "governance_transparency_visibility",
+            "trust_summaries",
+            "explainability_visibility",
+            "integrity_visibility",
+            "public_trust_diagnostics",
+            "unsupported_public_trust_visibility",
+            "deterministic_guarantees",
+            "inherited_prohibitions",
+            "inherited_constraints",
+            "explicit_limitations",
+        ):
+            object.__setattr__(self, field_name, tuple(getattr(self, field_name)))
+
+
+def default_trust_visibility_identity() -> TrustVisibilityIdentity:
+    return TrustVisibilityIdentity(
+        trust_visibility_id="v4_5b_1_public_trust_visibility",
+        trust_summary_id="v4_5b_1_public_trust_summary",
+        transparency_reference_id="transparency::v4_5b_1.public_trust",
+        evidence_reference_id="evidence::v4_5b_1.public_trust",
+        continuity_reference_id="continuity::v4_5b_1.public_trust",
+        explainability_reference_id="explainability::v4_5b_1.public_trust",
+        integrity_reference_id="integrity::v4_5b_1.public_trust",
+        diagnostics_reference_id="diagnostics::v4_5b_1.public_trust",
+        unsupported_state_reference_id="unsupported::v4_5b_1.public_trust",
+        lineage_reference_id="lineage::v4_5b_1.public_trust",
+        provenance_reference_id="provenance::v4_5b_1.public_trust",
+        phase_id=V4_5B_1_TRUST_VISIBILITY_FOUNDATION_PHASE_ID,
+        schema_version=V4_5B_1_TRUST_VISIBILITY_FOUNDATION_SCHEMA_VERSION,
+        generated_at=V4_5B_1_TRUST_VISIBILITY_FOUNDATION_GENERATED_AT,
+        classification=V4_5B_1_TRUST_VISIBILITY_FOUNDATION_CLASSIFICATION,
+        source_readiness_closeout_report_reference=(
+            V4_5A_8_READINESS_CLOSEOUT_REPORT_REFERENCE
+        ),
+        source_readiness_closeout_hash_reference=(
+            V4_5A_8_READINESS_CLOSEOUT_REPORT_HASH_REFERENCE
+        ),
+    )
+
+
+def default_trust_visibility_records() -> tuple[TrustVisibilityRecord, ...]:
+    identity = default_trust_visibility_identity()
+    return (
+        TrustVisibilityRecord(
+            trust_record_id="public_trust_visibility_foundation",
+            trust_visibility_id=identity.trust_visibility_id,
+            trust_summary_id=identity.trust_summary_id,
+            transparency_reference_id=identity.transparency_reference_id,
+            evidence_reference_id=identity.evidence_reference_id,
+            continuity_reference_id=identity.continuity_reference_id,
+            explainability_reference_id=identity.explainability_reference_id,
+            integrity_reference_id=identity.integrity_reference_id,
+            diagnostics_reference_id=identity.diagnostics_reference_id,
+            unsupported_state_reference_id=identity.unsupported_state_reference_id,
+            lineage_reference_id=identity.lineage_reference_id,
+            provenance_reference_id=identity.provenance_reference_id,
+            visibility_state="public_trust_visibility_foundation_visible",
+            deterministic_order=1,
+        ),
+    )
+
+
+def default_evidence_visibility() -> tuple[PublicTrustEvidenceVisibility, ...]:
+    return tuple(
+        PublicTrustEvidenceVisibility(
+            evidence_visibility_id=f"public_trust_evidence_{visibility_type}",
+            evidence_visibility_type=visibility_type,
+            evidence_reference_ids=(f"evidence_{visibility_type}",),
+            visibility_preserved=True,
+            visibility_state="public_trust_evidence_visibility_visible",
+            deterministic_order=order,
+        )
+        for order, visibility_type in enumerate(
+            PUBLIC_TRUST_EVIDENCE_VISIBILITY_TYPES,
+            start=1,
+        )
+    )
+
+
+def default_unsupported_state_visibility() -> tuple[UnsupportedStateVisibility, ...]:
+    return tuple(
+        UnsupportedStateVisibility(
+            unsupported_visibility_id=f"unsupported_state_visibility_{state_type}",
+            unsupported_state_type=state_type,
+            evidence_reference_ids=(f"evidence_{state_type}",),
+            visibility_preserved=True,
+            visibility_state="unsupported_state_visibility_fail_visible",
+            deterministic_order=order,
+        )
+        for order, state_type in enumerate(
+            UNSUPPORTED_STATE_VISIBILITY_TYPES,
+            start=1,
+        )
+    )
+
+
+def default_governance_transparency_visibility() -> tuple[
+    GovernanceTransparencyVisibility, ...
+]:
+    return tuple(
+        GovernanceTransparencyVisibility(
+            transparency_visibility_id=f"governance_transparency_{transparency_type}",
+            transparency_type=transparency_type,
+            evidence_reference_ids=(f"evidence_{transparency_type}",),
+            visibility_preserved=True,
+            visibility_state="governance_transparency_visibility_visible",
+            deterministic_order=order,
+        )
+        for order, transparency_type in enumerate(
+            GOVERNANCE_TRANSPARENCY_VISIBILITY_TYPES,
+            start=1,
+        )
+    )
+
+
+def default_trust_summaries() -> tuple[TrustSummaryRecord, ...]:
+    identity = default_trust_visibility_identity()
+    return tuple(
+        TrustSummaryRecord(
+            trust_summary_record_id=f"trust_summary_{summary_type}",
+            trust_summary_id=identity.trust_summary_id,
+            summary_type=summary_type,
+            evidence_reference_ids=(f"evidence_{summary_type}",),
+            summary_state="trust_summary_descriptive_only",
+            deterministic_order=order,
+        )
+        for order, summary_type in enumerate(TRUST_SUMMARY_TYPES, start=1)
+    )
+
+
+def default_explainability_visibility() -> tuple[PublicExplainabilityVisibility, ...]:
+    return tuple(
+        PublicExplainabilityVisibility(
+            explainability_visibility_id=f"public_explainability_{visibility_type}",
+            explainability_visibility_type=visibility_type,
+            evidence_reference_ids=(f"evidence_{visibility_type}",),
+            visibility_preserved=True,
+            visibility_state="public_explainability_visibility_visible",
+            deterministic_order=order,
+        )
+        for order, visibility_type in enumerate(
+            PUBLIC_EXPLAINABILITY_VISIBILITY_TYPES,
+            start=1,
+        )
+    )
+
+
+def default_integrity_visibility() -> tuple[PublicIntegrityVisibility, ...]:
+    return tuple(
+        PublicIntegrityVisibility(
+            integrity_visibility_id=f"public_integrity_{visibility_type}",
+            integrity_visibility_type=visibility_type,
+            evidence_reference_ids=(f"evidence_{visibility_type}",),
+            visibility_preserved=True,
+            visibility_state="public_integrity_visibility_visible",
+            deterministic_order=order,
+        )
+        for order, visibility_type in enumerate(
+            PUBLIC_INTEGRITY_VISIBILITY_TYPES,
+            start=1,
+        )
+    )
+
+
+def default_public_trust_diagnostics() -> tuple[PublicTrustDiagnosticRecord, ...]:
+    return tuple(
+        PublicTrustDiagnosticRecord(
+            diagnostic_id=f"public_trust_diagnostic_{diagnostic_type}",
+            diagnostic_type=diagnostic_type,
+            evidence_reference_ids=(f"evidence_{diagnostic_type}",),
+            message=(
+                f"{diagnostic_type} remains explicit, fail-visible, and "
+                "descriptive-only for public trust visibility."
+            ),
+            visibility_state="fail_visible_public_trust_diagnostic_visible",
+            deterministic_order=order,
+        )
+        for order, diagnostic_type in enumerate(PUBLIC_TRUST_DIAGNOSTIC_TYPES, start=1)
+    )
+
+
+def default_unsupported_public_trust_visibility() -> tuple[
+    UnsupportedPublicTrustVisibility, ...
+]:
+    return tuple(
+        UnsupportedPublicTrustVisibility(
+            state_id=f"unsupported_public_trust_state_{unsupported_state}",
+            unsupported_state=unsupported_state,
+            explicit_reason=(
+                f"{unsupported_state} remains unsupported for v4.5B.1 public "
+                "trust visibility foundations."
+            ),
+            evidence_reference_ids=("evidence_unsupported_public_trust_states",),
+            visibility_state="unsupported_public_trust_state_fail_visible",
+            deterministic_order=order,
+        )
+        for order, unsupported_state in enumerate(
+            UNSUPPORTED_PUBLIC_TRUST_OPERATIONAL_STATES,
+            start=1,
+        )
+    )
+
+
+def default_v4_5b_1_trust_visibility_foundation() -> (
+    TrustVisibilityFoundationIntelligence
+):
+    return TrustVisibilityFoundationIntelligence(
+        trust_identity=default_trust_visibility_identity(),
+        trust_visibility_records=default_trust_visibility_records(),
+        evidence_visibility=default_evidence_visibility(),
+        unsupported_state_visibility=default_unsupported_state_visibility(),
+        governance_transparency_visibility=(
+            default_governance_transparency_visibility()
+        ),
+        trust_summaries=default_trust_summaries(),
+        explainability_visibility=default_explainability_visibility(),
+        integrity_visibility=default_integrity_visibility(),
+        public_trust_diagnostics=default_public_trust_diagnostics(),
+        unsupported_public_trust_visibility=(
+            default_unsupported_public_trust_visibility()
+        ),
+        deterministic_guarantees=(
+            V4_5B_1_TRUST_VISIBILITY_FOUNDATION_DETERMINISTIC_GUARANTEES
+        ),
+        inherited_prohibitions=(
+            V4_5B_1_TRUST_VISIBILITY_FOUNDATION_INHERITED_PROHIBITIONS
+        ),
+        inherited_constraints=(
+            V4_5B_1_TRUST_VISIBILITY_FOUNDATION_INHERITED_CONSTRAINTS
+        ),
+        explicit_limitations=(
+            V4_5B_1_TRUST_VISIBILITY_FOUNDATION_EXPLICIT_LIMITATIONS
+        ),
+    )

--- a/backend/app/public_trust_visibility/v4_5b_1_trust_visibility_foundation_serialization.py
+++ b/backend/app/public_trust_visibility/v4_5b_1_trust_visibility_foundation_serialization.py
@@ -1,0 +1,217 @@
+"""Deterministic serialization for v4.5B.1 trust visibility foundations."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, is_dataclass
+from typing import Any, Mapping
+
+from .v4_5b_1_trust_visibility_foundation_models import (
+    GovernanceTransparencyVisibility,
+    PublicExplainabilityVisibility,
+    PublicIntegrityVisibility,
+    PublicTrustDiagnosticRecord,
+    PublicTrustEvidenceVisibility,
+    TrustSummaryRecord,
+    TrustVisibilityFoundationIntelligence,
+    TrustVisibilityIdentity,
+    TrustVisibilityRecord,
+    UnsupportedPublicTrustVisibility,
+    UnsupportedStateVisibility,
+)
+
+
+def _sorted_tuple(values: tuple[str, ...] | list[str]) -> list[str]:
+    return sorted(tuple(values or ()))
+
+
+def canonicalize_v4_5b_1_trust_visibility_foundation_evidence(
+    payload: Any,
+) -> Any:
+    if is_dataclass(payload) and not isinstance(payload, type):
+        return canonicalize_v4_5b_1_trust_visibility_foundation_evidence(
+            asdict(payload)
+        )
+    if isinstance(payload, Mapping):
+        return {
+            str(key): canonicalize_v4_5b_1_trust_visibility_foundation_evidence(value)
+            for key, value in sorted(payload.items(), key=lambda item: str(item[0]))
+        }
+    if isinstance(payload, tuple | list):
+        return [
+            canonicalize_v4_5b_1_trust_visibility_foundation_evidence(value)
+            for value in payload
+        ]
+    return payload
+
+
+def stable_serialize_v4_5b_1_trust_visibility_foundation(payload: Any) -> str:
+    return json.dumps(
+        canonicalize_v4_5b_1_trust_visibility_foundation_evidence(payload),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        default=str,
+    )
+
+
+def _export_with_sorted_evidence(record: object) -> dict[str, Any]:
+    data = asdict(record)
+    if "evidence_reference_ids" in data:
+        data["evidence_reference_ids"] = _sorted_tuple(data["evidence_reference_ids"])
+    return data
+
+
+def export_trust_visibility_identity(
+    identity: TrustVisibilityIdentity,
+) -> dict[str, Any]:
+    return asdict(identity)
+
+
+def export_trust_visibility_record(
+    record: TrustVisibilityRecord,
+) -> dict[str, Any]:
+    return asdict(record)
+
+
+def export_public_trust_evidence_visibility(
+    record: PublicTrustEvidenceVisibility,
+) -> dict[str, Any]:
+    return _export_with_sorted_evidence(record)
+
+
+def export_unsupported_state_visibility(
+    record: UnsupportedStateVisibility,
+) -> dict[str, Any]:
+    return _export_with_sorted_evidence(record)
+
+
+def export_governance_transparency_visibility(
+    record: GovernanceTransparencyVisibility,
+) -> dict[str, Any]:
+    return _export_with_sorted_evidence(record)
+
+
+def export_trust_summary_record(record: TrustSummaryRecord) -> dict[str, Any]:
+    return _export_with_sorted_evidence(record)
+
+
+def export_public_explainability_visibility(
+    record: PublicExplainabilityVisibility,
+) -> dict[str, Any]:
+    return _export_with_sorted_evidence(record)
+
+
+def export_public_integrity_visibility(
+    record: PublicIntegrityVisibility,
+) -> dict[str, Any]:
+    return _export_with_sorted_evidence(record)
+
+
+def export_public_trust_diagnostic_record(
+    record: PublicTrustDiagnosticRecord,
+) -> dict[str, Any]:
+    return _export_with_sorted_evidence(record)
+
+
+def export_unsupported_public_trust_visibility(
+    record: UnsupportedPublicTrustVisibility,
+) -> dict[str, Any]:
+    return _export_with_sorted_evidence(record)
+
+
+def export_v4_5b_1_trust_visibility_foundation(
+    intelligence: TrustVisibilityFoundationIntelligence,
+) -> dict[str, Any]:
+    data = asdict(intelligence)
+    data["trust_identity"] = export_trust_visibility_identity(
+        intelligence.trust_identity
+    )
+    data["trust_visibility_records"] = [
+        export_trust_visibility_record(record)
+        for record in sorted(
+            intelligence.trust_visibility_records,
+            key=lambda item: (item.deterministic_order, item.trust_record_id),
+        )
+    ]
+    data["evidence_visibility"] = [
+        export_public_trust_evidence_visibility(record)
+        for record in sorted(
+            intelligence.evidence_visibility,
+            key=lambda item: (item.deterministic_order, item.evidence_visibility_id),
+        )
+    ]
+    data["unsupported_state_visibility"] = [
+        export_unsupported_state_visibility(record)
+        for record in sorted(
+            intelligence.unsupported_state_visibility,
+            key=lambda item: (item.deterministic_order, item.unsupported_visibility_id),
+        )
+    ]
+    data["governance_transparency_visibility"] = [
+        export_governance_transparency_visibility(record)
+        for record in sorted(
+            intelligence.governance_transparency_visibility,
+            key=lambda item: (
+                item.deterministic_order,
+                item.transparency_visibility_id,
+            ),
+        )
+    ]
+    data["trust_summaries"] = [
+        export_trust_summary_record(record)
+        for record in sorted(
+            intelligence.trust_summaries,
+            key=lambda item: (item.deterministic_order, item.trust_summary_record_id),
+        )
+    ]
+    data["explainability_visibility"] = [
+        export_public_explainability_visibility(record)
+        for record in sorted(
+            intelligence.explainability_visibility,
+            key=lambda item: (
+                item.deterministic_order,
+                item.explainability_visibility_id,
+            ),
+        )
+    ]
+    data["integrity_visibility"] = [
+        export_public_integrity_visibility(record)
+        for record in sorted(
+            intelligence.integrity_visibility,
+            key=lambda item: (item.deterministic_order, item.integrity_visibility_id),
+        )
+    ]
+    data["public_trust_diagnostics"] = [
+        export_public_trust_diagnostic_record(record)
+        for record in sorted(
+            intelligence.public_trust_diagnostics,
+            key=lambda item: (item.deterministic_order, item.diagnostic_id),
+        )
+    ]
+    data["unsupported_public_trust_visibility"] = [
+        export_unsupported_public_trust_visibility(record)
+        for record in sorted(
+            intelligence.unsupported_public_trust_visibility,
+            key=lambda item: (item.deterministic_order, item.state_id),
+        )
+    ]
+    data["deterministic_guarantees"] = _sorted_tuple(data["deterministic_guarantees"])
+    data["inherited_prohibitions"] = _sorted_tuple(data["inherited_prohibitions"])
+    data["inherited_constraints"] = _sorted_tuple(data["inherited_constraints"])
+    data["explicit_limitations"] = _sorted_tuple(data["explicit_limitations"])
+    return data
+
+
+def serialize_trust_visibility_identity(identity: TrustVisibilityIdentity) -> str:
+    return stable_serialize_v4_5b_1_trust_visibility_foundation(
+        export_trust_visibility_identity(identity)
+    )
+
+
+def serialize_v4_5b_1_trust_visibility_foundation(
+    intelligence: TrustVisibilityFoundationIntelligence,
+) -> str:
+    return stable_serialize_v4_5b_1_trust_visibility_foundation(
+        export_v4_5b_1_trust_visibility_foundation(intelligence)
+    )

--- a/backend/app/public_trust_visibility/v4_5b_1_trust_visibility_foundation_visibility.py
+++ b/backend/app/public_trust_visibility/v4_5b_1_trust_visibility_foundation_visibility.py
@@ -1,0 +1,439 @@
+"""Visibility helpers for v4.5B.1 trust visibility foundations."""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any, Iterable
+
+from .v4_5b_1_trust_visibility_foundation_models import (
+    GOVERNANCE_TRANSPARENCY_VISIBILITY_TYPES,
+    PUBLIC_EXPLAINABILITY_VISIBILITY_TYPES,
+    PUBLIC_INTEGRITY_VISIBILITY_TYPES,
+    PUBLIC_TRUST_DIAGNOSTIC_TYPES,
+    PUBLIC_TRUST_EVIDENCE_VISIBILITY_TYPES,
+    TRUST_SUMMARY_TYPES,
+    UNSUPPORTED_PUBLIC_TRUST_OPERATIONAL_STATES,
+    UNSUPPORTED_STATE_VISIBILITY_TYPES,
+    GovernanceTransparencyVisibility,
+    PublicExplainabilityVisibility,
+    PublicIntegrityVisibility,
+    PublicTrustDiagnosticRecord,
+    PublicTrustEvidenceVisibility,
+    TrustSummaryRecord,
+    TrustVisibilityFoundationIntelligence,
+    TrustVisibilityRecord,
+    UnsupportedPublicTrustVisibility,
+    UnsupportedStateVisibility,
+)
+
+
+def _ordered_ids(values: Iterable[str]) -> list[str]:
+    return sorted(tuple(values or ()))
+
+
+def count_evidence_visibility_types(
+    records: Iterable[PublicTrustEvidenceVisibility],
+) -> dict[str, int]:
+    counts = Counter(record.evidence_visibility_type for record in records)
+    return {
+        item: int(counts.get(item, 0))
+        for item in PUBLIC_TRUST_EVIDENCE_VISIBILITY_TYPES
+    }
+
+
+def count_unsupported_state_visibility_types(
+    records: Iterable[UnsupportedStateVisibility],
+) -> dict[str, int]:
+    counts = Counter(record.unsupported_state_type for record in records)
+    return {item: int(counts.get(item, 0)) for item in UNSUPPORTED_STATE_VISIBILITY_TYPES}
+
+
+def count_governance_transparency_visibility_types(
+    records: Iterable[GovernanceTransparencyVisibility],
+) -> dict[str, int]:
+    counts = Counter(record.transparency_type for record in records)
+    return {
+        item: int(counts.get(item, 0))
+        for item in GOVERNANCE_TRANSPARENCY_VISIBILITY_TYPES
+    }
+
+
+def count_trust_summary_types(
+    records: Iterable[TrustSummaryRecord],
+) -> dict[str, int]:
+    counts = Counter(record.summary_type for record in records)
+    return {item: int(counts.get(item, 0)) for item in TRUST_SUMMARY_TYPES}
+
+
+def count_explainability_visibility_types(
+    records: Iterable[PublicExplainabilityVisibility],
+) -> dict[str, int]:
+    counts = Counter(record.explainability_visibility_type for record in records)
+    return {
+        item: int(counts.get(item, 0))
+        for item in PUBLIC_EXPLAINABILITY_VISIBILITY_TYPES
+    }
+
+
+def count_integrity_visibility_types(
+    records: Iterable[PublicIntegrityVisibility],
+) -> dict[str, int]:
+    counts = Counter(record.integrity_visibility_type for record in records)
+    return {item: int(counts.get(item, 0)) for item in PUBLIC_INTEGRITY_VISIBILITY_TYPES}
+
+
+def count_public_trust_diagnostic_types(
+    records: Iterable[PublicTrustDiagnosticRecord],
+) -> dict[str, int]:
+    counts = Counter(record.diagnostic_type for record in records)
+    return {item: int(counts.get(item, 0)) for item in PUBLIC_TRUST_DIAGNOSTIC_TYPES}
+
+
+def count_unsupported_public_trust_states(
+    records: Iterable[UnsupportedPublicTrustVisibility],
+) -> dict[str, int]:
+    counts = Counter(record.unsupported_state for record in records)
+    return {
+        item: int(counts.get(item, 0))
+        for item in UNSUPPORTED_PUBLIC_TRUST_OPERATIONAL_STATES
+    }
+
+
+def trust_visibility_summary(
+    records: Iterable[TrustVisibilityRecord],
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "trust_record_id": record.trust_record_id,
+            "trust_visibility_id": record.trust_visibility_id,
+            "trust_summary_id": record.trust_summary_id,
+            "transparency_reference_id": record.transparency_reference_id,
+            "evidence_reference_id": record.evidence_reference_id,
+            "continuity_reference_id": record.continuity_reference_id,
+            "explainability_reference_id": record.explainability_reference_id,
+            "integrity_reference_id": record.integrity_reference_id,
+            "diagnostics_reference_id": record.diagnostics_reference_id,
+            "unsupported_state_reference_id": record.unsupported_state_reference_id,
+            "lineage_reference_id": record.lineage_reference_id,
+            "provenance_reference_id": record.provenance_reference_id,
+            "descriptive_only": record.descriptive_only,
+            "publicly_transparent": record.publicly_transparent,
+            "fail_visible": record.fail_visible,
+            "trust_authority_enabled": record.trust_authority_enabled,
+            "authorization_enabled": record.authorization_enabled,
+            "approval_enabled": record.approval_enabled,
+            "ranking_enabled": record.ranking_enabled,
+            "recommendation_enabled": record.recommendation_enabled,
+        }
+        for record in sorted(
+            records,
+            key=lambda item: (item.deterministic_order, item.trust_record_id),
+        )
+    ]
+
+
+def evidence_visibility_summary(
+    records: Iterable[PublicTrustEvidenceVisibility],
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "evidence_visibility_id": record.evidence_visibility_id,
+            "evidence_visibility_type": record.evidence_visibility_type,
+            "evidence_reference_ids": _ordered_ids(record.evidence_reference_ids),
+            "visibility_preserved": record.visibility_preserved,
+            "descriptive_only": record.descriptive_only,
+            "replay_safe": record.replay_safe,
+            "provenance_safe": record.provenance_safe,
+            "authorization_enabled": record.authorization_enabled,
+            "approval_enabled": record.approval_enabled,
+            "scoring_enabled": record.scoring_enabled,
+        }
+        for record in sorted(
+            records,
+            key=lambda item: (item.deterministic_order, item.evidence_visibility_id),
+        )
+    ]
+
+
+def unsupported_state_summary(
+    records: Iterable[UnsupportedStateVisibility],
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "unsupported_visibility_id": record.unsupported_visibility_id,
+            "unsupported_state_type": record.unsupported_state_type,
+            "evidence_reference_ids": _ordered_ids(record.evidence_reference_ids),
+            "visibility_preserved": record.visibility_preserved,
+            "descriptive_only": record.descriptive_only,
+            "fail_visible": record.fail_visible,
+            "suppression_enabled": record.suppression_enabled,
+            "hidden_fallback_enabled": record.hidden_fallback_enabled,
+            "authorization_enabled": record.authorization_enabled,
+            "approval_enabled": record.approval_enabled,
+            "remediation_enabled": record.remediation_enabled,
+        }
+        for record in sorted(
+            records,
+            key=lambda item: (item.deterministic_order, item.unsupported_visibility_id),
+        )
+    ]
+
+
+def governance_transparency_summary(
+    records: Iterable[GovernanceTransparencyVisibility],
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "transparency_visibility_id": record.transparency_visibility_id,
+            "transparency_type": record.transparency_type,
+            "evidence_reference_ids": _ordered_ids(record.evidence_reference_ids),
+            "visibility_preserved": record.visibility_preserved,
+            "descriptive_only": record.descriptive_only,
+            "public_visibility": record.public_visibility,
+            "operational_approval_enabled": record.operational_approval_enabled,
+            "authorization_enabled": record.authorization_enabled,
+            "approval_enabled": record.approval_enabled,
+        }
+        for record in sorted(
+            records,
+            key=lambda item: (
+                item.deterministic_order,
+                item.transparency_visibility_id,
+            ),
+        )
+    ]
+
+
+def trust_summary_visibility(
+    records: Iterable[TrustSummaryRecord],
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "trust_summary_record_id": record.trust_summary_record_id,
+            "trust_summary_id": record.trust_summary_id,
+            "summary_type": record.summary_type,
+            "evidence_reference_ids": _ordered_ids(record.evidence_reference_ids),
+            "summary_state": record.summary_state,
+            "descriptive_only": record.descriptive_only,
+            "authorization_enabled": record.authorization_enabled,
+            "approval_enabled": record.approval_enabled,
+            "ranking_enabled": record.ranking_enabled,
+            "recommendation_enabled": record.recommendation_enabled,
+            "execution_enablement_enabled": record.execution_enablement_enabled,
+            "production_enablement_enabled": record.production_enablement_enabled,
+        }
+        for record in sorted(
+            records,
+            key=lambda item: (item.deterministic_order, item.trust_summary_record_id),
+        )
+    ]
+
+
+def explainability_summary(
+    records: Iterable[PublicExplainabilityVisibility],
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "explainability_visibility_id": record.explainability_visibility_id,
+            "explainability_visibility_type": record.explainability_visibility_type,
+            "evidence_reference_ids": _ordered_ids(record.evidence_reference_ids),
+            "visibility_preserved": record.visibility_preserved,
+            "descriptive_only": record.descriptive_only,
+            "recommendation_enabled": record.recommendation_enabled,
+            "decision_enabled": record.decision_enabled,
+            "authorization_enabled": record.authorization_enabled,
+        }
+        for record in sorted(
+            records,
+            key=lambda item: (
+                item.deterministic_order,
+                item.explainability_visibility_id,
+            ),
+        )
+    ]
+
+
+def integrity_summary(
+    records: Iterable[PublicIntegrityVisibility],
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "integrity_visibility_id": record.integrity_visibility_id,
+            "integrity_visibility_type": record.integrity_visibility_type,
+            "evidence_reference_ids": _ordered_ids(record.evidence_reference_ids),
+            "visibility_preserved": record.visibility_preserved,
+            "descriptive_only": record.descriptive_only,
+            "operational_semantics_enabled": record.operational_semantics_enabled,
+            "approval_enabled": record.approval_enabled,
+            "authorization_enabled": record.authorization_enabled,
+        }
+        for record in sorted(
+            records,
+            key=lambda item: (item.deterministic_order, item.integrity_visibility_id),
+        )
+    ]
+
+
+def diagnostics_summary(
+    records: Iterable[PublicTrustDiagnosticRecord],
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "diagnostic_id": record.diagnostic_id,
+            "diagnostic_type": record.diagnostic_type,
+            "evidence_reference_ids": _ordered_ids(record.evidence_reference_ids),
+            "message": record.message,
+            "fail_visible": record.fail_visible,
+            "descriptive_only": record.descriptive_only,
+            "silent_fallback_enabled": record.silent_fallback_enabled,
+            "hidden_fallback_enabled": record.hidden_fallback_enabled,
+            "authorization_enabled": record.authorization_enabled,
+            "approval_enabled": record.approval_enabled,
+            "remediation_enabled": record.remediation_enabled,
+            "repair_enabled": record.repair_enabled,
+            "mitigation_enabled": record.mitigation_enabled,
+            "auto_correction_enabled": record.auto_correction_enabled,
+            "ranking_enabled": record.ranking_enabled,
+            "recommendation_enabled": record.recommendation_enabled,
+            "orchestration_response_enabled": record.orchestration_response_enabled,
+        }
+        for record in sorted(
+            records,
+            key=lambda item: (item.deterministic_order, item.diagnostic_id),
+        )
+    ]
+
+
+def unsupported_public_trust_summary(
+    records: Iterable[UnsupportedPublicTrustVisibility],
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "state_id": record.state_id,
+            "unsupported_state": record.unsupported_state,
+            "explicit_reason": record.explicit_reason,
+            "evidence_reference_ids": _ordered_ids(record.evidence_reference_ids),
+            "fail_visible": record.fail_visible,
+            "descriptive_only": record.descriptive_only,
+            "authorization_enabled": record.authorization_enabled,
+            "approval_enabled": record.approval_enabled,
+            "operational_enabled": record.operational_enabled,
+            "remediation_enabled": record.remediation_enabled,
+            "repair_enabled": record.repair_enabled,
+            "mitigation_enabled": record.mitigation_enabled,
+            "automated_correction_enabled": record.automated_correction_enabled,
+            "ranking_enabled": record.ranking_enabled,
+            "recommendation_enabled": record.recommendation_enabled,
+            "suppression_enabled": record.suppression_enabled,
+        }
+        for record in sorted(
+            records,
+            key=lambda item: (item.deterministic_order, item.state_id),
+        )
+    ]
+
+
+def validate_required_trust_visibility_foundation(
+    intelligence: TrustVisibilityFoundationIntelligence,
+) -> dict[str, Any]:
+    evidence_counts = count_evidence_visibility_types(intelligence.evidence_visibility)
+    unsupported_counts = count_unsupported_state_visibility_types(
+        intelligence.unsupported_state_visibility
+    )
+    transparency_counts = count_governance_transparency_visibility_types(
+        intelligence.governance_transparency_visibility
+    )
+    summary_counts = count_trust_summary_types(intelligence.trust_summaries)
+    explainability_counts = count_explainability_visibility_types(
+        intelligence.explainability_visibility
+    )
+    integrity_counts = count_integrity_visibility_types(intelligence.integrity_visibility)
+    diagnostic_counts = count_public_trust_diagnostic_types(
+        intelligence.public_trust_diagnostics
+    )
+    unsupported_operational_counts = count_unsupported_public_trust_states(
+        intelligence.unsupported_public_trust_visibility
+    )
+    missing_evidence_types = sorted(
+        key for key, value in evidence_counts.items() if value < 1
+    )
+    missing_unsupported_types = sorted(
+        key for key, value in unsupported_counts.items() if value < 1
+    )
+    missing_transparency_types = sorted(
+        key for key, value in transparency_counts.items() if value < 1
+    )
+    missing_summary_types = sorted(
+        key for key, value in summary_counts.items() if value < 1
+    )
+    missing_explainability_types = sorted(
+        key for key, value in explainability_counts.items() if value < 1
+    )
+    missing_integrity_types = sorted(
+        key for key, value in integrity_counts.items() if value < 1
+    )
+    missing_diagnostic_types = sorted(
+        key for key, value in diagnostic_counts.items() if value < 1
+    )
+    missing_unsupported_states = sorted(
+        key for key, value in unsupported_operational_counts.items() if value < 1
+    )
+    return {
+        "valid": not (
+            missing_evidence_types
+            or missing_unsupported_types
+            or missing_transparency_types
+            or missing_summary_types
+            or missing_explainability_types
+            or missing_integrity_types
+            or missing_diagnostic_types
+            or missing_unsupported_states
+        ),
+        "evidence_counts": evidence_counts,
+        "unsupported_counts": unsupported_counts,
+        "transparency_counts": transparency_counts,
+        "summary_counts": summary_counts,
+        "explainability_counts": explainability_counts,
+        "integrity_counts": integrity_counts,
+        "diagnostic_counts": diagnostic_counts,
+        "unsupported_operational_counts": unsupported_operational_counts,
+        "missing_evidence_types": missing_evidence_types,
+        "missing_unsupported_types": missing_unsupported_types,
+        "missing_transparency_types": missing_transparency_types,
+        "missing_summary_types": missing_summary_types,
+        "missing_explainability_types": missing_explainability_types,
+        "missing_integrity_types": missing_integrity_types,
+        "missing_diagnostic_types": missing_diagnostic_types,
+        "missing_unsupported_states": missing_unsupported_states,
+    }
+
+
+def descriptive_only_public_trust_summary(
+    intelligence: TrustVisibilityFoundationIntelligence,
+) -> dict[str, Any]:
+    return {
+        "descriptive_only": intelligence.descriptive_only,
+        "publicly_transparent": intelligence.publicly_transparent,
+        "public_trust_visibility_statement": (
+            intelligence.public_trust_visibility_statement
+        ),
+        "trust_visibility_non_authority_statement": (
+            intelligence.trust_visibility_non_authority_statement
+        ),
+        "non_operational": intelligence.non_operational,
+        "non_authorizing": intelligence.non_authorizing,
+        "non_approving": intelligence.non_approving,
+        "non_executing": intelligence.non_executing,
+        "non_remediating": intelligence.non_remediating,
+        "non_runtime_mutating": intelligence.non_runtime_mutating,
+        "non_ranking": intelligence.non_ranking,
+        "non_recommending": intelligence.non_recommending,
+        "trust_authorization_enabled": intelligence.trust_authorization_enabled,
+        "trust_approval_enabled": intelligence.trust_approval_enabled,
+        "trust_ranking_enabled": intelligence.trust_ranking_enabled,
+        "trust_recommendation_enabled": intelligence.trust_recommendation_enabled,
+        "planner_integration_enabled": intelligence.planner_integration_enabled,
+        "production_consumption_enabled": intelligence.production_consumption_enabled,
+        "runtime_mutation_enabled": intelligence.runtime_mutation_enabled,
+        "operational_mutation_enabled": intelligence.operational_mutation_enabled,
+    }

--- a/backend/scripts/report_v4_5b_1_trust_visibility_foundations.py
+++ b/backend/scripts/report_v4_5b_1_trust_visibility_foundations.py
@@ -1,0 +1,122 @@
+"""Generate deterministic v4.5B.1 public trust visibility foundation report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+APP_ROOT = BACKEND_ROOT / "app"
+if str(APP_ROOT) not in sys.path:
+    sys.path.insert(0, str(APP_ROOT))
+
+from public_trust_visibility.v4_5b_1_trust_visibility_foundation_audit import (  # noqa: E402
+    build_v4_5b_1_trust_visibility_foundation_report,
+)
+
+
+REPORT_PATH = Path("docs/generated/v4_5b_1_trust_visibility_foundations_report.json")
+
+
+def write_report(report: dict[str, object], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        default=str(REPORT_PATH),
+        help="v4.5B.1 public trust visibility JSON report output path",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    output_path = Path(args.output)
+    report = build_v4_5b_1_trust_visibility_foundation_report()
+    write_report(report, output_path)
+    summary = report["summary"]
+    print(f"wrote {output_path}")
+    print(f"foundation_status={report['foundation_status']}")
+    print(f"trust_visibility_record_count={summary['trust_visibility_record_count']}")
+    print(f"evidence_visibility_count={summary['evidence_visibility_count']}")
+    print(
+        "unsupported_state_visibility_count="
+        f"{summary['unsupported_state_visibility_count']}"
+    )
+    print(
+        "governance_transparency_visibility_count="
+        f"{summary['governance_transparency_visibility_count']}"
+    )
+    print(f"trust_summary_count={summary['trust_summary_count']}")
+    print(f"explainability_visibility_count={summary['explainability_visibility_count']}")
+    print(f"integrity_visibility_count={summary['integrity_visibility_count']}")
+    print(f"public_trust_diagnostic_count={summary['public_trust_diagnostic_count']}")
+    print(
+        "unsupported_public_trust_state_count="
+        f"{summary['unsupported_public_trust_state_count']}"
+    )
+    print(
+        "deterministic_serialization_verified="
+        f"{summary['deterministic_serialization_verified']}"
+    )
+    print(f"deterministic_hashing_verified={summary['deterministic_hashing_verified']}")
+    print(f"evidence_visibility_stable={summary['evidence_visibility_stable']}")
+    print(
+        "unsupported_state_visibility_preserved="
+        f"{summary['unsupported_state_visibility_preserved']}"
+    )
+    print(
+        "governance_transparency_visibility_preserved="
+        f"{summary['governance_transparency_visibility_preserved']}"
+    )
+    print(f"trust_summary_stable={summary['trust_summary_stable']}")
+    print(f"explainability_visibility_stable={summary['explainability_visibility_stable']}")
+    print(f"integrity_visibility_stable={summary['integrity_visibility_stable']}")
+    print(f"lineage_continuity_preserved={summary['lineage_continuity_preserved']}")
+    print(
+        "provenance_continuity_preserved="
+        f"{summary['provenance_continuity_preserved']}"
+    )
+    print(f"evidence_continuity_preserved={summary['evidence_continuity_preserved']}")
+    print(
+        "fail_visible_public_trust_diagnostics_verified="
+        f"{summary['fail_visible_public_trust_diagnostics_verified']}"
+    )
+    print(
+        "descriptive_only_guarantees_verified="
+        f"{summary['descriptive_only_guarantees_verified']}"
+    )
+    print(f"publicly_transparent={summary['publicly_transparent']}")
+    print(
+        "public_trust_visibility_statement="
+        f"{summary['public_trust_visibility_statement']}"
+    )
+    print(
+        "trust_visibility_non_authority_statement="
+        f"{summary['trust_visibility_non_authority_statement']}"
+    )
+    print(f"inherited_prohibition_count={summary['inherited_prohibition_count']}")
+    print(f"inherited_constraint_count={summary['inherited_constraint_count']}")
+    print(f"explicit_limitation_count={summary['explicit_limitation_count']}")
+    print(f"validation_error_count={summary['validation_error_count']}")
+    for key in sorted(k for k in summary if k.startswith("enabled_")):
+        print(f"{key}={summary[key]}")
+    print(f"repository_remains={','.join(summary['repository_remains'])}")
+    print(f"deterministic_report_hash={report['deterministic_report_hash']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_v4_5b_1_trust_visibility_foundations.py
+++ b/backend/tests/test_v4_5b_1_trust_visibility_foundations.py
@@ -1,0 +1,341 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError, replace
+from pathlib import Path
+import sys
+
+import pytest
+
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+APP_ROOT = BACKEND_ROOT / "app"
+if str(APP_ROOT) not in sys.path:
+    sys.path.insert(0, str(APP_ROOT))
+
+from public_trust_visibility.v4_5b_1_trust_visibility_foundation_audit import (  # noqa: E402
+    build_v4_5b_1_trust_visibility_foundation,
+    build_v4_5b_1_trust_visibility_foundation_report,
+    contaminate_v4_5b_1_trust_visibility_foundation_for_non_operational_validation,
+    enabled_trust_visibility_capability_flags,
+    trust_visibility_capability_counter_values,
+    trust_visibility_foundation_equal,
+    validate_descriptive_only_public_trust_guarantees,
+    validate_fail_visible_public_trust_diagnostics,
+    validate_governance_transparency_visibility_preservation,
+    validate_lineage_and_provenance_preservation,
+    validate_public_explainability_visibility,
+    validate_public_integrity_visibility,
+    validate_public_trust_evidence_visibility,
+    validate_trust_summary_stability,
+    validate_trust_visibility_identity_integrity,
+    validate_trust_visibility_ordering_stability,
+    validate_trust_visibility_serialization_and_hashing,
+    validate_unsupported_state_visibility_preservation,
+    validate_v4_5b_1_trust_visibility_foundation,
+)
+from public_trust_visibility.v4_5b_1_trust_visibility_foundation_hashing import (  # noqa: E402
+    hash_governance_transparency_visibility,
+    hash_public_trust_diagnostic_record,
+    hash_public_trust_evidence_visibility,
+    hash_trust_summary_record,
+    hash_trust_visibility_identity,
+    hash_trust_visibility_record,
+    hash_v4_5b_1_trust_visibility_foundation,
+)
+from public_trust_visibility.v4_5b_1_trust_visibility_foundation_models import (  # noqa: E402
+    GOVERNANCE_TRANSPARENCY_VISIBILITY_TYPES,
+    PUBLIC_EXPLAINABILITY_VISIBILITY_TYPES,
+    PUBLIC_INTEGRITY_VISIBILITY_TYPES,
+    PUBLIC_TRUST_DIAGNOSTIC_TYPES,
+    PUBLIC_TRUST_EVIDENCE_VISIBILITY_TYPES,
+    PUBLIC_TRUST_VISIBILITY_NON_AUTHORITY_STATEMENT,
+    PUBLIC_TRUST_VISIBILITY_STATEMENT,
+    TRUST_SUMMARY_TYPES,
+    UNSUPPORTED_PUBLIC_TRUST_OPERATIONAL_STATES,
+    UNSUPPORTED_STATE_VISIBILITY_TYPES,
+    V4_5B_1_TRUST_VISIBILITY_FOUNDATION_SCHEMA_VERSION,
+    V4_5B_1_TRUST_VISIBILITY_FOUNDATION_STATUS_STABLE,
+)
+from public_trust_visibility.v4_5b_1_trust_visibility_foundation_serialization import (  # noqa: E402
+    serialize_v4_5b_1_trust_visibility_foundation,
+)
+from public_trust_visibility.v4_5b_1_trust_visibility_foundation_visibility import (  # noqa: E402
+    descriptive_only_public_trust_summary,
+    diagnostics_summary,
+    evidence_visibility_summary,
+    explainability_summary,
+    governance_transparency_summary,
+    integrity_summary,
+    trust_summary_visibility,
+    trust_visibility_summary,
+    unsupported_public_trust_summary,
+    unsupported_state_summary,
+    validate_required_trust_visibility_foundation,
+)
+
+
+def test_v4_5b_1_models_are_immutable_and_descriptive_only():
+    intelligence = build_v4_5b_1_trust_visibility_foundation()
+
+    with pytest.raises(FrozenInstanceError):
+        intelligence.trust_authorization_enabled = True
+
+    assert (
+        intelligence.trust_identity.schema_version
+        == V4_5B_1_TRUST_VISIBILITY_FOUNDATION_SCHEMA_VERSION
+    )
+    assert intelligence.descriptive_only is True
+    assert intelligence.publicly_transparent is True
+    assert intelligence.non_operational is True
+    assert intelligence.non_executing is True
+    assert intelligence.non_authorizing is True
+    assert intelligence.non_approving is True
+    assert intelligence.non_remediating is True
+    assert intelligence.non_runtime_mutating is True
+    assert intelligence.non_ranking is True
+    assert intelligence.non_recommending is True
+    assert intelligence.trust_authorization_enabled is False
+    assert intelligence.trust_approval_enabled is False
+    assert intelligence.trust_ranking_enabled is False
+    assert intelligence.trust_recommendation_enabled is False
+    assert intelligence.production_consumption_enabled is False
+    assert enabled_trust_visibility_capability_flags(intelligence) == {}
+    assert all(
+        value == 0
+        for value in trust_visibility_capability_counter_values(intelligence).values()
+    )
+
+
+def test_v4_5b_1_required_visibility_sets_are_complete():
+    intelligence = build_v4_5b_1_trust_visibility_foundation()
+    visibility = validate_required_trust_visibility_foundation(intelligence)
+
+    assert visibility["valid"] is True
+    assert set(visibility["evidence_counts"]) == set(
+        PUBLIC_TRUST_EVIDENCE_VISIBILITY_TYPES
+    )
+    assert set(visibility["unsupported_counts"]) == set(
+        UNSUPPORTED_STATE_VISIBILITY_TYPES
+    )
+    assert set(visibility["transparency_counts"]) == set(
+        GOVERNANCE_TRANSPARENCY_VISIBILITY_TYPES
+    )
+    assert set(visibility["summary_counts"]) == set(TRUST_SUMMARY_TYPES)
+    assert set(visibility["explainability_counts"]) == set(
+        PUBLIC_EXPLAINABILITY_VISIBILITY_TYPES
+    )
+    assert set(visibility["integrity_counts"]) == set(
+        PUBLIC_INTEGRITY_VISIBILITY_TYPES
+    )
+    assert set(visibility["diagnostic_counts"]) == set(PUBLIC_TRUST_DIAGNOSTIC_TYPES)
+    assert set(visibility["unsupported_operational_counts"]) == set(
+        UNSUPPORTED_PUBLIC_TRUST_OPERATIONAL_STATES
+    )
+    assert visibility["missing_evidence_types"] == []
+    assert visibility["missing_unsupported_types"] == []
+    assert visibility["missing_transparency_types"] == []
+    assert visibility["missing_summary_types"] == []
+    assert visibility["missing_explainability_types"] == []
+    assert visibility["missing_integrity_types"] == []
+    assert visibility["missing_diagnostic_types"] == []
+    assert visibility["missing_unsupported_states"] == []
+
+
+def test_v4_5b_1_serialization_hashing_and_equality_are_stable():
+    first = build_v4_5b_1_trust_visibility_foundation()
+    second = build_v4_5b_1_trust_visibility_foundation()
+    serialization = validate_trust_visibility_serialization_and_hashing(first)
+
+    assert first == second
+    assert trust_visibility_foundation_equal(first, second)
+    assert serialize_v4_5b_1_trust_visibility_foundation(first) == (
+        serialize_v4_5b_1_trust_visibility_foundation(second)
+    )
+    assert hash_v4_5b_1_trust_visibility_foundation(first) == (
+        hash_v4_5b_1_trust_visibility_foundation(second)
+    )
+    assert serialization["valid"] is True
+    assert len(hash_trust_visibility_identity(first.trust_identity)) == 64
+    assert len(hash_trust_visibility_record(first.trust_visibility_records[0])) == 64
+    assert len(hash_public_trust_evidence_visibility(first.evidence_visibility[0])) == 64
+    assert len(
+        hash_governance_transparency_visibility(
+            first.governance_transparency_visibility[0]
+        )
+    ) == 64
+    assert len(hash_trust_summary_record(first.trust_summaries[0])) == 64
+    assert len(hash_public_trust_diagnostic_record(first.public_trust_diagnostics[0])) == 64
+
+
+def test_v4_5b_1_ordering_survives_reordered_collections():
+    intelligence = build_v4_5b_1_trust_visibility_foundation()
+    reordered = replace(
+        intelligence,
+        trust_visibility_records=tuple(reversed(intelligence.trust_visibility_records)),
+        evidence_visibility=tuple(reversed(intelligence.evidence_visibility)),
+        unsupported_state_visibility=tuple(
+            reversed(intelligence.unsupported_state_visibility)
+        ),
+        governance_transparency_visibility=tuple(
+            reversed(intelligence.governance_transparency_visibility)
+        ),
+        trust_summaries=tuple(reversed(intelligence.trust_summaries)),
+        explainability_visibility=tuple(
+            reversed(intelligence.explainability_visibility)
+        ),
+        integrity_visibility=tuple(reversed(intelligence.integrity_visibility)),
+        public_trust_diagnostics=tuple(
+            reversed(intelligence.public_trust_diagnostics)
+        ),
+        unsupported_public_trust_visibility=tuple(
+            reversed(intelligence.unsupported_public_trust_visibility)
+        ),
+        deterministic_guarantees=tuple(reversed(intelligence.deterministic_guarantees)),
+        inherited_prohibitions=tuple(reversed(intelligence.inherited_prohibitions)),
+        inherited_constraints=tuple(reversed(intelligence.inherited_constraints)),
+        explicit_limitations=tuple(reversed(intelligence.explicit_limitations)),
+    )
+
+    assert validate_trust_visibility_ordering_stability(intelligence)["valid"] is True
+    assert serialize_v4_5b_1_trust_visibility_foundation(
+        intelligence
+    ) == serialize_v4_5b_1_trust_visibility_foundation(reordered)
+    assert hash_v4_5b_1_trust_visibility_foundation(
+        intelligence
+    ) == hash_v4_5b_1_trust_visibility_foundation(reordered)
+
+
+def test_v4_5b_1_trust_visibility_layers_are_stable():
+    intelligence = build_v4_5b_1_trust_visibility_foundation()
+
+    assert validate_trust_visibility_identity_integrity(intelligence)["valid"] is True
+    assert validate_public_trust_evidence_visibility(intelligence)["valid"] is True
+    assert (
+        validate_unsupported_state_visibility_preservation(intelligence)["valid"]
+        is True
+    )
+    assert (
+        validate_governance_transparency_visibility_preservation(intelligence)["valid"]
+        is True
+    )
+    assert validate_trust_summary_stability(intelligence)["valid"] is True
+    assert validate_public_explainability_visibility(intelligence)["valid"] is True
+    assert validate_public_integrity_visibility(intelligence)["valid"] is True
+
+
+def test_v4_5b_1_lineage_provenance_and_fail_visible_diagnostics_are_preserved():
+    intelligence = build_v4_5b_1_trust_visibility_foundation()
+    lineage = validate_lineage_and_provenance_preservation(intelligence)
+    fail_visible = validate_fail_visible_public_trust_diagnostics(intelligence)
+
+    assert lineage["valid"] is True
+    assert lineage["lineage_continuity_preserved"] is True
+    assert lineage["provenance_continuity_preserved"] is True
+    assert lineage["evidence_continuity_preserved"] is True
+    assert fail_visible["valid"] is True
+    assert fail_visible["fail_visible"] is True
+    assert fail_visible["silent_fallback_enabled_count"] == 0
+    assert fail_visible["hidden_fallback_enabled_count"] == 0
+    assert fail_visible["authorization_enabled_count"] == 0
+    assert fail_visible["approval_enabled_count"] == 0
+    assert fail_visible["ranking_enabled_count"] == 0
+    assert fail_visible["recommendation_enabled_count"] == 0
+    assert fail_visible["missing_diagnostic_types"] == []
+    assert fail_visible["missing_unsupported_states"] == []
+
+
+def test_v4_5b_1_visibility_helpers_are_non_operational():
+    intelligence = build_v4_5b_1_trust_visibility_foundation()
+
+    assert len(trust_visibility_summary(intelligence.trust_visibility_records)) == 1
+    assert len(evidence_visibility_summary(intelligence.evidence_visibility)) == len(
+        PUBLIC_TRUST_EVIDENCE_VISIBILITY_TYPES
+    )
+    assert len(
+        unsupported_state_summary(intelligence.unsupported_state_visibility)
+    ) == len(UNSUPPORTED_STATE_VISIBILITY_TYPES)
+    assert len(
+        governance_transparency_summary(intelligence.governance_transparency_visibility)
+    ) == len(GOVERNANCE_TRANSPARENCY_VISIBILITY_TYPES)
+    assert len(trust_summary_visibility(intelligence.trust_summaries)) == len(
+        TRUST_SUMMARY_TYPES
+    )
+    assert len(explainability_summary(intelligence.explainability_visibility)) == len(
+        PUBLIC_EXPLAINABILITY_VISIBILITY_TYPES
+    )
+    assert len(integrity_summary(intelligence.integrity_visibility)) == len(
+        PUBLIC_INTEGRITY_VISIBILITY_TYPES
+    )
+    assert len(diagnostics_summary(intelligence.public_trust_diagnostics)) == len(
+        PUBLIC_TRUST_DIAGNOSTIC_TYPES
+    )
+    assert len(
+        unsupported_public_trust_summary(
+            intelligence.unsupported_public_trust_visibility
+        )
+    ) == len(UNSUPPORTED_PUBLIC_TRUST_OPERATIONAL_STATES)
+    summary = descriptive_only_public_trust_summary(intelligence)
+    assert summary["public_trust_visibility_statement"] == (
+        PUBLIC_TRUST_VISIBILITY_STATEMENT
+    )
+    assert summary["trust_visibility_non_authority_statement"] == (
+        PUBLIC_TRUST_VISIBILITY_NON_AUTHORITY_STATEMENT
+    )
+    assert summary["trust_authorization_enabled"] is False
+    assert summary["trust_approval_enabled"] is False
+    assert summary["trust_ranking_enabled"] is False
+    assert summary["trust_recommendation_enabled"] is False
+
+
+def test_v4_5b_1_contamination_is_fail_visible():
+    contaminated = (
+        contaminate_v4_5b_1_trust_visibility_foundation_for_non_operational_validation()
+    )
+    validation = validate_v4_5b_1_trust_visibility_foundation(contaminated)
+    descriptive = validate_descriptive_only_public_trust_guarantees(contaminated)
+
+    assert validation["valid"] is False
+    assert "descriptive_only_guarantees" in validation["failed_validations"]
+    assert descriptive["valid"] is False
+    assert descriptive["counters"]["enabled_runtime_execution_count"] > 0
+    assert descriptive["counters"]["enabled_trust_authorization_count"] > 0
+    assert descriptive["counters"]["enabled_trust_approval_count"] > 0
+    assert descriptive["counters"]["enabled_trust_ranking_count"] > 0
+    assert descriptive["counters"]["enabled_trust_recommendation_count"] > 0
+    assert descriptive["counters"]["enabled_remediation_count"] > 0
+
+
+def test_v4_5b_1_report_is_replay_safe_and_certifies_public_trust_boundary():
+    first = build_v4_5b_1_trust_visibility_foundation_report()
+    second = build_v4_5b_1_trust_visibility_foundation_report()
+    summary = first["summary"]
+
+    assert first == second
+    assert first["foundation_status"] == V4_5B_1_TRUST_VISIBILITY_FOUNDATION_STATUS_STABLE
+    assert first["deterministic_report_hash"] == second["deterministic_report_hash"]
+    assert len(first["deterministic_report_hash"]) == 64
+    assert summary["validation_error_count"] == 0
+    assert summary["deterministic_serialization_verified"] is True
+    assert summary["deterministic_hashing_verified"] is True
+    assert summary["descriptive_only_guarantees_verified"] is True
+    assert summary["public_trust_visibility_statement"] == (
+        PUBLIC_TRUST_VISIBILITY_STATEMENT
+    )
+    assert summary["trust_visibility_non_authority_statement"] == (
+        PUBLIC_TRUST_VISIBILITY_NON_AUTHORITY_STATEMENT
+    )
+    assert summary["repository_remains"] == [
+        "NON-operational",
+        "NON-authorizing",
+        "NON-approving",
+        "NON-executing",
+        "NON-remediating",
+        "NON-runtime-mutating",
+        "NON-ranking",
+        "NON-recommending",
+    ]
+    assert all(
+        value == 0 for key, value in summary.items() if key.startswith("enabled_")
+    )

--- a/docs/generated/v4_5b_1_trust_visibility_foundations_report.json
+++ b/docs/generated/v4_5b_1_trust_visibility_foundations_report.json
@@ -1,0 +1,3243 @@
+{
+  "deterministic_hash_evidence": {
+    "evidence_visibility_hashes": {
+      "public_trust_evidence_continuity_visibility": "2632a98c1be30e073f81b046a6500078db4f24a923c9e3b54aa5fd570531be2f",
+      "public_trust_evidence_deterministic_evidence_visibility": "da355ff729cd670eda995047eaa5ab73f48f9d3f62508a608f038106da8ea42a",
+      "public_trust_evidence_diagnostics_visibility": "c27e67466800954105fbdc0b9b88f44b15a81a512a5e07f3f04060d2d9a45663",
+      "public_trust_evidence_explainability_visibility": "ef85456f2258e5056e02c9de266293564087da8544209a35d3fa0462b4b2c074",
+      "public_trust_evidence_integrity_visibility": "9ecd51c8e64d93b612d287981d1d35614adc0fcdaee75f33afd22baebf7cc5eb",
+      "public_trust_evidence_lineage_visibility": "24cd7342a5e8448034fb95a3cfb841a37a06b207ebb01dfb137de8b6314c75cd",
+      "public_trust_evidence_provenance_visibility": "78af829a255d25800143cbcb1ffd8fd86b93d45f4ebc7edbb579308494bf1d1e",
+      "public_trust_evidence_replay_safe_evidence_visibility": "ddd4824bb71bf4c641fc4699327860520afcfcf6fd08e0798aaa0a429cad4b7f"
+    },
+    "explainability_visibility_hashes": {
+      "public_explainability_continuity_explanation_visibility": "bb2c12a83406cc411b3c9c9a2739cccde46c4294c111dffed555eb0b7f5cbcba",
+      "public_explainability_evidence_to_explanation_visibility": "73ce69e6bdfdb3585edb9a004eb788bd92efdd864f2b79116aa2e31613d00bb1",
+      "public_explainability_explanation_chain_visibility": "0c1b02705591c6c56d0117654df31ac77385cc9cf2878e6a9d3b68c6c6b1924b",
+      "public_explainability_fail_visible_explanation_diagnostics": "6c85bd7f9b8aebd44086bc621c69c0075ae3ac7a4ea82731d01367cf04e67338",
+      "public_explainability_integrity_explanation_visibility": "1a8cef95945bd695984b5ebe70f22b230c78f0868c3e4461915eaf8b7ecbf352"
+    },
+    "governance_transparency_hashes": {
+      "governance_transparency_continuity_guarantees": "5c091bc0ebf9e81649403b2a755c443d48e70a5f1e708b031ca45ede3f966f9f",
+      "governance_transparency_descriptive_only_guarantees": "59d4b30b25738d1fdbe2feb65e5af505c9f932683a04f7cae8cc3a9f44887b1b",
+      "governance_transparency_deterministic_guarantees": "471254ec89e001c572cb3bbef39a8ef21c9b6371203e77dffaf68e405feb599a",
+      "governance_transparency_explainability_guarantees": "bc1bedf0633062e573043dc4312b087a5c9edd09e822efa806307109a6f24693",
+      "governance_transparency_fail_visible_limitations": "7109966b7d76c0a7a08a1470a403e50d88f5a6826d99af3a718dbb8116bb6156",
+      "governance_transparency_governance_safe_limitations": "0d45993a74dd2bbdb149efbfe1aae41f62250e6ecf76ccb34bafae5d3f92001a",
+      "governance_transparency_inherited_constraints": "0d9d6e12529e9906b434257647e229b4bdf48054374cc5d06875bc16efab24b5",
+      "governance_transparency_inherited_prohibitions": "66f80c8bcd73c9ccb43c744586e1081f62cc93212c32648c9a610ff5292240c3"
+    },
+    "integrity_visibility_hashes": {
+      "public_integrity_degradation_visibility": "95af62d71d64e687ec2475d3c3fe5023f861fde0cb632bac5ab63cb34d083bbc",
+      "public_integrity_diagnostics_visibility": "e2a19b1c4d7c3a745c6709c370455466b1bb446b979d47d696d550cfb1fc5eb0",
+      "public_integrity_fail_visible_integrity_summaries": "6063bf26e9905d0bc192711bc8d40a5c4eecb526801a97c7f5e7cde19730254e",
+      "public_integrity_integrity_continuity_visibility": "9e504dd1802211e49f02bcbc75f5d8df93f0c7415f84926fa1b885aea5abade4",
+      "public_integrity_unsupported_integrity_states": "f5b18ad807a3afd4e508dbef7117a9a0118408bb9be292909d0f6de0b66eca0e"
+    },
+    "public_trust_diagnostic_hashes": {
+      "public_trust_diagnostic_incomplete_continuity_visibility": "ddeee90f3ab698fcc0a996fa13e5b21ddcddd753dff231a11be7e8102fb1bc09",
+      "public_trust_diagnostic_incomplete_explainability_visibility": "a5807e52a7798e8aabcef82be42e91cba0e8a6a9eaab8082ace4472cbba00924",
+      "public_trust_diagnostic_incomplete_integrity_visibility": "0baddacc606ab18aa9d8a804c29a9b5475008b2439fbce4f8a46e00cc174a838",
+      "public_trust_diagnostic_inherited_limitation_visibility_gaps": "8582dc6305b08c0c7283323194cd4cdc61a99a1f32c770a72a209879a63aad0b",
+      "public_trust_diagnostic_inherited_prohibition_visibility_gaps": "8a879c845e618b28346b4738259cb2049ffbb1300498484110abd065dd91e361",
+      "public_trust_diagnostic_missing_evidence_visibility": "570b9058241b818f2d7549a7f748faac470eb8d73483ceceec9ba1878d5c9a5c",
+      "public_trust_diagnostic_unsupported_operational_states": "0ddf9aa6b4c0e40337b6227a5c4403e028005fef0bb37075b621586487d4ffc4",
+      "public_trust_diagnostic_unsupported_public_trust_states": "074855acaaba47dea582017b4513a1282fe371869463f472f44ad7360507578d"
+    },
+    "trust_identity_hash": "5be39e2186034b92d1684ebc95c04925388b0b261d59a671ae56812e643239d1",
+    "trust_summary_hashes": {
+      "trust_summary_evidence_continuity_visibility": "ef8498a7f51cdf2ec5417b5f9fc004af5802ba1889959ec20ed55ef45639beab",
+      "trust_summary_explainability_continuity_visibility": "3475111bc426b40e32df3f9f2340e4a9cba633e46d504ab1207e6c410d31cad5",
+      "trust_summary_fail_visible_diagnostics_visibility": "c7e279be955708275c3076f7ce31f91c59455bb440be76d895fa26341e625685",
+      "trust_summary_governance_transparency_visibility": "eb46a8cbe36f2fcfbaaac51cc864cc777415e98e9b6b64aedb9e58fc4fdf5541",
+      "trust_summary_integrity_continuity_visibility": "7342ae06f2fea2626cfdf830705f60539f87b377d02b5a8ef081a18df17652d2",
+      "trust_summary_unsupported_state_visibility": "06d26c90246966183bb2ec5bd94210bc238ca86fd6b23dcda78fcbd9881e7215"
+    },
+    "trust_visibility_foundation_hash": "7770f5890f8422af4a8bc78ff1ff5d25b6deff0169fa01ba2d685a77d1a71a61",
+    "trust_visibility_record_hashes": {
+      "public_trust_visibility_foundation": "5791cefcc21b1d0c7e4ebbccd169c8407b3f997e6a5f0cfd4ab23d07574359fe"
+    },
+    "unsupported_public_trust_hashes": {
+      "unsupported_public_trust_state_automated_correction": "d56571925712198a7d177e34e19eb758b9c3c624a5b914799439f8668847a8a0",
+      "unsupported_public_trust_state_automated_mitigation": "32b0bb49f17172bc97ced24ceec22c788b5688761ebc34b848975a4672e4d7ab",
+      "unsupported_public_trust_state_automated_remediation": "c8a59e55ed871a0438961bcf40ccf373b9b64a1a00b0cf6e6ae252c724d3cd71",
+      "unsupported_public_trust_state_automated_repair": "76abf127b33517643bb2f59786ceb0c417ccd5271f8dd8240de1b2a65c9081b8",
+      "unsupported_public_trust_state_implicit_operational_behavior": "50cb4af62b2df71a26ad20dc8a9edf2bd47857a889cefe759b2e21865555226f",
+      "unsupported_public_trust_state_operational_mutation": "80d604ec646dbad574bc2d8f5c760887d9f7e428eb7e9ad62cc1bb5eeb8a5c4e",
+      "unsupported_public_trust_state_orchestration_approval": "68704c40c3cce2a104c1805f90bfe4e0d3788bba54b7838ccfd9306c25dbfd9f",
+      "unsupported_public_trust_state_orchestration_authorization": "1080616da37ce5fb8c1287764cf6a85b573030415b0479f634809701a2e8688e",
+      "unsupported_public_trust_state_orchestration_decisions": "83e36a8e60cdf7b2b220e79d6f6f2f5bffa92961a5be106e3805547b484e6c74",
+      "unsupported_public_trust_state_orchestration_dispatch": "7895b564994d7a73395342104ba87d0c36de813c88eb10de4942b90a299e726c",
+      "unsupported_public_trust_state_orchestration_execution": "d75f89469ec18ac88e169a5bdcc7bbcf9eab98078e311ddb07a4e023b4610869",
+      "unsupported_public_trust_state_orchestration_recommendations": "7d85a85733f53edfbf81c8a1a6be5162fde1740e57becf7228cafc9d36ec9aba",
+      "unsupported_public_trust_state_orchestration_routing": "e22154d23c6e6c95cd416f15d78dcd6fbe3ba93e870ca3ed61d79b16d958f88e",
+      "unsupported_public_trust_state_orchestration_scheduling": "d2c2615c44befd8f8254fbf6875c511c0c8be04e3d82839c542f0d0854a5dee2",
+      "unsupported_public_trust_state_orchestration_sequencing": "d5e969c8def0d07079e0dce1c7a9d5ad0153b10c9ce9e4fb4f84ece973b03734",
+      "unsupported_public_trust_state_orchestration_traversal": "db2187720afde1d77b416aedf8ae23e6e75ba010cda7cfbdaa42e41da732b256",
+      "unsupported_public_trust_state_planner_integration": "2dcf2b563a14001d594f768d2188ee3e1909af08fef898df615695ea3b54fd1b",
+      "unsupported_public_trust_state_production_consumption": "1e7621a433beb8ba704fbc97075810ddb164241ffe9ddff3b9b772d1094a05ea",
+      "unsupported_public_trust_state_runtime_mutation": "d2071943d3c1335e6fa58c7adbcaadf7b39915f2d354c32aa232f8516a43ab98",
+      "unsupported_public_trust_state_trust_based_approval": "bcfd1e2c7a5fb6d238d8c53426cd4e777e9e885a560014311ad47542fc61d014",
+      "unsupported_public_trust_state_trust_based_authorization": "b1d981ce8ce9beaba57ea393266a8888befe5ae15e81b0d970da9c455d0bafc8",
+      "unsupported_public_trust_state_trust_based_ranking": "fc311cf7d6fe6d46b23dea3afc2b529bbcce88c255968ee6ed51219396493a70",
+      "unsupported_public_trust_state_trust_based_recommendation": "3223d357ed37cc60ca5378231aed67a083f84d05637bbbe08af5b87f3792d740"
+    },
+    "unsupported_state_visibility_hashes": {
+      "unsupported_state_visibility_unsupported_continuity_states": "cb7e0aea428d5dfdb264db9536bd951bab928067e1f7a720344734ba5e17157d",
+      "unsupported_state_visibility_unsupported_degradation_states": "c21a3965b8f6dce1792d5ecae88f1808bcf2f0bba83ab6a600dda5ef9e6200e9",
+      "unsupported_state_visibility_unsupported_drift_states": "c23fd94d55c79263fdfbf5cb20d6ffb894a998145c4924af99cba1c750be7c4e",
+      "unsupported_state_visibility_unsupported_explainability_states": "fbae2f0996f32d3ac07f4fa1bdcce19c64fa40f40f60c74176f71fd71236fbc4",
+      "unsupported_state_visibility_unsupported_operational_states": "3c58251f6150c3db74cc3067270cd7a054f7b6c1ffc12b6409f632bbf95c3ec5",
+      "unsupported_state_visibility_unsupported_propagation_states": "34b932c58a98a193029b25c2544b28b2a8b62da9e6b3593d0797499bae0ab3fd"
+    }
+  },
+  "deterministic_report_hash": "e6bd404e3d548fe2d016621aa94ac584614e784a592d18c722ea1f5b174a8039",
+  "exported_intelligence": {
+    "auto_correction_enabled": false,
+    "descriptive_only": true,
+    "deterministic_guarantees": [
+      "deterministic_governance_transparency_visibility",
+      "deterministic_public_explainability_visibility",
+      "deterministic_public_integrity_visibility",
+      "deterministic_public_trust_evidence_visibility",
+      "deterministic_trust_summary_visibility",
+      "deterministic_trust_visibility_identity",
+      "deterministic_unsupported_state_visibility",
+      "lineage_continuity_preserved",
+      "provenance_continuity_preserved",
+      "publicly_transparent_descriptive_only_visibility",
+      "stable_replay_safe_hashing",
+      "stable_replay_safe_serialization"
+    ],
+    "evidence_visibility": [
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 1,
+        "evidence_reference_ids": [
+          "evidence_deterministic_evidence_visibility"
+        ],
+        "evidence_visibility_id": "public_trust_evidence_deterministic_evidence_visibility",
+        "evidence_visibility_type": "deterministic_evidence_visibility",
+        "provenance_safe": true,
+        "replay_safe": true,
+        "scoring_enabled": false,
+        "visibility_preserved": true,
+        "visibility_state": "public_trust_evidence_visibility_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 2,
+        "evidence_reference_ids": [
+          "evidence_replay_safe_evidence_visibility"
+        ],
+        "evidence_visibility_id": "public_trust_evidence_replay_safe_evidence_visibility",
+        "evidence_visibility_type": "replay_safe_evidence_visibility",
+        "provenance_safe": true,
+        "replay_safe": true,
+        "scoring_enabled": false,
+        "visibility_preserved": true,
+        "visibility_state": "public_trust_evidence_visibility_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 3,
+        "evidence_reference_ids": [
+          "evidence_provenance_visibility"
+        ],
+        "evidence_visibility_id": "public_trust_evidence_provenance_visibility",
+        "evidence_visibility_type": "provenance_visibility",
+        "provenance_safe": true,
+        "replay_safe": true,
+        "scoring_enabled": false,
+        "visibility_preserved": true,
+        "visibility_state": "public_trust_evidence_visibility_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 4,
+        "evidence_reference_ids": [
+          "evidence_lineage_visibility"
+        ],
+        "evidence_visibility_id": "public_trust_evidence_lineage_visibility",
+        "evidence_visibility_type": "lineage_visibility",
+        "provenance_safe": true,
+        "replay_safe": true,
+        "scoring_enabled": false,
+        "visibility_preserved": true,
+        "visibility_state": "public_trust_evidence_visibility_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 5,
+        "evidence_reference_ids": [
+          "evidence_continuity_visibility"
+        ],
+        "evidence_visibility_id": "public_trust_evidence_continuity_visibility",
+        "evidence_visibility_type": "continuity_visibility",
+        "provenance_safe": true,
+        "replay_safe": true,
+        "scoring_enabled": false,
+        "visibility_preserved": true,
+        "visibility_state": "public_trust_evidence_visibility_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 6,
+        "evidence_reference_ids": [
+          "evidence_integrity_visibility"
+        ],
+        "evidence_visibility_id": "public_trust_evidence_integrity_visibility",
+        "evidence_visibility_type": "integrity_visibility",
+        "provenance_safe": true,
+        "replay_safe": true,
+        "scoring_enabled": false,
+        "visibility_preserved": true,
+        "visibility_state": "public_trust_evidence_visibility_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 7,
+        "evidence_reference_ids": [
+          "evidence_explainability_visibility"
+        ],
+        "evidence_visibility_id": "public_trust_evidence_explainability_visibility",
+        "evidence_visibility_type": "explainability_visibility",
+        "provenance_safe": true,
+        "replay_safe": true,
+        "scoring_enabled": false,
+        "visibility_preserved": true,
+        "visibility_state": "public_trust_evidence_visibility_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 8,
+        "evidence_reference_ids": [
+          "evidence_diagnostics_visibility"
+        ],
+        "evidence_visibility_id": "public_trust_evidence_diagnostics_visibility",
+        "evidence_visibility_type": "diagnostics_visibility",
+        "provenance_safe": true,
+        "replay_safe": true,
+        "scoring_enabled": false,
+        "visibility_preserved": true,
+        "visibility_state": "public_trust_evidence_visibility_visible"
+      }
+    ],
+    "explainability_visibility": [
+      {
+        "authorization_enabled": false,
+        "decision_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 1,
+        "evidence_reference_ids": [
+          "evidence_explanation_chain_visibility"
+        ],
+        "explainability_visibility_id": "public_explainability_explanation_chain_visibility",
+        "explainability_visibility_type": "explanation_chain_visibility",
+        "recommendation_enabled": false,
+        "visibility_preserved": true,
+        "visibility_state": "public_explainability_visibility_visible"
+      },
+      {
+        "authorization_enabled": false,
+        "decision_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 2,
+        "evidence_reference_ids": [
+          "evidence_evidence_to_explanation_visibility"
+        ],
+        "explainability_visibility_id": "public_explainability_evidence_to_explanation_visibility",
+        "explainability_visibility_type": "evidence_to_explanation_visibility",
+        "recommendation_enabled": false,
+        "visibility_preserved": true,
+        "visibility_state": "public_explainability_visibility_visible"
+      },
+      {
+        "authorization_enabled": false,
+        "decision_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 3,
+        "evidence_reference_ids": [
+          "evidence_continuity_explanation_visibility"
+        ],
+        "explainability_visibility_id": "public_explainability_continuity_explanation_visibility",
+        "explainability_visibility_type": "continuity_explanation_visibility",
+        "recommendation_enabled": false,
+        "visibility_preserved": true,
+        "visibility_state": "public_explainability_visibility_visible"
+      },
+      {
+        "authorization_enabled": false,
+        "decision_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 4,
+        "evidence_reference_ids": [
+          "evidence_integrity_explanation_visibility"
+        ],
+        "explainability_visibility_id": "public_explainability_integrity_explanation_visibility",
+        "explainability_visibility_type": "integrity_explanation_visibility",
+        "recommendation_enabled": false,
+        "visibility_preserved": true,
+        "visibility_state": "public_explainability_visibility_visible"
+      },
+      {
+        "authorization_enabled": false,
+        "decision_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 5,
+        "evidence_reference_ids": [
+          "evidence_fail_visible_explanation_diagnostics"
+        ],
+        "explainability_visibility_id": "public_explainability_fail_visible_explanation_diagnostics",
+        "explainability_visibility_type": "fail_visible_explanation_diagnostics",
+        "recommendation_enabled": false,
+        "visibility_preserved": true,
+        "visibility_state": "public_explainability_visibility_visible"
+      }
+    ],
+    "explicit_limitations": [
+      "trust_visibility_does_not_approve",
+      "trust_visibility_does_not_authorize",
+      "trust_visibility_does_not_enable_production",
+      "trust_visibility_does_not_execute",
+      "trust_visibility_does_not_imply_correctness_guarantees",
+      "trust_visibility_does_not_integrate_planners",
+      "trust_visibility_does_not_mitigate_or_correct",
+      "trust_visibility_does_not_mutate_runtime_state",
+      "trust_visibility_does_not_rank",
+      "trust_visibility_does_not_recommend",
+      "trust_visibility_does_not_remediate_or_repair"
+    ],
+    "governance_transparency_visibility": [
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 1,
+        "evidence_reference_ids": [
+          "evidence_inherited_prohibitions"
+        ],
+        "operational_approval_enabled": false,
+        "public_visibility": true,
+        "transparency_type": "inherited_prohibitions",
+        "transparency_visibility_id": "governance_transparency_inherited_prohibitions",
+        "visibility_preserved": true,
+        "visibility_state": "governance_transparency_visibility_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 2,
+        "evidence_reference_ids": [
+          "evidence_inherited_constraints"
+        ],
+        "operational_approval_enabled": false,
+        "public_visibility": true,
+        "transparency_type": "inherited_constraints",
+        "transparency_visibility_id": "governance_transparency_inherited_constraints",
+        "visibility_preserved": true,
+        "visibility_state": "governance_transparency_visibility_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 3,
+        "evidence_reference_ids": [
+          "evidence_governance_safe_limitations"
+        ],
+        "operational_approval_enabled": false,
+        "public_visibility": true,
+        "transparency_type": "governance_safe_limitations",
+        "transparency_visibility_id": "governance_transparency_governance_safe_limitations",
+        "visibility_preserved": true,
+        "visibility_state": "governance_transparency_visibility_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 4,
+        "evidence_reference_ids": [
+          "evidence_descriptive_only_guarantees"
+        ],
+        "operational_approval_enabled": false,
+        "public_visibility": true,
+        "transparency_type": "descriptive_only_guarantees",
+        "transparency_visibility_id": "governance_transparency_descriptive_only_guarantees",
+        "visibility_preserved": true,
+        "visibility_state": "governance_transparency_visibility_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 5,
+        "evidence_reference_ids": [
+          "evidence_fail_visible_limitations"
+        ],
+        "operational_approval_enabled": false,
+        "public_visibility": true,
+        "transparency_type": "fail_visible_limitations",
+        "transparency_visibility_id": "governance_transparency_fail_visible_limitations",
+        "visibility_preserved": true,
+        "visibility_state": "governance_transparency_visibility_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 6,
+        "evidence_reference_ids": [
+          "evidence_continuity_guarantees"
+        ],
+        "operational_approval_enabled": false,
+        "public_visibility": true,
+        "transparency_type": "continuity_guarantees",
+        "transparency_visibility_id": "governance_transparency_continuity_guarantees",
+        "visibility_preserved": true,
+        "visibility_state": "governance_transparency_visibility_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 7,
+        "evidence_reference_ids": [
+          "evidence_explainability_guarantees"
+        ],
+        "operational_approval_enabled": false,
+        "public_visibility": true,
+        "transparency_type": "explainability_guarantees",
+        "transparency_visibility_id": "governance_transparency_explainability_guarantees",
+        "visibility_preserved": true,
+        "visibility_state": "governance_transparency_visibility_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 8,
+        "evidence_reference_ids": [
+          "evidence_deterministic_guarantees"
+        ],
+        "operational_approval_enabled": false,
+        "public_visibility": true,
+        "transparency_type": "deterministic_guarantees",
+        "transparency_visibility_id": "governance_transparency_deterministic_guarantees",
+        "visibility_preserved": true,
+        "visibility_state": "governance_transparency_visibility_visible"
+      }
+    ],
+    "inherited_constraints": [
+      "NON-approving",
+      "NON-authorizing",
+      "NON-executing",
+      "NON-operational",
+      "NON-ranking",
+      "NON-recommending",
+      "NON-remediating",
+      "NON-runtime-mutating",
+      "descriptive-only",
+      "deterministic",
+      "explainability-first",
+      "fail-visible",
+      "governance-safe",
+      "integrity-safe",
+      "lineage-safe",
+      "provenance-safe",
+      "publicly transparent",
+      "replay-safe",
+      "rollback-safe"
+    ],
+    "inherited_prohibitions": [
+      "automated_correction_prohibited",
+      "automated_mitigation_prohibited",
+      "automated_remediation_prohibited",
+      "automated_repair_prohibited",
+      "implicit_operational_behavior_prohibited",
+      "operational_mutation_prohibited",
+      "orchestration_approval_prohibited",
+      "orchestration_authorization_prohibited",
+      "orchestration_decisions_prohibited",
+      "orchestration_dispatch_prohibited",
+      "orchestration_execution_prohibited",
+      "orchestration_recommendations_prohibited",
+      "orchestration_routing_prohibited",
+      "orchestration_scheduling_prohibited",
+      "orchestration_sequencing_prohibited",
+      "orchestration_traversal_prohibited",
+      "planner_integration_prohibited",
+      "production_consumption_prohibited",
+      "runtime_mutation_prohibited",
+      "trust_based_approval_prohibited",
+      "trust_based_authorization_prohibited",
+      "trust_based_ranking_prohibited",
+      "trust_based_recommendation_prohibited"
+    ],
+    "integrity_visibility": [
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 1,
+        "evidence_reference_ids": [
+          "evidence_integrity_continuity_visibility"
+        ],
+        "integrity_visibility_id": "public_integrity_integrity_continuity_visibility",
+        "integrity_visibility_type": "integrity_continuity_visibility",
+        "operational_semantics_enabled": false,
+        "visibility_preserved": true,
+        "visibility_state": "public_integrity_visibility_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 2,
+        "evidence_reference_ids": [
+          "evidence_degradation_visibility"
+        ],
+        "integrity_visibility_id": "public_integrity_degradation_visibility",
+        "integrity_visibility_type": "degradation_visibility",
+        "operational_semantics_enabled": false,
+        "visibility_preserved": true,
+        "visibility_state": "public_integrity_visibility_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 3,
+        "evidence_reference_ids": [
+          "evidence_diagnostics_visibility"
+        ],
+        "integrity_visibility_id": "public_integrity_diagnostics_visibility",
+        "integrity_visibility_type": "diagnostics_visibility",
+        "operational_semantics_enabled": false,
+        "visibility_preserved": true,
+        "visibility_state": "public_integrity_visibility_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 4,
+        "evidence_reference_ids": [
+          "evidence_fail_visible_integrity_summaries"
+        ],
+        "integrity_visibility_id": "public_integrity_fail_visible_integrity_summaries",
+        "integrity_visibility_type": "fail_visible_integrity_summaries",
+        "operational_semantics_enabled": false,
+        "visibility_preserved": true,
+        "visibility_state": "public_integrity_visibility_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 5,
+        "evidence_reference_ids": [
+          "evidence_unsupported_integrity_states"
+        ],
+        "integrity_visibility_id": "public_integrity_unsupported_integrity_states",
+        "integrity_visibility_type": "unsupported_integrity_states",
+        "operational_semantics_enabled": false,
+        "visibility_preserved": true,
+        "visibility_state": "public_integrity_visibility_visible"
+      }
+    ],
+    "mitigation_enabled": false,
+    "non_approving": true,
+    "non_authorizing": true,
+    "non_executing": true,
+    "non_operational": true,
+    "non_ranking": true,
+    "non_recommending": true,
+    "non_remediating": true,
+    "non_runtime_mutating": true,
+    "operational_mutation_enabled": false,
+    "orchestration_approval_enabled": false,
+    "orchestration_authorization_enabled": false,
+    "orchestration_decision_enabled": false,
+    "orchestration_dispatch_enabled": false,
+    "orchestration_execution_enabled": false,
+    "orchestration_recommendation_enabled": false,
+    "orchestration_routing_enabled": false,
+    "orchestration_scheduling_enabled": false,
+    "orchestration_sequencing_enabled": false,
+    "orchestration_traversal_enabled": false,
+    "planner_execution_enabled": false,
+    "planner_integration_enabled": false,
+    "production_consumption_enabled": false,
+    "public_trust_diagnostics": [
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "auto_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 1,
+        "diagnostic_id": "public_trust_diagnostic_missing_evidence_visibility",
+        "diagnostic_type": "missing_evidence_visibility",
+        "evidence_reference_ids": [
+          "evidence_missing_evidence_visibility"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "message": "missing_evidence_visibility remains explicit, fail-visible, and descriptive-only for public trust visibility.",
+        "mitigation_enabled": false,
+        "orchestration_response_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "silent_fallback_enabled": false,
+        "visibility_state": "fail_visible_public_trust_diagnostic_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "auto_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 2,
+        "diagnostic_id": "public_trust_diagnostic_incomplete_continuity_visibility",
+        "diagnostic_type": "incomplete_continuity_visibility",
+        "evidence_reference_ids": [
+          "evidence_incomplete_continuity_visibility"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "message": "incomplete_continuity_visibility remains explicit, fail-visible, and descriptive-only for public trust visibility.",
+        "mitigation_enabled": false,
+        "orchestration_response_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "silent_fallback_enabled": false,
+        "visibility_state": "fail_visible_public_trust_diagnostic_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "auto_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 3,
+        "diagnostic_id": "public_trust_diagnostic_unsupported_public_trust_states",
+        "diagnostic_type": "unsupported_public_trust_states",
+        "evidence_reference_ids": [
+          "evidence_unsupported_public_trust_states"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "message": "unsupported_public_trust_states remains explicit, fail-visible, and descriptive-only for public trust visibility.",
+        "mitigation_enabled": false,
+        "orchestration_response_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "silent_fallback_enabled": false,
+        "visibility_state": "fail_visible_public_trust_diagnostic_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "auto_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 4,
+        "diagnostic_id": "public_trust_diagnostic_unsupported_operational_states",
+        "diagnostic_type": "unsupported_operational_states",
+        "evidence_reference_ids": [
+          "evidence_unsupported_operational_states"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "message": "unsupported_operational_states remains explicit, fail-visible, and descriptive-only for public trust visibility.",
+        "mitigation_enabled": false,
+        "orchestration_response_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "silent_fallback_enabled": false,
+        "visibility_state": "fail_visible_public_trust_diagnostic_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "auto_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 5,
+        "diagnostic_id": "public_trust_diagnostic_incomplete_explainability_visibility",
+        "diagnostic_type": "incomplete_explainability_visibility",
+        "evidence_reference_ids": [
+          "evidence_incomplete_explainability_visibility"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "message": "incomplete_explainability_visibility remains explicit, fail-visible, and descriptive-only for public trust visibility.",
+        "mitigation_enabled": false,
+        "orchestration_response_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "silent_fallback_enabled": false,
+        "visibility_state": "fail_visible_public_trust_diagnostic_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "auto_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 6,
+        "diagnostic_id": "public_trust_diagnostic_incomplete_integrity_visibility",
+        "diagnostic_type": "incomplete_integrity_visibility",
+        "evidence_reference_ids": [
+          "evidence_incomplete_integrity_visibility"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "message": "incomplete_integrity_visibility remains explicit, fail-visible, and descriptive-only for public trust visibility.",
+        "mitigation_enabled": false,
+        "orchestration_response_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "silent_fallback_enabled": false,
+        "visibility_state": "fail_visible_public_trust_diagnostic_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "auto_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 7,
+        "diagnostic_id": "public_trust_diagnostic_inherited_limitation_visibility_gaps",
+        "diagnostic_type": "inherited_limitation_visibility_gaps",
+        "evidence_reference_ids": [
+          "evidence_inherited_limitation_visibility_gaps"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "message": "inherited_limitation_visibility_gaps remains explicit, fail-visible, and descriptive-only for public trust visibility.",
+        "mitigation_enabled": false,
+        "orchestration_response_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "silent_fallback_enabled": false,
+        "visibility_state": "fail_visible_public_trust_diagnostic_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "auto_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 8,
+        "diagnostic_id": "public_trust_diagnostic_inherited_prohibition_visibility_gaps",
+        "diagnostic_type": "inherited_prohibition_visibility_gaps",
+        "evidence_reference_ids": [
+          "evidence_inherited_prohibition_visibility_gaps"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "message": "inherited_prohibition_visibility_gaps remains explicit, fail-visible, and descriptive-only for public trust visibility.",
+        "mitigation_enabled": false,
+        "orchestration_response_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "silent_fallback_enabled": false,
+        "visibility_state": "fail_visible_public_trust_diagnostic_visible"
+      }
+    ],
+    "public_trust_visibility_statement": "Public trust visibility is descriptive-only.",
+    "publicly_transparent": true,
+    "ranking_enabled": false,
+    "recommendation_enabled": false,
+    "remediation_enabled": false,
+    "repair_enabled": false,
+    "runtime_execution_enabled": false,
+    "runtime_mutation_enabled": false,
+    "trust_approval_enabled": false,
+    "trust_authorization_enabled": false,
+    "trust_identity": {
+      "classification": "governance_safe_public_trust_visibility_descriptive_only",
+      "continuity_reference_id": "continuity::v4_5b_1.public_trust",
+      "diagnostics_reference_id": "diagnostics::v4_5b_1.public_trust",
+      "evidence_reference_id": "evidence::v4_5b_1.public_trust",
+      "explainability_reference_id": "explainability::v4_5b_1.public_trust",
+      "generated_at": "2026-05-18T00:00:00+00:00",
+      "integrity_reference_id": "integrity::v4_5b_1.public_trust",
+      "lineage_reference_id": "lineage::v4_5b_1.public_trust",
+      "phase_id": "v4_5b_1_trust_visibility_foundations",
+      "provenance_reference_id": "provenance::v4_5b_1.public_trust",
+      "schema_version": "v4_5b_1.trust_visibility_foundations.1",
+      "source_readiness_closeout_hash_reference": "efa3eb2730857cd4916ba21fb7678eb25077dd912eee9db1c14045d24286744c",
+      "source_readiness_closeout_report_reference": "docs/generated/v4_5a_8_readiness_closeout_report.json",
+      "transparency_reference_id": "transparency::v4_5b_1.public_trust",
+      "trust_summary_id": "v4_5b_1_public_trust_summary",
+      "trust_visibility_id": "v4_5b_1_public_trust_visibility",
+      "unsupported_state_reference_id": "unsupported::v4_5b_1.public_trust"
+    },
+    "trust_ranking_enabled": false,
+    "trust_recommendation_enabled": false,
+    "trust_summaries": [
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 1,
+        "evidence_reference_ids": [
+          "evidence_evidence_continuity_visibility"
+        ],
+        "execution_enablement_enabled": false,
+        "production_enablement_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "summary_state": "trust_summary_descriptive_only",
+        "summary_type": "evidence_continuity_visibility",
+        "trust_summary_id": "v4_5b_1_public_trust_summary",
+        "trust_summary_record_id": "trust_summary_evidence_continuity_visibility"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 2,
+        "evidence_reference_ids": [
+          "evidence_integrity_continuity_visibility"
+        ],
+        "execution_enablement_enabled": false,
+        "production_enablement_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "summary_state": "trust_summary_descriptive_only",
+        "summary_type": "integrity_continuity_visibility",
+        "trust_summary_id": "v4_5b_1_public_trust_summary",
+        "trust_summary_record_id": "trust_summary_integrity_continuity_visibility"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 3,
+        "evidence_reference_ids": [
+          "evidence_explainability_continuity_visibility"
+        ],
+        "execution_enablement_enabled": false,
+        "production_enablement_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "summary_state": "trust_summary_descriptive_only",
+        "summary_type": "explainability_continuity_visibility",
+        "trust_summary_id": "v4_5b_1_public_trust_summary",
+        "trust_summary_record_id": "trust_summary_explainability_continuity_visibility"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 4,
+        "evidence_reference_ids": [
+          "evidence_unsupported_state_visibility"
+        ],
+        "execution_enablement_enabled": false,
+        "production_enablement_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "summary_state": "trust_summary_descriptive_only",
+        "summary_type": "unsupported_state_visibility",
+        "trust_summary_id": "v4_5b_1_public_trust_summary",
+        "trust_summary_record_id": "trust_summary_unsupported_state_visibility"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 5,
+        "evidence_reference_ids": [
+          "evidence_fail_visible_diagnostics_visibility"
+        ],
+        "execution_enablement_enabled": false,
+        "production_enablement_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "summary_state": "trust_summary_descriptive_only",
+        "summary_type": "fail_visible_diagnostics_visibility",
+        "trust_summary_id": "v4_5b_1_public_trust_summary",
+        "trust_summary_record_id": "trust_summary_fail_visible_diagnostics_visibility"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 6,
+        "evidence_reference_ids": [
+          "evidence_governance_transparency_visibility"
+        ],
+        "execution_enablement_enabled": false,
+        "production_enablement_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "summary_state": "trust_summary_descriptive_only",
+        "summary_type": "governance_transparency_visibility",
+        "trust_summary_id": "v4_5b_1_public_trust_summary",
+        "trust_summary_record_id": "trust_summary_governance_transparency_visibility"
+      }
+    ],
+    "trust_visibility_non_authority_statement": "Trust visibility does NOT imply authorization, approval, operational readiness, or production enablement.",
+    "trust_visibility_records": [
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "continuity_reference_id": "continuity::v4_5b_1.public_trust",
+        "descriptive_only": true,
+        "deterministic_order": 1,
+        "diagnostics_reference_id": "diagnostics::v4_5b_1.public_trust",
+        "evidence_reference_id": "evidence::v4_5b_1.public_trust",
+        "execution_enabled": false,
+        "explainability_reference_id": "explainability::v4_5b_1.public_trust",
+        "fail_visible": true,
+        "integrity_reference_id": "integrity::v4_5b_1.public_trust",
+        "lineage_reference_id": "lineage::v4_5b_1.public_trust",
+        "non_approving": true,
+        "non_authorizing": true,
+        "production_enablement_enabled": false,
+        "provenance_reference_id": "provenance::v4_5b_1.public_trust",
+        "publicly_transparent": true,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "transparency_reference_id": "transparency::v4_5b_1.public_trust",
+        "trust_authority_enabled": false,
+        "trust_record_id": "public_trust_visibility_foundation",
+        "trust_summary_id": "v4_5b_1_public_trust_summary",
+        "trust_visibility_id": "v4_5b_1_public_trust_visibility",
+        "unsupported_state_reference_id": "unsupported::v4_5b_1.public_trust",
+        "visibility_state": "public_trust_visibility_foundation_visible"
+      }
+    ],
+    "unsupported_public_trust_visibility": [
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 1,
+        "evidence_reference_ids": [
+          "evidence_unsupported_public_trust_states"
+        ],
+        "explicit_reason": "orchestration_execution remains unsupported for v4.5B.1 public trust visibility foundations.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_public_trust_state_orchestration_execution",
+        "suppression_enabled": false,
+        "unsupported_state": "orchestration_execution",
+        "visibility_state": "unsupported_public_trust_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 2,
+        "evidence_reference_ids": [
+          "evidence_unsupported_public_trust_states"
+        ],
+        "explicit_reason": "orchestration_authorization remains unsupported for v4.5B.1 public trust visibility foundations.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_public_trust_state_orchestration_authorization",
+        "suppression_enabled": false,
+        "unsupported_state": "orchestration_authorization",
+        "visibility_state": "unsupported_public_trust_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 3,
+        "evidence_reference_ids": [
+          "evidence_unsupported_public_trust_states"
+        ],
+        "explicit_reason": "orchestration_approval remains unsupported for v4.5B.1 public trust visibility foundations.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_public_trust_state_orchestration_approval",
+        "suppression_enabled": false,
+        "unsupported_state": "orchestration_approval",
+        "visibility_state": "unsupported_public_trust_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 4,
+        "evidence_reference_ids": [
+          "evidence_unsupported_public_trust_states"
+        ],
+        "explicit_reason": "orchestration_dispatch remains unsupported for v4.5B.1 public trust visibility foundations.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_public_trust_state_orchestration_dispatch",
+        "suppression_enabled": false,
+        "unsupported_state": "orchestration_dispatch",
+        "visibility_state": "unsupported_public_trust_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 5,
+        "evidence_reference_ids": [
+          "evidence_unsupported_public_trust_states"
+        ],
+        "explicit_reason": "orchestration_routing remains unsupported for v4.5B.1 public trust visibility foundations.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_public_trust_state_orchestration_routing",
+        "suppression_enabled": false,
+        "unsupported_state": "orchestration_routing",
+        "visibility_state": "unsupported_public_trust_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 6,
+        "evidence_reference_ids": [
+          "evidence_unsupported_public_trust_states"
+        ],
+        "explicit_reason": "orchestration_traversal remains unsupported for v4.5B.1 public trust visibility foundations.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_public_trust_state_orchestration_traversal",
+        "suppression_enabled": false,
+        "unsupported_state": "orchestration_traversal",
+        "visibility_state": "unsupported_public_trust_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 7,
+        "evidence_reference_ids": [
+          "evidence_unsupported_public_trust_states"
+        ],
+        "explicit_reason": "orchestration_scheduling remains unsupported for v4.5B.1 public trust visibility foundations.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_public_trust_state_orchestration_scheduling",
+        "suppression_enabled": false,
+        "unsupported_state": "orchestration_scheduling",
+        "visibility_state": "unsupported_public_trust_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 8,
+        "evidence_reference_ids": [
+          "evidence_unsupported_public_trust_states"
+        ],
+        "explicit_reason": "orchestration_sequencing remains unsupported for v4.5B.1 public trust visibility foundations.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_public_trust_state_orchestration_sequencing",
+        "suppression_enabled": false,
+        "unsupported_state": "orchestration_sequencing",
+        "visibility_state": "unsupported_public_trust_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 9,
+        "evidence_reference_ids": [
+          "evidence_unsupported_public_trust_states"
+        ],
+        "explicit_reason": "orchestration_decisions remains unsupported for v4.5B.1 public trust visibility foundations.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_public_trust_state_orchestration_decisions",
+        "suppression_enabled": false,
+        "unsupported_state": "orchestration_decisions",
+        "visibility_state": "unsupported_public_trust_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 10,
+        "evidence_reference_ids": [
+          "evidence_unsupported_public_trust_states"
+        ],
+        "explicit_reason": "orchestration_recommendations remains unsupported for v4.5B.1 public trust visibility foundations.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_public_trust_state_orchestration_recommendations",
+        "suppression_enabled": false,
+        "unsupported_state": "orchestration_recommendations",
+        "visibility_state": "unsupported_public_trust_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 11,
+        "evidence_reference_ids": [
+          "evidence_unsupported_public_trust_states"
+        ],
+        "explicit_reason": "trust_based_authorization remains unsupported for v4.5B.1 public trust visibility foundations.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_public_trust_state_trust_based_authorization",
+        "suppression_enabled": false,
+        "unsupported_state": "trust_based_authorization",
+        "visibility_state": "unsupported_public_trust_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 12,
+        "evidence_reference_ids": [
+          "evidence_unsupported_public_trust_states"
+        ],
+        "explicit_reason": "trust_based_approval remains unsupported for v4.5B.1 public trust visibility foundations.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_public_trust_state_trust_based_approval",
+        "suppression_enabled": false,
+        "unsupported_state": "trust_based_approval",
+        "visibility_state": "unsupported_public_trust_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 13,
+        "evidence_reference_ids": [
+          "evidence_unsupported_public_trust_states"
+        ],
+        "explicit_reason": "trust_based_ranking remains unsupported for v4.5B.1 public trust visibility foundations.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_public_trust_state_trust_based_ranking",
+        "suppression_enabled": false,
+        "unsupported_state": "trust_based_ranking",
+        "visibility_state": "unsupported_public_trust_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 14,
+        "evidence_reference_ids": [
+          "evidence_unsupported_public_trust_states"
+        ],
+        "explicit_reason": "trust_based_recommendation remains unsupported for v4.5B.1 public trust visibility foundations.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_public_trust_state_trust_based_recommendation",
+        "suppression_enabled": false,
+        "unsupported_state": "trust_based_recommendation",
+        "visibility_state": "unsupported_public_trust_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 15,
+        "evidence_reference_ids": [
+          "evidence_unsupported_public_trust_states"
+        ],
+        "explicit_reason": "automated_remediation remains unsupported for v4.5B.1 public trust visibility foundations.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_public_trust_state_automated_remediation",
+        "suppression_enabled": false,
+        "unsupported_state": "automated_remediation",
+        "visibility_state": "unsupported_public_trust_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 16,
+        "evidence_reference_ids": [
+          "evidence_unsupported_public_trust_states"
+        ],
+        "explicit_reason": "automated_repair remains unsupported for v4.5B.1 public trust visibility foundations.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_public_trust_state_automated_repair",
+        "suppression_enabled": false,
+        "unsupported_state": "automated_repair",
+        "visibility_state": "unsupported_public_trust_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 17,
+        "evidence_reference_ids": [
+          "evidence_unsupported_public_trust_states"
+        ],
+        "explicit_reason": "automated_mitigation remains unsupported for v4.5B.1 public trust visibility foundations.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_public_trust_state_automated_mitigation",
+        "suppression_enabled": false,
+        "unsupported_state": "automated_mitigation",
+        "visibility_state": "unsupported_public_trust_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 18,
+        "evidence_reference_ids": [
+          "evidence_unsupported_public_trust_states"
+        ],
+        "explicit_reason": "automated_correction remains unsupported for v4.5B.1 public trust visibility foundations.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_public_trust_state_automated_correction",
+        "suppression_enabled": false,
+        "unsupported_state": "automated_correction",
+        "visibility_state": "unsupported_public_trust_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 19,
+        "evidence_reference_ids": [
+          "evidence_unsupported_public_trust_states"
+        ],
+        "explicit_reason": "planner_integration remains unsupported for v4.5B.1 public trust visibility foundations.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_public_trust_state_planner_integration",
+        "suppression_enabled": false,
+        "unsupported_state": "planner_integration",
+        "visibility_state": "unsupported_public_trust_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 20,
+        "evidence_reference_ids": [
+          "evidence_unsupported_public_trust_states"
+        ],
+        "explicit_reason": "production_consumption remains unsupported for v4.5B.1 public trust visibility foundations.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_public_trust_state_production_consumption",
+        "suppression_enabled": false,
+        "unsupported_state": "production_consumption",
+        "visibility_state": "unsupported_public_trust_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 21,
+        "evidence_reference_ids": [
+          "evidence_unsupported_public_trust_states"
+        ],
+        "explicit_reason": "runtime_mutation remains unsupported for v4.5B.1 public trust visibility foundations.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_public_trust_state_runtime_mutation",
+        "suppression_enabled": false,
+        "unsupported_state": "runtime_mutation",
+        "visibility_state": "unsupported_public_trust_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 22,
+        "evidence_reference_ids": [
+          "evidence_unsupported_public_trust_states"
+        ],
+        "explicit_reason": "operational_mutation remains unsupported for v4.5B.1 public trust visibility foundations.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_public_trust_state_operational_mutation",
+        "suppression_enabled": false,
+        "unsupported_state": "operational_mutation",
+        "visibility_state": "unsupported_public_trust_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 23,
+        "evidence_reference_ids": [
+          "evidence_unsupported_public_trust_states"
+        ],
+        "explicit_reason": "implicit_operational_behavior remains unsupported for v4.5B.1 public trust visibility foundations.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_public_trust_state_implicit_operational_behavior",
+        "suppression_enabled": false,
+        "unsupported_state": "implicit_operational_behavior",
+        "visibility_state": "unsupported_public_trust_state_fail_visible"
+      }
+    ],
+    "unsupported_state_visibility": [
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 1,
+        "evidence_reference_ids": [
+          "evidence_unsupported_drift_states"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "remediation_enabled": false,
+        "suppression_enabled": false,
+        "unsupported_state_type": "unsupported_drift_states",
+        "unsupported_visibility_id": "unsupported_state_visibility_unsupported_drift_states",
+        "visibility_preserved": true,
+        "visibility_state": "unsupported_state_visibility_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 2,
+        "evidence_reference_ids": [
+          "evidence_unsupported_propagation_states"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "remediation_enabled": false,
+        "suppression_enabled": false,
+        "unsupported_state_type": "unsupported_propagation_states",
+        "unsupported_visibility_id": "unsupported_state_visibility_unsupported_propagation_states",
+        "visibility_preserved": true,
+        "visibility_state": "unsupported_state_visibility_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 3,
+        "evidence_reference_ids": [
+          "evidence_unsupported_degradation_states"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "remediation_enabled": false,
+        "suppression_enabled": false,
+        "unsupported_state_type": "unsupported_degradation_states",
+        "unsupported_visibility_id": "unsupported_state_visibility_unsupported_degradation_states",
+        "visibility_preserved": true,
+        "visibility_state": "unsupported_state_visibility_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 4,
+        "evidence_reference_ids": [
+          "evidence_unsupported_explainability_states"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "remediation_enabled": false,
+        "suppression_enabled": false,
+        "unsupported_state_type": "unsupported_explainability_states",
+        "unsupported_visibility_id": "unsupported_state_visibility_unsupported_explainability_states",
+        "visibility_preserved": true,
+        "visibility_state": "unsupported_state_visibility_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 5,
+        "evidence_reference_ids": [
+          "evidence_unsupported_continuity_states"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "remediation_enabled": false,
+        "suppression_enabled": false,
+        "unsupported_state_type": "unsupported_continuity_states",
+        "unsupported_visibility_id": "unsupported_state_visibility_unsupported_continuity_states",
+        "visibility_preserved": true,
+        "visibility_state": "unsupported_state_visibility_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 6,
+        "evidence_reference_ids": [
+          "evidence_unsupported_operational_states"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "remediation_enabled": false,
+        "suppression_enabled": false,
+        "unsupported_state_type": "unsupported_operational_states",
+        "unsupported_visibility_id": "unsupported_state_visibility_unsupported_operational_states",
+        "visibility_preserved": true,
+        "visibility_state": "unsupported_state_visibility_fail_visible"
+      }
+    ]
+  },
+  "foundation_status": "v4_5b_1_trust_visibility_foundations_stable",
+  "generated_at": "2026-05-18T00:00:00+00:00",
+  "phase_id": "v4_5b_1_trust_visibility_foundations",
+  "purpose": "deterministic_public_trust_visibility_foundations_descriptive_only",
+  "schema_version": "v4_5b_1.trust_visibility_foundations_report.1",
+  "summary": {
+    "descriptive_only_guarantees_verified": true,
+    "deterministic_hashing_verified": true,
+    "deterministic_serialization_verified": true,
+    "diagnostic_counts": {
+      "incomplete_continuity_visibility": 1,
+      "incomplete_explainability_visibility": 1,
+      "incomplete_integrity_visibility": 1,
+      "inherited_limitation_visibility_gaps": 1,
+      "inherited_prohibition_visibility_gaps": 1,
+      "missing_evidence_visibility": 1,
+      "unsupported_operational_states": 1,
+      "unsupported_public_trust_states": 1
+    },
+    "enabled_auto_correction_count": 0,
+    "enabled_mitigation_count": 0,
+    "enabled_operational_mutation_count": 0,
+    "enabled_orchestration_approval_count": 0,
+    "enabled_orchestration_authorization_count": 0,
+    "enabled_orchestration_decision_count": 0,
+    "enabled_orchestration_dispatch_count": 0,
+    "enabled_orchestration_recommendation_count": 0,
+    "enabled_orchestration_routing_count": 0,
+    "enabled_orchestration_scheduling_count": 0,
+    "enabled_orchestration_sequencing_count": 0,
+    "enabled_orchestration_traversal_count": 0,
+    "enabled_planner_integration_count": 0,
+    "enabled_production_consumption_count": 0,
+    "enabled_remediation_count": 0,
+    "enabled_repair_count": 0,
+    "enabled_runtime_execution_count": 0,
+    "enabled_runtime_mutation_count": 0,
+    "enabled_trust_approval_count": 0,
+    "enabled_trust_authorization_count": 0,
+    "enabled_trust_ranking_count": 0,
+    "enabled_trust_recommendation_count": 0,
+    "evidence_continuity_preserved": true,
+    "evidence_counts": {
+      "continuity_visibility": 1,
+      "deterministic_evidence_visibility": 1,
+      "diagnostics_visibility": 1,
+      "explainability_visibility": 1,
+      "integrity_visibility": 1,
+      "lineage_visibility": 1,
+      "provenance_visibility": 1,
+      "replay_safe_evidence_visibility": 1
+    },
+    "evidence_visibility_count": 8,
+    "evidence_visibility_stable": true,
+    "explainability_counts": {
+      "continuity_explanation_visibility": 1,
+      "evidence_to_explanation_visibility": 1,
+      "explanation_chain_visibility": 1,
+      "fail_visible_explanation_diagnostics": 1,
+      "integrity_explanation_visibility": 1
+    },
+    "explainability_visibility_count": 5,
+    "explainability_visibility_stable": true,
+    "explicit_limitation_count": 11,
+    "fail_visible_public_trust_diagnostics_verified": true,
+    "governance_transparency_visibility_count": 8,
+    "governance_transparency_visibility_preserved": true,
+    "inherited_constraint_count": 19,
+    "inherited_prohibition_count": 23,
+    "integrity_counts": {
+      "degradation_visibility": 1,
+      "diagnostics_visibility": 1,
+      "fail_visible_integrity_summaries": 1,
+      "integrity_continuity_visibility": 1,
+      "unsupported_integrity_states": 1
+    },
+    "integrity_visibility_count": 5,
+    "integrity_visibility_stable": true,
+    "lineage_continuity_preserved": true,
+    "provenance_continuity_preserved": true,
+    "public_trust_diagnostic_count": 8,
+    "public_trust_visibility_statement": "Public trust visibility is descriptive-only.",
+    "publicly_transparent": true,
+    "repository_remains": [
+      "NON-operational",
+      "NON-authorizing",
+      "NON-approving",
+      "NON-executing",
+      "NON-remediating",
+      "NON-runtime-mutating",
+      "NON-ranking",
+      "NON-recommending"
+    ],
+    "summary_counts": {
+      "evidence_continuity_visibility": 1,
+      "explainability_continuity_visibility": 1,
+      "fail_visible_diagnostics_visibility": 1,
+      "governance_transparency_visibility": 1,
+      "integrity_continuity_visibility": 1,
+      "unsupported_state_visibility": 1
+    },
+    "transparency_counts": {
+      "continuity_guarantees": 1,
+      "descriptive_only_guarantees": 1,
+      "deterministic_guarantees": 1,
+      "explainability_guarantees": 1,
+      "fail_visible_limitations": 1,
+      "governance_safe_limitations": 1,
+      "inherited_constraints": 1,
+      "inherited_prohibitions": 1
+    },
+    "trust_summary_count": 6,
+    "trust_summary_stable": true,
+    "trust_visibility_non_authority_statement": "Trust visibility does NOT imply authorization, approval, operational readiness, or production enablement.",
+    "trust_visibility_record_count": 1,
+    "unsupported_counts": {
+      "unsupported_continuity_states": 1,
+      "unsupported_degradation_states": 1,
+      "unsupported_drift_states": 1,
+      "unsupported_explainability_states": 1,
+      "unsupported_operational_states": 1,
+      "unsupported_propagation_states": 1
+    },
+    "unsupported_operational_counts": {
+      "automated_correction": 1,
+      "automated_mitigation": 1,
+      "automated_remediation": 1,
+      "automated_repair": 1,
+      "implicit_operational_behavior": 1,
+      "operational_mutation": 1,
+      "orchestration_approval": 1,
+      "orchestration_authorization": 1,
+      "orchestration_decisions": 1,
+      "orchestration_dispatch": 1,
+      "orchestration_execution": 1,
+      "orchestration_recommendations": 1,
+      "orchestration_routing": 1,
+      "orchestration_scheduling": 1,
+      "orchestration_sequencing": 1,
+      "orchestration_traversal": 1,
+      "planner_integration": 1,
+      "production_consumption": 1,
+      "runtime_mutation": 1,
+      "trust_based_approval": 1,
+      "trust_based_authorization": 1,
+      "trust_based_ranking": 1,
+      "trust_based_recommendation": 1
+    },
+    "unsupported_public_trust_state_count": 23,
+    "unsupported_state_visibility_count": 6,
+    "unsupported_state_visibility_preserved": true,
+    "validation_error_count": 0
+  },
+  "validation": {
+    "failed_validations": [],
+    "foundation_status": "v4_5b_1_trust_visibility_foundations_stable",
+    "valid": true,
+    "validation_error_count": 0,
+    "validations": {
+      "descriptive_only_guarantees": {
+        "counters": {
+          "enabled_auto_correction_count": 0,
+          "enabled_mitigation_count": 0,
+          "enabled_operational_mutation_count": 0,
+          "enabled_orchestration_approval_count": 0,
+          "enabled_orchestration_authorization_count": 0,
+          "enabled_orchestration_decision_count": 0,
+          "enabled_orchestration_dispatch_count": 0,
+          "enabled_orchestration_recommendation_count": 0,
+          "enabled_orchestration_routing_count": 0,
+          "enabled_orchestration_scheduling_count": 0,
+          "enabled_orchestration_sequencing_count": 0,
+          "enabled_orchestration_traversal_count": 0,
+          "enabled_planner_integration_count": 0,
+          "enabled_production_consumption_count": 0,
+          "enabled_remediation_count": 0,
+          "enabled_repair_count": 0,
+          "enabled_runtime_execution_count": 0,
+          "enabled_runtime_mutation_count": 0,
+          "enabled_trust_approval_count": 0,
+          "enabled_trust_authorization_count": 0,
+          "enabled_trust_ranking_count": 0,
+          "enabled_trust_recommendation_count": 0
+        },
+        "descriptive_failures": [],
+        "enabled_flags": {},
+        "explicit_limitation_count": 11,
+        "inherited_constraint_count": 19,
+        "inherited_prohibition_count": 23,
+        "missing_disabled_counters": [],
+        "public_trust_visibility_statement": "Public trust visibility is descriptive-only.",
+        "publicly_transparent": true,
+        "repository_remains": {
+          "NON-approving": true,
+          "NON-authorizing": true,
+          "NON-executing": true,
+          "NON-operational": true,
+          "NON-ranking": true,
+          "NON-recommending": true,
+          "NON-remediating": true,
+          "NON-runtime-mutating": true
+        },
+        "statement_valid": true,
+        "trust_visibility_non_authority_statement": "Trust visibility does NOT imply authorization, approval, operational readiness, or production enablement.",
+        "valid": true
+      },
+      "evidence_visibility": {
+        "evidence_visibility_count": 8,
+        "missing_evidence_visibility_types": [],
+        "unsafe_evidence_visibility_ids": [],
+        "valid": true
+      },
+      "explainability_visibility": {
+        "explainability_visibility_count": 5,
+        "missing_explainability_types": [],
+        "unsafe_explainability_ids": [],
+        "valid": true
+      },
+      "fail_visible_public_trust": {
+        "approval_enabled_count": 0,
+        "authorization_enabled_count": 0,
+        "fail_visible": true,
+        "hidden_fallback_enabled_count": 0,
+        "missing_diagnostic_types": [],
+        "missing_unsupported_states": [],
+        "public_trust_diagnostic_count": 8,
+        "ranking_enabled_count": 0,
+        "recommendation_enabled_count": 0,
+        "silent_fallback_enabled_count": 0,
+        "unsafe_diagnostic_ids": [],
+        "unsafe_unsupported_ids": [],
+        "unsupported_public_trust_state_count": 23,
+        "valid": true
+      },
+      "governance_transparency": {
+        "missing_transparency_types": [],
+        "transparency_visibility_count": 8,
+        "unsafe_transparency_ids": [],
+        "valid": true
+      },
+      "identity_integrity": {
+        "missing_identity_fields": [],
+        "phase_id": "v4_5b_1_trust_visibility_foundations",
+        "schema_version": "v4_5b_1.trust_visibility_foundations.1",
+        "source_report_hash_matches": true,
+        "source_report_present": true,
+        "valid": true
+      },
+      "integrity_visibility": {
+        "integrity_visibility_count": 5,
+        "missing_integrity_types": [],
+        "unsafe_integrity_ids": [],
+        "valid": true
+      },
+      "lineage_and_provenance": {
+        "continuity_reference_preserved": true,
+        "evidence_continuity_preserved": true,
+        "lineage_continuity_preserved": true,
+        "missing_evidence_reference_ids": [],
+        "provenance_continuity_preserved": true,
+        "valid": true
+      },
+      "ordering_stability": {
+        "order_groups": {
+          "evidence_visibility": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8
+          ],
+          "explainability_visibility": [
+            1,
+            2,
+            3,
+            4,
+            5
+          ],
+          "governance_transparency_visibility": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8
+          ],
+          "integrity_visibility": [
+            1,
+            2,
+            3,
+            4,
+            5
+          ],
+          "public_trust_diagnostics": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8
+          ],
+          "trust_summaries": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6
+          ],
+          "trust_visibility_records": [
+            1
+          ],
+          "unsupported_public_trust_visibility": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+            21,
+            22,
+            23
+          ],
+          "unsupported_state_visibility": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6
+          ]
+        },
+        "unordered_groups": [],
+        "valid": true
+      },
+      "required_visibility": {
+        "diagnostic_counts": {
+          "incomplete_continuity_visibility": 1,
+          "incomplete_explainability_visibility": 1,
+          "incomplete_integrity_visibility": 1,
+          "inherited_limitation_visibility_gaps": 1,
+          "inherited_prohibition_visibility_gaps": 1,
+          "missing_evidence_visibility": 1,
+          "unsupported_operational_states": 1,
+          "unsupported_public_trust_states": 1
+        },
+        "evidence_counts": {
+          "continuity_visibility": 1,
+          "deterministic_evidence_visibility": 1,
+          "diagnostics_visibility": 1,
+          "explainability_visibility": 1,
+          "integrity_visibility": 1,
+          "lineage_visibility": 1,
+          "provenance_visibility": 1,
+          "replay_safe_evidence_visibility": 1
+        },
+        "explainability_counts": {
+          "continuity_explanation_visibility": 1,
+          "evidence_to_explanation_visibility": 1,
+          "explanation_chain_visibility": 1,
+          "fail_visible_explanation_diagnostics": 1,
+          "integrity_explanation_visibility": 1
+        },
+        "integrity_counts": {
+          "degradation_visibility": 1,
+          "diagnostics_visibility": 1,
+          "fail_visible_integrity_summaries": 1,
+          "integrity_continuity_visibility": 1,
+          "unsupported_integrity_states": 1
+        },
+        "missing_diagnostic_types": [],
+        "missing_evidence_types": [],
+        "missing_explainability_types": [],
+        "missing_integrity_types": [],
+        "missing_summary_types": [],
+        "missing_transparency_types": [],
+        "missing_unsupported_states": [],
+        "missing_unsupported_types": [],
+        "summary_counts": {
+          "evidence_continuity_visibility": 1,
+          "explainability_continuity_visibility": 1,
+          "fail_visible_diagnostics_visibility": 1,
+          "governance_transparency_visibility": 1,
+          "integrity_continuity_visibility": 1,
+          "unsupported_state_visibility": 1
+        },
+        "transparency_counts": {
+          "continuity_guarantees": 1,
+          "descriptive_only_guarantees": 1,
+          "deterministic_guarantees": 1,
+          "explainability_guarantees": 1,
+          "fail_visible_limitations": 1,
+          "governance_safe_limitations": 1,
+          "inherited_constraints": 1,
+          "inherited_prohibitions": 1
+        },
+        "unsupported_counts": {
+          "unsupported_continuity_states": 1,
+          "unsupported_degradation_states": 1,
+          "unsupported_drift_states": 1,
+          "unsupported_explainability_states": 1,
+          "unsupported_operational_states": 1,
+          "unsupported_propagation_states": 1
+        },
+        "unsupported_operational_counts": {
+          "automated_correction": 1,
+          "automated_mitigation": 1,
+          "automated_remediation": 1,
+          "automated_repair": 1,
+          "implicit_operational_behavior": 1,
+          "operational_mutation": 1,
+          "orchestration_approval": 1,
+          "orchestration_authorization": 1,
+          "orchestration_decisions": 1,
+          "orchestration_dispatch": 1,
+          "orchestration_execution": 1,
+          "orchestration_recommendations": 1,
+          "orchestration_routing": 1,
+          "orchestration_scheduling": 1,
+          "orchestration_sequencing": 1,
+          "orchestration_traversal": 1,
+          "planner_integration": 1,
+          "production_consumption": 1,
+          "runtime_mutation": 1,
+          "trust_based_approval": 1,
+          "trust_based_authorization": 1,
+          "trust_based_ranking": 1,
+          "trust_based_recommendation": 1
+        },
+        "valid": true
+      },
+      "serialization_hashing": {
+        "hashing_stable": true,
+        "rebuilt_trust_visibility_hash": "7770f5890f8422af4a8bc78ff1ff5d25b6deff0169fa01ba2d685a77d1a71a61",
+        "serialization_length": 46719,
+        "serialization_stable": true,
+        "trust_visibility_hash": "7770f5890f8422af4a8bc78ff1ff5d25b6deff0169fa01ba2d685a77d1a71a61",
+        "valid": true
+      },
+      "trust_summary": {
+        "missing_summary_types": [],
+        "trust_summary_count": 6,
+        "unsafe_summary_ids": [],
+        "valid": true
+      },
+      "unsupported_state_visibility": {
+        "missing_unsupported_state_types": [],
+        "unsafe_unsupported_state_ids": [],
+        "unsupported_state_visibility_count": 6,
+        "valid": true
+      }
+    }
+  },
+  "visibility": {
+    "descriptive_only": {
+      "descriptive_only": true,
+      "non_approving": true,
+      "non_authorizing": true,
+      "non_executing": true,
+      "non_operational": true,
+      "non_ranking": true,
+      "non_recommending": true,
+      "non_remediating": true,
+      "non_runtime_mutating": true,
+      "operational_mutation_enabled": false,
+      "planner_integration_enabled": false,
+      "production_consumption_enabled": false,
+      "public_trust_visibility_statement": "Public trust visibility is descriptive-only.",
+      "publicly_transparent": true,
+      "runtime_mutation_enabled": false,
+      "trust_approval_enabled": false,
+      "trust_authorization_enabled": false,
+      "trust_ranking_enabled": false,
+      "trust_recommendation_enabled": false,
+      "trust_visibility_non_authority_statement": "Trust visibility does NOT imply authorization, approval, operational readiness, or production enablement."
+    },
+    "diagnostics": [
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "auto_correction_enabled": false,
+        "descriptive_only": true,
+        "diagnostic_id": "public_trust_diagnostic_missing_evidence_visibility",
+        "diagnostic_type": "missing_evidence_visibility",
+        "evidence_reference_ids": [
+          "evidence_missing_evidence_visibility"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "message": "missing_evidence_visibility remains explicit, fail-visible, and descriptive-only for public trust visibility.",
+        "mitigation_enabled": false,
+        "orchestration_response_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "silent_fallback_enabled": false
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "auto_correction_enabled": false,
+        "descriptive_only": true,
+        "diagnostic_id": "public_trust_diagnostic_incomplete_continuity_visibility",
+        "diagnostic_type": "incomplete_continuity_visibility",
+        "evidence_reference_ids": [
+          "evidence_incomplete_continuity_visibility"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "message": "incomplete_continuity_visibility remains explicit, fail-visible, and descriptive-only for public trust visibility.",
+        "mitigation_enabled": false,
+        "orchestration_response_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "silent_fallback_enabled": false
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "auto_correction_enabled": false,
+        "descriptive_only": true,
+        "diagnostic_id": "public_trust_diagnostic_unsupported_public_trust_states",
+        "diagnostic_type": "unsupported_public_trust_states",
+        "evidence_reference_ids": [
+          "evidence_unsupported_public_trust_states"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "message": "unsupported_public_trust_states remains explicit, fail-visible, and descriptive-only for public trust visibility.",
+        "mitigation_enabled": false,
+        "orchestration_response_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "silent_fallback_enabled": false
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "auto_correction_enabled": false,
+        "descriptive_only": true,
+        "diagnostic_id": "public_trust_diagnostic_unsupported_operational_states",
+        "diagnostic_type": "unsupported_operational_states",
+        "evidence_reference_ids": [
+          "evidence_unsupported_operational_states"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "message": "unsupported_operational_states remains explicit, fail-visible, and descriptive-only for public trust visibility.",
+        "mitigation_enabled": false,
+        "orchestration_response_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "silent_fallback_enabled": false
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "auto_correction_enabled": false,
+        "descriptive_only": true,
+        "diagnostic_id": "public_trust_diagnostic_incomplete_explainability_visibility",
+        "diagnostic_type": "incomplete_explainability_visibility",
+        "evidence_reference_ids": [
+          "evidence_incomplete_explainability_visibility"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "message": "incomplete_explainability_visibility remains explicit, fail-visible, and descriptive-only for public trust visibility.",
+        "mitigation_enabled": false,
+        "orchestration_response_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "silent_fallback_enabled": false
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "auto_correction_enabled": false,
+        "descriptive_only": true,
+        "diagnostic_id": "public_trust_diagnostic_incomplete_integrity_visibility",
+        "diagnostic_type": "incomplete_integrity_visibility",
+        "evidence_reference_ids": [
+          "evidence_incomplete_integrity_visibility"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "message": "incomplete_integrity_visibility remains explicit, fail-visible, and descriptive-only for public trust visibility.",
+        "mitigation_enabled": false,
+        "orchestration_response_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "silent_fallback_enabled": false
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "auto_correction_enabled": false,
+        "descriptive_only": true,
+        "diagnostic_id": "public_trust_diagnostic_inherited_limitation_visibility_gaps",
+        "diagnostic_type": "inherited_limitation_visibility_gaps",
+        "evidence_reference_ids": [
+          "evidence_inherited_limitation_visibility_gaps"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "message": "inherited_limitation_visibility_gaps remains explicit, fail-visible, and descriptive-only for public trust visibility.",
+        "mitigation_enabled": false,
+        "orchestration_response_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "silent_fallback_enabled": false
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "auto_correction_enabled": false,
+        "descriptive_only": true,
+        "diagnostic_id": "public_trust_diagnostic_inherited_prohibition_visibility_gaps",
+        "diagnostic_type": "inherited_prohibition_visibility_gaps",
+        "evidence_reference_ids": [
+          "evidence_inherited_prohibition_visibility_gaps"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "message": "inherited_prohibition_visibility_gaps remains explicit, fail-visible, and descriptive-only for public trust visibility.",
+        "mitigation_enabled": false,
+        "orchestration_response_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "silent_fallback_enabled": false
+      }
+    ],
+    "explainability": [
+      {
+        "authorization_enabled": false,
+        "decision_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_explanation_chain_visibility"
+        ],
+        "explainability_visibility_id": "public_explainability_explanation_chain_visibility",
+        "explainability_visibility_type": "explanation_chain_visibility",
+        "recommendation_enabled": false,
+        "visibility_preserved": true
+      },
+      {
+        "authorization_enabled": false,
+        "decision_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_evidence_to_explanation_visibility"
+        ],
+        "explainability_visibility_id": "public_explainability_evidence_to_explanation_visibility",
+        "explainability_visibility_type": "evidence_to_explanation_visibility",
+        "recommendation_enabled": false,
+        "visibility_preserved": true
+      },
+      {
+        "authorization_enabled": false,
+        "decision_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_continuity_explanation_visibility"
+        ],
+        "explainability_visibility_id": "public_explainability_continuity_explanation_visibility",
+        "explainability_visibility_type": "continuity_explanation_visibility",
+        "recommendation_enabled": false,
+        "visibility_preserved": true
+      },
+      {
+        "authorization_enabled": false,
+        "decision_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_integrity_explanation_visibility"
+        ],
+        "explainability_visibility_id": "public_explainability_integrity_explanation_visibility",
+        "explainability_visibility_type": "integrity_explanation_visibility",
+        "recommendation_enabled": false,
+        "visibility_preserved": true
+      },
+      {
+        "authorization_enabled": false,
+        "decision_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_fail_visible_explanation_diagnostics"
+        ],
+        "explainability_visibility_id": "public_explainability_fail_visible_explanation_diagnostics",
+        "explainability_visibility_type": "fail_visible_explanation_diagnostics",
+        "recommendation_enabled": false,
+        "visibility_preserved": true
+      }
+    ],
+    "governance_transparency": [
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_inherited_prohibitions"
+        ],
+        "operational_approval_enabled": false,
+        "public_visibility": true,
+        "transparency_type": "inherited_prohibitions",
+        "transparency_visibility_id": "governance_transparency_inherited_prohibitions",
+        "visibility_preserved": true
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_inherited_constraints"
+        ],
+        "operational_approval_enabled": false,
+        "public_visibility": true,
+        "transparency_type": "inherited_constraints",
+        "transparency_visibility_id": "governance_transparency_inherited_constraints",
+        "visibility_preserved": true
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_governance_safe_limitations"
+        ],
+        "operational_approval_enabled": false,
+        "public_visibility": true,
+        "transparency_type": "governance_safe_limitations",
+        "transparency_visibility_id": "governance_transparency_governance_safe_limitations",
+        "visibility_preserved": true
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_descriptive_only_guarantees"
+        ],
+        "operational_approval_enabled": false,
+        "public_visibility": true,
+        "transparency_type": "descriptive_only_guarantees",
+        "transparency_visibility_id": "governance_transparency_descriptive_only_guarantees",
+        "visibility_preserved": true
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_fail_visible_limitations"
+        ],
+        "operational_approval_enabled": false,
+        "public_visibility": true,
+        "transparency_type": "fail_visible_limitations",
+        "transparency_visibility_id": "governance_transparency_fail_visible_limitations",
+        "visibility_preserved": true
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_continuity_guarantees"
+        ],
+        "operational_approval_enabled": false,
+        "public_visibility": true,
+        "transparency_type": "continuity_guarantees",
+        "transparency_visibility_id": "governance_transparency_continuity_guarantees",
+        "visibility_preserved": true
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_explainability_guarantees"
+        ],
+        "operational_approval_enabled": false,
+        "public_visibility": true,
+        "transparency_type": "explainability_guarantees",
+        "transparency_visibility_id": "governance_transparency_explainability_guarantees",
+        "visibility_preserved": true
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_deterministic_guarantees"
+        ],
+        "operational_approval_enabled": false,
+        "public_visibility": true,
+        "transparency_type": "deterministic_guarantees",
+        "transparency_visibility_id": "governance_transparency_deterministic_guarantees",
+        "visibility_preserved": true
+      }
+    ],
+    "integrity": [
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_integrity_continuity_visibility"
+        ],
+        "integrity_visibility_id": "public_integrity_integrity_continuity_visibility",
+        "integrity_visibility_type": "integrity_continuity_visibility",
+        "operational_semantics_enabled": false,
+        "visibility_preserved": true
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_degradation_visibility"
+        ],
+        "integrity_visibility_id": "public_integrity_degradation_visibility",
+        "integrity_visibility_type": "degradation_visibility",
+        "operational_semantics_enabled": false,
+        "visibility_preserved": true
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_diagnostics_visibility"
+        ],
+        "integrity_visibility_id": "public_integrity_diagnostics_visibility",
+        "integrity_visibility_type": "diagnostics_visibility",
+        "operational_semantics_enabled": false,
+        "visibility_preserved": true
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_fail_visible_integrity_summaries"
+        ],
+        "integrity_visibility_id": "public_integrity_fail_visible_integrity_summaries",
+        "integrity_visibility_type": "fail_visible_integrity_summaries",
+        "operational_semantics_enabled": false,
+        "visibility_preserved": true
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_integrity_states"
+        ],
+        "integrity_visibility_id": "public_integrity_unsupported_integrity_states",
+        "integrity_visibility_type": "unsupported_integrity_states",
+        "operational_semantics_enabled": false,
+        "visibility_preserved": true
+      }
+    ],
+    "public_trust_evidence": [
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_deterministic_evidence_visibility"
+        ],
+        "evidence_visibility_id": "public_trust_evidence_deterministic_evidence_visibility",
+        "evidence_visibility_type": "deterministic_evidence_visibility",
+        "provenance_safe": true,
+        "replay_safe": true,
+        "scoring_enabled": false,
+        "visibility_preserved": true
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_replay_safe_evidence_visibility"
+        ],
+        "evidence_visibility_id": "public_trust_evidence_replay_safe_evidence_visibility",
+        "evidence_visibility_type": "replay_safe_evidence_visibility",
+        "provenance_safe": true,
+        "replay_safe": true,
+        "scoring_enabled": false,
+        "visibility_preserved": true
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_provenance_visibility"
+        ],
+        "evidence_visibility_id": "public_trust_evidence_provenance_visibility",
+        "evidence_visibility_type": "provenance_visibility",
+        "provenance_safe": true,
+        "replay_safe": true,
+        "scoring_enabled": false,
+        "visibility_preserved": true
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_lineage_visibility"
+        ],
+        "evidence_visibility_id": "public_trust_evidence_lineage_visibility",
+        "evidence_visibility_type": "lineage_visibility",
+        "provenance_safe": true,
+        "replay_safe": true,
+        "scoring_enabled": false,
+        "visibility_preserved": true
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_continuity_visibility"
+        ],
+        "evidence_visibility_id": "public_trust_evidence_continuity_visibility",
+        "evidence_visibility_type": "continuity_visibility",
+        "provenance_safe": true,
+        "replay_safe": true,
+        "scoring_enabled": false,
+        "visibility_preserved": true
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_integrity_visibility"
+        ],
+        "evidence_visibility_id": "public_trust_evidence_integrity_visibility",
+        "evidence_visibility_type": "integrity_visibility",
+        "provenance_safe": true,
+        "replay_safe": true,
+        "scoring_enabled": false,
+        "visibility_preserved": true
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_explainability_visibility"
+        ],
+        "evidence_visibility_id": "public_trust_evidence_explainability_visibility",
+        "evidence_visibility_type": "explainability_visibility",
+        "provenance_safe": true,
+        "replay_safe": true,
+        "scoring_enabled": false,
+        "visibility_preserved": true
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_diagnostics_visibility"
+        ],
+        "evidence_visibility_id": "public_trust_evidence_diagnostics_visibility",
+        "evidence_visibility_type": "diagnostics_visibility",
+        "provenance_safe": true,
+        "replay_safe": true,
+        "scoring_enabled": false,
+        "visibility_preserved": true
+      }
+    ],
+    "trust_summaries": [
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_evidence_continuity_visibility"
+        ],
+        "execution_enablement_enabled": false,
+        "production_enablement_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "summary_state": "trust_summary_descriptive_only",
+        "summary_type": "evidence_continuity_visibility",
+        "trust_summary_id": "v4_5b_1_public_trust_summary",
+        "trust_summary_record_id": "trust_summary_evidence_continuity_visibility"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_integrity_continuity_visibility"
+        ],
+        "execution_enablement_enabled": false,
+        "production_enablement_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "summary_state": "trust_summary_descriptive_only",
+        "summary_type": "integrity_continuity_visibility",
+        "trust_summary_id": "v4_5b_1_public_trust_summary",
+        "trust_summary_record_id": "trust_summary_integrity_continuity_visibility"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_explainability_continuity_visibility"
+        ],
+        "execution_enablement_enabled": false,
+        "production_enablement_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "summary_state": "trust_summary_descriptive_only",
+        "summary_type": "explainability_continuity_visibility",
+        "trust_summary_id": "v4_5b_1_public_trust_summary",
+        "trust_summary_record_id": "trust_summary_explainability_continuity_visibility"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_state_visibility"
+        ],
+        "execution_enablement_enabled": false,
+        "production_enablement_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "summary_state": "trust_summary_descriptive_only",
+        "summary_type": "unsupported_state_visibility",
+        "trust_summary_id": "v4_5b_1_public_trust_summary",
+        "trust_summary_record_id": "trust_summary_unsupported_state_visibility"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_fail_visible_diagnostics_visibility"
+        ],
+        "execution_enablement_enabled": false,
+        "production_enablement_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "summary_state": "trust_summary_descriptive_only",
+        "summary_type": "fail_visible_diagnostics_visibility",
+        "trust_summary_id": "v4_5b_1_public_trust_summary",
+        "trust_summary_record_id": "trust_summary_fail_visible_diagnostics_visibility"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_governance_transparency_visibility"
+        ],
+        "execution_enablement_enabled": false,
+        "production_enablement_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "summary_state": "trust_summary_descriptive_only",
+        "summary_type": "governance_transparency_visibility",
+        "trust_summary_id": "v4_5b_1_public_trust_summary",
+        "trust_summary_record_id": "trust_summary_governance_transparency_visibility"
+      }
+    ],
+    "trust_visibility": [
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "continuity_reference_id": "continuity::v4_5b_1.public_trust",
+        "descriptive_only": true,
+        "diagnostics_reference_id": "diagnostics::v4_5b_1.public_trust",
+        "evidence_reference_id": "evidence::v4_5b_1.public_trust",
+        "explainability_reference_id": "explainability::v4_5b_1.public_trust",
+        "fail_visible": true,
+        "integrity_reference_id": "integrity::v4_5b_1.public_trust",
+        "lineage_reference_id": "lineage::v4_5b_1.public_trust",
+        "provenance_reference_id": "provenance::v4_5b_1.public_trust",
+        "publicly_transparent": true,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "transparency_reference_id": "transparency::v4_5b_1.public_trust",
+        "trust_authority_enabled": false,
+        "trust_record_id": "public_trust_visibility_foundation",
+        "trust_summary_id": "v4_5b_1_public_trust_summary",
+        "trust_visibility_id": "v4_5b_1_public_trust_visibility",
+        "unsupported_state_reference_id": "unsupported::v4_5b_1.public_trust"
+      }
+    ],
+    "unsupported_public_trust": [
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_public_trust_states"
+        ],
+        "explicit_reason": "orchestration_execution remains unsupported for v4.5B.1 public trust visibility foundations.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_public_trust_state_orchestration_execution",
+        "suppression_enabled": false,
+        "unsupported_state": "orchestration_execution"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_public_trust_states"
+        ],
+        "explicit_reason": "orchestration_authorization remains unsupported for v4.5B.1 public trust visibility foundations.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_public_trust_state_orchestration_authorization",
+        "suppression_enabled": false,
+        "unsupported_state": "orchestration_authorization"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_public_trust_states"
+        ],
+        "explicit_reason": "orchestration_approval remains unsupported for v4.5B.1 public trust visibility foundations.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_public_trust_state_orchestration_approval",
+        "suppression_enabled": false,
+        "unsupported_state": "orchestration_approval"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_public_trust_states"
+        ],
+        "explicit_reason": "orchestration_dispatch remains unsupported for v4.5B.1 public trust visibility foundations.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_public_trust_state_orchestration_dispatch",
+        "suppression_enabled": false,
+        "unsupported_state": "orchestration_dispatch"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_public_trust_states"
+        ],
+        "explicit_reason": "orchestration_routing remains unsupported for v4.5B.1 public trust visibility foundations.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_public_trust_state_orchestration_routing",
+        "suppression_enabled": false,
+        "unsupported_state": "orchestration_routing"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_public_trust_states"
+        ],
+        "explicit_reason": "orchestration_traversal remains unsupported for v4.5B.1 public trust visibility foundations.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_public_trust_state_orchestration_traversal",
+        "suppression_enabled": false,
+        "unsupported_state": "orchestration_traversal"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_public_trust_states"
+        ],
+        "explicit_reason": "orchestration_scheduling remains unsupported for v4.5B.1 public trust visibility foundations.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_public_trust_state_orchestration_scheduling",
+        "suppression_enabled": false,
+        "unsupported_state": "orchestration_scheduling"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_public_trust_states"
+        ],
+        "explicit_reason": "orchestration_sequencing remains unsupported for v4.5B.1 public trust visibility foundations.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_public_trust_state_orchestration_sequencing",
+        "suppression_enabled": false,
+        "unsupported_state": "orchestration_sequencing"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_public_trust_states"
+        ],
+        "explicit_reason": "orchestration_decisions remains unsupported for v4.5B.1 public trust visibility foundations.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_public_trust_state_orchestration_decisions",
+        "suppression_enabled": false,
+        "unsupported_state": "orchestration_decisions"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_public_trust_states"
+        ],
+        "explicit_reason": "orchestration_recommendations remains unsupported for v4.5B.1 public trust visibility foundations.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_public_trust_state_orchestration_recommendations",
+        "suppression_enabled": false,
+        "unsupported_state": "orchestration_recommendations"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_public_trust_states"
+        ],
+        "explicit_reason": "trust_based_authorization remains unsupported for v4.5B.1 public trust visibility foundations.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_public_trust_state_trust_based_authorization",
+        "suppression_enabled": false,
+        "unsupported_state": "trust_based_authorization"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_public_trust_states"
+        ],
+        "explicit_reason": "trust_based_approval remains unsupported for v4.5B.1 public trust visibility foundations.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_public_trust_state_trust_based_approval",
+        "suppression_enabled": false,
+        "unsupported_state": "trust_based_approval"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_public_trust_states"
+        ],
+        "explicit_reason": "trust_based_ranking remains unsupported for v4.5B.1 public trust visibility foundations.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_public_trust_state_trust_based_ranking",
+        "suppression_enabled": false,
+        "unsupported_state": "trust_based_ranking"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_public_trust_states"
+        ],
+        "explicit_reason": "trust_based_recommendation remains unsupported for v4.5B.1 public trust visibility foundations.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_public_trust_state_trust_based_recommendation",
+        "suppression_enabled": false,
+        "unsupported_state": "trust_based_recommendation"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_public_trust_states"
+        ],
+        "explicit_reason": "automated_remediation remains unsupported for v4.5B.1 public trust visibility foundations.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_public_trust_state_automated_remediation",
+        "suppression_enabled": false,
+        "unsupported_state": "automated_remediation"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_public_trust_states"
+        ],
+        "explicit_reason": "automated_repair remains unsupported for v4.5B.1 public trust visibility foundations.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_public_trust_state_automated_repair",
+        "suppression_enabled": false,
+        "unsupported_state": "automated_repair"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_public_trust_states"
+        ],
+        "explicit_reason": "automated_mitigation remains unsupported for v4.5B.1 public trust visibility foundations.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_public_trust_state_automated_mitigation",
+        "suppression_enabled": false,
+        "unsupported_state": "automated_mitigation"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_public_trust_states"
+        ],
+        "explicit_reason": "automated_correction remains unsupported for v4.5B.1 public trust visibility foundations.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_public_trust_state_automated_correction",
+        "suppression_enabled": false,
+        "unsupported_state": "automated_correction"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_public_trust_states"
+        ],
+        "explicit_reason": "planner_integration remains unsupported for v4.5B.1 public trust visibility foundations.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_public_trust_state_planner_integration",
+        "suppression_enabled": false,
+        "unsupported_state": "planner_integration"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_public_trust_states"
+        ],
+        "explicit_reason": "production_consumption remains unsupported for v4.5B.1 public trust visibility foundations.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_public_trust_state_production_consumption",
+        "suppression_enabled": false,
+        "unsupported_state": "production_consumption"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_public_trust_states"
+        ],
+        "explicit_reason": "runtime_mutation remains unsupported for v4.5B.1 public trust visibility foundations.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_public_trust_state_runtime_mutation",
+        "suppression_enabled": false,
+        "unsupported_state": "runtime_mutation"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_public_trust_states"
+        ],
+        "explicit_reason": "operational_mutation remains unsupported for v4.5B.1 public trust visibility foundations.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_public_trust_state_operational_mutation",
+        "suppression_enabled": false,
+        "unsupported_state": "operational_mutation"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_public_trust_states"
+        ],
+        "explicit_reason": "implicit_operational_behavior remains unsupported for v4.5B.1 public trust visibility foundations.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_public_trust_state_implicit_operational_behavior",
+        "suppression_enabled": false,
+        "unsupported_state": "implicit_operational_behavior"
+      }
+    ],
+    "unsupported_states": [
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_drift_states"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "remediation_enabled": false,
+        "suppression_enabled": false,
+        "unsupported_state_type": "unsupported_drift_states",
+        "unsupported_visibility_id": "unsupported_state_visibility_unsupported_drift_states",
+        "visibility_preserved": true
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_propagation_states"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "remediation_enabled": false,
+        "suppression_enabled": false,
+        "unsupported_state_type": "unsupported_propagation_states",
+        "unsupported_visibility_id": "unsupported_state_visibility_unsupported_propagation_states",
+        "visibility_preserved": true
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_degradation_states"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "remediation_enabled": false,
+        "suppression_enabled": false,
+        "unsupported_state_type": "unsupported_degradation_states",
+        "unsupported_visibility_id": "unsupported_state_visibility_unsupported_degradation_states",
+        "visibility_preserved": true
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_explainability_states"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "remediation_enabled": false,
+        "suppression_enabled": false,
+        "unsupported_state_type": "unsupported_explainability_states",
+        "unsupported_visibility_id": "unsupported_state_visibility_unsupported_explainability_states",
+        "visibility_preserved": true
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_continuity_states"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "remediation_enabled": false,
+        "suppression_enabled": false,
+        "unsupported_state_type": "unsupported_continuity_states",
+        "unsupported_visibility_id": "unsupported_state_visibility_unsupported_continuity_states",
+        "visibility_preserved": true
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_operational_states"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "remediation_enabled": false,
+        "suppression_enabled": false,
+        "unsupported_state_type": "unsupported_operational_states",
+        "unsupported_visibility_id": "unsupported_state_visibility_unsupported_operational_states",
+        "visibility_preserved": true
+      }
+    ]
+  }
+}

--- a/docs/migration/V4_5B_1_TRUST_VISIBILITY_FOUNDATIONS.md
+++ b/docs/migration/V4_5B_1_TRUST_VISIBILITY_FOUNDATIONS.md
@@ -1,0 +1,136 @@
+# V4.5B.1 Trust Visibility Foundations
+
+## Architectural Purpose
+
+v4.5B.1 establishes deterministic public trust visibility foundations on top
+of the completed v4.5A governance-safe drift intelligence chain. The package is
+descriptive-only public visibility infrastructure for trust identity, evidence
+visibility, unsupported-state visibility, governance transparency,
+explainability visibility, integrity visibility, and fail-visible public
+diagnostics.
+
+This phase does not create operational trust authority. Public trust visibility
+is descriptive-only. Trust visibility does NOT imply authorization, approval,
+operational readiness, or production enablement.
+
+## Deterministic Public Trust Philosophy
+
+The implementation preserves the inherited constraints:
+
+- deterministic
+- governance-safe
+- replay-safe
+- rollback-safe
+- lineage-safe
+- provenance-safe
+- integrity-safe
+- explainability-first
+- fail-visible
+- descriptive-only
+- publicly transparent
+
+Trust visibility is modeled as explicit records and summaries. It is not a
+score, rank, recommendation, approval, authorization, execution guarantee,
+correctness guarantee, operational readiness claim, or production enablement
+signal.
+
+## Governance Transparency Visibility
+
+Governance transparency records expose inherited prohibitions, inherited
+constraints, governance-safe limitations, descriptive-only guarantees,
+fail-visible limitations, continuity guarantees, explainability guarantees, and
+deterministic guarantees.
+
+The transparency layer remains public-facing visibility only. It does not add
+approval semantics, authorization semantics, operational behavior, or runtime
+authority.
+
+## Unsupported-State Visibility Philosophy
+
+Unsupported drift, propagation, degradation, explainability, continuity, and
+operational states remain explicit and fail-visible. Unsupported states are not
+suppressed, normalized away, repaired, backfilled, or given fallback behavior.
+
+## Explainability Visibility Philosophy
+
+Public explainability visibility covers explanation chains,
+evidence-to-explanation visibility, continuity explanation visibility,
+integrity explanation visibility, and fail-visible explanation diagnostics.
+These records do not recommend action, assign authority, rank outcomes, or
+drive operational decisions.
+
+## Integrity Visibility Philosophy
+
+Public integrity visibility covers integrity continuity, degradation
+visibility, diagnostics visibility, fail-visible integrity summaries, and
+unsupported integrity states. Integrity visibility remains descriptive-only and
+does not imply approval, correctness guarantees, or operational readiness.
+
+## Fail-Visible Public Diagnostics Philosophy
+
+Diagnostics remain explicit for missing evidence visibility, incomplete
+continuity visibility, unsupported public trust states, unsupported operational
+states, incomplete explainability visibility, incomplete integrity visibility,
+inherited limitation visibility gaps, and inherited prohibition visibility
+gaps.
+
+No diagnostic suppresses, remediates, ranks, recommends, authorizes, approves,
+or triggers operational behavior.
+
+## Hashing Guarantees
+
+Trust visibility records, transparency records, unsupported-state records,
+trust summaries, diagnostics records, explainability records, and integrity
+records use deterministic SHA-256 hashing over canonical JSON serialization.
+Hashes are stable, replay-safe, provenance-safe, and integrity-safe.
+
+## Serialization Guarantees
+
+Serialization uses deterministic ordering for record collections and evidence
+references. It preserves replayability, provenance continuity, lineage
+continuity, unsupported-state visibility, and descriptive-only statements.
+
+## Inherited Prohibitions
+
+The repository remains:
+
+- NON-operational
+- NON-authorizing
+- NON-approving
+- NON-executing
+- NON-remediating
+- NON-runtime-mutating
+- NON-ranking
+- NON-recommending
+
+This phase preserves prohibitions against orchestration execution,
+authorization, approval, dispatch, routing, traversal, scheduling, sequencing,
+decisions, recommendations, trust-based authorization, trust-based approval,
+trust-based ranking, trust-based recommendation, automated remediation,
+automated repair, automated mitigation, automated correction, planner
+integration, production consumption, runtime mutation, operational mutation,
+and implicit operational behavior.
+
+## Unsupported Operational States
+
+Unsupported operational states are represented as fail-visible public trust
+visibility records. They are explicit visibility artifacts only and do not
+enable fallback behavior, suppression behavior, trust scoring, trust ranking,
+trust recommendation, authorization, approval, execution, planner integration,
+production consumption, or runtime mutation.
+
+## Intentionally Preserved Limitations
+
+v4.5B.1 intentionally preserves these limitations:
+
+- Public trust visibility does not authorize or approve.
+- Public trust visibility does not rank or recommend.
+- Public trust visibility does not execute.
+- Public trust visibility does not enable production.
+- Public trust visibility does not imply correctness guarantees.
+- Public trust visibility does not remediate, repair, mitigate, or correct.
+- Public trust visibility does not integrate planners.
+- Public trust visibility does not mutate runtime state.
+
+The phase is a deterministic descriptive foundation for later public trust
+visibility work only.


### PR DESCRIPTION
Implement governance-safe deterministic public trust visibility foundations including transparency visibility, unsupported-state visibility, explainability visibility, integrity visibility, fail-visible public diagnostics, hashing, serialization, reporting, and descriptive-only public trust guarantees without introducing authorization, approval, recommendation, execution, or operational behavior.