### PR TITLE
v4.5B.2: implement support status visibility

### DIFF
--- a/backend/app/public_trust_visibility/v4_5b_2_support_status_visibility_audit.py
+++ b/backend/app/public_trust_visibility/v4_5b_2_support_status_visibility_audit.py
@@ -1,0 +1,1098 @@
+"""Audit for deterministic v4.5B.2 support status visibility.
+
+The audit validates descriptive support status visibility only. It does not
+authorize, approve, execute, dispatch, route, traverse, schedule, sequence,
+decide, recommend, rank, remediate, repair, mitigate, correct, integrate
+planners, consume production paths, or mutate runtime or operational state.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import is_dataclass, replace
+from pathlib import Path
+from typing import Any, Iterable
+
+from .v4_5b_2_support_status_visibility_hashing import (
+    deterministic_v4_5b_2_support_status_visibility_hash,
+    hash_continuity_support_visibility,
+    hash_evidence_based_support_visibility,
+    hash_experimental_deprecated_visibility,
+    hash_explainability_support_visibility,
+    hash_public_support_surface_visibility,
+    hash_support_classification_visibility,
+    hash_support_diagnostic_record,
+    hash_support_status_identity,
+    hash_support_summary_record,
+    hash_support_visibility_record,
+    hash_unsupported_support_operational_state_visibility,
+    hash_unsupported_support_state_visibility,
+    hash_v4_5b_2_support_status_visibility,
+)
+from .v4_5b_2_support_status_visibility_models import (
+    CONTINUITY_SUPPORT_VISIBILITY_TYPES,
+    EVIDENCE_BASED_SUPPORT_VISIBILITY_TYPES,
+    EXPERIMENTAL_DEPRECATED_VISIBILITY_TYPES,
+    EXPLAINABILITY_SUPPORT_VISIBILITY_TYPES,
+    PUBLIC_SUPPORT_SURFACE_TYPES,
+    SUPPORT_CLASSIFICATION_NON_AUTHORITY_STATEMENT,
+    SUPPORT_CLASSIFICATION_TYPES,
+    SUPPORT_DIAGNOSTIC_TYPES,
+    SUPPORT_STATUS_VISIBILITY_STATEMENT,
+    SUPPORT_SUMMARY_TYPES,
+    UNSUPPORTED_SUPPORT_OPERATIONAL_STATES,
+    UNSUPPORTED_SUPPORT_STATE_TYPES,
+    V4_5B_2_SUPPORT_STATUS_VISIBILITY_DISABLED_COUNTER_NAMES,
+    V4_5B_2_SUPPORT_STATUS_VISIBILITY_GENERATED_AT,
+    V4_5B_2_SUPPORT_STATUS_VISIBILITY_PHASE_ID,
+    V4_5B_2_SUPPORT_STATUS_VISIBILITY_PURPOSE,
+    V4_5B_2_SUPPORT_STATUS_VISIBILITY_REPORT_SCHEMA_VERSION,
+    V4_5B_2_SUPPORT_STATUS_VISIBILITY_STATUS_BLOCKED,
+    V4_5B_2_SUPPORT_STATUS_VISIBILITY_STATUS_STABLE,
+    SupportStatusVisibilityIntelligence,
+    default_v4_5b_2_support_status_visibility,
+)
+from .v4_5b_2_support_status_visibility_serialization import (
+    export_v4_5b_2_support_status_visibility,
+    serialize_v4_5b_2_support_status_visibility,
+)
+from .v4_5b_2_support_status_visibility_visibility import (
+    continuity_support_summary,
+    descriptive_only_support_status_summary,
+    evidence_based_support_summary,
+    experimental_deprecated_summary,
+    explainability_support_summary,
+    support_classification_summary,
+    support_diagnostic_summary,
+    support_summary_visibility,
+    support_surface_summary,
+    support_visibility_summary,
+    unsupported_operational_state_summary,
+    unsupported_state_summary,
+    validate_required_support_status_visibility,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+CAPABILITY_COUNTER_FIELD_MAP: dict[str, tuple[str, ...]] = {
+    "enabled_runtime_execution_count": (
+        "runtime_execution_enabled",
+        "orchestration_execution_enabled",
+        "planner_execution_enabled",
+        "execution_enabled",
+        "execution_enablement_enabled",
+        "execution_semantics_enabled",
+    ),
+    "enabled_orchestration_authorization_count": (
+        "orchestration_authorization_enabled",
+        "authorization_enabled",
+    ),
+    "enabled_orchestration_approval_count": (
+        "orchestration_approval_enabled",
+        "approval_enabled",
+    ),
+    "enabled_orchestration_dispatch_count": (
+        "orchestration_dispatch_enabled",
+        "dispatch_enabled",
+    ),
+    "enabled_orchestration_routing_count": (
+        "orchestration_routing_enabled",
+        "routing_enabled",
+    ),
+    "enabled_orchestration_traversal_count": (
+        "orchestration_traversal_enabled",
+        "traversal_enabled",
+    ),
+    "enabled_orchestration_scheduling_count": (
+        "orchestration_scheduling_enabled",
+        "scheduling_enabled",
+    ),
+    "enabled_orchestration_sequencing_count": (
+        "orchestration_sequencing_enabled",
+        "sequencing_enabled",
+    ),
+    "enabled_orchestration_decision_count": (
+        "orchestration_decision_enabled",
+        "decision_enabled",
+    ),
+    "enabled_orchestration_recommendation_count": (
+        "orchestration_recommendation_enabled",
+        "orchestration_response_enabled",
+    ),
+    "enabled_support_authorization_count": (
+        "support_authorization_enabled",
+        "support_authority_enabled",
+        "authorization_enabled",
+    ),
+    "enabled_support_approval_count": (
+        "support_approval_enabled",
+        "approval_enabled",
+        "operational_approval_enabled",
+    ),
+    "enabled_support_ranking_count": (
+        "support_ranking_enabled",
+        "ranking_enabled",
+        "trust_scoring_enabled",
+    ),
+    "enabled_support_recommendation_count": (
+        "support_recommendation_enabled",
+        "recommendation_enabled",
+    ),
+    "enabled_remediation_count": ("remediation_enabled",),
+    "enabled_repair_count": ("repair_enabled",),
+    "enabled_mitigation_count": ("mitigation_enabled",),
+    "enabled_auto_correction_count": (
+        "auto_correction_enabled",
+        "automated_correction_enabled",
+    ),
+    "enabled_planner_integration_count": ("planner_integration_enabled",),
+    "enabled_production_consumption_count": (
+        "production_consumption_enabled",
+        "production_enablement_enabled",
+    ),
+    "enabled_runtime_mutation_count": (
+        "runtime_mutation_enabled",
+        "runtime_enablement_enabled",
+    ),
+    "enabled_operational_mutation_count": (
+        "operational_mutation_enabled",
+        "operational_behavior_enabled",
+        "operational_semantics_enabled",
+        "operational_enabled",
+    ),
+}
+
+PROHIBITED_BOOLEAN_FIELD_NAMES: tuple[str, ...] = tuple(
+    sorted({field for fields in CAPABILITY_COUNTER_FIELD_MAP.values() for field in fields})
+)
+
+
+def build_v4_5b_2_support_status_visibility() -> SupportStatusVisibilityIntelligence:
+    return default_v4_5b_2_support_status_visibility()
+
+
+def _iter_dataclass_objects(value: Any) -> Iterable[Any]:
+    if is_dataclass(value) and not isinstance(value, type):
+        yield value
+        for item in value.__dict__.values():
+            yield from _iter_dataclass_objects(item)
+    elif isinstance(value, dict):
+        for item in value.values():
+            yield from _iter_dataclass_objects(item)
+    elif isinstance(value, tuple | list | set):
+        for item in value:
+            yield from _iter_dataclass_objects(item)
+
+
+def _relative_path_exists(reference: str) -> bool:
+    return (REPO_ROOT / reference).exists()
+
+
+def _report_hash_matches(reference: str, expected_hash: str) -> bool:
+    path = REPO_ROOT / reference
+    if not path.exists():
+        return False
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return False
+    return payload.get("deterministic_report_hash") == expected_hash
+
+
+def enabled_support_status_capability_flags(
+    intelligence: SupportStatusVisibilityIntelligence,
+) -> dict[str, list[str]]:
+    enabled: dict[str, list[str]] = {}
+    for item in _iter_dataclass_objects(intelligence):
+        item_id = (
+            getattr(item, "support_record_id", None)
+            or getattr(item, "classification_visibility_id", None)
+            or getattr(item, "surface_visibility_id", None)
+            or getattr(item, "unsupported_visibility_id", None)
+            or getattr(item, "experimental_deprecated_id", None)
+            or getattr(item, "evidence_support_id", None)
+            or getattr(item, "explainability_support_id", None)
+            or getattr(item, "continuity_support_id", None)
+            or getattr(item, "support_summary_record_id", None)
+            or getattr(item, "diagnostic_id", None)
+            or getattr(item, "state_id", None)
+            or getattr(item, "support_status_id", item.__class__.__name__)
+        )
+        for field_name in PROHIBITED_BOOLEAN_FIELD_NAMES:
+            if bool(getattr(item, field_name, False)):
+                enabled.setdefault(str(item_id), []).append(field_name)
+    return {key: sorted(values) for key, values in sorted(enabled.items())}
+
+
+def support_status_capability_counter_values(
+    intelligence: SupportStatusVisibilityIntelligence,
+) -> dict[str, int]:
+    objects = tuple(_iter_dataclass_objects(intelligence))
+    counters: dict[str, int] = {}
+    for counter_name, field_names in CAPABILITY_COUNTER_FIELD_MAP.items():
+        counters[counter_name] = sum(
+            1
+            for item in objects
+            for field_name in field_names
+            if bool(getattr(item, field_name, False))
+        )
+    return counters
+
+
+def support_status_visibility_equal(
+    left: SupportStatusVisibilityIntelligence,
+    right: SupportStatusVisibilityIntelligence,
+) -> bool:
+    return serialize_v4_5b_2_support_status_visibility(
+        left
+    ) == serialize_v4_5b_2_support_status_visibility(right)
+
+
+def validate_support_status_ordering_stability(
+    intelligence: SupportStatusVisibilityIntelligence,
+) -> dict[str, Any]:
+    order_groups = {
+        "support_visibility_records": tuple(
+            record.deterministic_order for record in intelligence.support_visibility_records
+        ),
+        "support_classifications": tuple(
+            record.deterministic_order for record in intelligence.support_classifications
+        ),
+        "support_surfaces": tuple(
+            record.deterministic_order for record in intelligence.support_surfaces
+        ),
+        "unsupported_state_visibility": tuple(
+            record.deterministic_order
+            for record in intelligence.unsupported_state_visibility
+        ),
+        "experimental_deprecated_visibility": tuple(
+            record.deterministic_order
+            for record in intelligence.experimental_deprecated_visibility
+        ),
+        "evidence_based_support_visibility": tuple(
+            record.deterministic_order
+            for record in intelligence.evidence_based_support_visibility
+        ),
+        "explainability_support_visibility": tuple(
+            record.deterministic_order
+            for record in intelligence.explainability_support_visibility
+        ),
+        "continuity_support_visibility": tuple(
+            record.deterministic_order
+            for record in intelligence.continuity_support_visibility
+        ),
+        "support_summaries": tuple(
+            record.deterministic_order for record in intelligence.support_summaries
+        ),
+        "support_diagnostics": tuple(
+            record.deterministic_order for record in intelligence.support_diagnostics
+        ),
+        "unsupported_operational_state_visibility": tuple(
+            record.deterministic_order
+            for record in intelligence.unsupported_operational_state_visibility
+        ),
+    }
+    unordered_groups = sorted(
+        key for key, values in order_groups.items() if tuple(sorted(values)) != values
+    )
+    return {
+        "valid": not unordered_groups,
+        "order_groups": {key: list(values) for key, values in order_groups.items()},
+        "unordered_groups": unordered_groups,
+    }
+
+
+def validate_support_identity_integrity(
+    intelligence: SupportStatusVisibilityIntelligence,
+) -> dict[str, Any]:
+    identity = intelligence.support_identity
+    required_values = {
+        "support_status_id": identity.support_status_id,
+        "support_summary_id": identity.support_summary_id,
+        "support_scope_id": identity.support_scope_id,
+        "support_reference_id": identity.support_reference_id,
+        "evidence_reference_id": identity.evidence_reference_id,
+        "explainability_reference_id": identity.explainability_reference_id,
+        "continuity_reference_id": identity.continuity_reference_id,
+        "diagnostics_reference_id": identity.diagnostics_reference_id,
+        "lineage_reference_id": identity.lineage_reference_id,
+        "provenance_reference_id": identity.provenance_reference_id,
+    }
+    missing_fields = sorted(key for key, value in required_values.items() if not value)
+    source_report_present = _relative_path_exists(
+        identity.source_trust_visibility_report_reference
+    )
+    source_report_hash_matches = _report_hash_matches(
+        identity.source_trust_visibility_report_reference,
+        identity.source_trust_visibility_hash_reference,
+    )
+    return {
+        "valid": not missing_fields
+        and identity.phase_id == V4_5B_2_SUPPORT_STATUS_VISIBILITY_PHASE_ID
+        and source_report_present
+        and source_report_hash_matches,
+        "missing_identity_fields": missing_fields,
+        "phase_id": identity.phase_id,
+        "schema_version": identity.schema_version,
+        "source_report_present": source_report_present,
+        "source_report_hash_matches": source_report_hash_matches,
+    }
+
+
+def validate_support_classification_stability(
+    intelligence: SupportStatusVisibilityIntelligence,
+) -> dict[str, Any]:
+    records = intelligence.support_classifications
+    present = {record.support_classification for record in records}
+    missing_types = sorted(set(SUPPORT_CLASSIFICATION_TYPES) - present)
+    unsafe_ids = sorted(
+        record.classification_visibility_id
+        for record in records
+        if (
+            not record.descriptive_only
+            or record.operational_approval_enabled
+            or record.execution_semantics_enabled
+            or record.authorization_enabled
+            or record.approval_enabled
+        )
+    )
+    return {
+        "valid": not (missing_types or unsafe_ids),
+        "support_classification_count": len(records),
+        "missing_classifications": missing_types,
+        "unsafe_classification_ids": unsafe_ids,
+    }
+
+
+def validate_public_support_surface_visibility(
+    intelligence: SupportStatusVisibilityIntelligence,
+) -> dict[str, Any]:
+    records = intelligence.support_surfaces
+    present = {record.support_surface for record in records}
+    missing_types = sorted(set(PUBLIC_SUPPORT_SURFACE_TYPES) - present)
+    unsafe_ids = sorted(
+        record.surface_visibility_id
+        for record in records
+        if (
+            record.support_classification not in SUPPORT_CLASSIFICATION_TYPES
+            or not record.descriptive_only
+            or record.ranking_enabled
+            or record.recommendation_enabled
+            or record.operational_enabled
+        )
+    )
+    return {
+        "valid": not (missing_types or unsafe_ids),
+        "support_surface_count": len(records),
+        "missing_surfaces": missing_types,
+        "unsafe_surface_ids": unsafe_ids,
+    }
+
+
+def validate_unsupported_state_visibility_preservation(
+    intelligence: SupportStatusVisibilityIntelligence,
+) -> dict[str, Any]:
+    records = intelligence.unsupported_state_visibility
+    present = {record.unsupported_state_type for record in records}
+    missing_types = sorted(set(UNSUPPORTED_SUPPORT_STATE_TYPES) - present)
+    unsafe_ids = sorted(
+        record.unsupported_visibility_id
+        for record in records
+        if (
+            not record.descriptive_only
+            or not record.fail_visible
+            or record.suppression_enabled
+            or record.hidden_fallback_enabled
+            or record.authorization_enabled
+            or record.approval_enabled
+            or record.remediation_enabled
+        )
+    )
+    return {
+        "valid": not (missing_types or unsafe_ids),
+        "unsupported_state_visibility_count": len(records),
+        "missing_unsupported_state_types": missing_types,
+        "unsafe_unsupported_state_ids": unsafe_ids,
+    }
+
+
+def validate_experimental_deprecated_visibility_preservation(
+    intelligence: SupportStatusVisibilityIntelligence,
+) -> dict[str, Any]:
+    records = intelligence.experimental_deprecated_visibility
+    present = {record.visibility_type for record in records}
+    missing_types = sorted(set(EXPERIMENTAL_DEPRECATED_VISIBILITY_TYPES) - present)
+    unsafe_ids = sorted(
+        record.experimental_deprecated_id
+        for record in records
+        if (
+            not record.descriptive_only
+            or record.automatic_migration_enabled
+            or record.operational_fallback_enabled
+            or record.authorization_enabled
+            or record.approval_enabled
+        )
+    )
+    return {
+        "valid": not (missing_types or unsafe_ids),
+        "experimental_deprecated_count": len(records),
+        "missing_experimental_deprecated_types": missing_types,
+        "unsafe_experimental_deprecated_ids": unsafe_ids,
+    }
+
+
+def validate_evidence_based_support_visibility(
+    intelligence: SupportStatusVisibilityIntelligence,
+) -> dict[str, Any]:
+    records = intelligence.evidence_based_support_visibility
+    present = {record.evidence_support_type for record in records}
+    missing_types = sorted(set(EVIDENCE_BASED_SUPPORT_VISIBILITY_TYPES) - present)
+    unsafe_ids = sorted(
+        record.evidence_support_id
+        for record in records
+        if (
+            not record.descriptive_only
+            or not record.replay_safe
+            or not record.provenance_safe
+            or record.trust_scoring_enabled
+            or record.approval_enabled
+            or record.authorization_enabled
+        )
+    )
+    return {
+        "valid": not (missing_types or unsafe_ids),
+        "evidence_based_support_count": len(records),
+        "missing_evidence_support_types": missing_types,
+        "unsafe_evidence_support_ids": unsafe_ids,
+    }
+
+
+def validate_explainability_support_visibility(
+    intelligence: SupportStatusVisibilityIntelligence,
+) -> dict[str, Any]:
+    records = intelligence.explainability_support_visibility
+    present = {record.explainability_support_type for record in records}
+    missing_types = sorted(set(EXPLAINABILITY_SUPPORT_VISIBILITY_TYPES) - present)
+    unsafe_ids = sorted(
+        record.explainability_support_id
+        for record in records
+        if (
+            not record.descriptive_only
+            or record.recommendation_enabled
+            or record.operational_semantics_enabled
+            or record.authorization_enabled
+        )
+    )
+    return {
+        "valid": not (missing_types or unsafe_ids),
+        "explainability_support_count": len(records),
+        "missing_explainability_support_types": missing_types,
+        "unsafe_explainability_support_ids": unsafe_ids,
+    }
+
+
+def validate_continuity_support_visibility(
+    intelligence: SupportStatusVisibilityIntelligence,
+) -> dict[str, Any]:
+    records = intelligence.continuity_support_visibility
+    present = {record.continuity_support_type for record in records}
+    missing_types = sorted(set(CONTINUITY_SUPPORT_VISIBILITY_TYPES) - present)
+    unsafe_ids = sorted(
+        record.continuity_support_id
+        for record in records
+        if (
+            not record.continuity_reference_id
+            or not record.descriptive_only
+            or record.restoration_enabled
+            or record.repair_enabled
+            or record.remediation_enabled
+            or record.authorization_enabled
+        )
+    )
+    return {
+        "valid": not (missing_types or unsafe_ids),
+        "continuity_support_count": len(records),
+        "missing_continuity_support_types": missing_types,
+        "unsafe_continuity_support_ids": unsafe_ids,
+    }
+
+
+def validate_support_summary_stability(
+    intelligence: SupportStatusVisibilityIntelligence,
+) -> dict[str, Any]:
+    records = intelligence.support_summaries
+    present = {record.summary_type for record in records}
+    missing_types = sorted(set(SUPPORT_SUMMARY_TYPES) - present)
+    unsafe_ids = sorted(
+        record.support_summary_record_id
+        for record in records
+        if (
+            not record.descriptive_only
+            or record.authorization_enabled
+            or record.approval_enabled
+            or record.ranking_enabled
+            or record.recommendation_enabled
+            or record.execution_enablement_enabled
+            or record.production_enablement_enabled
+        )
+    )
+    return {
+        "valid": not (missing_types or unsafe_ids),
+        "support_summary_count": len(records),
+        "missing_summary_types": missing_types,
+        "unsafe_summary_ids": unsafe_ids,
+    }
+
+
+def validate_lineage_and_provenance_preservation(
+    intelligence: SupportStatusVisibilityIntelligence,
+) -> dict[str, Any]:
+    identity = intelligence.support_identity
+    missing_lineage = not bool(identity.lineage_reference_id)
+    missing_provenance = not bool(identity.provenance_reference_id)
+    missing_continuity = not bool(identity.continuity_reference_id)
+    missing_evidence = sorted(
+        str(
+            getattr(item, "classification_visibility_id", None)
+            or getattr(item, "surface_visibility_id", None)
+            or getattr(item, "unsupported_visibility_id", None)
+            or getattr(item, "experimental_deprecated_id", None)
+            or getattr(item, "evidence_support_id", None)
+            or getattr(item, "explainability_support_id", None)
+            or getattr(item, "continuity_support_id", None)
+            or getattr(item, "support_summary_record_id", None)
+            or getattr(item, "diagnostic_id", None)
+            or getattr(item, "state_id", "")
+        )
+        for item in _iter_dataclass_objects(intelligence)
+        if hasattr(item, "evidence_reference_ids")
+        and not tuple(getattr(item, "evidence_reference_ids"))
+    )
+    return {
+        "valid": not (
+            missing_lineage
+            or missing_provenance
+            or missing_continuity
+            or missing_evidence
+        ),
+        "lineage_continuity_preserved": not missing_lineage,
+        "provenance_continuity_preserved": not missing_provenance,
+        "continuity_reference_preserved": not missing_continuity,
+        "evidence_continuity_preserved": not missing_evidence,
+        "missing_evidence_reference_ids": missing_evidence,
+    }
+
+
+def validate_support_status_serialization_and_hashing(
+    intelligence: SupportStatusVisibilityIntelligence,
+) -> dict[str, Any]:
+    first_serialization = serialize_v4_5b_2_support_status_visibility(intelligence)
+    second_serialization = serialize_v4_5b_2_support_status_visibility(intelligence)
+    first_hash = hash_v4_5b_2_support_status_visibility(intelligence)
+    second_hash = hash_v4_5b_2_support_status_visibility(intelligence)
+    rebuilt_hash = hash_v4_5b_2_support_status_visibility(
+        build_v4_5b_2_support_status_visibility()
+    )
+    return {
+        "valid": (
+            first_serialization == second_serialization
+            and first_hash == second_hash
+            and first_hash == rebuilt_hash
+        ),
+        "serialization_stable": first_serialization == second_serialization,
+        "hashing_stable": first_hash == second_hash == rebuilt_hash,
+        "support_status_hash": first_hash,
+        "rebuilt_support_status_hash": rebuilt_hash,
+        "serialization_length": len(first_serialization),
+    }
+
+
+def validate_fail_visible_support_diagnostics(
+    intelligence: SupportStatusVisibilityIntelligence,
+) -> dict[str, Any]:
+    diagnostics = intelligence.support_diagnostics
+    unsupported = intelligence.unsupported_operational_state_visibility
+    missing_diagnostic_types = sorted(
+        set(SUPPORT_DIAGNOSTIC_TYPES) - {record.diagnostic_type for record in diagnostics}
+    )
+    missing_unsupported_states = sorted(
+        set(UNSUPPORTED_SUPPORT_OPERATIONAL_STATES)
+        - {record.unsupported_state for record in unsupported}
+    )
+    unsafe_diagnostic_ids = sorted(
+        record.diagnostic_id
+        for record in diagnostics
+        if (
+            not record.fail_visible
+            or not record.descriptive_only
+            or record.silent_fallback_enabled
+            or record.hidden_fallback_enabled
+            or record.authorization_enabled
+            or record.approval_enabled
+            or record.remediation_enabled
+            or record.repair_enabled
+            or record.mitigation_enabled
+            or record.auto_correction_enabled
+            or record.ranking_enabled
+            or record.recommendation_enabled
+            or record.orchestration_response_enabled
+        )
+    )
+    unsafe_unsupported_ids = sorted(
+        record.state_id
+        for record in unsupported
+        if (
+            not record.fail_visible
+            or not record.descriptive_only
+            or record.authorization_enabled
+            or record.approval_enabled
+            or record.operational_enabled
+            or record.remediation_enabled
+            or record.repair_enabled
+            or record.mitigation_enabled
+            or record.automated_correction_enabled
+            or record.ranking_enabled
+            or record.recommendation_enabled
+            or record.suppression_enabled
+        )
+    )
+    return {
+        "valid": not (
+            missing_diagnostic_types
+            or missing_unsupported_states
+            or unsafe_diagnostic_ids
+            or unsafe_unsupported_ids
+        ),
+        "support_diagnostic_count": len(diagnostics),
+        "unsupported_operational_state_count": len(unsupported),
+        "missing_diagnostic_types": missing_diagnostic_types,
+        "missing_unsupported_states": missing_unsupported_states,
+        "unsafe_diagnostic_ids": unsafe_diagnostic_ids,
+        "unsafe_unsupported_ids": unsafe_unsupported_ids,
+        "fail_visible": all(record.fail_visible for record in diagnostics)
+        and all(record.fail_visible for record in unsupported),
+        "silent_fallback_enabled_count": sum(
+            1 for record in diagnostics if record.silent_fallback_enabled
+        ),
+        "hidden_fallback_enabled_count": sum(
+            1 for record in diagnostics if record.hidden_fallback_enabled
+        ),
+        "authorization_enabled_count": sum(
+            1 for record in diagnostics if record.authorization_enabled
+        )
+        + sum(1 for record in unsupported if record.authorization_enabled),
+        "approval_enabled_count": sum(
+            1 for record in diagnostics if record.approval_enabled
+        )
+        + sum(1 for record in unsupported if record.approval_enabled),
+        "ranking_enabled_count": sum(
+            1 for record in diagnostics if record.ranking_enabled
+        )
+        + sum(1 for record in unsupported if record.ranking_enabled),
+        "recommendation_enabled_count": sum(
+            1 for record in diagnostics if record.recommendation_enabled
+        )
+        + sum(1 for record in unsupported if record.recommendation_enabled),
+    }
+
+
+def validate_descriptive_only_support_guarantees(
+    intelligence: SupportStatusVisibilityIntelligence,
+) -> dict[str, Any]:
+    counters = support_status_capability_counter_values(intelligence)
+    enabled_flags = enabled_support_status_capability_flags(intelligence)
+    descriptive_failures = sorted(
+        str(
+            getattr(item, "support_record_id", None)
+            or getattr(item, "classification_visibility_id", None)
+            or getattr(item, "surface_visibility_id", None)
+            or getattr(item, "diagnostic_id", None)
+            or getattr(item, "state_id", None)
+            or getattr(item, "support_status_id", item.__class__.__name__)
+        )
+        for item in _iter_dataclass_objects(intelligence)
+        if hasattr(item, "descriptive_only") and not getattr(item, "descriptive_only")
+    )
+    missing_disabled_counters = sorted(
+        set(V4_5B_2_SUPPORT_STATUS_VISIBILITY_DISABLED_COUNTER_NAMES) - set(counters)
+    )
+    required_repository_states = {
+        "NON-operational": intelligence.non_operational,
+        "NON-authorizing": intelligence.non_authorizing,
+        "NON-approving": intelligence.non_approving,
+        "NON-executing": intelligence.non_executing,
+        "NON-remediating": intelligence.non_remediating,
+        "NON-runtime-mutating": intelligence.non_runtime_mutating,
+        "NON-ranking": intelligence.non_ranking,
+        "NON-recommending": intelligence.non_recommending,
+    }
+    statement_valid = (
+        intelligence.support_status_visibility_statement
+        == SUPPORT_STATUS_VISIBILITY_STATEMENT
+        and intelligence.support_classification_non_authority_statement
+        == SUPPORT_CLASSIFICATION_NON_AUTHORITY_STATEMENT
+    )
+    return {
+        "valid": (
+            not enabled_flags
+            and all(value == 0 for value in counters.values())
+            and not descriptive_failures
+            and not missing_disabled_counters
+            and all(required_repository_states.values())
+            and intelligence.publicly_transparent
+            and statement_valid
+        ),
+        "enabled_flags": enabled_flags,
+        "counters": counters,
+        "descriptive_failures": descriptive_failures,
+        "missing_disabled_counters": missing_disabled_counters,
+        "repository_remains": required_repository_states,
+        "publicly_transparent": intelligence.publicly_transparent,
+        "support_status_visibility_statement": (
+            intelligence.support_status_visibility_statement
+        ),
+        "support_classification_non_authority_statement": (
+            intelligence.support_classification_non_authority_statement
+        ),
+        "statement_valid": statement_valid,
+        "inherited_prohibition_count": len(intelligence.inherited_prohibitions),
+        "inherited_constraint_count": len(intelligence.inherited_constraints),
+        "explicit_limitation_count": len(intelligence.explicit_limitations),
+    }
+
+
+def validate_v4_5b_2_support_status_visibility(
+    intelligence: SupportStatusVisibilityIntelligence | None = None,
+) -> dict[str, Any]:
+    if intelligence is None:
+        intelligence = build_v4_5b_2_support_status_visibility()
+    validations = {
+        "required_visibility": validate_required_support_status_visibility(
+            intelligence
+        ),
+        "ordering_stability": validate_support_status_ordering_stability(
+            intelligence
+        ),
+        "identity_integrity": validate_support_identity_integrity(intelligence),
+        "support_classification": validate_support_classification_stability(
+            intelligence
+        ),
+        "support_surface": validate_public_support_surface_visibility(intelligence),
+        "unsupported_state_visibility": (
+            validate_unsupported_state_visibility_preservation(intelligence)
+        ),
+        "experimental_deprecated": (
+            validate_experimental_deprecated_visibility_preservation(intelligence)
+        ),
+        "evidence_based_support": validate_evidence_based_support_visibility(
+            intelligence
+        ),
+        "explainability_support": validate_explainability_support_visibility(
+            intelligence
+        ),
+        "continuity_support": validate_continuity_support_visibility(intelligence),
+        "support_summary": validate_support_summary_stability(intelligence),
+        "lineage_and_provenance": validate_lineage_and_provenance_preservation(
+            intelligence
+        ),
+        "serialization_hashing": validate_support_status_serialization_and_hashing(
+            intelligence
+        ),
+        "fail_visible_support": validate_fail_visible_support_diagnostics(
+            intelligence
+        ),
+        "descriptive_only_guarantees": validate_descriptive_only_support_guarantees(
+            intelligence
+        ),
+    }
+    failed_validations = sorted(
+        name for name, result in validations.items() if not result["valid"]
+    )
+    return {
+        "valid": not failed_validations,
+        "foundation_status": (
+            V4_5B_2_SUPPORT_STATUS_VISIBILITY_STATUS_STABLE
+            if not failed_validations
+            else V4_5B_2_SUPPORT_STATUS_VISIBILITY_STATUS_BLOCKED
+        ),
+        "validation_error_count": len(failed_validations),
+        "failed_validations": failed_validations,
+        "validations": validations,
+    }
+
+
+def build_v4_5b_2_support_status_visibility_report() -> dict[str, Any]:
+    intelligence = build_v4_5b_2_support_status_visibility()
+    exported = export_v4_5b_2_support_status_visibility(intelligence)
+    validation = validate_v4_5b_2_support_status_visibility(intelligence)
+    required_visibility = validation["validations"]["required_visibility"]
+    serialization_hashing = validation["validations"]["serialization_hashing"]
+    classification = validation["validations"]["support_classification"]
+    surface = validation["validations"]["support_surface"]
+    unsupported = validation["validations"]["unsupported_state_visibility"]
+    experimental = validation["validations"]["experimental_deprecated"]
+    evidence = validation["validations"]["evidence_based_support"]
+    explainability = validation["validations"]["explainability_support"]
+    continuity = validation["validations"]["continuity_support"]
+    lineage_provenance = validation["validations"]["lineage_and_provenance"]
+    fail_visible = validation["validations"]["fail_visible_support"]
+    descriptive_only = validation["validations"]["descriptive_only_guarantees"]
+    counters = descriptive_only["counters"]
+
+    deterministic_hash_evidence = {
+        "support_identity_hash": hash_support_status_identity(
+            intelligence.support_identity
+        ),
+        "support_status_hash": hash_v4_5b_2_support_status_visibility(intelligence),
+        "support_visibility_record_hashes": {
+            record.support_record_id: hash_support_visibility_record(record)
+            for record in sorted(
+                intelligence.support_visibility_records,
+                key=lambda item: (item.deterministic_order, item.support_record_id),
+            )
+        },
+        "support_classification_hashes": {
+            record.classification_visibility_id: (
+                hash_support_classification_visibility(record)
+            )
+            for record in sorted(
+                intelligence.support_classifications,
+                key=lambda item: (
+                    item.deterministic_order,
+                    item.classification_visibility_id,
+                ),
+            )
+        },
+        "support_surface_hashes": {
+            record.surface_visibility_id: hash_public_support_surface_visibility(record)
+            for record in sorted(
+                intelligence.support_surfaces,
+                key=lambda item: (item.deterministic_order, item.surface_visibility_id),
+            )
+        },
+        "unsupported_state_hashes": {
+            record.unsupported_visibility_id: hash_unsupported_support_state_visibility(
+                record
+            )
+            for record in sorted(
+                intelligence.unsupported_state_visibility,
+                key=lambda item: (
+                    item.deterministic_order,
+                    item.unsupported_visibility_id,
+                ),
+            )
+        },
+        "experimental_deprecated_hashes": {
+            record.experimental_deprecated_id: (
+                hash_experimental_deprecated_visibility(record)
+            )
+            for record in sorted(
+                intelligence.experimental_deprecated_visibility,
+                key=lambda item: (
+                    item.deterministic_order,
+                    item.experimental_deprecated_id,
+                ),
+            )
+        },
+        "evidence_based_support_hashes": {
+            record.evidence_support_id: hash_evidence_based_support_visibility(record)
+            for record in sorted(
+                intelligence.evidence_based_support_visibility,
+                key=lambda item: (item.deterministic_order, item.evidence_support_id),
+            )
+        },
+        "explainability_support_hashes": {
+            record.explainability_support_id: hash_explainability_support_visibility(
+                record
+            )
+            for record in sorted(
+                intelligence.explainability_support_visibility,
+                key=lambda item: (
+                    item.deterministic_order,
+                    item.explainability_support_id,
+                ),
+            )
+        },
+        "continuity_support_hashes": {
+            record.continuity_support_id: hash_continuity_support_visibility(record)
+            for record in sorted(
+                intelligence.continuity_support_visibility,
+                key=lambda item: (item.deterministic_order, item.continuity_support_id),
+            )
+        },
+        "support_summary_hashes": {
+            record.support_summary_record_id: hash_support_summary_record(record)
+            for record in sorted(
+                intelligence.support_summaries,
+                key=lambda item: (item.deterministic_order, item.support_summary_record_id),
+            )
+        },
+        "support_diagnostic_hashes": {
+            record.diagnostic_id: hash_support_diagnostic_record(record)
+            for record in sorted(
+                intelligence.support_diagnostics,
+                key=lambda item: (item.deterministic_order, item.diagnostic_id),
+            )
+        },
+        "unsupported_operational_hashes": {
+            record.state_id: hash_unsupported_support_operational_state_visibility(
+                record
+            )
+            for record in sorted(
+                intelligence.unsupported_operational_state_visibility,
+                key=lambda item: (item.deterministic_order, item.state_id),
+            )
+        },
+    }
+    summary = {
+        "support_visibility_record_count": len(intelligence.support_visibility_records),
+        "support_classification_count": len(intelligence.support_classifications),
+        "support_surface_count": len(intelligence.support_surfaces),
+        "unsupported_state_visibility_count": len(
+            intelligence.unsupported_state_visibility
+        ),
+        "experimental_deprecated_count": len(
+            intelligence.experimental_deprecated_visibility
+        ),
+        "evidence_based_support_count": len(
+            intelligence.evidence_based_support_visibility
+        ),
+        "explainability_support_count": len(
+            intelligence.explainability_support_visibility
+        ),
+        "continuity_support_count": len(intelligence.continuity_support_visibility),
+        "support_summary_count": len(intelligence.support_summaries),
+        "support_diagnostic_count": len(intelligence.support_diagnostics),
+        "unsupported_operational_state_count": len(
+            intelligence.unsupported_operational_state_visibility
+        ),
+        "classification_counts": required_visibility["classification_counts"],
+        "surface_counts": required_visibility["surface_counts"],
+        "unsupported_counts": required_visibility["unsupported_counts"],
+        "experimental_counts": required_visibility["experimental_counts"],
+        "evidence_counts": required_visibility["evidence_counts"],
+        "explainability_counts": required_visibility["explainability_counts"],
+        "continuity_counts": required_visibility["continuity_counts"],
+        "summary_counts": required_visibility["summary_counts"],
+        "diagnostic_counts": required_visibility["diagnostic_counts"],
+        "unsupported_operational_counts": required_visibility[
+            "unsupported_operational_counts"
+        ],
+        "deterministic_serialization_verified": serialization_hashing[
+            "serialization_stable"
+        ],
+        "deterministic_hashing_verified": serialization_hashing["hashing_stable"],
+        "support_classification_stable": classification["valid"],
+        "support_surface_visibility_stable": surface["valid"],
+        "unsupported_state_visibility_preserved": unsupported["valid"],
+        "experimental_deprecated_visibility_preserved": experimental["valid"],
+        "evidence_based_support_visibility_stable": evidence["valid"],
+        "explainability_support_visibility_stable": explainability["valid"],
+        "continuity_support_visibility_stable": continuity["valid"],
+        "lineage_continuity_preserved": lineage_provenance[
+            "lineage_continuity_preserved"
+        ],
+        "provenance_continuity_preserved": lineage_provenance[
+            "provenance_continuity_preserved"
+        ],
+        "evidence_continuity_preserved": lineage_provenance[
+            "evidence_continuity_preserved"
+        ],
+        "fail_visible_support_diagnostics_verified": fail_visible["valid"],
+        "descriptive_only_guarantees_verified": descriptive_only["valid"],
+        "publicly_transparent": descriptive_only["publicly_transparent"],
+        "support_status_visibility_statement": (
+            descriptive_only["support_status_visibility_statement"]
+        ),
+        "support_classification_non_authority_statement": (
+            descriptive_only["support_classification_non_authority_statement"]
+        ),
+        "inherited_prohibition_count": descriptive_only[
+            "inherited_prohibition_count"
+        ],
+        "inherited_constraint_count": descriptive_only["inherited_constraint_count"],
+        "explicit_limitation_count": descriptive_only["explicit_limitation_count"],
+        "validation_error_count": validation["validation_error_count"],
+        "repository_remains": [
+            "NON-operational",
+            "NON-authorizing",
+            "NON-approving",
+            "NON-executing",
+            "NON-remediating",
+            "NON-runtime-mutating",
+            "NON-ranking",
+            "NON-recommending",
+        ],
+    }
+    summary.update(counters)
+    report = {
+        "phase_id": V4_5B_2_SUPPORT_STATUS_VISIBILITY_PHASE_ID,
+        "schema_version": V4_5B_2_SUPPORT_STATUS_VISIBILITY_REPORT_SCHEMA_VERSION,
+        "generated_at": V4_5B_2_SUPPORT_STATUS_VISIBILITY_GENERATED_AT,
+        "purpose": V4_5B_2_SUPPORT_STATUS_VISIBILITY_PURPOSE,
+        "foundation_status": validation["foundation_status"],
+        "summary": summary,
+        "visibility": {
+            "support_status": support_visibility_summary(
+                intelligence.support_visibility_records
+            ),
+            "support_classifications": support_classification_summary(
+                intelligence.support_classifications
+            ),
+            "support_surfaces": support_surface_summary(
+                intelligence.support_surfaces
+            ),
+            "unsupported_states": unsupported_state_summary(
+                intelligence.unsupported_state_visibility
+            ),
+            "experimental_deprecated": experimental_deprecated_summary(
+                intelligence.experimental_deprecated_visibility
+            ),
+            "evidence_based_support": evidence_based_support_summary(
+                intelligence.evidence_based_support_visibility
+            ),
+            "explainability_support": explainability_support_summary(
+                intelligence.explainability_support_visibility
+            ),
+            "continuity_support": continuity_support_summary(
+                intelligence.continuity_support_visibility
+            ),
+            "support_summaries": support_summary_visibility(
+                intelligence.support_summaries
+            ),
+            "support_diagnostics": support_diagnostic_summary(
+                intelligence.support_diagnostics
+            ),
+            "unsupported_operational_states": unsupported_operational_state_summary(
+                intelligence.unsupported_operational_state_visibility
+            ),
+            "descriptive_only": descriptive_only_support_status_summary(
+                intelligence
+            ),
+        },
+        "deterministic_hash_evidence": deterministic_hash_evidence,
+        "validation": validation,
+        "exported_intelligence": exported,
+    }
+    report["deterministic_report_hash"] = (
+        deterministic_v4_5b_2_support_status_visibility_hash(report)
+    )
+    return report
+
+
+def contaminate_v4_5b_2_support_status_visibility_for_non_operational_validation(
+    intelligence: SupportStatusVisibilityIntelligence | None = None,
+) -> SupportStatusVisibilityIntelligence:
+    if intelligence is None:
+        intelligence = build_v4_5b_2_support_status_visibility()
+    return replace(
+        intelligence,
+        runtime_execution_enabled=True,
+        support_authorization_enabled=True,
+        support_approval_enabled=True,
+        support_ranking_enabled=True,
+        support_recommendation_enabled=True,
+        remediation_enabled=True,
+        planner_integration_enabled=True,
+    )

--- a/backend/app/public_trust_visibility/v4_5b_2_support_status_visibility_hashing.py
+++ b/backend/app/public_trust_visibility/v4_5b_2_support_status_visibility_hashing.py
@@ -1,0 +1,138 @@
+"""Deterministic hashing for v4.5B.2 support status visibility."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+from .v4_5b_2_support_status_visibility_models import (
+    ContinuitySupportVisibility,
+    EvidenceBasedSupportVisibility,
+    ExperimentalDeprecatedVisibility,
+    ExplainabilitySupportVisibility,
+    PublicSupportSurfaceVisibility,
+    SupportClassificationVisibility,
+    SupportDiagnosticRecord,
+    SupportStatusIdentity,
+    SupportStatusVisibilityIntelligence,
+    SupportSummaryRecord,
+    SupportVisibilityRecord,
+    UnsupportedSupportOperationalStateVisibility,
+    UnsupportedSupportStateVisibility,
+)
+from .v4_5b_2_support_status_visibility_serialization import (
+    export_continuity_support_visibility,
+    export_evidence_based_support_visibility,
+    export_experimental_deprecated_visibility,
+    export_explainability_support_visibility,
+    export_public_support_surface_visibility,
+    export_support_classification_visibility,
+    export_support_diagnostic_record,
+    export_support_status_identity,
+    export_support_summary_record,
+    export_support_visibility_record,
+    export_unsupported_support_operational_state_visibility,
+    export_unsupported_support_state_visibility,
+    export_v4_5b_2_support_status_visibility,
+    stable_serialize_v4_5b_2_support_status_visibility,
+)
+
+
+def deterministic_v4_5b_2_support_status_visibility_hash(payload: Any) -> str:
+    return hashlib.sha256(
+        stable_serialize_v4_5b_2_support_status_visibility(payload).encode("utf-8")
+    ).hexdigest()
+
+
+def hash_support_status_identity(identity: SupportStatusIdentity) -> str:
+    return deterministic_v4_5b_2_support_status_visibility_hash(
+        export_support_status_identity(identity)
+    )
+
+
+def hash_support_visibility_record(record: SupportVisibilityRecord) -> str:
+    return deterministic_v4_5b_2_support_status_visibility_hash(
+        export_support_visibility_record(record)
+    )
+
+
+def hash_support_classification_visibility(
+    record: SupportClassificationVisibility,
+) -> str:
+    return deterministic_v4_5b_2_support_status_visibility_hash(
+        export_support_classification_visibility(record)
+    )
+
+
+def hash_public_support_surface_visibility(
+    record: PublicSupportSurfaceVisibility,
+) -> str:
+    return deterministic_v4_5b_2_support_status_visibility_hash(
+        export_public_support_surface_visibility(record)
+    )
+
+
+def hash_unsupported_support_state_visibility(
+    record: UnsupportedSupportStateVisibility,
+) -> str:
+    return deterministic_v4_5b_2_support_status_visibility_hash(
+        export_unsupported_support_state_visibility(record)
+    )
+
+
+def hash_experimental_deprecated_visibility(
+    record: ExperimentalDeprecatedVisibility,
+) -> str:
+    return deterministic_v4_5b_2_support_status_visibility_hash(
+        export_experimental_deprecated_visibility(record)
+    )
+
+
+def hash_evidence_based_support_visibility(
+    record: EvidenceBasedSupportVisibility,
+) -> str:
+    return deterministic_v4_5b_2_support_status_visibility_hash(
+        export_evidence_based_support_visibility(record)
+    )
+
+
+def hash_explainability_support_visibility(
+    record: ExplainabilitySupportVisibility,
+) -> str:
+    return deterministic_v4_5b_2_support_status_visibility_hash(
+        export_explainability_support_visibility(record)
+    )
+
+
+def hash_continuity_support_visibility(record: ContinuitySupportVisibility) -> str:
+    return deterministic_v4_5b_2_support_status_visibility_hash(
+        export_continuity_support_visibility(record)
+    )
+
+
+def hash_support_summary_record(record: SupportSummaryRecord) -> str:
+    return deterministic_v4_5b_2_support_status_visibility_hash(
+        export_support_summary_record(record)
+    )
+
+
+def hash_support_diagnostic_record(record: SupportDiagnosticRecord) -> str:
+    return deterministic_v4_5b_2_support_status_visibility_hash(
+        export_support_diagnostic_record(record)
+    )
+
+
+def hash_unsupported_support_operational_state_visibility(
+    record: UnsupportedSupportOperationalStateVisibility,
+) -> str:
+    return deterministic_v4_5b_2_support_status_visibility_hash(
+        export_unsupported_support_operational_state_visibility(record)
+    )
+
+
+def hash_v4_5b_2_support_status_visibility(
+    intelligence: SupportStatusVisibilityIntelligence,
+) -> str:
+    return deterministic_v4_5b_2_support_status_visibility_hash(
+        export_v4_5b_2_support_status_visibility(intelligence)
+    )

--- a/backend/app/public_trust_visibility/v4_5b_2_support_status_visibility_models.py
+++ b/backend/app/public_trust_visibility/v4_5b_2_support_status_visibility_models.py
@@ -1,0 +1,849 @@
+"""Deterministic v4.5B.2 support status visibility models.
+
+The v4.5B.2 layer models public support status visibility without enabling
+support authority, approval, authorization, ranking, recommendation, execution,
+remediation, runtime mutation, planner integration, production consumption, or
+operational behavior.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+V4_5B_2_SUPPORT_STATUS_VISIBILITY_PHASE_ID = "v4_5b_2_support_status_visibility"
+V4_5B_2_SUPPORT_STATUS_VISIBILITY_SCHEMA_VERSION = (
+    "v4_5b_2.support_status_visibility.1"
+)
+V4_5B_2_SUPPORT_STATUS_VISIBILITY_REPORT_SCHEMA_VERSION = (
+    "v4_5b_2.support_status_visibility_report.1"
+)
+V4_5B_2_SUPPORT_STATUS_VISIBILITY_GENERATED_AT = "2026-05-18T00:00:00+00:00"
+V4_5B_2_SUPPORT_STATUS_VISIBILITY_STATUS_STABLE = (
+    "v4_5b_2_support_status_visibility_stable"
+)
+V4_5B_2_SUPPORT_STATUS_VISIBILITY_STATUS_BLOCKED = (
+    "v4_5b_2_support_status_visibility_blocked"
+)
+V4_5B_2_SUPPORT_STATUS_VISIBILITY_PURPOSE = (
+    "deterministic_governance_safe_support_status_visibility_descriptive_only"
+)
+V4_5B_2_SUPPORT_STATUS_VISIBILITY_CLASSIFICATION = (
+    "governance_safe_public_support_status_visibility_descriptive_only"
+)
+
+V4_5B_1_TRUST_VISIBILITY_FOUNDATION_REPORT_REFERENCE = (
+    "docs/generated/v4_5b_1_trust_visibility_foundations_report.json"
+)
+V4_5B_1_TRUST_VISIBILITY_FOUNDATION_REPORT_HASH_REFERENCE = (
+    "e6bd404e3d548fe2d016621aa94ac584614e784a592d18c722ea1f5b174a8039"
+)
+
+SUPPORT_STATUS_VISIBILITY_STATEMENT = "Support status visibility is descriptive-only."
+SUPPORT_CLASSIFICATION_NON_AUTHORITY_STATEMENT = (
+    "Support classifications do NOT imply authorization, approval, operational "
+    "readiness, execution safety, or production enablement."
+)
+
+SUPPORT_CLASSIFICATION_TYPES: tuple[str, ...] = (
+    "supported",
+    "partially_supported",
+    "unsupported",
+    "experimental",
+    "deprecated",
+    "blocked",
+    "unknown",
+)
+
+PUBLIC_SUPPORT_SURFACE_TYPES: tuple[str, ...] = (
+    "mechanics",
+    "systems",
+    "planner_sections",
+    "data_sources",
+    "evidence_chains",
+    "explainability_surfaces",
+    "continuity_surfaces",
+    "diagnostics_surfaces",
+)
+
+UNSUPPORTED_SUPPORT_STATE_TYPES: tuple[str, ...] = (
+    "unsupported_mechanics",
+    "unsupported_planner_sections",
+    "unsupported_evidence_chains",
+    "unsupported_explainability_surfaces",
+    "unsupported_continuity_surfaces",
+    "unsupported_diagnostics_surfaces",
+    "unsupported_operational_states",
+)
+
+EXPERIMENTAL_DEPRECATED_VISIBILITY_TYPES: tuple[str, ...] = (
+    "experimental_systems",
+    "experimental_surfaces",
+    "deprecated_systems",
+    "deprecated_surfaces",
+    "blocked_systems",
+    "blocked_surfaces",
+    "unknown_support_states",
+)
+
+EVIDENCE_BASED_SUPPORT_VISIBILITY_TYPES: tuple[str, ...] = (
+    "evidence_backed_support",
+    "partially_evidenced_support",
+    "unsupported_evidence_states",
+    "continuity_backed_support_visibility",
+    "explainability_backed_support_visibility",
+    "diagnostics_backed_support_visibility",
+)
+
+EXPLAINABILITY_SUPPORT_VISIBILITY_TYPES: tuple[str, ...] = (
+    "explainability_supported_states",
+    "partially_explainable_states",
+    "unsupported_explainability_states",
+    "continuity_explainability_visibility",
+    "fail_visible_explainability_diagnostics",
+)
+
+CONTINUITY_SUPPORT_VISIBILITY_TYPES: tuple[str, ...] = (
+    "continuity_supported_states",
+    "partially_continuous_states",
+    "unsupported_continuity_states",
+    "evidence_continuity_visibility",
+    "fail_visible_continuity_diagnostics",
+)
+
+SUPPORT_SUMMARY_TYPES: tuple[str, ...] = (
+    "support_classification_summary",
+    "surface_support_summary",
+    "unsupported_state_summary",
+    "experimental_deprecated_summary",
+    "evidence_based_support_summary",
+    "explainability_support_summary",
+    "continuity_support_summary",
+    "diagnostics_support_summary",
+)
+
+SUPPORT_DIAGNOSTIC_TYPES: tuple[str, ...] = (
+    "missing_support_evidence",
+    "unsupported_visibility_gaps",
+    "unsupported_explainability_gaps",
+    "unsupported_continuity_gaps",
+    "blocked_visibility_states",
+    "deprecated_visibility_states",
+    "unknown_support_states",
+    "inherited_limitation_visibility_gaps",
+    "inherited_prohibition_visibility_gaps",
+)
+
+UNSUPPORTED_SUPPORT_OPERATIONAL_STATES: tuple[str, ...] = (
+    "orchestration_execution",
+    "orchestration_authorization",
+    "orchestration_approval",
+    "orchestration_dispatch",
+    "orchestration_routing",
+    "orchestration_traversal",
+    "orchestration_scheduling",
+    "orchestration_sequencing",
+    "orchestration_decisions",
+    "orchestration_recommendations",
+    "support_based_authorization",
+    "support_based_approval",
+    "support_based_ranking",
+    "support_based_recommendation",
+    "automated_remediation",
+    "automated_repair",
+    "automated_mitigation",
+    "automated_correction",
+    "planner_integration",
+    "production_consumption",
+    "runtime_mutation",
+    "operational_mutation",
+    "implicit_operational_behavior",
+)
+
+V4_5B_2_SUPPORT_STATUS_VISIBILITY_DISABLED_COUNTER_NAMES: tuple[str, ...] = (
+    "enabled_runtime_execution_count",
+    "enabled_orchestration_authorization_count",
+    "enabled_orchestration_approval_count",
+    "enabled_orchestration_dispatch_count",
+    "enabled_orchestration_routing_count",
+    "enabled_orchestration_traversal_count",
+    "enabled_orchestration_scheduling_count",
+    "enabled_orchestration_sequencing_count",
+    "enabled_orchestration_decision_count",
+    "enabled_orchestration_recommendation_count",
+    "enabled_support_authorization_count",
+    "enabled_support_approval_count",
+    "enabled_support_ranking_count",
+    "enabled_support_recommendation_count",
+    "enabled_remediation_count",
+    "enabled_repair_count",
+    "enabled_mitigation_count",
+    "enabled_auto_correction_count",
+    "enabled_planner_integration_count",
+    "enabled_production_consumption_count",
+    "enabled_runtime_mutation_count",
+    "enabled_operational_mutation_count",
+)
+
+V4_5B_2_SUPPORT_STATUS_VISIBILITY_DETERMINISTIC_GUARANTEES: tuple[str, ...] = (
+    "deterministic_support_status_identity",
+    "deterministic_support_classification_visibility",
+    "deterministic_public_support_surface_visibility",
+    "deterministic_unsupported_state_visibility",
+    "deterministic_experimental_deprecated_visibility",
+    "deterministic_evidence_based_support_visibility",
+    "deterministic_explainability_support_visibility",
+    "deterministic_continuity_support_visibility",
+    "stable_replay_safe_serialization",
+    "stable_replay_safe_hashing",
+    "lineage_continuity_preserved",
+    "provenance_continuity_preserved",
+    "publicly_transparent_descriptive_only_support_visibility",
+)
+
+V4_5B_2_SUPPORT_STATUS_VISIBILITY_INHERITED_PROHIBITIONS: tuple[str, ...] = (
+    "orchestration_execution_prohibited",
+    "orchestration_authorization_prohibited",
+    "orchestration_approval_prohibited",
+    "orchestration_dispatch_prohibited",
+    "orchestration_routing_prohibited",
+    "orchestration_traversal_prohibited",
+    "orchestration_scheduling_prohibited",
+    "orchestration_sequencing_prohibited",
+    "orchestration_decisions_prohibited",
+    "orchestration_recommendations_prohibited",
+    "support_based_authorization_prohibited",
+    "support_based_approval_prohibited",
+    "support_based_ranking_prohibited",
+    "support_based_recommendation_prohibited",
+    "automated_remediation_prohibited",
+    "automated_repair_prohibited",
+    "automated_mitigation_prohibited",
+    "automated_correction_prohibited",
+    "planner_integration_prohibited",
+    "production_consumption_prohibited",
+    "runtime_mutation_prohibited",
+    "operational_mutation_prohibited",
+    "implicit_operational_behavior_prohibited",
+)
+
+V4_5B_2_SUPPORT_STATUS_VISIBILITY_INHERITED_CONSTRAINTS: tuple[str, ...] = (
+    "deterministic",
+    "governance-safe",
+    "replay-safe",
+    "rollback-safe",
+    "lineage-safe",
+    "provenance-safe",
+    "integrity-safe",
+    "explainability-first",
+    "fail-visible",
+    "descriptive-only",
+    "publicly transparent",
+    "NON-operational",
+    "NON-authorizing",
+    "NON-approving",
+    "NON-executing",
+    "NON-remediating",
+    "NON-runtime-mutating",
+    "NON-ranking",
+    "NON-recommending",
+)
+
+V4_5B_2_SUPPORT_STATUS_VISIBILITY_EXPLICIT_LIMITATIONS: tuple[str, ...] = (
+    "support_visibility_does_not_authorize",
+    "support_visibility_does_not_approve",
+    "support_visibility_does_not_rank",
+    "support_visibility_does_not_recommend",
+    "support_visibility_does_not_execute",
+    "support_visibility_does_not_enable_production",
+    "support_visibility_does_not_imply_correctness_guarantees",
+    "support_visibility_does_not_imply_execution_safety",
+    "support_visibility_does_not_remediate_or_repair",
+    "support_visibility_does_not_mitigate_or_correct",
+    "support_visibility_does_not_integrate_planners",
+    "support_visibility_does_not_mutate_runtime_state",
+)
+
+
+def _set_tuple_field(instance: object, field_name: str) -> None:
+    object.__setattr__(instance, field_name, tuple(getattr(instance, field_name)))
+
+
+@dataclass(frozen=True)
+class SupportStatusIdentity:
+    support_status_id: str
+    support_summary_id: str
+    support_scope_id: str
+    support_reference_id: str
+    evidence_reference_id: str
+    explainability_reference_id: str
+    continuity_reference_id: str
+    diagnostics_reference_id: str
+    lineage_reference_id: str
+    provenance_reference_id: str
+    phase_id: str
+    schema_version: str
+    generated_at: str
+    classification: str
+    source_trust_visibility_report_reference: str
+    source_trust_visibility_hash_reference: str
+
+
+@dataclass(frozen=True)
+class SupportVisibilityRecord:
+    support_record_id: str
+    support_status_id: str
+    support_summary_id: str
+    support_scope_id: str
+    support_reference_id: str
+    evidence_reference_id: str
+    explainability_reference_id: str
+    continuity_reference_id: str
+    diagnostics_reference_id: str
+    lineage_reference_id: str
+    provenance_reference_id: str
+    visibility_state: str
+    deterministic_order: int
+    descriptive_only: bool = True
+    publicly_transparent: bool = True
+    fail_visible: bool = True
+    non_authorizing: bool = True
+    non_approving: bool = True
+    support_authority_enabled: bool = False
+    authorization_enabled: bool = False
+    approval_enabled: bool = False
+    ranking_enabled: bool = False
+    recommendation_enabled: bool = False
+    execution_enabled: bool = False
+    production_enablement_enabled: bool = False
+
+
+@dataclass(frozen=True)
+class SupportClassificationVisibility:
+    classification_visibility_id: str
+    support_classification: str
+    evidence_reference_ids: tuple[str, ...]
+    visibility_state: str
+    deterministic_order: int
+    descriptive_only: bool = True
+    operational_approval_enabled: bool = False
+    execution_semantics_enabled: bool = False
+    authorization_enabled: bool = False
+    approval_enabled: bool = False
+
+    def __post_init__(self) -> None:
+        _set_tuple_field(self, "evidence_reference_ids")
+
+
+@dataclass(frozen=True)
+class PublicSupportSurfaceVisibility:
+    surface_visibility_id: str
+    support_surface: str
+    support_classification: str
+    evidence_reference_ids: tuple[str, ...]
+    visibility_state: str
+    deterministic_order: int
+    descriptive_only: bool = True
+    ranking_enabled: bool = False
+    recommendation_enabled: bool = False
+    operational_enabled: bool = False
+
+    def __post_init__(self) -> None:
+        _set_tuple_field(self, "evidence_reference_ids")
+
+
+@dataclass(frozen=True)
+class UnsupportedSupportStateVisibility:
+    unsupported_visibility_id: str
+    unsupported_state_type: str
+    evidence_reference_ids: tuple[str, ...]
+    visibility_state: str
+    deterministic_order: int
+    descriptive_only: bool = True
+    fail_visible: bool = True
+    suppression_enabled: bool = False
+    hidden_fallback_enabled: bool = False
+    authorization_enabled: bool = False
+    approval_enabled: bool = False
+    remediation_enabled: bool = False
+
+    def __post_init__(self) -> None:
+        _set_tuple_field(self, "evidence_reference_ids")
+
+
+@dataclass(frozen=True)
+class ExperimentalDeprecatedVisibility:
+    experimental_deprecated_id: str
+    visibility_type: str
+    evidence_reference_ids: tuple[str, ...]
+    visibility_state: str
+    deterministic_order: int
+    descriptive_only: bool = True
+    automatic_migration_enabled: bool = False
+    operational_fallback_enabled: bool = False
+    authorization_enabled: bool = False
+    approval_enabled: bool = False
+
+    def __post_init__(self) -> None:
+        _set_tuple_field(self, "evidence_reference_ids")
+
+
+@dataclass(frozen=True)
+class EvidenceBasedSupportVisibility:
+    evidence_support_id: str
+    evidence_support_type: str
+    evidence_reference_ids: tuple[str, ...]
+    visibility_state: str
+    deterministic_order: int
+    descriptive_only: bool = True
+    replay_safe: bool = True
+    provenance_safe: bool = True
+    trust_scoring_enabled: bool = False
+    approval_enabled: bool = False
+    authorization_enabled: bool = False
+
+    def __post_init__(self) -> None:
+        _set_tuple_field(self, "evidence_reference_ids")
+
+
+@dataclass(frozen=True)
+class ExplainabilitySupportVisibility:
+    explainability_support_id: str
+    explainability_support_type: str
+    evidence_reference_ids: tuple[str, ...]
+    visibility_state: str
+    deterministic_order: int
+    descriptive_only: bool = True
+    recommendation_enabled: bool = False
+    operational_semantics_enabled: bool = False
+    authorization_enabled: bool = False
+
+    def __post_init__(self) -> None:
+        _set_tuple_field(self, "evidence_reference_ids")
+
+
+@dataclass(frozen=True)
+class ContinuitySupportVisibility:
+    continuity_support_id: str
+    continuity_support_type: str
+    continuity_reference_id: str
+    evidence_reference_ids: tuple[str, ...]
+    visibility_state: str
+    deterministic_order: int
+    descriptive_only: bool = True
+    restoration_enabled: bool = False
+    repair_enabled: bool = False
+    remediation_enabled: bool = False
+    authorization_enabled: bool = False
+
+    def __post_init__(self) -> None:
+        _set_tuple_field(self, "evidence_reference_ids")
+
+
+@dataclass(frozen=True)
+class SupportSummaryRecord:
+    support_summary_record_id: str
+    support_summary_id: str
+    summary_type: str
+    evidence_reference_ids: tuple[str, ...]
+    summary_state: str
+    deterministic_order: int
+    descriptive_only: bool = True
+    authorization_enabled: bool = False
+    approval_enabled: bool = False
+    ranking_enabled: bool = False
+    recommendation_enabled: bool = False
+    execution_enablement_enabled: bool = False
+    production_enablement_enabled: bool = False
+
+    def __post_init__(self) -> None:
+        _set_tuple_field(self, "evidence_reference_ids")
+
+
+@dataclass(frozen=True)
+class SupportDiagnosticRecord:
+    diagnostic_id: str
+    diagnostic_type: str
+    evidence_reference_ids: tuple[str, ...]
+    message: str
+    visibility_state: str
+    deterministic_order: int
+    fail_visible: bool = True
+    descriptive_only: bool = True
+    silent_fallback_enabled: bool = False
+    hidden_fallback_enabled: bool = False
+    authorization_enabled: bool = False
+    approval_enabled: bool = False
+    remediation_enabled: bool = False
+    repair_enabled: bool = False
+    mitigation_enabled: bool = False
+    auto_correction_enabled: bool = False
+    ranking_enabled: bool = False
+    recommendation_enabled: bool = False
+    orchestration_response_enabled: bool = False
+
+    def __post_init__(self) -> None:
+        _set_tuple_field(self, "evidence_reference_ids")
+
+
+@dataclass(frozen=True)
+class UnsupportedSupportOperationalStateVisibility:
+    state_id: str
+    unsupported_state: str
+    explicit_reason: str
+    evidence_reference_ids: tuple[str, ...]
+    visibility_state: str
+    deterministic_order: int
+    fail_visible: bool = True
+    descriptive_only: bool = True
+    authorization_enabled: bool = False
+    approval_enabled: bool = False
+    operational_enabled: bool = False
+    remediation_enabled: bool = False
+    repair_enabled: bool = False
+    mitigation_enabled: bool = False
+    automated_correction_enabled: bool = False
+    ranking_enabled: bool = False
+    recommendation_enabled: bool = False
+    suppression_enabled: bool = False
+
+    def __post_init__(self) -> None:
+        _set_tuple_field(self, "evidence_reference_ids")
+
+
+@dataclass(frozen=True)
+class SupportStatusVisibilityIntelligence:
+    support_identity: SupportStatusIdentity
+    support_visibility_records: tuple[SupportVisibilityRecord, ...]
+    support_classifications: tuple[SupportClassificationVisibility, ...]
+    support_surfaces: tuple[PublicSupportSurfaceVisibility, ...]
+    unsupported_state_visibility: tuple[UnsupportedSupportStateVisibility, ...]
+    experimental_deprecated_visibility: tuple[ExperimentalDeprecatedVisibility, ...]
+    evidence_based_support_visibility: tuple[EvidenceBasedSupportVisibility, ...]
+    explainability_support_visibility: tuple[ExplainabilitySupportVisibility, ...]
+    continuity_support_visibility: tuple[ContinuitySupportVisibility, ...]
+    support_summaries: tuple[SupportSummaryRecord, ...]
+    support_diagnostics: tuple[SupportDiagnosticRecord, ...]
+    unsupported_operational_state_visibility: tuple[
+        UnsupportedSupportOperationalStateVisibility, ...
+    ]
+    deterministic_guarantees: tuple[str, ...]
+    inherited_prohibitions: tuple[str, ...]
+    inherited_constraints: tuple[str, ...]
+    explicit_limitations: tuple[str, ...]
+    support_status_visibility_statement: str = SUPPORT_STATUS_VISIBILITY_STATEMENT
+    support_classification_non_authority_statement: str = (
+        SUPPORT_CLASSIFICATION_NON_AUTHORITY_STATEMENT
+    )
+    descriptive_only: bool = True
+    publicly_transparent: bool = True
+    non_operational: bool = True
+    non_authorizing: bool = True
+    non_approving: bool = True
+    non_executing: bool = True
+    non_remediating: bool = True
+    non_runtime_mutating: bool = True
+    non_ranking: bool = True
+    non_recommending: bool = True
+    runtime_execution_enabled: bool = False
+    orchestration_execution_enabled: bool = False
+    orchestration_authorization_enabled: bool = False
+    orchestration_approval_enabled: bool = False
+    orchestration_dispatch_enabled: bool = False
+    orchestration_routing_enabled: bool = False
+    orchestration_traversal_enabled: bool = False
+    orchestration_scheduling_enabled: bool = False
+    orchestration_sequencing_enabled: bool = False
+    orchestration_decision_enabled: bool = False
+    orchestration_recommendation_enabled: bool = False
+    support_authorization_enabled: bool = False
+    support_approval_enabled: bool = False
+    support_ranking_enabled: bool = False
+    support_recommendation_enabled: bool = False
+    remediation_enabled: bool = False
+    repair_enabled: bool = False
+    mitigation_enabled: bool = False
+    auto_correction_enabled: bool = False
+    ranking_enabled: bool = False
+    recommendation_enabled: bool = False
+    planner_integration_enabled: bool = False
+    planner_execution_enabled: bool = False
+    production_consumption_enabled: bool = False
+    runtime_mutation_enabled: bool = False
+    operational_mutation_enabled: bool = False
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "support_visibility_records",
+            "support_classifications",
+            "support_surfaces",
+            "unsupported_state_visibility",
+            "experimental_deprecated_visibility",
+            "evidence_based_support_visibility",
+            "explainability_support_visibility",
+            "continuity_support_visibility",
+            "support_summaries",
+            "support_diagnostics",
+            "unsupported_operational_state_visibility",
+            "deterministic_guarantees",
+            "inherited_prohibitions",
+            "inherited_constraints",
+            "explicit_limitations",
+        ):
+            object.__setattr__(self, field_name, tuple(getattr(self, field_name)))
+
+
+def default_support_status_identity() -> SupportStatusIdentity:
+    return SupportStatusIdentity(
+        support_status_id="v4_5b_2_support_status_visibility",
+        support_summary_id="v4_5b_2_support_summary",
+        support_scope_id="scope::v4_5b_2.public_support",
+        support_reference_id="support::v4_5b_2.public_support",
+        evidence_reference_id="evidence::v4_5b_2.public_support",
+        explainability_reference_id="explainability::v4_5b_2.public_support",
+        continuity_reference_id="continuity::v4_5b_2.public_support",
+        diagnostics_reference_id="diagnostics::v4_5b_2.public_support",
+        lineage_reference_id="lineage::v4_5b_2.public_support",
+        provenance_reference_id="provenance::v4_5b_2.public_support",
+        phase_id=V4_5B_2_SUPPORT_STATUS_VISIBILITY_PHASE_ID,
+        schema_version=V4_5B_2_SUPPORT_STATUS_VISIBILITY_SCHEMA_VERSION,
+        generated_at=V4_5B_2_SUPPORT_STATUS_VISIBILITY_GENERATED_AT,
+        classification=V4_5B_2_SUPPORT_STATUS_VISIBILITY_CLASSIFICATION,
+        source_trust_visibility_report_reference=(
+            V4_5B_1_TRUST_VISIBILITY_FOUNDATION_REPORT_REFERENCE
+        ),
+        source_trust_visibility_hash_reference=(
+            V4_5B_1_TRUST_VISIBILITY_FOUNDATION_REPORT_HASH_REFERENCE
+        ),
+    )
+
+
+def default_support_visibility_records() -> tuple[SupportVisibilityRecord, ...]:
+    identity = default_support_status_identity()
+    return (
+        SupportVisibilityRecord(
+            support_record_id="public_support_status_visibility_foundation",
+            support_status_id=identity.support_status_id,
+            support_summary_id=identity.support_summary_id,
+            support_scope_id=identity.support_scope_id,
+            support_reference_id=identity.support_reference_id,
+            evidence_reference_id=identity.evidence_reference_id,
+            explainability_reference_id=identity.explainability_reference_id,
+            continuity_reference_id=identity.continuity_reference_id,
+            diagnostics_reference_id=identity.diagnostics_reference_id,
+            lineage_reference_id=identity.lineage_reference_id,
+            provenance_reference_id=identity.provenance_reference_id,
+            visibility_state="public_support_status_visibility_visible",
+            deterministic_order=1,
+        ),
+    )
+
+
+def default_support_classifications() -> tuple[SupportClassificationVisibility, ...]:
+    return tuple(
+        SupportClassificationVisibility(
+            classification_visibility_id=f"support_classification_{classification}",
+            support_classification=classification,
+            evidence_reference_ids=(f"evidence_{classification}_classification",),
+            visibility_state="support_classification_descriptive_only",
+            deterministic_order=order,
+        )
+        for order, classification in enumerate(SUPPORT_CLASSIFICATION_TYPES, start=1)
+    )
+
+
+def default_support_surfaces() -> tuple[PublicSupportSurfaceVisibility, ...]:
+    classifications = (
+        "supported",
+        "partially_supported",
+        "unsupported",
+        "experimental",
+        "deprecated",
+        "blocked",
+        "unknown",
+        "partially_supported",
+    )
+    return tuple(
+        PublicSupportSurfaceVisibility(
+            surface_visibility_id=f"support_surface_{surface}",
+            support_surface=surface,
+            support_classification=classifications[order - 1],
+            evidence_reference_ids=(f"evidence_{surface}_support_surface",),
+            visibility_state="public_support_surface_visibility_visible",
+            deterministic_order=order,
+        )
+        for order, surface in enumerate(PUBLIC_SUPPORT_SURFACE_TYPES, start=1)
+    )
+
+
+def default_unsupported_state_visibility() -> tuple[
+    UnsupportedSupportStateVisibility, ...
+]:
+    return tuple(
+        UnsupportedSupportStateVisibility(
+            unsupported_visibility_id=f"unsupported_support_state_{state_type}",
+            unsupported_state_type=state_type,
+            evidence_reference_ids=(f"evidence_{state_type}",),
+            visibility_state="unsupported_support_state_fail_visible",
+            deterministic_order=order,
+        )
+        for order, state_type in enumerate(UNSUPPORTED_SUPPORT_STATE_TYPES, start=1)
+    )
+
+
+def default_experimental_deprecated_visibility() -> tuple[
+    ExperimentalDeprecatedVisibility, ...
+]:
+    return tuple(
+        ExperimentalDeprecatedVisibility(
+            experimental_deprecated_id=f"experimental_deprecated_{visibility_type}",
+            visibility_type=visibility_type,
+            evidence_reference_ids=(f"evidence_{visibility_type}",),
+            visibility_state="experimental_deprecated_visibility_descriptive_only",
+            deterministic_order=order,
+        )
+        for order, visibility_type in enumerate(
+            EXPERIMENTAL_DEPRECATED_VISIBILITY_TYPES,
+            start=1,
+        )
+    )
+
+
+def default_evidence_based_support_visibility() -> tuple[
+    EvidenceBasedSupportVisibility, ...
+]:
+    return tuple(
+        EvidenceBasedSupportVisibility(
+            evidence_support_id=f"evidence_based_support_{visibility_type}",
+            evidence_support_type=visibility_type,
+            evidence_reference_ids=(f"evidence_{visibility_type}",),
+            visibility_state="evidence_based_support_visibility_visible",
+            deterministic_order=order,
+        )
+        for order, visibility_type in enumerate(
+            EVIDENCE_BASED_SUPPORT_VISIBILITY_TYPES,
+            start=1,
+        )
+    )
+
+
+def default_explainability_support_visibility() -> tuple[
+    ExplainabilitySupportVisibility, ...
+]:
+    return tuple(
+        ExplainabilitySupportVisibility(
+            explainability_support_id=f"explainability_support_{visibility_type}",
+            explainability_support_type=visibility_type,
+            evidence_reference_ids=(f"evidence_{visibility_type}",),
+            visibility_state="explainability_support_visibility_visible",
+            deterministic_order=order,
+        )
+        for order, visibility_type in enumerate(
+            EXPLAINABILITY_SUPPORT_VISIBILITY_TYPES,
+            start=1,
+        )
+    )
+
+
+def default_continuity_support_visibility() -> tuple[ContinuitySupportVisibility, ...]:
+    return tuple(
+        ContinuitySupportVisibility(
+            continuity_support_id=f"continuity_support_{visibility_type}",
+            continuity_support_type=visibility_type,
+            continuity_reference_id=f"continuity_reference_{visibility_type}",
+            evidence_reference_ids=(f"evidence_{visibility_type}",),
+            visibility_state="continuity_support_visibility_visible",
+            deterministic_order=order,
+        )
+        for order, visibility_type in enumerate(
+            CONTINUITY_SUPPORT_VISIBILITY_TYPES,
+            start=1,
+        )
+    )
+
+
+def default_support_summaries() -> tuple[SupportSummaryRecord, ...]:
+    identity = default_support_status_identity()
+    return tuple(
+        SupportSummaryRecord(
+            support_summary_record_id=f"support_summary_{summary_type}",
+            support_summary_id=identity.support_summary_id,
+            summary_type=summary_type,
+            evidence_reference_ids=(f"evidence_{summary_type}",),
+            summary_state="support_summary_descriptive_only",
+            deterministic_order=order,
+        )
+        for order, summary_type in enumerate(SUPPORT_SUMMARY_TYPES, start=1)
+    )
+
+
+def default_support_diagnostics() -> tuple[SupportDiagnosticRecord, ...]:
+    return tuple(
+        SupportDiagnosticRecord(
+            diagnostic_id=f"support_diagnostic_{diagnostic_type}",
+            diagnostic_type=diagnostic_type,
+            evidence_reference_ids=(f"evidence_{diagnostic_type}",),
+            message=(
+                f"{diagnostic_type} remains explicit, fail-visible, and "
+                "descriptive-only for support status visibility."
+            ),
+            visibility_state="fail_visible_support_diagnostic_visible",
+            deterministic_order=order,
+        )
+        for order, diagnostic_type in enumerate(SUPPORT_DIAGNOSTIC_TYPES, start=1)
+    )
+
+
+def default_unsupported_operational_state_visibility() -> tuple[
+    UnsupportedSupportOperationalStateVisibility, ...
+]:
+    return tuple(
+        UnsupportedSupportOperationalStateVisibility(
+            state_id=f"unsupported_support_operational_state_{unsupported_state}",
+            unsupported_state=unsupported_state,
+            explicit_reason=(
+                f"{unsupported_state} remains unsupported for v4.5B.2 support "
+                "status visibility."
+            ),
+            evidence_reference_ids=("evidence_unsupported_support_operational_states",),
+            visibility_state="unsupported_support_operational_state_fail_visible",
+            deterministic_order=order,
+        )
+        for order, unsupported_state in enumerate(
+            UNSUPPORTED_SUPPORT_OPERATIONAL_STATES,
+            start=1,
+        )
+    )
+
+
+def default_v4_5b_2_support_status_visibility() -> SupportStatusVisibilityIntelligence:
+    return SupportStatusVisibilityIntelligence(
+        support_identity=default_support_status_identity(),
+        support_visibility_records=default_support_visibility_records(),
+        support_classifications=default_support_classifications(),
+        support_surfaces=default_support_surfaces(),
+        unsupported_state_visibility=default_unsupported_state_visibility(),
+        experimental_deprecated_visibility=(
+            default_experimental_deprecated_visibility()
+        ),
+        evidence_based_support_visibility=default_evidence_based_support_visibility(),
+        explainability_support_visibility=default_explainability_support_visibility(),
+        continuity_support_visibility=default_continuity_support_visibility(),
+        support_summaries=default_support_summaries(),
+        support_diagnostics=default_support_diagnostics(),
+        unsupported_operational_state_visibility=(
+            default_unsupported_operational_state_visibility()
+        ),
+        deterministic_guarantees=(
+            V4_5B_2_SUPPORT_STATUS_VISIBILITY_DETERMINISTIC_GUARANTEES
+        ),
+        inherited_prohibitions=(
+            V4_5B_2_SUPPORT_STATUS_VISIBILITY_INHERITED_PROHIBITIONS
+        ),
+        inherited_constraints=(
+            V4_5B_2_SUPPORT_STATUS_VISIBILITY_INHERITED_CONSTRAINTS
+        ),
+        explicit_limitations=(
+            V4_5B_2_SUPPORT_STATUS_VISIBILITY_EXPLICIT_LIMITATIONS
+        ),
+    )

--- a/backend/app/public_trust_visibility/v4_5b_2_support_status_visibility_serialization.py
+++ b/backend/app/public_trust_visibility/v4_5b_2_support_status_visibility_serialization.py
@@ -1,0 +1,234 @@
+"""Deterministic serialization for v4.5B.2 support status visibility."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, is_dataclass
+from typing import Any, Mapping
+
+from .v4_5b_2_support_status_visibility_models import (
+    ContinuitySupportVisibility,
+    EvidenceBasedSupportVisibility,
+    ExperimentalDeprecatedVisibility,
+    ExplainabilitySupportVisibility,
+    PublicSupportSurfaceVisibility,
+    SupportClassificationVisibility,
+    SupportDiagnosticRecord,
+    SupportStatusIdentity,
+    SupportStatusVisibilityIntelligence,
+    SupportSummaryRecord,
+    SupportVisibilityRecord,
+    UnsupportedSupportOperationalStateVisibility,
+    UnsupportedSupportStateVisibility,
+)
+
+
+def _sorted_tuple(values: tuple[str, ...] | list[str]) -> list[str]:
+    return sorted(tuple(values or ()))
+
+
+def canonicalize_v4_5b_2_support_status_visibility_evidence(payload: Any) -> Any:
+    if is_dataclass(payload) and not isinstance(payload, type):
+        return canonicalize_v4_5b_2_support_status_visibility_evidence(
+            asdict(payload)
+        )
+    if isinstance(payload, Mapping):
+        return {
+            str(key): canonicalize_v4_5b_2_support_status_visibility_evidence(value)
+            for key, value in sorted(payload.items(), key=lambda item: str(item[0]))
+        }
+    if isinstance(payload, tuple | list):
+        return [
+            canonicalize_v4_5b_2_support_status_visibility_evidence(value)
+            for value in payload
+        ]
+    return payload
+
+
+def stable_serialize_v4_5b_2_support_status_visibility(payload: Any) -> str:
+    return json.dumps(
+        canonicalize_v4_5b_2_support_status_visibility_evidence(payload),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        default=str,
+    )
+
+
+def _export_with_sorted_evidence(record: object) -> dict[str, Any]:
+    data = asdict(record)
+    if "evidence_reference_ids" in data:
+        data["evidence_reference_ids"] = _sorted_tuple(data["evidence_reference_ids"])
+    return data
+
+
+def export_support_status_identity(identity: SupportStatusIdentity) -> dict[str, Any]:
+    return asdict(identity)
+
+
+def export_support_visibility_record(record: SupportVisibilityRecord) -> dict[str, Any]:
+    return asdict(record)
+
+
+def export_support_classification_visibility(
+    record: SupportClassificationVisibility,
+) -> dict[str, Any]:
+    return _export_with_sorted_evidence(record)
+
+
+def export_public_support_surface_visibility(
+    record: PublicSupportSurfaceVisibility,
+) -> dict[str, Any]:
+    return _export_with_sorted_evidence(record)
+
+
+def export_unsupported_support_state_visibility(
+    record: UnsupportedSupportStateVisibility,
+) -> dict[str, Any]:
+    return _export_with_sorted_evidence(record)
+
+
+def export_experimental_deprecated_visibility(
+    record: ExperimentalDeprecatedVisibility,
+) -> dict[str, Any]:
+    return _export_with_sorted_evidence(record)
+
+
+def export_evidence_based_support_visibility(
+    record: EvidenceBasedSupportVisibility,
+) -> dict[str, Any]:
+    return _export_with_sorted_evidence(record)
+
+
+def export_explainability_support_visibility(
+    record: ExplainabilitySupportVisibility,
+) -> dict[str, Any]:
+    return _export_with_sorted_evidence(record)
+
+
+def export_continuity_support_visibility(
+    record: ContinuitySupportVisibility,
+) -> dict[str, Any]:
+    return _export_with_sorted_evidence(record)
+
+
+def export_support_summary_record(record: SupportSummaryRecord) -> dict[str, Any]:
+    return _export_with_sorted_evidence(record)
+
+
+def export_support_diagnostic_record(record: SupportDiagnosticRecord) -> dict[str, Any]:
+    return _export_with_sorted_evidence(record)
+
+
+def export_unsupported_support_operational_state_visibility(
+    record: UnsupportedSupportOperationalStateVisibility,
+) -> dict[str, Any]:
+    return _export_with_sorted_evidence(record)
+
+
+def export_v4_5b_2_support_status_visibility(
+    intelligence: SupportStatusVisibilityIntelligence,
+) -> dict[str, Any]:
+    data = asdict(intelligence)
+    data["support_identity"] = export_support_status_identity(
+        intelligence.support_identity
+    )
+    data["support_visibility_records"] = [
+        export_support_visibility_record(record)
+        for record in sorted(
+            intelligence.support_visibility_records,
+            key=lambda item: (item.deterministic_order, item.support_record_id),
+        )
+    ]
+    data["support_classifications"] = [
+        export_support_classification_visibility(record)
+        for record in sorted(
+            intelligence.support_classifications,
+            key=lambda item: (
+                item.deterministic_order,
+                item.classification_visibility_id,
+            ),
+        )
+    ]
+    data["support_surfaces"] = [
+        export_public_support_surface_visibility(record)
+        for record in sorted(
+            intelligence.support_surfaces,
+            key=lambda item: (item.deterministic_order, item.surface_visibility_id),
+        )
+    ]
+    data["unsupported_state_visibility"] = [
+        export_unsupported_support_state_visibility(record)
+        for record in sorted(
+            intelligence.unsupported_state_visibility,
+            key=lambda item: (item.deterministic_order, item.unsupported_visibility_id),
+        )
+    ]
+    data["experimental_deprecated_visibility"] = [
+        export_experimental_deprecated_visibility(record)
+        for record in sorted(
+            intelligence.experimental_deprecated_visibility,
+            key=lambda item: (item.deterministic_order, item.experimental_deprecated_id),
+        )
+    ]
+    data["evidence_based_support_visibility"] = [
+        export_evidence_based_support_visibility(record)
+        for record in sorted(
+            intelligence.evidence_based_support_visibility,
+            key=lambda item: (item.deterministic_order, item.evidence_support_id),
+        )
+    ]
+    data["explainability_support_visibility"] = [
+        export_explainability_support_visibility(record)
+        for record in sorted(
+            intelligence.explainability_support_visibility,
+            key=lambda item: (item.deterministic_order, item.explainability_support_id),
+        )
+    ]
+    data["continuity_support_visibility"] = [
+        export_continuity_support_visibility(record)
+        for record in sorted(
+            intelligence.continuity_support_visibility,
+            key=lambda item: (item.deterministic_order, item.continuity_support_id),
+        )
+    ]
+    data["support_summaries"] = [
+        export_support_summary_record(record)
+        for record in sorted(
+            intelligence.support_summaries,
+            key=lambda item: (item.deterministic_order, item.support_summary_record_id),
+        )
+    ]
+    data["support_diagnostics"] = [
+        export_support_diagnostic_record(record)
+        for record in sorted(
+            intelligence.support_diagnostics,
+            key=lambda item: (item.deterministic_order, item.diagnostic_id),
+        )
+    ]
+    data["unsupported_operational_state_visibility"] = [
+        export_unsupported_support_operational_state_visibility(record)
+        for record in sorted(
+            intelligence.unsupported_operational_state_visibility,
+            key=lambda item: (item.deterministic_order, item.state_id),
+        )
+    ]
+    data["deterministic_guarantees"] = _sorted_tuple(data["deterministic_guarantees"])
+    data["inherited_prohibitions"] = _sorted_tuple(data["inherited_prohibitions"])
+    data["inherited_constraints"] = _sorted_tuple(data["inherited_constraints"])
+    data["explicit_limitations"] = _sorted_tuple(data["explicit_limitations"])
+    return data
+
+
+def serialize_support_status_identity(identity: SupportStatusIdentity) -> str:
+    return stable_serialize_v4_5b_2_support_status_visibility(
+        export_support_status_identity(identity)
+    )
+
+
+def serialize_v4_5b_2_support_status_visibility(
+    intelligence: SupportStatusVisibilityIntelligence,
+) -> str:
+    return stable_serialize_v4_5b_2_support_status_visibility(
+        export_v4_5b_2_support_status_visibility(intelligence)
+    )

--- a/backend/app/public_trust_visibility/v4_5b_2_support_status_visibility_visibility.py
+++ b/backend/app/public_trust_visibility/v4_5b_2_support_status_visibility_visibility.py
@@ -1,0 +1,498 @@
+"""Visibility helpers for v4.5B.2 support status visibility."""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any, Iterable
+
+from .v4_5b_2_support_status_visibility_models import (
+    CONTINUITY_SUPPORT_VISIBILITY_TYPES,
+    EVIDENCE_BASED_SUPPORT_VISIBILITY_TYPES,
+    EXPERIMENTAL_DEPRECATED_VISIBILITY_TYPES,
+    EXPLAINABILITY_SUPPORT_VISIBILITY_TYPES,
+    PUBLIC_SUPPORT_SURFACE_TYPES,
+    SUPPORT_CLASSIFICATION_TYPES,
+    SUPPORT_DIAGNOSTIC_TYPES,
+    SUPPORT_SUMMARY_TYPES,
+    UNSUPPORTED_SUPPORT_OPERATIONAL_STATES,
+    UNSUPPORTED_SUPPORT_STATE_TYPES,
+    ContinuitySupportVisibility,
+    EvidenceBasedSupportVisibility,
+    ExperimentalDeprecatedVisibility,
+    ExplainabilitySupportVisibility,
+    PublicSupportSurfaceVisibility,
+    SupportClassificationVisibility,
+    SupportDiagnosticRecord,
+    SupportStatusVisibilityIntelligence,
+    SupportSummaryRecord,
+    SupportVisibilityRecord,
+    UnsupportedSupportOperationalStateVisibility,
+    UnsupportedSupportStateVisibility,
+)
+
+
+def _ordered_ids(values: Iterable[str]) -> list[str]:
+    return sorted(tuple(values or ()))
+
+
+def _count(items: Iterable[str], expected: tuple[str, ...]) -> dict[str, int]:
+    counts = Counter(items)
+    return {item: int(counts.get(item, 0)) for item in expected}
+
+
+def count_support_classifications(
+    records: Iterable[SupportClassificationVisibility],
+) -> dict[str, int]:
+    return _count(
+        (record.support_classification for record in records),
+        SUPPORT_CLASSIFICATION_TYPES,
+    )
+
+
+def count_support_surfaces(
+    records: Iterable[PublicSupportSurfaceVisibility],
+) -> dict[str, int]:
+    return _count((record.support_surface for record in records), PUBLIC_SUPPORT_SURFACE_TYPES)
+
+
+def count_unsupported_support_states(
+    records: Iterable[UnsupportedSupportStateVisibility],
+) -> dict[str, int]:
+    return _count(
+        (record.unsupported_state_type for record in records),
+        UNSUPPORTED_SUPPORT_STATE_TYPES,
+    )
+
+
+def count_experimental_deprecated_types(
+    records: Iterable[ExperimentalDeprecatedVisibility],
+) -> dict[str, int]:
+    return _count(
+        (record.visibility_type for record in records),
+        EXPERIMENTAL_DEPRECATED_VISIBILITY_TYPES,
+    )
+
+
+def count_evidence_based_support_types(
+    records: Iterable[EvidenceBasedSupportVisibility],
+) -> dict[str, int]:
+    return _count(
+        (record.evidence_support_type for record in records),
+        EVIDENCE_BASED_SUPPORT_VISIBILITY_TYPES,
+    )
+
+
+def count_explainability_support_types(
+    records: Iterable[ExplainabilitySupportVisibility],
+) -> dict[str, int]:
+    return _count(
+        (record.explainability_support_type for record in records),
+        EXPLAINABILITY_SUPPORT_VISIBILITY_TYPES,
+    )
+
+
+def count_continuity_support_types(
+    records: Iterable[ContinuitySupportVisibility],
+) -> dict[str, int]:
+    return _count(
+        (record.continuity_support_type for record in records),
+        CONTINUITY_SUPPORT_VISIBILITY_TYPES,
+    )
+
+
+def count_support_summary_types(
+    records: Iterable[SupportSummaryRecord],
+) -> dict[str, int]:
+    return _count((record.summary_type for record in records), SUPPORT_SUMMARY_TYPES)
+
+
+def count_support_diagnostic_types(
+    records: Iterable[SupportDiagnosticRecord],
+) -> dict[str, int]:
+    return _count((record.diagnostic_type for record in records), SUPPORT_DIAGNOSTIC_TYPES)
+
+
+def count_unsupported_operational_states(
+    records: Iterable[UnsupportedSupportOperationalStateVisibility],
+) -> dict[str, int]:
+    return _count(
+        (record.unsupported_state for record in records),
+        UNSUPPORTED_SUPPORT_OPERATIONAL_STATES,
+    )
+
+
+def support_visibility_summary(
+    records: Iterable[SupportVisibilityRecord],
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "support_record_id": record.support_record_id,
+            "support_status_id": record.support_status_id,
+            "support_summary_id": record.support_summary_id,
+            "support_scope_id": record.support_scope_id,
+            "support_reference_id": record.support_reference_id,
+            "evidence_reference_id": record.evidence_reference_id,
+            "explainability_reference_id": record.explainability_reference_id,
+            "continuity_reference_id": record.continuity_reference_id,
+            "diagnostics_reference_id": record.diagnostics_reference_id,
+            "lineage_reference_id": record.lineage_reference_id,
+            "provenance_reference_id": record.provenance_reference_id,
+            "descriptive_only": record.descriptive_only,
+            "publicly_transparent": record.publicly_transparent,
+            "fail_visible": record.fail_visible,
+            "support_authority_enabled": record.support_authority_enabled,
+            "authorization_enabled": record.authorization_enabled,
+            "approval_enabled": record.approval_enabled,
+            "ranking_enabled": record.ranking_enabled,
+            "recommendation_enabled": record.recommendation_enabled,
+        }
+        for record in sorted(
+            records,
+            key=lambda item: (item.deterministic_order, item.support_record_id),
+        )
+    ]
+
+
+def support_classification_summary(
+    records: Iterable[SupportClassificationVisibility],
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "classification_visibility_id": record.classification_visibility_id,
+            "support_classification": record.support_classification,
+            "evidence_reference_ids": _ordered_ids(record.evidence_reference_ids),
+            "descriptive_only": record.descriptive_only,
+            "operational_approval_enabled": record.operational_approval_enabled,
+            "execution_semantics_enabled": record.execution_semantics_enabled,
+            "authorization_enabled": record.authorization_enabled,
+            "approval_enabled": record.approval_enabled,
+        }
+        for record in sorted(
+            records,
+            key=lambda item: (
+                item.deterministic_order,
+                item.classification_visibility_id,
+            ),
+        )
+    ]
+
+
+def support_surface_summary(
+    records: Iterable[PublicSupportSurfaceVisibility],
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "surface_visibility_id": record.surface_visibility_id,
+            "support_surface": record.support_surface,
+            "support_classification": record.support_classification,
+            "evidence_reference_ids": _ordered_ids(record.evidence_reference_ids),
+            "descriptive_only": record.descriptive_only,
+            "ranking_enabled": record.ranking_enabled,
+            "recommendation_enabled": record.recommendation_enabled,
+            "operational_enabled": record.operational_enabled,
+        }
+        for record in sorted(
+            records,
+            key=lambda item: (item.deterministic_order, item.surface_visibility_id),
+        )
+    ]
+
+
+def unsupported_state_summary(
+    records: Iterable[UnsupportedSupportStateVisibility],
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "unsupported_visibility_id": record.unsupported_visibility_id,
+            "unsupported_state_type": record.unsupported_state_type,
+            "evidence_reference_ids": _ordered_ids(record.evidence_reference_ids),
+            "descriptive_only": record.descriptive_only,
+            "fail_visible": record.fail_visible,
+            "suppression_enabled": record.suppression_enabled,
+            "hidden_fallback_enabled": record.hidden_fallback_enabled,
+            "authorization_enabled": record.authorization_enabled,
+            "approval_enabled": record.approval_enabled,
+            "remediation_enabled": record.remediation_enabled,
+        }
+        for record in sorted(
+            records,
+            key=lambda item: (item.deterministic_order, item.unsupported_visibility_id),
+        )
+    ]
+
+
+def experimental_deprecated_summary(
+    records: Iterable[ExperimentalDeprecatedVisibility],
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "experimental_deprecated_id": record.experimental_deprecated_id,
+            "visibility_type": record.visibility_type,
+            "evidence_reference_ids": _ordered_ids(record.evidence_reference_ids),
+            "descriptive_only": record.descriptive_only,
+            "automatic_migration_enabled": record.automatic_migration_enabled,
+            "operational_fallback_enabled": record.operational_fallback_enabled,
+            "authorization_enabled": record.authorization_enabled,
+            "approval_enabled": record.approval_enabled,
+        }
+        for record in sorted(
+            records,
+            key=lambda item: (item.deterministic_order, item.experimental_deprecated_id),
+        )
+    ]
+
+
+def evidence_based_support_summary(
+    records: Iterable[EvidenceBasedSupportVisibility],
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "evidence_support_id": record.evidence_support_id,
+            "evidence_support_type": record.evidence_support_type,
+            "evidence_reference_ids": _ordered_ids(record.evidence_reference_ids),
+            "descriptive_only": record.descriptive_only,
+            "replay_safe": record.replay_safe,
+            "provenance_safe": record.provenance_safe,
+            "trust_scoring_enabled": record.trust_scoring_enabled,
+            "approval_enabled": record.approval_enabled,
+            "authorization_enabled": record.authorization_enabled,
+        }
+        for record in sorted(
+            records,
+            key=lambda item: (item.deterministic_order, item.evidence_support_id),
+        )
+    ]
+
+
+def explainability_support_summary(
+    records: Iterable[ExplainabilitySupportVisibility],
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "explainability_support_id": record.explainability_support_id,
+            "explainability_support_type": record.explainability_support_type,
+            "evidence_reference_ids": _ordered_ids(record.evidence_reference_ids),
+            "descriptive_only": record.descriptive_only,
+            "recommendation_enabled": record.recommendation_enabled,
+            "operational_semantics_enabled": record.operational_semantics_enabled,
+            "authorization_enabled": record.authorization_enabled,
+        }
+        for record in sorted(
+            records,
+            key=lambda item: (item.deterministic_order, item.explainability_support_id),
+        )
+    ]
+
+
+def continuity_support_summary(
+    records: Iterable[ContinuitySupportVisibility],
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "continuity_support_id": record.continuity_support_id,
+            "continuity_support_type": record.continuity_support_type,
+            "continuity_reference_id": record.continuity_reference_id,
+            "evidence_reference_ids": _ordered_ids(record.evidence_reference_ids),
+            "descriptive_only": record.descriptive_only,
+            "restoration_enabled": record.restoration_enabled,
+            "repair_enabled": record.repair_enabled,
+            "remediation_enabled": record.remediation_enabled,
+            "authorization_enabled": record.authorization_enabled,
+        }
+        for record in sorted(
+            records,
+            key=lambda item: (item.deterministic_order, item.continuity_support_id),
+        )
+    ]
+
+
+def support_summary_visibility(
+    records: Iterable[SupportSummaryRecord],
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "support_summary_record_id": record.support_summary_record_id,
+            "support_summary_id": record.support_summary_id,
+            "summary_type": record.summary_type,
+            "evidence_reference_ids": _ordered_ids(record.evidence_reference_ids),
+            "summary_state": record.summary_state,
+            "descriptive_only": record.descriptive_only,
+            "authorization_enabled": record.authorization_enabled,
+            "approval_enabled": record.approval_enabled,
+            "ranking_enabled": record.ranking_enabled,
+            "recommendation_enabled": record.recommendation_enabled,
+            "execution_enablement_enabled": record.execution_enablement_enabled,
+            "production_enablement_enabled": record.production_enablement_enabled,
+        }
+        for record in sorted(
+            records,
+            key=lambda item: (item.deterministic_order, item.support_summary_record_id),
+        )
+    ]
+
+
+def support_diagnostic_summary(
+    records: Iterable[SupportDiagnosticRecord],
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "diagnostic_id": record.diagnostic_id,
+            "diagnostic_type": record.diagnostic_type,
+            "evidence_reference_ids": _ordered_ids(record.evidence_reference_ids),
+            "message": record.message,
+            "fail_visible": record.fail_visible,
+            "descriptive_only": record.descriptive_only,
+            "silent_fallback_enabled": record.silent_fallback_enabled,
+            "hidden_fallback_enabled": record.hidden_fallback_enabled,
+            "authorization_enabled": record.authorization_enabled,
+            "approval_enabled": record.approval_enabled,
+            "remediation_enabled": record.remediation_enabled,
+            "repair_enabled": record.repair_enabled,
+            "mitigation_enabled": record.mitigation_enabled,
+            "auto_correction_enabled": record.auto_correction_enabled,
+            "ranking_enabled": record.ranking_enabled,
+            "recommendation_enabled": record.recommendation_enabled,
+            "orchestration_response_enabled": record.orchestration_response_enabled,
+        }
+        for record in sorted(
+            records,
+            key=lambda item: (item.deterministic_order, item.diagnostic_id),
+        )
+    ]
+
+
+def unsupported_operational_state_summary(
+    records: Iterable[UnsupportedSupportOperationalStateVisibility],
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "state_id": record.state_id,
+            "unsupported_state": record.unsupported_state,
+            "explicit_reason": record.explicit_reason,
+            "evidence_reference_ids": _ordered_ids(record.evidence_reference_ids),
+            "fail_visible": record.fail_visible,
+            "descriptive_only": record.descriptive_only,
+            "authorization_enabled": record.authorization_enabled,
+            "approval_enabled": record.approval_enabled,
+            "operational_enabled": record.operational_enabled,
+            "remediation_enabled": record.remediation_enabled,
+            "repair_enabled": record.repair_enabled,
+            "mitigation_enabled": record.mitigation_enabled,
+            "automated_correction_enabled": record.automated_correction_enabled,
+            "ranking_enabled": record.ranking_enabled,
+            "recommendation_enabled": record.recommendation_enabled,
+            "suppression_enabled": record.suppression_enabled,
+        }
+        for record in sorted(
+            records,
+            key=lambda item: (item.deterministic_order, item.state_id),
+        )
+    ]
+
+
+def validate_required_support_status_visibility(
+    intelligence: SupportStatusVisibilityIntelligence,
+) -> dict[str, Any]:
+    classification_counts = count_support_classifications(
+        intelligence.support_classifications
+    )
+    surface_counts = count_support_surfaces(intelligence.support_surfaces)
+    unsupported_counts = count_unsupported_support_states(
+        intelligence.unsupported_state_visibility
+    )
+    experimental_counts = count_experimental_deprecated_types(
+        intelligence.experimental_deprecated_visibility
+    )
+    evidence_counts = count_evidence_based_support_types(
+        intelligence.evidence_based_support_visibility
+    )
+    explainability_counts = count_explainability_support_types(
+        intelligence.explainability_support_visibility
+    )
+    continuity_counts = count_continuity_support_types(
+        intelligence.continuity_support_visibility
+    )
+    summary_counts = count_support_summary_types(intelligence.support_summaries)
+    diagnostic_counts = count_support_diagnostic_types(
+        intelligence.support_diagnostics
+    )
+    unsupported_operational_counts = count_unsupported_operational_states(
+        intelligence.unsupported_operational_state_visibility
+    )
+    missing = {
+        "missing_classifications": sorted(
+            key for key, value in classification_counts.items() if value < 1
+        ),
+        "missing_surfaces": sorted(
+            key for key, value in surface_counts.items() if value < 1
+        ),
+        "missing_unsupported_states": sorted(
+            key for key, value in unsupported_counts.items() if value < 1
+        ),
+        "missing_experimental_deprecated": sorted(
+            key for key, value in experimental_counts.items() if value < 1
+        ),
+        "missing_evidence_support": sorted(
+            key for key, value in evidence_counts.items() if value < 1
+        ),
+        "missing_explainability_support": sorted(
+            key for key, value in explainability_counts.items() if value < 1
+        ),
+        "missing_continuity_support": sorted(
+            key for key, value in continuity_counts.items() if value < 1
+        ),
+        "missing_summaries": sorted(
+            key for key, value in summary_counts.items() if value < 1
+        ),
+        "missing_diagnostics": sorted(
+            key for key, value in diagnostic_counts.items() if value < 1
+        ),
+        "missing_unsupported_operational_states": sorted(
+            key for key, value in unsupported_operational_counts.items() if value < 1
+        ),
+    }
+    return {
+        "valid": not any(missing.values()),
+        "classification_counts": classification_counts,
+        "surface_counts": surface_counts,
+        "unsupported_counts": unsupported_counts,
+        "experimental_counts": experimental_counts,
+        "evidence_counts": evidence_counts,
+        "explainability_counts": explainability_counts,
+        "continuity_counts": continuity_counts,
+        "summary_counts": summary_counts,
+        "diagnostic_counts": diagnostic_counts,
+        "unsupported_operational_counts": unsupported_operational_counts,
+        **missing,
+    }
+
+
+def descriptive_only_support_status_summary(
+    intelligence: SupportStatusVisibilityIntelligence,
+) -> dict[str, Any]:
+    return {
+        "descriptive_only": intelligence.descriptive_only,
+        "publicly_transparent": intelligence.publicly_transparent,
+        "support_status_visibility_statement": (
+            intelligence.support_status_visibility_statement
+        ),
+        "support_classification_non_authority_statement": (
+            intelligence.support_classification_non_authority_statement
+        ),
+        "non_operational": intelligence.non_operational,
+        "non_authorizing": intelligence.non_authorizing,
+        "non_approving": intelligence.non_approving,
+        "non_executing": intelligence.non_executing,
+        "non_remediating": intelligence.non_remediating,
+        "non_runtime_mutating": intelligence.non_runtime_mutating,
+        "non_ranking": intelligence.non_ranking,
+        "non_recommending": intelligence.non_recommending,
+        "support_authorization_enabled": intelligence.support_authorization_enabled,
+        "support_approval_enabled": intelligence.support_approval_enabled,
+        "support_ranking_enabled": intelligence.support_ranking_enabled,
+        "support_recommendation_enabled": intelligence.support_recommendation_enabled,
+        "planner_integration_enabled": intelligence.planner_integration_enabled,
+        "production_consumption_enabled": intelligence.production_consumption_enabled,
+        "runtime_mutation_enabled": intelligence.runtime_mutation_enabled,
+        "operational_mutation_enabled": intelligence.operational_mutation_enabled,
+    }

--- a/backend/scripts/report_v4_5b_2_support_status_visibility.py
+++ b/backend/scripts/report_v4_5b_2_support_status_visibility.py
@@ -1,0 +1,131 @@
+"""Generate deterministic v4.5B.2 support status visibility report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+APP_ROOT = BACKEND_ROOT / "app"
+if str(APP_ROOT) not in sys.path:
+    sys.path.insert(0, str(APP_ROOT))
+
+from public_trust_visibility.v4_5b_2_support_status_visibility_audit import (  # noqa: E402
+    build_v4_5b_2_support_status_visibility_report,
+)
+
+
+REPORT_PATH = Path("docs/generated/v4_5b_2_support_status_visibility_report.json")
+
+
+def write_report(report: dict[str, object], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        default=str(REPORT_PATH),
+        help="v4.5B.2 support status visibility JSON report output path",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    output_path = Path(args.output)
+    report = build_v4_5b_2_support_status_visibility_report()
+    write_report(report, output_path)
+    summary = report["summary"]
+    print(f"wrote {output_path}")
+    print(f"foundation_status={report['foundation_status']}")
+    print(f"support_visibility_record_count={summary['support_visibility_record_count']}")
+    print(f"support_classification_count={summary['support_classification_count']}")
+    print(f"support_surface_count={summary['support_surface_count']}")
+    print(
+        "unsupported_state_visibility_count="
+        f"{summary['unsupported_state_visibility_count']}"
+    )
+    print(f"experimental_deprecated_count={summary['experimental_deprecated_count']}")
+    print(f"evidence_based_support_count={summary['evidence_based_support_count']}")
+    print(f"explainability_support_count={summary['explainability_support_count']}")
+    print(f"continuity_support_count={summary['continuity_support_count']}")
+    print(f"support_summary_count={summary['support_summary_count']}")
+    print(f"support_diagnostic_count={summary['support_diagnostic_count']}")
+    print(
+        "unsupported_operational_state_count="
+        f"{summary['unsupported_operational_state_count']}"
+    )
+    print(
+        "deterministic_serialization_verified="
+        f"{summary['deterministic_serialization_verified']}"
+    )
+    print(f"deterministic_hashing_verified={summary['deterministic_hashing_verified']}")
+    print(f"support_classification_stable={summary['support_classification_stable']}")
+    print(f"support_surface_visibility_stable={summary['support_surface_visibility_stable']}")
+    print(
+        "unsupported_state_visibility_preserved="
+        f"{summary['unsupported_state_visibility_preserved']}"
+    )
+    print(
+        "experimental_deprecated_visibility_preserved="
+        f"{summary['experimental_deprecated_visibility_preserved']}"
+    )
+    print(
+        "evidence_based_support_visibility_stable="
+        f"{summary['evidence_based_support_visibility_stable']}"
+    )
+    print(
+        "explainability_support_visibility_stable="
+        f"{summary['explainability_support_visibility_stable']}"
+    )
+    print(
+        "continuity_support_visibility_stable="
+        f"{summary['continuity_support_visibility_stable']}"
+    )
+    print(f"lineage_continuity_preserved={summary['lineage_continuity_preserved']}")
+    print(
+        "provenance_continuity_preserved="
+        f"{summary['provenance_continuity_preserved']}"
+    )
+    print(f"evidence_continuity_preserved={summary['evidence_continuity_preserved']}")
+    print(
+        "fail_visible_support_diagnostics_verified="
+        f"{summary['fail_visible_support_diagnostics_verified']}"
+    )
+    print(
+        "descriptive_only_guarantees_verified="
+        f"{summary['descriptive_only_guarantees_verified']}"
+    )
+    print(f"publicly_transparent={summary['publicly_transparent']}")
+    print(
+        "support_status_visibility_statement="
+        f"{summary['support_status_visibility_statement']}"
+    )
+    print(
+        "support_classification_non_authority_statement="
+        f"{summary['support_classification_non_authority_statement']}"
+    )
+    print(f"inherited_prohibition_count={summary['inherited_prohibition_count']}")
+    print(f"inherited_constraint_count={summary['inherited_constraint_count']}")
+    print(f"explicit_limitation_count={summary['explicit_limitation_count']}")
+    print(f"validation_error_count={summary['validation_error_count']}")
+    for key in sorted(k for k in summary if k.startswith("enabled_")):
+        print(f"{key}={summary[key]}")
+    print(f"repository_remains={','.join(summary['repository_remains'])}")
+    print(f"deterministic_report_hash={report['deterministic_report_hash']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_v4_5b_2_support_status_visibility.py
+++ b/backend/tests/test_v4_5b_2_support_status_visibility.py
@@ -1,0 +1,364 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError, replace
+from pathlib import Path
+import sys
+
+import pytest
+
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+APP_ROOT = BACKEND_ROOT / "app"
+if str(APP_ROOT) not in sys.path:
+    sys.path.insert(0, str(APP_ROOT))
+
+from public_trust_visibility.v4_5b_2_support_status_visibility_audit import (  # noqa: E402
+    build_v4_5b_2_support_status_visibility,
+    build_v4_5b_2_support_status_visibility_report,
+    contaminate_v4_5b_2_support_status_visibility_for_non_operational_validation,
+    enabled_support_status_capability_flags,
+    support_status_capability_counter_values,
+    support_status_visibility_equal,
+    validate_descriptive_only_support_guarantees,
+    validate_evidence_based_support_visibility,
+    validate_experimental_deprecated_visibility_preservation,
+    validate_explainability_support_visibility,
+    validate_fail_visible_support_diagnostics,
+    validate_lineage_and_provenance_preservation,
+    validate_public_support_surface_visibility,
+    validate_support_classification_stability,
+    validate_support_identity_integrity,
+    validate_support_status_ordering_stability,
+    validate_support_status_serialization_and_hashing,
+    validate_support_summary_stability,
+    validate_unsupported_state_visibility_preservation,
+    validate_v4_5b_2_support_status_visibility,
+)
+from public_trust_visibility.v4_5b_2_support_status_visibility_hashing import (  # noqa: E402
+    hash_evidence_based_support_visibility,
+    hash_experimental_deprecated_visibility,
+    hash_public_support_surface_visibility,
+    hash_support_classification_visibility,
+    hash_support_diagnostic_record,
+    hash_support_status_identity,
+    hash_support_summary_record,
+    hash_support_visibility_record,
+    hash_v4_5b_2_support_status_visibility,
+)
+from public_trust_visibility.v4_5b_2_support_status_visibility_models import (  # noqa: E402
+    EVIDENCE_BASED_SUPPORT_VISIBILITY_TYPES,
+    EXPERIMENTAL_DEPRECATED_VISIBILITY_TYPES,
+    EXPLAINABILITY_SUPPORT_VISIBILITY_TYPES,
+    PUBLIC_SUPPORT_SURFACE_TYPES,
+    SUPPORT_CLASSIFICATION_NON_AUTHORITY_STATEMENT,
+    SUPPORT_CLASSIFICATION_TYPES,
+    SUPPORT_DIAGNOSTIC_TYPES,
+    SUPPORT_STATUS_VISIBILITY_STATEMENT,
+    SUPPORT_SUMMARY_TYPES,
+    UNSUPPORTED_SUPPORT_OPERATIONAL_STATES,
+    UNSUPPORTED_SUPPORT_STATE_TYPES,
+    V4_5B_2_SUPPORT_STATUS_VISIBILITY_SCHEMA_VERSION,
+    V4_5B_2_SUPPORT_STATUS_VISIBILITY_STATUS_STABLE,
+)
+from public_trust_visibility.v4_5b_2_support_status_visibility_serialization import (  # noqa: E402
+    serialize_v4_5b_2_support_status_visibility,
+)
+from public_trust_visibility.v4_5b_2_support_status_visibility_visibility import (  # noqa: E402
+    continuity_support_summary,
+    descriptive_only_support_status_summary,
+    evidence_based_support_summary,
+    experimental_deprecated_summary,
+    explainability_support_summary,
+    support_classification_summary,
+    support_diagnostic_summary,
+    support_summary_visibility,
+    support_surface_summary,
+    support_visibility_summary,
+    unsupported_operational_state_summary,
+    unsupported_state_summary,
+    validate_required_support_status_visibility,
+)
+
+
+def test_v4_5b_2_models_are_immutable_and_descriptive_only():
+    intelligence = build_v4_5b_2_support_status_visibility()
+
+    with pytest.raises(FrozenInstanceError):
+        intelligence.support_authorization_enabled = True
+
+    assert (
+        intelligence.support_identity.schema_version
+        == V4_5B_2_SUPPORT_STATUS_VISIBILITY_SCHEMA_VERSION
+    )
+    assert intelligence.descriptive_only is True
+    assert intelligence.publicly_transparent is True
+    assert intelligence.non_operational is True
+    assert intelligence.non_executing is True
+    assert intelligence.non_authorizing is True
+    assert intelligence.non_approving is True
+    assert intelligence.non_remediating is True
+    assert intelligence.non_runtime_mutating is True
+    assert intelligence.non_ranking is True
+    assert intelligence.non_recommending is True
+    assert intelligence.support_authorization_enabled is False
+    assert intelligence.support_approval_enabled is False
+    assert intelligence.support_ranking_enabled is False
+    assert intelligence.support_recommendation_enabled is False
+    assert intelligence.production_consumption_enabled is False
+    assert enabled_support_status_capability_flags(intelligence) == {}
+    assert all(
+        value == 0
+        for value in support_status_capability_counter_values(intelligence).values()
+    )
+
+
+def test_v4_5b_2_required_visibility_sets_are_complete():
+    intelligence = build_v4_5b_2_support_status_visibility()
+    visibility = validate_required_support_status_visibility(intelligence)
+
+    assert visibility["valid"] is True
+    assert set(visibility["classification_counts"]) == set(SUPPORT_CLASSIFICATION_TYPES)
+    assert set(visibility["surface_counts"]) == set(PUBLIC_SUPPORT_SURFACE_TYPES)
+    assert set(visibility["unsupported_counts"]) == set(UNSUPPORTED_SUPPORT_STATE_TYPES)
+    assert set(visibility["experimental_counts"]) == set(
+        EXPERIMENTAL_DEPRECATED_VISIBILITY_TYPES
+    )
+    assert set(visibility["evidence_counts"]) == set(
+        EVIDENCE_BASED_SUPPORT_VISIBILITY_TYPES
+    )
+    assert set(visibility["explainability_counts"]) == set(
+        EXPLAINABILITY_SUPPORT_VISIBILITY_TYPES
+    )
+    assert set(visibility["summary_counts"]) == set(SUPPORT_SUMMARY_TYPES)
+    assert set(visibility["diagnostic_counts"]) == set(SUPPORT_DIAGNOSTIC_TYPES)
+    assert set(visibility["unsupported_operational_counts"]) == set(
+        UNSUPPORTED_SUPPORT_OPERATIONAL_STATES
+    )
+    assert visibility["missing_classifications"] == []
+    assert visibility["missing_surfaces"] == []
+    assert visibility["missing_unsupported_states"] == []
+    assert visibility["missing_experimental_deprecated"] == []
+    assert visibility["missing_evidence_support"] == []
+    assert visibility["missing_explainability_support"] == []
+    assert visibility["missing_diagnostics"] == []
+    assert visibility["missing_unsupported_operational_states"] == []
+
+
+def test_v4_5b_2_serialization_hashing_and_equality_are_stable():
+    first = build_v4_5b_2_support_status_visibility()
+    second = build_v4_5b_2_support_status_visibility()
+    serialization = validate_support_status_serialization_and_hashing(first)
+
+    assert first == second
+    assert support_status_visibility_equal(first, second)
+    assert serialize_v4_5b_2_support_status_visibility(first) == (
+        serialize_v4_5b_2_support_status_visibility(second)
+    )
+    assert hash_v4_5b_2_support_status_visibility(first) == (
+        hash_v4_5b_2_support_status_visibility(second)
+    )
+    assert serialization["valid"] is True
+    assert len(hash_support_status_identity(first.support_identity)) == 64
+    assert len(hash_support_visibility_record(first.support_visibility_records[0])) == 64
+    assert len(hash_support_classification_visibility(first.support_classifications[0])) == 64
+    assert len(hash_public_support_surface_visibility(first.support_surfaces[0])) == 64
+    assert len(
+        hash_experimental_deprecated_visibility(
+            first.experimental_deprecated_visibility[0]
+        )
+    ) == 64
+    assert len(
+        hash_evidence_based_support_visibility(
+            first.evidence_based_support_visibility[0]
+        )
+    ) == 64
+    assert len(hash_support_summary_record(first.support_summaries[0])) == 64
+    assert len(hash_support_diagnostic_record(first.support_diagnostics[0])) == 64
+
+
+def test_v4_5b_2_ordering_survives_reordered_collections():
+    intelligence = build_v4_5b_2_support_status_visibility()
+    reordered = replace(
+        intelligence,
+        support_visibility_records=tuple(
+            reversed(intelligence.support_visibility_records)
+        ),
+        support_classifications=tuple(reversed(intelligence.support_classifications)),
+        support_surfaces=tuple(reversed(intelligence.support_surfaces)),
+        unsupported_state_visibility=tuple(
+            reversed(intelligence.unsupported_state_visibility)
+        ),
+        experimental_deprecated_visibility=tuple(
+            reversed(intelligence.experimental_deprecated_visibility)
+        ),
+        evidence_based_support_visibility=tuple(
+            reversed(intelligence.evidence_based_support_visibility)
+        ),
+        explainability_support_visibility=tuple(
+            reversed(intelligence.explainability_support_visibility)
+        ),
+        continuity_support_visibility=tuple(
+            reversed(intelligence.continuity_support_visibility)
+        ),
+        support_summaries=tuple(reversed(intelligence.support_summaries)),
+        support_diagnostics=tuple(reversed(intelligence.support_diagnostics)),
+        unsupported_operational_state_visibility=tuple(
+            reversed(intelligence.unsupported_operational_state_visibility)
+        ),
+        deterministic_guarantees=tuple(reversed(intelligence.deterministic_guarantees)),
+        inherited_prohibitions=tuple(reversed(intelligence.inherited_prohibitions)),
+        inherited_constraints=tuple(reversed(intelligence.inherited_constraints)),
+        explicit_limitations=tuple(reversed(intelligence.explicit_limitations)),
+    )
+
+    assert validate_support_status_ordering_stability(intelligence)["valid"] is True
+    assert serialize_v4_5b_2_support_status_visibility(
+        intelligence
+    ) == serialize_v4_5b_2_support_status_visibility(reordered)
+    assert hash_v4_5b_2_support_status_visibility(
+        intelligence
+    ) == hash_v4_5b_2_support_status_visibility(reordered)
+
+
+def test_v4_5b_2_support_visibility_layers_are_stable():
+    intelligence = build_v4_5b_2_support_status_visibility()
+
+    assert validate_support_identity_integrity(intelligence)["valid"] is True
+    assert validate_support_classification_stability(intelligence)["valid"] is True
+    assert validate_public_support_surface_visibility(intelligence)["valid"] is True
+    assert (
+        validate_unsupported_state_visibility_preservation(intelligence)["valid"]
+        is True
+    )
+    assert (
+        validate_experimental_deprecated_visibility_preservation(intelligence)["valid"]
+        is True
+    )
+    assert validate_evidence_based_support_visibility(intelligence)["valid"] is True
+    assert validate_explainability_support_visibility(intelligence)["valid"] is True
+    assert validate_support_summary_stability(intelligence)["valid"] is True
+
+
+def test_v4_5b_2_lineage_provenance_and_fail_visible_diagnostics_are_preserved():
+    intelligence = build_v4_5b_2_support_status_visibility()
+    lineage = validate_lineage_and_provenance_preservation(intelligence)
+    fail_visible = validate_fail_visible_support_diagnostics(intelligence)
+
+    assert lineage["valid"] is True
+    assert lineage["lineage_continuity_preserved"] is True
+    assert lineage["provenance_continuity_preserved"] is True
+    assert lineage["evidence_continuity_preserved"] is True
+    assert fail_visible["valid"] is True
+    assert fail_visible["fail_visible"] is True
+    assert fail_visible["silent_fallback_enabled_count"] == 0
+    assert fail_visible["hidden_fallback_enabled_count"] == 0
+    assert fail_visible["authorization_enabled_count"] == 0
+    assert fail_visible["approval_enabled_count"] == 0
+    assert fail_visible["ranking_enabled_count"] == 0
+    assert fail_visible["recommendation_enabled_count"] == 0
+    assert fail_visible["missing_diagnostic_types"] == []
+    assert fail_visible["missing_unsupported_states"] == []
+
+
+def test_v4_5b_2_visibility_helpers_are_non_operational():
+    intelligence = build_v4_5b_2_support_status_visibility()
+
+    assert len(support_visibility_summary(intelligence.support_visibility_records)) == 1
+    assert len(
+        support_classification_summary(intelligence.support_classifications)
+    ) == len(SUPPORT_CLASSIFICATION_TYPES)
+    assert len(support_surface_summary(intelligence.support_surfaces)) == len(
+        PUBLIC_SUPPORT_SURFACE_TYPES
+    )
+    assert len(unsupported_state_summary(intelligence.unsupported_state_visibility)) == len(
+        UNSUPPORTED_SUPPORT_STATE_TYPES
+    )
+    assert len(
+        experimental_deprecated_summary(intelligence.experimental_deprecated_visibility)
+    ) == len(EXPERIMENTAL_DEPRECATED_VISIBILITY_TYPES)
+    assert len(
+        evidence_based_support_summary(intelligence.evidence_based_support_visibility)
+    ) == len(EVIDENCE_BASED_SUPPORT_VISIBILITY_TYPES)
+    assert len(
+        explainability_support_summary(intelligence.explainability_support_visibility)
+    ) == len(EXPLAINABILITY_SUPPORT_VISIBILITY_TYPES)
+    assert len(
+        continuity_support_summary(intelligence.continuity_support_visibility)
+    ) > 0
+    assert len(support_summary_visibility(intelligence.support_summaries)) == len(
+        SUPPORT_SUMMARY_TYPES
+    )
+    assert len(support_diagnostic_summary(intelligence.support_diagnostics)) == len(
+        SUPPORT_DIAGNOSTIC_TYPES
+    )
+    assert len(
+        unsupported_operational_state_summary(
+            intelligence.unsupported_operational_state_visibility
+        )
+    ) == len(UNSUPPORTED_SUPPORT_OPERATIONAL_STATES)
+    summary = descriptive_only_support_status_summary(intelligence)
+    assert summary["support_status_visibility_statement"] == (
+        SUPPORT_STATUS_VISIBILITY_STATEMENT
+    )
+    assert summary["support_classification_non_authority_statement"] == (
+        SUPPORT_CLASSIFICATION_NON_AUTHORITY_STATEMENT
+    )
+    assert summary["support_authorization_enabled"] is False
+    assert summary["support_approval_enabled"] is False
+    assert summary["support_ranking_enabled"] is False
+    assert summary["support_recommendation_enabled"] is False
+
+
+def test_v4_5b_2_contamination_is_fail_visible():
+    contaminated = (
+        contaminate_v4_5b_2_support_status_visibility_for_non_operational_validation()
+    )
+    validation = validate_v4_5b_2_support_status_visibility(contaminated)
+    descriptive = validate_descriptive_only_support_guarantees(contaminated)
+
+    assert validation["valid"] is False
+    assert "descriptive_only_guarantees" in validation["failed_validations"]
+    assert descriptive["valid"] is False
+    assert descriptive["counters"]["enabled_runtime_execution_count"] > 0
+    assert descriptive["counters"]["enabled_support_authorization_count"] > 0
+    assert descriptive["counters"]["enabled_support_approval_count"] > 0
+    assert descriptive["counters"]["enabled_support_ranking_count"] > 0
+    assert descriptive["counters"]["enabled_support_recommendation_count"] > 0
+    assert descriptive["counters"]["enabled_remediation_count"] > 0
+
+
+def test_v4_5b_2_report_is_replay_safe_and_certifies_support_boundary():
+    first = build_v4_5b_2_support_status_visibility_report()
+    second = build_v4_5b_2_support_status_visibility_report()
+    summary = first["summary"]
+
+    assert first == second
+    assert first["foundation_status"] == V4_5B_2_SUPPORT_STATUS_VISIBILITY_STATUS_STABLE
+    assert first["deterministic_report_hash"] == second["deterministic_report_hash"]
+    assert len(first["deterministic_report_hash"]) == 64
+    assert summary["validation_error_count"] == 0
+    assert summary["deterministic_serialization_verified"] is True
+    assert summary["deterministic_hashing_verified"] is True
+    assert summary["support_classification_stable"] is True
+    assert summary["descriptive_only_guarantees_verified"] is True
+    assert summary["support_status_visibility_statement"] == (
+        SUPPORT_STATUS_VISIBILITY_STATEMENT
+    )
+    assert summary["support_classification_non_authority_statement"] == (
+        SUPPORT_CLASSIFICATION_NON_AUTHORITY_STATEMENT
+    )
+    assert summary["repository_remains"] == [
+        "NON-operational",
+        "NON-authorizing",
+        "NON-approving",
+        "NON-executing",
+        "NON-remediating",
+        "NON-runtime-mutating",
+        "NON-ranking",
+        "NON-recommending",
+    ]
+    assert all(
+        value == 0 for key, value in summary.items() if key.startswith("enabled_")
+    )

--- a/docs/generated/v4_5b_2_support_status_visibility_report.json
+++ b/docs/generated/v4_5b_2_support_status_visibility_report.json
@@ -1,0 +1,3751 @@
+{
+  "deterministic_hash_evidence": {
+    "continuity_support_hashes": {
+      "continuity_support_continuity_supported_states": "36ab8f9d9da13b21b83ca462825465c0418333b38f4cfc8701fc55ee1e1148b6",
+      "continuity_support_evidence_continuity_visibility": "948ec6b2c56db0fe0d5d3599d5a4a776b06ebfe57262789b0db3b50ff78995c1",
+      "continuity_support_fail_visible_continuity_diagnostics": "dd4692fbe17c18ba4be5f50de929a6aace2593603ff7fbf0e2c7760d4b8f1deb",
+      "continuity_support_partially_continuous_states": "165f9b51b66fb6fc87300aea727a864c8e2f15b8447c2ed4233c7946d18b89fd",
+      "continuity_support_unsupported_continuity_states": "ccd176a0c8622b46562319c16742e21297928d0eea9a70deb158161628b632cc"
+    },
+    "evidence_based_support_hashes": {
+      "evidence_based_support_continuity_backed_support_visibility": "74b6f449e9c0d659bd70b3e9b827b5ea6d258e2763a215ce25f543ba4dc19bbe",
+      "evidence_based_support_diagnostics_backed_support_visibility": "d47b69c951b1cb9f86f8ea80979533523c97e9d3e8333daa9c3278725055d10a",
+      "evidence_based_support_evidence_backed_support": "19b3f8cccb0ab9f0adcb76756e731d7ca7762653c5719e2c6bcf682b16b12e56",
+      "evidence_based_support_explainability_backed_support_visibility": "c9fc454dad2b6c5a68be7c6e1b8a3c74ce7949086d20694883b554b1029dba66",
+      "evidence_based_support_partially_evidenced_support": "f806327a32f66c9fd52a07906261e0a02743e2dd3158859c047c87460af109f3",
+      "evidence_based_support_unsupported_evidence_states": "ce0e37938bc3e59c1b59b446770cb855313b6ea1de7595288f3e8fe0923309f1"
+    },
+    "experimental_deprecated_hashes": {
+      "experimental_deprecated_blocked_surfaces": "88464755a805fadda9fa8c6fb913744c6b3de4e9d28b2333248f4793fd108ade",
+      "experimental_deprecated_blocked_systems": "8a0523ecc984df2573b153b4384446d30e6fb0504d0d4adbe41cad29b14d90f5",
+      "experimental_deprecated_deprecated_surfaces": "bfb92e7cd5f6ccd64bdb18f2dd842e7bada2e07c8b4b587b9d46cf72d3cb9f4d",
+      "experimental_deprecated_deprecated_systems": "54e071f62649e12057ace7addc23e9662654f86ef51be463297593b61303cfad",
+      "experimental_deprecated_experimental_surfaces": "d8d77382478eb838413e6924a0f5b383204b06d2598c78b9b16efba31a6c87c6",
+      "experimental_deprecated_experimental_systems": "40c356a899b5195c5ece19eba3d843d30998066881c033bf1c554704eb2bff12",
+      "experimental_deprecated_unknown_support_states": "e75bbabcb15a9c055d5786dca7a58ac7226fdf0ce3ed3bd53df960aaba62435f"
+    },
+    "explainability_support_hashes": {
+      "explainability_support_continuity_explainability_visibility": "78fb06742f9172ee772ca3e9e00361e6c84d5ba0138bb52f01457035b9e46a43",
+      "explainability_support_explainability_supported_states": "9f3969ff8218aa0736eb18e30244c6e1ffbf772672b6ca5e9776460c5c0b89d1",
+      "explainability_support_fail_visible_explainability_diagnostics": "c17664a6f7001a0fa5e565023bf8a5f718a9f06b1c46083dce0abadcc5381606",
+      "explainability_support_partially_explainable_states": "8e5ee7da067ef0e9519e9f3ef2912de98be9bc47e9eeb8b1d6226e088d1934e2",
+      "explainability_support_unsupported_explainability_states": "46a4c7406128f8026394538c7df9aa949c521f9d4e8ee2938c043613a4e37384"
+    },
+    "support_classification_hashes": {
+      "support_classification_blocked": "64d2cb514a555737286ca245bd52d4ca33296c20035fdba985bcf8a4f8f3b221",
+      "support_classification_deprecated": "0a8a5b95c872cbedd6b52bb878241d238913ab13727a95af894ae9a894ebbbe0",
+      "support_classification_experimental": "5a5b188b085ff6ada2a66e8cc84aa9a865d4b292b3562d44462ed2c69ba18714",
+      "support_classification_partially_supported": "9b06e097674cbb09156f814c9c6dc3d0a9398c2c19f210ea56b31260fdcdf361",
+      "support_classification_supported": "3359374d164b2c7d2616ad862301adbce7756be267dfca3148963df8aa22a0d1",
+      "support_classification_unknown": "d5fbe6b6dd2934145addf5eb2a17725e7a80da6d7a924970c9fb2ef7479be2d2",
+      "support_classification_unsupported": "9ce3ec0b6a080dadc04865fd5572ec7d7115008380696d276e0cce5343abf37b"
+    },
+    "support_diagnostic_hashes": {
+      "support_diagnostic_blocked_visibility_states": "b0b1d2fe134847b2bea5ecce0fa591e2716165f61c93c0d32c5c85271b82b77a",
+      "support_diagnostic_deprecated_visibility_states": "e91656ac3bd4c5e8f13a2ef635c560c787bfd1065fd209fd8ff243b7fb815842",
+      "support_diagnostic_inherited_limitation_visibility_gaps": "d8ba23acd595aa299356c8a217f3f0c59bc57718627a6359f49652879ed2050e",
+      "support_diagnostic_inherited_prohibition_visibility_gaps": "4b8f9e47c063350c5cd7ddcdde2b659139631149f35ff0f662defb2e4fa793d1",
+      "support_diagnostic_missing_support_evidence": "259f716a5089c52e9ce696a8a1c07a16c716fc67f83ecf8a75ae094f8bbca55d",
+      "support_diagnostic_unknown_support_states": "5b3397a2003a9a06d4c86fc93b5062b19810b98bc371508d44735261a873a82e",
+      "support_diagnostic_unsupported_continuity_gaps": "a41f6e486e133aaf2fecf05bc3719ca290ee64354cad81f2240a598f036877f4",
+      "support_diagnostic_unsupported_explainability_gaps": "a4435e0b5aef11a5fa06b16f756e283a6a92053bc29e63f796b5a4e95519197a",
+      "support_diagnostic_unsupported_visibility_gaps": "63f07b695bc314959ddeaf5d5d26388d19e5ef289c621e8c9b6da1aa1d67bcc7"
+    },
+    "support_identity_hash": "8d89732aea7aa0e5cde66105c5d067aa17a46da95625e99be433b7dc27c6f730",
+    "support_status_hash": "03b919155f02aff9629f0a5769c8d31cb32f61d5bcfde7aee6dd48a7aea773b8",
+    "support_summary_hashes": {
+      "support_summary_continuity_support_summary": "7e2628c3f3ba5ea4f0e1b2358d75e34185f5a423fdbf1fea3719a3c416f077b2",
+      "support_summary_diagnostics_support_summary": "8a902fef3fb009bd65dbc78898ef0c4e7b0ede8269d8fe69a3663ec9be1db868",
+      "support_summary_evidence_based_support_summary": "78b0306590fd7fa838f11dca2c147f5923462d334aa9bc9452ea84b5506d496c",
+      "support_summary_experimental_deprecated_summary": "fcba6043bb684616fa63c7f0103ba621d020b7a88167fa423c9579e01aff05ce",
+      "support_summary_explainability_support_summary": "ff0b3d06c5a6196522f54dab40170992bb59e0036c28f8a6db2bcc88374cf189",
+      "support_summary_support_classification_summary": "e3f98db52cc0e81d5103eb990f72e1c5bdcea75b7c6e5ab7a98cadd75e08ca2a",
+      "support_summary_surface_support_summary": "7ccb79bcaefc33ad16738af0e0b695f083867259a9f1c53a2f3133a8a295d010",
+      "support_summary_unsupported_state_summary": "8a0561ec7cae5de517d7b62a3c9e04d05ef66d6cdfb245934741f30e73daf838"
+    },
+    "support_surface_hashes": {
+      "support_surface_continuity_surfaces": "b147441eff35d349b5615d6aff37d824c2e7b32e4df55ba3accb0b0c1816aa01",
+      "support_surface_data_sources": "758503d21f88900d40bd0424409619d834c4c6f7c315fcd82ecfbc3442411ab3",
+      "support_surface_diagnostics_surfaces": "3b06c9b1cb35974d6676501ad8f8f5eab059d8e4462ba6295708f0a2c54c67df",
+      "support_surface_evidence_chains": "c25abc692d967e2e2f7862f004c7f81e28d422c44e95c0e7e4127535d9d5101a",
+      "support_surface_explainability_surfaces": "f18da2de35a053e1d81673b2336b6dd1fe7c5c4884be781ef7f1b7446ec7b458",
+      "support_surface_mechanics": "e6fc8718ede3944dcea73ef9d39ec57ebb8ec3d6b8a8ff181fd4afcad3e71aa3",
+      "support_surface_planner_sections": "19d35abf731bd805091445794aaf56cd40a980097476c047557c2b3ee0b73f34",
+      "support_surface_systems": "c995e143a547d61fdb5e330028d5dc856b137c7abfd5ee6b533ff2d7aca632bf"
+    },
+    "support_visibility_record_hashes": {
+      "public_support_status_visibility_foundation": "1b3b0bcbc920572446a2ebcb3ae5d8478c5a32073489659b54a8b55dfa6ebe70"
+    },
+    "unsupported_operational_hashes": {
+      "unsupported_support_operational_state_automated_correction": "b41921c77ba818a4f9eff829f30194296761006b7ea43a6dfa8b3246830131fd",
+      "unsupported_support_operational_state_automated_mitigation": "f7ef245bdbc52f782e22fbdb9a73c03b416aa88659115716503c255ca7482f9f",
+      "unsupported_support_operational_state_automated_remediation": "10c6160ab19751a629d80029c49e9e690ce2c3c015288b3e417e622b7e2f693b",
+      "unsupported_support_operational_state_automated_repair": "6b048650887ef39771f0ada302a8dfec100d412ff9ca4f078d08b5fbbf4f8e63",
+      "unsupported_support_operational_state_implicit_operational_behavior": "9c7cd113099f7c10e89508e8118ca001a21dd481dffa8c387ac1ada6543d3372",
+      "unsupported_support_operational_state_operational_mutation": "5e2be5fd28adc560ab8ae1e5f571c63ad4fa30f90bbf810c3abe61f4ebf2fe6d",
+      "unsupported_support_operational_state_orchestration_approval": "9920e513e6f34ff8c4c4690024be56468b0b0f1046ff34542d55552098958c81",
+      "unsupported_support_operational_state_orchestration_authorization": "d1ddabf2a8e5791fdfacc16b37bec4f8d3339fadf3dfdca8def1b407e9a6bb2e",
+      "unsupported_support_operational_state_orchestration_decisions": "c5b896a2153edb44326542cc51c522ce60ebc58e2fafda1d2b311c6e649fc246",
+      "unsupported_support_operational_state_orchestration_dispatch": "88e17a8d21a7bc289f1ee1ed6b2d6a818bf9299f308cb0004928ddcc1a8aa56f",
+      "unsupported_support_operational_state_orchestration_execution": "57a219bb4ea4658ad91ad63bd00fe6f432ec48df3ffed31b9c573785e4e9db31",
+      "unsupported_support_operational_state_orchestration_recommendations": "a968e8dfcfe6611248f5edf9e13937b649bd380bc35564450e0cf6aca3ce9185",
+      "unsupported_support_operational_state_orchestration_routing": "a7e4787184d2b817a40942bf2eedd8714bf1a84d8ce057fc9f4c030c42b53676",
+      "unsupported_support_operational_state_orchestration_scheduling": "0adde17ffb5bbc01f34fb46486b0bfd13fb778ec5ffab3766d61cd836c081a9e",
+      "unsupported_support_operational_state_orchestration_sequencing": "b44d5afd6d81831f824bac0f4f002f2a3ea5b1fe1f2f0c65ef3b5e60be65715b",
+      "unsupported_support_operational_state_orchestration_traversal": "4bcec8f95350fb596c5b0936b3647df7b0ea963c462ab34b5e8c445795b48182",
+      "unsupported_support_operational_state_planner_integration": "173fb2f515207ce524145f75199a05f581d759b6adf30ee40eba507a8dacd17e",
+      "unsupported_support_operational_state_production_consumption": "34e4b36f6ad766a14a795bc17cbef2ae3ae57d57dafeea998246bd9b12e78bcd",
+      "unsupported_support_operational_state_runtime_mutation": "30c0abf5590f5d9f65b2731de2761cc98bd8addf07922ad7008af5c6624650a3",
+      "unsupported_support_operational_state_support_based_approval": "c1c2a9bd7309c670b1316c5180c2a1ff4291f1b6f3d36454937f716743912acf",
+      "unsupported_support_operational_state_support_based_authorization": "1a885837adb5f15a65153c5d49e566b5690adf947ec5ac2eb2d6091b65dcf9c7",
+      "unsupported_support_operational_state_support_based_ranking": "85c641bafc776666bdae6978ff3c284520f3f73ca0a7b2bcd7805d0ba3404246",
+      "unsupported_support_operational_state_support_based_recommendation": "fb66de91cf66a74a6270ac24c414325644d754e4915e16623f09f6eea5c7f61e"
+    },
+    "unsupported_state_hashes": {
+      "unsupported_support_state_unsupported_continuity_surfaces": "64963f0462819394a5f7ef79d131221b95b986f0c112a64eeeab81069f24e1c1",
+      "unsupported_support_state_unsupported_diagnostics_surfaces": "7be580961e93cef0f78939299993dfd932d9f64ef1b347adc93c19f18963b0b4",
+      "unsupported_support_state_unsupported_evidence_chains": "77053f4025189aa83d1e66b8a9d3c6d903690c5a0fd4113a994d85e70d34c64e",
+      "unsupported_support_state_unsupported_explainability_surfaces": "8a16e06dc4a626f33ac1de177ee1cf8e4fcbffe659be6ea11cc56cfa28a73f58",
+      "unsupported_support_state_unsupported_mechanics": "18add00799a9a00b508b3358c63e5b8dd31e2b44fa73ba1b94018d9048058f34",
+      "unsupported_support_state_unsupported_operational_states": "bd82bb504ed25276dba03490bec98fe5726f605296ef387a2209e3df61f1f053",
+      "unsupported_support_state_unsupported_planner_sections": "e4dddeac2f796293136fdac4ec6c1150adf57a2b405686d827760dfe112850d6"
+    }
+  },
+  "deterministic_report_hash": "c716c22d2907e6f5d6d9eac4e5d3db7102b9b4411547dfe0b361dfedc5e2434e",
+  "exported_intelligence": {
+    "auto_correction_enabled": false,
+    "continuity_support_visibility": [
+      {
+        "authorization_enabled": false,
+        "continuity_reference_id": "continuity_reference_continuity_supported_states",
+        "continuity_support_id": "continuity_support_continuity_supported_states",
+        "continuity_support_type": "continuity_supported_states",
+        "descriptive_only": true,
+        "deterministic_order": 1,
+        "evidence_reference_ids": [
+          "evidence_continuity_supported_states"
+        ],
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "restoration_enabled": false,
+        "visibility_state": "continuity_support_visibility_visible"
+      },
+      {
+        "authorization_enabled": false,
+        "continuity_reference_id": "continuity_reference_partially_continuous_states",
+        "continuity_support_id": "continuity_support_partially_continuous_states",
+        "continuity_support_type": "partially_continuous_states",
+        "descriptive_only": true,
+        "deterministic_order": 2,
+        "evidence_reference_ids": [
+          "evidence_partially_continuous_states"
+        ],
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "restoration_enabled": false,
+        "visibility_state": "continuity_support_visibility_visible"
+      },
+      {
+        "authorization_enabled": false,
+        "continuity_reference_id": "continuity_reference_unsupported_continuity_states",
+        "continuity_support_id": "continuity_support_unsupported_continuity_states",
+        "continuity_support_type": "unsupported_continuity_states",
+        "descriptive_only": true,
+        "deterministic_order": 3,
+        "evidence_reference_ids": [
+          "evidence_unsupported_continuity_states"
+        ],
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "restoration_enabled": false,
+        "visibility_state": "continuity_support_visibility_visible"
+      },
+      {
+        "authorization_enabled": false,
+        "continuity_reference_id": "continuity_reference_evidence_continuity_visibility",
+        "continuity_support_id": "continuity_support_evidence_continuity_visibility",
+        "continuity_support_type": "evidence_continuity_visibility",
+        "descriptive_only": true,
+        "deterministic_order": 4,
+        "evidence_reference_ids": [
+          "evidence_evidence_continuity_visibility"
+        ],
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "restoration_enabled": false,
+        "visibility_state": "continuity_support_visibility_visible"
+      },
+      {
+        "authorization_enabled": false,
+        "continuity_reference_id": "continuity_reference_fail_visible_continuity_diagnostics",
+        "continuity_support_id": "continuity_support_fail_visible_continuity_diagnostics",
+        "continuity_support_type": "fail_visible_continuity_diagnostics",
+        "descriptive_only": true,
+        "deterministic_order": 5,
+        "evidence_reference_ids": [
+          "evidence_fail_visible_continuity_diagnostics"
+        ],
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "restoration_enabled": false,
+        "visibility_state": "continuity_support_visibility_visible"
+      }
+    ],
+    "descriptive_only": true,
+    "deterministic_guarantees": [
+      "deterministic_continuity_support_visibility",
+      "deterministic_evidence_based_support_visibility",
+      "deterministic_experimental_deprecated_visibility",
+      "deterministic_explainability_support_visibility",
+      "deterministic_public_support_surface_visibility",
+      "deterministic_support_classification_visibility",
+      "deterministic_support_status_identity",
+      "deterministic_unsupported_state_visibility",
+      "lineage_continuity_preserved",
+      "provenance_continuity_preserved",
+      "publicly_transparent_descriptive_only_support_visibility",
+      "stable_replay_safe_hashing",
+      "stable_replay_safe_serialization"
+    ],
+    "evidence_based_support_visibility": [
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 1,
+        "evidence_reference_ids": [
+          "evidence_evidence_backed_support"
+        ],
+        "evidence_support_id": "evidence_based_support_evidence_backed_support",
+        "evidence_support_type": "evidence_backed_support",
+        "provenance_safe": true,
+        "replay_safe": true,
+        "trust_scoring_enabled": false,
+        "visibility_state": "evidence_based_support_visibility_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 2,
+        "evidence_reference_ids": [
+          "evidence_partially_evidenced_support"
+        ],
+        "evidence_support_id": "evidence_based_support_partially_evidenced_support",
+        "evidence_support_type": "partially_evidenced_support",
+        "provenance_safe": true,
+        "replay_safe": true,
+        "trust_scoring_enabled": false,
+        "visibility_state": "evidence_based_support_visibility_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 3,
+        "evidence_reference_ids": [
+          "evidence_unsupported_evidence_states"
+        ],
+        "evidence_support_id": "evidence_based_support_unsupported_evidence_states",
+        "evidence_support_type": "unsupported_evidence_states",
+        "provenance_safe": true,
+        "replay_safe": true,
+        "trust_scoring_enabled": false,
+        "visibility_state": "evidence_based_support_visibility_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 4,
+        "evidence_reference_ids": [
+          "evidence_continuity_backed_support_visibility"
+        ],
+        "evidence_support_id": "evidence_based_support_continuity_backed_support_visibility",
+        "evidence_support_type": "continuity_backed_support_visibility",
+        "provenance_safe": true,
+        "replay_safe": true,
+        "trust_scoring_enabled": false,
+        "visibility_state": "evidence_based_support_visibility_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 5,
+        "evidence_reference_ids": [
+          "evidence_explainability_backed_support_visibility"
+        ],
+        "evidence_support_id": "evidence_based_support_explainability_backed_support_visibility",
+        "evidence_support_type": "explainability_backed_support_visibility",
+        "provenance_safe": true,
+        "replay_safe": true,
+        "trust_scoring_enabled": false,
+        "visibility_state": "evidence_based_support_visibility_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 6,
+        "evidence_reference_ids": [
+          "evidence_diagnostics_backed_support_visibility"
+        ],
+        "evidence_support_id": "evidence_based_support_diagnostics_backed_support_visibility",
+        "evidence_support_type": "diagnostics_backed_support_visibility",
+        "provenance_safe": true,
+        "replay_safe": true,
+        "trust_scoring_enabled": false,
+        "visibility_state": "evidence_based_support_visibility_visible"
+      }
+    ],
+    "experimental_deprecated_visibility": [
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automatic_migration_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 1,
+        "evidence_reference_ids": [
+          "evidence_experimental_systems"
+        ],
+        "experimental_deprecated_id": "experimental_deprecated_experimental_systems",
+        "operational_fallback_enabled": false,
+        "visibility_state": "experimental_deprecated_visibility_descriptive_only",
+        "visibility_type": "experimental_systems"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automatic_migration_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 2,
+        "evidence_reference_ids": [
+          "evidence_experimental_surfaces"
+        ],
+        "experimental_deprecated_id": "experimental_deprecated_experimental_surfaces",
+        "operational_fallback_enabled": false,
+        "visibility_state": "experimental_deprecated_visibility_descriptive_only",
+        "visibility_type": "experimental_surfaces"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automatic_migration_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 3,
+        "evidence_reference_ids": [
+          "evidence_deprecated_systems"
+        ],
+        "experimental_deprecated_id": "experimental_deprecated_deprecated_systems",
+        "operational_fallback_enabled": false,
+        "visibility_state": "experimental_deprecated_visibility_descriptive_only",
+        "visibility_type": "deprecated_systems"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automatic_migration_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 4,
+        "evidence_reference_ids": [
+          "evidence_deprecated_surfaces"
+        ],
+        "experimental_deprecated_id": "experimental_deprecated_deprecated_surfaces",
+        "operational_fallback_enabled": false,
+        "visibility_state": "experimental_deprecated_visibility_descriptive_only",
+        "visibility_type": "deprecated_surfaces"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automatic_migration_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 5,
+        "evidence_reference_ids": [
+          "evidence_blocked_systems"
+        ],
+        "experimental_deprecated_id": "experimental_deprecated_blocked_systems",
+        "operational_fallback_enabled": false,
+        "visibility_state": "experimental_deprecated_visibility_descriptive_only",
+        "visibility_type": "blocked_systems"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automatic_migration_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 6,
+        "evidence_reference_ids": [
+          "evidence_blocked_surfaces"
+        ],
+        "experimental_deprecated_id": "experimental_deprecated_blocked_surfaces",
+        "operational_fallback_enabled": false,
+        "visibility_state": "experimental_deprecated_visibility_descriptive_only",
+        "visibility_type": "blocked_surfaces"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automatic_migration_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 7,
+        "evidence_reference_ids": [
+          "evidence_unknown_support_states"
+        ],
+        "experimental_deprecated_id": "experimental_deprecated_unknown_support_states",
+        "operational_fallback_enabled": false,
+        "visibility_state": "experimental_deprecated_visibility_descriptive_only",
+        "visibility_type": "unknown_support_states"
+      }
+    ],
+    "explainability_support_visibility": [
+      {
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 1,
+        "evidence_reference_ids": [
+          "evidence_explainability_supported_states"
+        ],
+        "explainability_support_id": "explainability_support_explainability_supported_states",
+        "explainability_support_type": "explainability_supported_states",
+        "operational_semantics_enabled": false,
+        "recommendation_enabled": false,
+        "visibility_state": "explainability_support_visibility_visible"
+      },
+      {
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 2,
+        "evidence_reference_ids": [
+          "evidence_partially_explainable_states"
+        ],
+        "explainability_support_id": "explainability_support_partially_explainable_states",
+        "explainability_support_type": "partially_explainable_states",
+        "operational_semantics_enabled": false,
+        "recommendation_enabled": false,
+        "visibility_state": "explainability_support_visibility_visible"
+      },
+      {
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 3,
+        "evidence_reference_ids": [
+          "evidence_unsupported_explainability_states"
+        ],
+        "explainability_support_id": "explainability_support_unsupported_explainability_states",
+        "explainability_support_type": "unsupported_explainability_states",
+        "operational_semantics_enabled": false,
+        "recommendation_enabled": false,
+        "visibility_state": "explainability_support_visibility_visible"
+      },
+      {
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 4,
+        "evidence_reference_ids": [
+          "evidence_continuity_explainability_visibility"
+        ],
+        "explainability_support_id": "explainability_support_continuity_explainability_visibility",
+        "explainability_support_type": "continuity_explainability_visibility",
+        "operational_semantics_enabled": false,
+        "recommendation_enabled": false,
+        "visibility_state": "explainability_support_visibility_visible"
+      },
+      {
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 5,
+        "evidence_reference_ids": [
+          "evidence_fail_visible_explainability_diagnostics"
+        ],
+        "explainability_support_id": "explainability_support_fail_visible_explainability_diagnostics",
+        "explainability_support_type": "fail_visible_explainability_diagnostics",
+        "operational_semantics_enabled": false,
+        "recommendation_enabled": false,
+        "visibility_state": "explainability_support_visibility_visible"
+      }
+    ],
+    "explicit_limitations": [
+      "support_visibility_does_not_approve",
+      "support_visibility_does_not_authorize",
+      "support_visibility_does_not_enable_production",
+      "support_visibility_does_not_execute",
+      "support_visibility_does_not_imply_correctness_guarantees",
+      "support_visibility_does_not_imply_execution_safety",
+      "support_visibility_does_not_integrate_planners",
+      "support_visibility_does_not_mitigate_or_correct",
+      "support_visibility_does_not_mutate_runtime_state",
+      "support_visibility_does_not_rank",
+      "support_visibility_does_not_recommend",
+      "support_visibility_does_not_remediate_or_repair"
+    ],
+    "inherited_constraints": [
+      "NON-approving",
+      "NON-authorizing",
+      "NON-executing",
+      "NON-operational",
+      "NON-ranking",
+      "NON-recommending",
+      "NON-remediating",
+      "NON-runtime-mutating",
+      "descriptive-only",
+      "deterministic",
+      "explainability-first",
+      "fail-visible",
+      "governance-safe",
+      "integrity-safe",
+      "lineage-safe",
+      "provenance-safe",
+      "publicly transparent",
+      "replay-safe",
+      "rollback-safe"
+    ],
+    "inherited_prohibitions": [
+      "automated_correction_prohibited",
+      "automated_mitigation_prohibited",
+      "automated_remediation_prohibited",
+      "automated_repair_prohibited",
+      "implicit_operational_behavior_prohibited",
+      "operational_mutation_prohibited",
+      "orchestration_approval_prohibited",
+      "orchestration_authorization_prohibited",
+      "orchestration_decisions_prohibited",
+      "orchestration_dispatch_prohibited",
+      "orchestration_execution_prohibited",
+      "orchestration_recommendations_prohibited",
+      "orchestration_routing_prohibited",
+      "orchestration_scheduling_prohibited",
+      "orchestration_sequencing_prohibited",
+      "orchestration_traversal_prohibited",
+      "planner_integration_prohibited",
+      "production_consumption_prohibited",
+      "runtime_mutation_prohibited",
+      "support_based_approval_prohibited",
+      "support_based_authorization_prohibited",
+      "support_based_ranking_prohibited",
+      "support_based_recommendation_prohibited"
+    ],
+    "mitigation_enabled": false,
+    "non_approving": true,
+    "non_authorizing": true,
+    "non_executing": true,
+    "non_operational": true,
+    "non_ranking": true,
+    "non_recommending": true,
+    "non_remediating": true,
+    "non_runtime_mutating": true,
+    "operational_mutation_enabled": false,
+    "orchestration_approval_enabled": false,
+    "orchestration_authorization_enabled": false,
+    "orchestration_decision_enabled": false,
+    "orchestration_dispatch_enabled": false,
+    "orchestration_execution_enabled": false,
+    "orchestration_recommendation_enabled": false,
+    "orchestration_routing_enabled": false,
+    "orchestration_scheduling_enabled": false,
+    "orchestration_sequencing_enabled": false,
+    "orchestration_traversal_enabled": false,
+    "planner_execution_enabled": false,
+    "planner_integration_enabled": false,
+    "production_consumption_enabled": false,
+    "publicly_transparent": true,
+    "ranking_enabled": false,
+    "recommendation_enabled": false,
+    "remediation_enabled": false,
+    "repair_enabled": false,
+    "runtime_execution_enabled": false,
+    "runtime_mutation_enabled": false,
+    "support_approval_enabled": false,
+    "support_authorization_enabled": false,
+    "support_classification_non_authority_statement": "Support classifications do NOT imply authorization, approval, operational readiness, execution safety, or production enablement.",
+    "support_classifications": [
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "classification_visibility_id": "support_classification_supported",
+        "descriptive_only": true,
+        "deterministic_order": 1,
+        "evidence_reference_ids": [
+          "evidence_supported_classification"
+        ],
+        "execution_semantics_enabled": false,
+        "operational_approval_enabled": false,
+        "support_classification": "supported",
+        "visibility_state": "support_classification_descriptive_only"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "classification_visibility_id": "support_classification_partially_supported",
+        "descriptive_only": true,
+        "deterministic_order": 2,
+        "evidence_reference_ids": [
+          "evidence_partially_supported_classification"
+        ],
+        "execution_semantics_enabled": false,
+        "operational_approval_enabled": false,
+        "support_classification": "partially_supported",
+        "visibility_state": "support_classification_descriptive_only"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "classification_visibility_id": "support_classification_unsupported",
+        "descriptive_only": true,
+        "deterministic_order": 3,
+        "evidence_reference_ids": [
+          "evidence_unsupported_classification"
+        ],
+        "execution_semantics_enabled": false,
+        "operational_approval_enabled": false,
+        "support_classification": "unsupported",
+        "visibility_state": "support_classification_descriptive_only"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "classification_visibility_id": "support_classification_experimental",
+        "descriptive_only": true,
+        "deterministic_order": 4,
+        "evidence_reference_ids": [
+          "evidence_experimental_classification"
+        ],
+        "execution_semantics_enabled": false,
+        "operational_approval_enabled": false,
+        "support_classification": "experimental",
+        "visibility_state": "support_classification_descriptive_only"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "classification_visibility_id": "support_classification_deprecated",
+        "descriptive_only": true,
+        "deterministic_order": 5,
+        "evidence_reference_ids": [
+          "evidence_deprecated_classification"
+        ],
+        "execution_semantics_enabled": false,
+        "operational_approval_enabled": false,
+        "support_classification": "deprecated",
+        "visibility_state": "support_classification_descriptive_only"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "classification_visibility_id": "support_classification_blocked",
+        "descriptive_only": true,
+        "deterministic_order": 6,
+        "evidence_reference_ids": [
+          "evidence_blocked_classification"
+        ],
+        "execution_semantics_enabled": false,
+        "operational_approval_enabled": false,
+        "support_classification": "blocked",
+        "visibility_state": "support_classification_descriptive_only"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "classification_visibility_id": "support_classification_unknown",
+        "descriptive_only": true,
+        "deterministic_order": 7,
+        "evidence_reference_ids": [
+          "evidence_unknown_classification"
+        ],
+        "execution_semantics_enabled": false,
+        "operational_approval_enabled": false,
+        "support_classification": "unknown",
+        "visibility_state": "support_classification_descriptive_only"
+      }
+    ],
+    "support_diagnostics": [
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "auto_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 1,
+        "diagnostic_id": "support_diagnostic_missing_support_evidence",
+        "diagnostic_type": "missing_support_evidence",
+        "evidence_reference_ids": [
+          "evidence_missing_support_evidence"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "message": "missing_support_evidence remains explicit, fail-visible, and descriptive-only for support status visibility.",
+        "mitigation_enabled": false,
+        "orchestration_response_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "silent_fallback_enabled": false,
+        "visibility_state": "fail_visible_support_diagnostic_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "auto_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 2,
+        "diagnostic_id": "support_diagnostic_unsupported_visibility_gaps",
+        "diagnostic_type": "unsupported_visibility_gaps",
+        "evidence_reference_ids": [
+          "evidence_unsupported_visibility_gaps"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "message": "unsupported_visibility_gaps remains explicit, fail-visible, and descriptive-only for support status visibility.",
+        "mitigation_enabled": false,
+        "orchestration_response_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "silent_fallback_enabled": false,
+        "visibility_state": "fail_visible_support_diagnostic_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "auto_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 3,
+        "diagnostic_id": "support_diagnostic_unsupported_explainability_gaps",
+        "diagnostic_type": "unsupported_explainability_gaps",
+        "evidence_reference_ids": [
+          "evidence_unsupported_explainability_gaps"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "message": "unsupported_explainability_gaps remains explicit, fail-visible, and descriptive-only for support status visibility.",
+        "mitigation_enabled": false,
+        "orchestration_response_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "silent_fallback_enabled": false,
+        "visibility_state": "fail_visible_support_diagnostic_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "auto_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 4,
+        "diagnostic_id": "support_diagnostic_unsupported_continuity_gaps",
+        "diagnostic_type": "unsupported_continuity_gaps",
+        "evidence_reference_ids": [
+          "evidence_unsupported_continuity_gaps"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "message": "unsupported_continuity_gaps remains explicit, fail-visible, and descriptive-only for support status visibility.",
+        "mitigation_enabled": false,
+        "orchestration_response_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "silent_fallback_enabled": false,
+        "visibility_state": "fail_visible_support_diagnostic_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "auto_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 5,
+        "diagnostic_id": "support_diagnostic_blocked_visibility_states",
+        "diagnostic_type": "blocked_visibility_states",
+        "evidence_reference_ids": [
+          "evidence_blocked_visibility_states"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "message": "blocked_visibility_states remains explicit, fail-visible, and descriptive-only for support status visibility.",
+        "mitigation_enabled": false,
+        "orchestration_response_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "silent_fallback_enabled": false,
+        "visibility_state": "fail_visible_support_diagnostic_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "auto_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 6,
+        "diagnostic_id": "support_diagnostic_deprecated_visibility_states",
+        "diagnostic_type": "deprecated_visibility_states",
+        "evidence_reference_ids": [
+          "evidence_deprecated_visibility_states"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "message": "deprecated_visibility_states remains explicit, fail-visible, and descriptive-only for support status visibility.",
+        "mitigation_enabled": false,
+        "orchestration_response_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "silent_fallback_enabled": false,
+        "visibility_state": "fail_visible_support_diagnostic_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "auto_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 7,
+        "diagnostic_id": "support_diagnostic_unknown_support_states",
+        "diagnostic_type": "unknown_support_states",
+        "evidence_reference_ids": [
+          "evidence_unknown_support_states"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "message": "unknown_support_states remains explicit, fail-visible, and descriptive-only for support status visibility.",
+        "mitigation_enabled": false,
+        "orchestration_response_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "silent_fallback_enabled": false,
+        "visibility_state": "fail_visible_support_diagnostic_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "auto_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 8,
+        "diagnostic_id": "support_diagnostic_inherited_limitation_visibility_gaps",
+        "diagnostic_type": "inherited_limitation_visibility_gaps",
+        "evidence_reference_ids": [
+          "evidence_inherited_limitation_visibility_gaps"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "message": "inherited_limitation_visibility_gaps remains explicit, fail-visible, and descriptive-only for support status visibility.",
+        "mitigation_enabled": false,
+        "orchestration_response_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "silent_fallback_enabled": false,
+        "visibility_state": "fail_visible_support_diagnostic_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "auto_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 9,
+        "diagnostic_id": "support_diagnostic_inherited_prohibition_visibility_gaps",
+        "diagnostic_type": "inherited_prohibition_visibility_gaps",
+        "evidence_reference_ids": [
+          "evidence_inherited_prohibition_visibility_gaps"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "message": "inherited_prohibition_visibility_gaps remains explicit, fail-visible, and descriptive-only for support status visibility.",
+        "mitigation_enabled": false,
+        "orchestration_response_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "silent_fallback_enabled": false,
+        "visibility_state": "fail_visible_support_diagnostic_visible"
+      }
+    ],
+    "support_identity": {
+      "classification": "governance_safe_public_support_status_visibility_descriptive_only",
+      "continuity_reference_id": "continuity::v4_5b_2.public_support",
+      "diagnostics_reference_id": "diagnostics::v4_5b_2.public_support",
+      "evidence_reference_id": "evidence::v4_5b_2.public_support",
+      "explainability_reference_id": "explainability::v4_5b_2.public_support",
+      "generated_at": "2026-05-18T00:00:00+00:00",
+      "lineage_reference_id": "lineage::v4_5b_2.public_support",
+      "phase_id": "v4_5b_2_support_status_visibility",
+      "provenance_reference_id": "provenance::v4_5b_2.public_support",
+      "schema_version": "v4_5b_2.support_status_visibility.1",
+      "source_trust_visibility_hash_reference": "e6bd404e3d548fe2d016621aa94ac584614e784a592d18c722ea1f5b174a8039",
+      "source_trust_visibility_report_reference": "docs/generated/v4_5b_1_trust_visibility_foundations_report.json",
+      "support_reference_id": "support::v4_5b_2.public_support",
+      "support_scope_id": "scope::v4_5b_2.public_support",
+      "support_status_id": "v4_5b_2_support_status_visibility",
+      "support_summary_id": "v4_5b_2_support_summary"
+    },
+    "support_ranking_enabled": false,
+    "support_recommendation_enabled": false,
+    "support_status_visibility_statement": "Support status visibility is descriptive-only.",
+    "support_summaries": [
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 1,
+        "evidence_reference_ids": [
+          "evidence_support_classification_summary"
+        ],
+        "execution_enablement_enabled": false,
+        "production_enablement_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "summary_state": "support_summary_descriptive_only",
+        "summary_type": "support_classification_summary",
+        "support_summary_id": "v4_5b_2_support_summary",
+        "support_summary_record_id": "support_summary_support_classification_summary"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 2,
+        "evidence_reference_ids": [
+          "evidence_surface_support_summary"
+        ],
+        "execution_enablement_enabled": false,
+        "production_enablement_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "summary_state": "support_summary_descriptive_only",
+        "summary_type": "surface_support_summary",
+        "support_summary_id": "v4_5b_2_support_summary",
+        "support_summary_record_id": "support_summary_surface_support_summary"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 3,
+        "evidence_reference_ids": [
+          "evidence_unsupported_state_summary"
+        ],
+        "execution_enablement_enabled": false,
+        "production_enablement_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "summary_state": "support_summary_descriptive_only",
+        "summary_type": "unsupported_state_summary",
+        "support_summary_id": "v4_5b_2_support_summary",
+        "support_summary_record_id": "support_summary_unsupported_state_summary"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 4,
+        "evidence_reference_ids": [
+          "evidence_experimental_deprecated_summary"
+        ],
+        "execution_enablement_enabled": false,
+        "production_enablement_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "summary_state": "support_summary_descriptive_only",
+        "summary_type": "experimental_deprecated_summary",
+        "support_summary_id": "v4_5b_2_support_summary",
+        "support_summary_record_id": "support_summary_experimental_deprecated_summary"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 5,
+        "evidence_reference_ids": [
+          "evidence_evidence_based_support_summary"
+        ],
+        "execution_enablement_enabled": false,
+        "production_enablement_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "summary_state": "support_summary_descriptive_only",
+        "summary_type": "evidence_based_support_summary",
+        "support_summary_id": "v4_5b_2_support_summary",
+        "support_summary_record_id": "support_summary_evidence_based_support_summary"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 6,
+        "evidence_reference_ids": [
+          "evidence_explainability_support_summary"
+        ],
+        "execution_enablement_enabled": false,
+        "production_enablement_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "summary_state": "support_summary_descriptive_only",
+        "summary_type": "explainability_support_summary",
+        "support_summary_id": "v4_5b_2_support_summary",
+        "support_summary_record_id": "support_summary_explainability_support_summary"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 7,
+        "evidence_reference_ids": [
+          "evidence_continuity_support_summary"
+        ],
+        "execution_enablement_enabled": false,
+        "production_enablement_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "summary_state": "support_summary_descriptive_only",
+        "summary_type": "continuity_support_summary",
+        "support_summary_id": "v4_5b_2_support_summary",
+        "support_summary_record_id": "support_summary_continuity_support_summary"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 8,
+        "evidence_reference_ids": [
+          "evidence_diagnostics_support_summary"
+        ],
+        "execution_enablement_enabled": false,
+        "production_enablement_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "summary_state": "support_summary_descriptive_only",
+        "summary_type": "diagnostics_support_summary",
+        "support_summary_id": "v4_5b_2_support_summary",
+        "support_summary_record_id": "support_summary_diagnostics_support_summary"
+      }
+    ],
+    "support_surfaces": [
+      {
+        "descriptive_only": true,
+        "deterministic_order": 1,
+        "evidence_reference_ids": [
+          "evidence_mechanics_support_surface"
+        ],
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "support_classification": "supported",
+        "support_surface": "mechanics",
+        "surface_visibility_id": "support_surface_mechanics",
+        "visibility_state": "public_support_surface_visibility_visible"
+      },
+      {
+        "descriptive_only": true,
+        "deterministic_order": 2,
+        "evidence_reference_ids": [
+          "evidence_systems_support_surface"
+        ],
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "support_classification": "partially_supported",
+        "support_surface": "systems",
+        "surface_visibility_id": "support_surface_systems",
+        "visibility_state": "public_support_surface_visibility_visible"
+      },
+      {
+        "descriptive_only": true,
+        "deterministic_order": 3,
+        "evidence_reference_ids": [
+          "evidence_planner_sections_support_surface"
+        ],
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "support_classification": "unsupported",
+        "support_surface": "planner_sections",
+        "surface_visibility_id": "support_surface_planner_sections",
+        "visibility_state": "public_support_surface_visibility_visible"
+      },
+      {
+        "descriptive_only": true,
+        "deterministic_order": 4,
+        "evidence_reference_ids": [
+          "evidence_data_sources_support_surface"
+        ],
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "support_classification": "experimental",
+        "support_surface": "data_sources",
+        "surface_visibility_id": "support_surface_data_sources",
+        "visibility_state": "public_support_surface_visibility_visible"
+      },
+      {
+        "descriptive_only": true,
+        "deterministic_order": 5,
+        "evidence_reference_ids": [
+          "evidence_evidence_chains_support_surface"
+        ],
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "support_classification": "deprecated",
+        "support_surface": "evidence_chains",
+        "surface_visibility_id": "support_surface_evidence_chains",
+        "visibility_state": "public_support_surface_visibility_visible"
+      },
+      {
+        "descriptive_only": true,
+        "deterministic_order": 6,
+        "evidence_reference_ids": [
+          "evidence_explainability_surfaces_support_surface"
+        ],
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "support_classification": "blocked",
+        "support_surface": "explainability_surfaces",
+        "surface_visibility_id": "support_surface_explainability_surfaces",
+        "visibility_state": "public_support_surface_visibility_visible"
+      },
+      {
+        "descriptive_only": true,
+        "deterministic_order": 7,
+        "evidence_reference_ids": [
+          "evidence_continuity_surfaces_support_surface"
+        ],
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "support_classification": "unknown",
+        "support_surface": "continuity_surfaces",
+        "surface_visibility_id": "support_surface_continuity_surfaces",
+        "visibility_state": "public_support_surface_visibility_visible"
+      },
+      {
+        "descriptive_only": true,
+        "deterministic_order": 8,
+        "evidence_reference_ids": [
+          "evidence_diagnostics_surfaces_support_surface"
+        ],
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "support_classification": "partially_supported",
+        "support_surface": "diagnostics_surfaces",
+        "surface_visibility_id": "support_surface_diagnostics_surfaces",
+        "visibility_state": "public_support_surface_visibility_visible"
+      }
+    ],
+    "support_visibility_records": [
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "continuity_reference_id": "continuity::v4_5b_2.public_support",
+        "descriptive_only": true,
+        "deterministic_order": 1,
+        "diagnostics_reference_id": "diagnostics::v4_5b_2.public_support",
+        "evidence_reference_id": "evidence::v4_5b_2.public_support",
+        "execution_enabled": false,
+        "explainability_reference_id": "explainability::v4_5b_2.public_support",
+        "fail_visible": true,
+        "lineage_reference_id": "lineage::v4_5b_2.public_support",
+        "non_approving": true,
+        "non_authorizing": true,
+        "production_enablement_enabled": false,
+        "provenance_reference_id": "provenance::v4_5b_2.public_support",
+        "publicly_transparent": true,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "support_authority_enabled": false,
+        "support_record_id": "public_support_status_visibility_foundation",
+        "support_reference_id": "support::v4_5b_2.public_support",
+        "support_scope_id": "scope::v4_5b_2.public_support",
+        "support_status_id": "v4_5b_2_support_status_visibility",
+        "support_summary_id": "v4_5b_2_support_summary",
+        "visibility_state": "public_support_status_visibility_visible"
+      }
+    ],
+    "unsupported_operational_state_visibility": [
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 1,
+        "evidence_reference_ids": [
+          "evidence_unsupported_support_operational_states"
+        ],
+        "explicit_reason": "orchestration_execution remains unsupported for v4.5B.2 support status visibility.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_support_operational_state_orchestration_execution",
+        "suppression_enabled": false,
+        "unsupported_state": "orchestration_execution",
+        "visibility_state": "unsupported_support_operational_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 2,
+        "evidence_reference_ids": [
+          "evidence_unsupported_support_operational_states"
+        ],
+        "explicit_reason": "orchestration_authorization remains unsupported for v4.5B.2 support status visibility.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_support_operational_state_orchestration_authorization",
+        "suppression_enabled": false,
+        "unsupported_state": "orchestration_authorization",
+        "visibility_state": "unsupported_support_operational_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 3,
+        "evidence_reference_ids": [
+          "evidence_unsupported_support_operational_states"
+        ],
+        "explicit_reason": "orchestration_approval remains unsupported for v4.5B.2 support status visibility.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_support_operational_state_orchestration_approval",
+        "suppression_enabled": false,
+        "unsupported_state": "orchestration_approval",
+        "visibility_state": "unsupported_support_operational_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 4,
+        "evidence_reference_ids": [
+          "evidence_unsupported_support_operational_states"
+        ],
+        "explicit_reason": "orchestration_dispatch remains unsupported for v4.5B.2 support status visibility.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_support_operational_state_orchestration_dispatch",
+        "suppression_enabled": false,
+        "unsupported_state": "orchestration_dispatch",
+        "visibility_state": "unsupported_support_operational_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 5,
+        "evidence_reference_ids": [
+          "evidence_unsupported_support_operational_states"
+        ],
+        "explicit_reason": "orchestration_routing remains unsupported for v4.5B.2 support status visibility.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_support_operational_state_orchestration_routing",
+        "suppression_enabled": false,
+        "unsupported_state": "orchestration_routing",
+        "visibility_state": "unsupported_support_operational_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 6,
+        "evidence_reference_ids": [
+          "evidence_unsupported_support_operational_states"
+        ],
+        "explicit_reason": "orchestration_traversal remains unsupported for v4.5B.2 support status visibility.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_support_operational_state_orchestration_traversal",
+        "suppression_enabled": false,
+        "unsupported_state": "orchestration_traversal",
+        "visibility_state": "unsupported_support_operational_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 7,
+        "evidence_reference_ids": [
+          "evidence_unsupported_support_operational_states"
+        ],
+        "explicit_reason": "orchestration_scheduling remains unsupported for v4.5B.2 support status visibility.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_support_operational_state_orchestration_scheduling",
+        "suppression_enabled": false,
+        "unsupported_state": "orchestration_scheduling",
+        "visibility_state": "unsupported_support_operational_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 8,
+        "evidence_reference_ids": [
+          "evidence_unsupported_support_operational_states"
+        ],
+        "explicit_reason": "orchestration_sequencing remains unsupported for v4.5B.2 support status visibility.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_support_operational_state_orchestration_sequencing",
+        "suppression_enabled": false,
+        "unsupported_state": "orchestration_sequencing",
+        "visibility_state": "unsupported_support_operational_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 9,
+        "evidence_reference_ids": [
+          "evidence_unsupported_support_operational_states"
+        ],
+        "explicit_reason": "orchestration_decisions remains unsupported for v4.5B.2 support status visibility.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_support_operational_state_orchestration_decisions",
+        "suppression_enabled": false,
+        "unsupported_state": "orchestration_decisions",
+        "visibility_state": "unsupported_support_operational_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 10,
+        "evidence_reference_ids": [
+          "evidence_unsupported_support_operational_states"
+        ],
+        "explicit_reason": "orchestration_recommendations remains unsupported for v4.5B.2 support status visibility.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_support_operational_state_orchestration_recommendations",
+        "suppression_enabled": false,
+        "unsupported_state": "orchestration_recommendations",
+        "visibility_state": "unsupported_support_operational_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 11,
+        "evidence_reference_ids": [
+          "evidence_unsupported_support_operational_states"
+        ],
+        "explicit_reason": "support_based_authorization remains unsupported for v4.5B.2 support status visibility.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_support_operational_state_support_based_authorization",
+        "suppression_enabled": false,
+        "unsupported_state": "support_based_authorization",
+        "visibility_state": "unsupported_support_operational_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 12,
+        "evidence_reference_ids": [
+          "evidence_unsupported_support_operational_states"
+        ],
+        "explicit_reason": "support_based_approval remains unsupported for v4.5B.2 support status visibility.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_support_operational_state_support_based_approval",
+        "suppression_enabled": false,
+        "unsupported_state": "support_based_approval",
+        "visibility_state": "unsupported_support_operational_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 13,
+        "evidence_reference_ids": [
+          "evidence_unsupported_support_operational_states"
+        ],
+        "explicit_reason": "support_based_ranking remains unsupported for v4.5B.2 support status visibility.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_support_operational_state_support_based_ranking",
+        "suppression_enabled": false,
+        "unsupported_state": "support_based_ranking",
+        "visibility_state": "unsupported_support_operational_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 14,
+        "evidence_reference_ids": [
+          "evidence_unsupported_support_operational_states"
+        ],
+        "explicit_reason": "support_based_recommendation remains unsupported for v4.5B.2 support status visibility.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_support_operational_state_support_based_recommendation",
+        "suppression_enabled": false,
+        "unsupported_state": "support_based_recommendation",
+        "visibility_state": "unsupported_support_operational_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 15,
+        "evidence_reference_ids": [
+          "evidence_unsupported_support_operational_states"
+        ],
+        "explicit_reason": "automated_remediation remains unsupported for v4.5B.2 support status visibility.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_support_operational_state_automated_remediation",
+        "suppression_enabled": false,
+        "unsupported_state": "automated_remediation",
+        "visibility_state": "unsupported_support_operational_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 16,
+        "evidence_reference_ids": [
+          "evidence_unsupported_support_operational_states"
+        ],
+        "explicit_reason": "automated_repair remains unsupported for v4.5B.2 support status visibility.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_support_operational_state_automated_repair",
+        "suppression_enabled": false,
+        "unsupported_state": "automated_repair",
+        "visibility_state": "unsupported_support_operational_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 17,
+        "evidence_reference_ids": [
+          "evidence_unsupported_support_operational_states"
+        ],
+        "explicit_reason": "automated_mitigation remains unsupported for v4.5B.2 support status visibility.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_support_operational_state_automated_mitigation",
+        "suppression_enabled": false,
+        "unsupported_state": "automated_mitigation",
+        "visibility_state": "unsupported_support_operational_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 18,
+        "evidence_reference_ids": [
+          "evidence_unsupported_support_operational_states"
+        ],
+        "explicit_reason": "automated_correction remains unsupported for v4.5B.2 support status visibility.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_support_operational_state_automated_correction",
+        "suppression_enabled": false,
+        "unsupported_state": "automated_correction",
+        "visibility_state": "unsupported_support_operational_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 19,
+        "evidence_reference_ids": [
+          "evidence_unsupported_support_operational_states"
+        ],
+        "explicit_reason": "planner_integration remains unsupported for v4.5B.2 support status visibility.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_support_operational_state_planner_integration",
+        "suppression_enabled": false,
+        "unsupported_state": "planner_integration",
+        "visibility_state": "unsupported_support_operational_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 20,
+        "evidence_reference_ids": [
+          "evidence_unsupported_support_operational_states"
+        ],
+        "explicit_reason": "production_consumption remains unsupported for v4.5B.2 support status visibility.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_support_operational_state_production_consumption",
+        "suppression_enabled": false,
+        "unsupported_state": "production_consumption",
+        "visibility_state": "unsupported_support_operational_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 21,
+        "evidence_reference_ids": [
+          "evidence_unsupported_support_operational_states"
+        ],
+        "explicit_reason": "runtime_mutation remains unsupported for v4.5B.2 support status visibility.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_support_operational_state_runtime_mutation",
+        "suppression_enabled": false,
+        "unsupported_state": "runtime_mutation",
+        "visibility_state": "unsupported_support_operational_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 22,
+        "evidence_reference_ids": [
+          "evidence_unsupported_support_operational_states"
+        ],
+        "explicit_reason": "operational_mutation remains unsupported for v4.5B.2 support status visibility.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_support_operational_state_operational_mutation",
+        "suppression_enabled": false,
+        "unsupported_state": "operational_mutation",
+        "visibility_state": "unsupported_support_operational_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 23,
+        "evidence_reference_ids": [
+          "evidence_unsupported_support_operational_states"
+        ],
+        "explicit_reason": "implicit_operational_behavior remains unsupported for v4.5B.2 support status visibility.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_support_operational_state_implicit_operational_behavior",
+        "suppression_enabled": false,
+        "unsupported_state": "implicit_operational_behavior",
+        "visibility_state": "unsupported_support_operational_state_fail_visible"
+      }
+    ],
+    "unsupported_state_visibility": [
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 1,
+        "evidence_reference_ids": [
+          "evidence_unsupported_mechanics"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "remediation_enabled": false,
+        "suppression_enabled": false,
+        "unsupported_state_type": "unsupported_mechanics",
+        "unsupported_visibility_id": "unsupported_support_state_unsupported_mechanics",
+        "visibility_state": "unsupported_support_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 2,
+        "evidence_reference_ids": [
+          "evidence_unsupported_planner_sections"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "remediation_enabled": false,
+        "suppression_enabled": false,
+        "unsupported_state_type": "unsupported_planner_sections",
+        "unsupported_visibility_id": "unsupported_support_state_unsupported_planner_sections",
+        "visibility_state": "unsupported_support_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 3,
+        "evidence_reference_ids": [
+          "evidence_unsupported_evidence_chains"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "remediation_enabled": false,
+        "suppression_enabled": false,
+        "unsupported_state_type": "unsupported_evidence_chains",
+        "unsupported_visibility_id": "unsupported_support_state_unsupported_evidence_chains",
+        "visibility_state": "unsupported_support_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 4,
+        "evidence_reference_ids": [
+          "evidence_unsupported_explainability_surfaces"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "remediation_enabled": false,
+        "suppression_enabled": false,
+        "unsupported_state_type": "unsupported_explainability_surfaces",
+        "unsupported_visibility_id": "unsupported_support_state_unsupported_explainability_surfaces",
+        "visibility_state": "unsupported_support_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 5,
+        "evidence_reference_ids": [
+          "evidence_unsupported_continuity_surfaces"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "remediation_enabled": false,
+        "suppression_enabled": false,
+        "unsupported_state_type": "unsupported_continuity_surfaces",
+        "unsupported_visibility_id": "unsupported_support_state_unsupported_continuity_surfaces",
+        "visibility_state": "unsupported_support_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 6,
+        "evidence_reference_ids": [
+          "evidence_unsupported_diagnostics_surfaces"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "remediation_enabled": false,
+        "suppression_enabled": false,
+        "unsupported_state_type": "unsupported_diagnostics_surfaces",
+        "unsupported_visibility_id": "unsupported_support_state_unsupported_diagnostics_surfaces",
+        "visibility_state": "unsupported_support_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 7,
+        "evidence_reference_ids": [
+          "evidence_unsupported_operational_states"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "remediation_enabled": false,
+        "suppression_enabled": false,
+        "unsupported_state_type": "unsupported_operational_states",
+        "unsupported_visibility_id": "unsupported_support_state_unsupported_operational_states",
+        "visibility_state": "unsupported_support_state_fail_visible"
+      }
+    ]
+  },
+  "foundation_status": "v4_5b_2_support_status_visibility_stable",
+  "generated_at": "2026-05-18T00:00:00+00:00",
+  "phase_id": "v4_5b_2_support_status_visibility",
+  "purpose": "deterministic_governance_safe_support_status_visibility_descriptive_only",
+  "schema_version": "v4_5b_2.support_status_visibility_report.1",
+  "summary": {
+    "classification_counts": {
+      "blocked": 1,
+      "deprecated": 1,
+      "experimental": 1,
+      "partially_supported": 1,
+      "supported": 1,
+      "unknown": 1,
+      "unsupported": 1
+    },
+    "continuity_counts": {
+      "continuity_supported_states": 1,
+      "evidence_continuity_visibility": 1,
+      "fail_visible_continuity_diagnostics": 1,
+      "partially_continuous_states": 1,
+      "unsupported_continuity_states": 1
+    },
+    "continuity_support_count": 5,
+    "continuity_support_visibility_stable": true,
+    "descriptive_only_guarantees_verified": true,
+    "deterministic_hashing_verified": true,
+    "deterministic_serialization_verified": true,
+    "diagnostic_counts": {
+      "blocked_visibility_states": 1,
+      "deprecated_visibility_states": 1,
+      "inherited_limitation_visibility_gaps": 1,
+      "inherited_prohibition_visibility_gaps": 1,
+      "missing_support_evidence": 1,
+      "unknown_support_states": 1,
+      "unsupported_continuity_gaps": 1,
+      "unsupported_explainability_gaps": 1,
+      "unsupported_visibility_gaps": 1
+    },
+    "enabled_auto_correction_count": 0,
+    "enabled_mitigation_count": 0,
+    "enabled_operational_mutation_count": 0,
+    "enabled_orchestration_approval_count": 0,
+    "enabled_orchestration_authorization_count": 0,
+    "enabled_orchestration_decision_count": 0,
+    "enabled_orchestration_dispatch_count": 0,
+    "enabled_orchestration_recommendation_count": 0,
+    "enabled_orchestration_routing_count": 0,
+    "enabled_orchestration_scheduling_count": 0,
+    "enabled_orchestration_sequencing_count": 0,
+    "enabled_orchestration_traversal_count": 0,
+    "enabled_planner_integration_count": 0,
+    "enabled_production_consumption_count": 0,
+    "enabled_remediation_count": 0,
+    "enabled_repair_count": 0,
+    "enabled_runtime_execution_count": 0,
+    "enabled_runtime_mutation_count": 0,
+    "enabled_support_approval_count": 0,
+    "enabled_support_authorization_count": 0,
+    "enabled_support_ranking_count": 0,
+    "enabled_support_recommendation_count": 0,
+    "evidence_based_support_count": 6,
+    "evidence_based_support_visibility_stable": true,
+    "evidence_continuity_preserved": true,
+    "evidence_counts": {
+      "continuity_backed_support_visibility": 1,
+      "diagnostics_backed_support_visibility": 1,
+      "evidence_backed_support": 1,
+      "explainability_backed_support_visibility": 1,
+      "partially_evidenced_support": 1,
+      "unsupported_evidence_states": 1
+    },
+    "experimental_counts": {
+      "blocked_surfaces": 1,
+      "blocked_systems": 1,
+      "deprecated_surfaces": 1,
+      "deprecated_systems": 1,
+      "experimental_surfaces": 1,
+      "experimental_systems": 1,
+      "unknown_support_states": 1
+    },
+    "experimental_deprecated_count": 7,
+    "experimental_deprecated_visibility_preserved": true,
+    "explainability_counts": {
+      "continuity_explainability_visibility": 1,
+      "explainability_supported_states": 1,
+      "fail_visible_explainability_diagnostics": 1,
+      "partially_explainable_states": 1,
+      "unsupported_explainability_states": 1
+    },
+    "explainability_support_count": 5,
+    "explainability_support_visibility_stable": true,
+    "explicit_limitation_count": 12,
+    "fail_visible_support_diagnostics_verified": true,
+    "inherited_constraint_count": 19,
+    "inherited_prohibition_count": 23,
+    "lineage_continuity_preserved": true,
+    "provenance_continuity_preserved": true,
+    "publicly_transparent": true,
+    "repository_remains": [
+      "NON-operational",
+      "NON-authorizing",
+      "NON-approving",
+      "NON-executing",
+      "NON-remediating",
+      "NON-runtime-mutating",
+      "NON-ranking",
+      "NON-recommending"
+    ],
+    "summary_counts": {
+      "continuity_support_summary": 1,
+      "diagnostics_support_summary": 1,
+      "evidence_based_support_summary": 1,
+      "experimental_deprecated_summary": 1,
+      "explainability_support_summary": 1,
+      "support_classification_summary": 1,
+      "surface_support_summary": 1,
+      "unsupported_state_summary": 1
+    },
+    "support_classification_count": 7,
+    "support_classification_non_authority_statement": "Support classifications do NOT imply authorization, approval, operational readiness, execution safety, or production enablement.",
+    "support_classification_stable": true,
+    "support_diagnostic_count": 9,
+    "support_status_visibility_statement": "Support status visibility is descriptive-only.",
+    "support_summary_count": 8,
+    "support_surface_count": 8,
+    "support_surface_visibility_stable": true,
+    "support_visibility_record_count": 1,
+    "surface_counts": {
+      "continuity_surfaces": 1,
+      "data_sources": 1,
+      "diagnostics_surfaces": 1,
+      "evidence_chains": 1,
+      "explainability_surfaces": 1,
+      "mechanics": 1,
+      "planner_sections": 1,
+      "systems": 1
+    },
+    "unsupported_counts": {
+      "unsupported_continuity_surfaces": 1,
+      "unsupported_diagnostics_surfaces": 1,
+      "unsupported_evidence_chains": 1,
+      "unsupported_explainability_surfaces": 1,
+      "unsupported_mechanics": 1,
+      "unsupported_operational_states": 1,
+      "unsupported_planner_sections": 1
+    },
+    "unsupported_operational_counts": {
+      "automated_correction": 1,
+      "automated_mitigation": 1,
+      "automated_remediation": 1,
+      "automated_repair": 1,
+      "implicit_operational_behavior": 1,
+      "operational_mutation": 1,
+      "orchestration_approval": 1,
+      "orchestration_authorization": 1,
+      "orchestration_decisions": 1,
+      "orchestration_dispatch": 1,
+      "orchestration_execution": 1,
+      "orchestration_recommendations": 1,
+      "orchestration_routing": 1,
+      "orchestration_scheduling": 1,
+      "orchestration_sequencing": 1,
+      "orchestration_traversal": 1,
+      "planner_integration": 1,
+      "production_consumption": 1,
+      "runtime_mutation": 1,
+      "support_based_approval": 1,
+      "support_based_authorization": 1,
+      "support_based_ranking": 1,
+      "support_based_recommendation": 1
+    },
+    "unsupported_operational_state_count": 23,
+    "unsupported_state_visibility_count": 7,
+    "unsupported_state_visibility_preserved": true,
+    "validation_error_count": 0
+  },
+  "validation": {
+    "failed_validations": [],
+    "foundation_status": "v4_5b_2_support_status_visibility_stable",
+    "valid": true,
+    "validation_error_count": 0,
+    "validations": {
+      "continuity_support": {
+        "continuity_support_count": 5,
+        "missing_continuity_support_types": [],
+        "unsafe_continuity_support_ids": [],
+        "valid": true
+      },
+      "descriptive_only_guarantees": {
+        "counters": {
+          "enabled_auto_correction_count": 0,
+          "enabled_mitigation_count": 0,
+          "enabled_operational_mutation_count": 0,
+          "enabled_orchestration_approval_count": 0,
+          "enabled_orchestration_authorization_count": 0,
+          "enabled_orchestration_decision_count": 0,
+          "enabled_orchestration_dispatch_count": 0,
+          "enabled_orchestration_recommendation_count": 0,
+          "enabled_orchestration_routing_count": 0,
+          "enabled_orchestration_scheduling_count": 0,
+          "enabled_orchestration_sequencing_count": 0,
+          "enabled_orchestration_traversal_count": 0,
+          "enabled_planner_integration_count": 0,
+          "enabled_production_consumption_count": 0,
+          "enabled_remediation_count": 0,
+          "enabled_repair_count": 0,
+          "enabled_runtime_execution_count": 0,
+          "enabled_runtime_mutation_count": 0,
+          "enabled_support_approval_count": 0,
+          "enabled_support_authorization_count": 0,
+          "enabled_support_ranking_count": 0,
+          "enabled_support_recommendation_count": 0
+        },
+        "descriptive_failures": [],
+        "enabled_flags": {},
+        "explicit_limitation_count": 12,
+        "inherited_constraint_count": 19,
+        "inherited_prohibition_count": 23,
+        "missing_disabled_counters": [],
+        "publicly_transparent": true,
+        "repository_remains": {
+          "NON-approving": true,
+          "NON-authorizing": true,
+          "NON-executing": true,
+          "NON-operational": true,
+          "NON-ranking": true,
+          "NON-recommending": true,
+          "NON-remediating": true,
+          "NON-runtime-mutating": true
+        },
+        "statement_valid": true,
+        "support_classification_non_authority_statement": "Support classifications do NOT imply authorization, approval, operational readiness, execution safety, or production enablement.",
+        "support_status_visibility_statement": "Support status visibility is descriptive-only.",
+        "valid": true
+      },
+      "evidence_based_support": {
+        "evidence_based_support_count": 6,
+        "missing_evidence_support_types": [],
+        "unsafe_evidence_support_ids": [],
+        "valid": true
+      },
+      "experimental_deprecated": {
+        "experimental_deprecated_count": 7,
+        "missing_experimental_deprecated_types": [],
+        "unsafe_experimental_deprecated_ids": [],
+        "valid": true
+      },
+      "explainability_support": {
+        "explainability_support_count": 5,
+        "missing_explainability_support_types": [],
+        "unsafe_explainability_support_ids": [],
+        "valid": true
+      },
+      "fail_visible_support": {
+        "approval_enabled_count": 0,
+        "authorization_enabled_count": 0,
+        "fail_visible": true,
+        "hidden_fallback_enabled_count": 0,
+        "missing_diagnostic_types": [],
+        "missing_unsupported_states": [],
+        "ranking_enabled_count": 0,
+        "recommendation_enabled_count": 0,
+        "silent_fallback_enabled_count": 0,
+        "support_diagnostic_count": 9,
+        "unsafe_diagnostic_ids": [],
+        "unsafe_unsupported_ids": [],
+        "unsupported_operational_state_count": 23,
+        "valid": true
+      },
+      "identity_integrity": {
+        "missing_identity_fields": [],
+        "phase_id": "v4_5b_2_support_status_visibility",
+        "schema_version": "v4_5b_2.support_status_visibility.1",
+        "source_report_hash_matches": true,
+        "source_report_present": true,
+        "valid": true
+      },
+      "lineage_and_provenance": {
+        "continuity_reference_preserved": true,
+        "evidence_continuity_preserved": true,
+        "lineage_continuity_preserved": true,
+        "missing_evidence_reference_ids": [],
+        "provenance_continuity_preserved": true,
+        "valid": true
+      },
+      "ordering_stability": {
+        "order_groups": {
+          "continuity_support_visibility": [
+            1,
+            2,
+            3,
+            4,
+            5
+          ],
+          "evidence_based_support_visibility": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6
+          ],
+          "experimental_deprecated_visibility": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "explainability_support_visibility": [
+            1,
+            2,
+            3,
+            4,
+            5
+          ],
+          "support_classifications": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "support_diagnostics": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9
+          ],
+          "support_summaries": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8
+          ],
+          "support_surfaces": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8
+          ],
+          "support_visibility_records": [
+            1
+          ],
+          "unsupported_operational_state_visibility": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+            21,
+            22,
+            23
+          ],
+          "unsupported_state_visibility": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ]
+        },
+        "unordered_groups": [],
+        "valid": true
+      },
+      "required_visibility": {
+        "classification_counts": {
+          "blocked": 1,
+          "deprecated": 1,
+          "experimental": 1,
+          "partially_supported": 1,
+          "supported": 1,
+          "unknown": 1,
+          "unsupported": 1
+        },
+        "continuity_counts": {
+          "continuity_supported_states": 1,
+          "evidence_continuity_visibility": 1,
+          "fail_visible_continuity_diagnostics": 1,
+          "partially_continuous_states": 1,
+          "unsupported_continuity_states": 1
+        },
+        "diagnostic_counts": {
+          "blocked_visibility_states": 1,
+          "deprecated_visibility_states": 1,
+          "inherited_limitation_visibility_gaps": 1,
+          "inherited_prohibition_visibility_gaps": 1,
+          "missing_support_evidence": 1,
+          "unknown_support_states": 1,
+          "unsupported_continuity_gaps": 1,
+          "unsupported_explainability_gaps": 1,
+          "unsupported_visibility_gaps": 1
+        },
+        "evidence_counts": {
+          "continuity_backed_support_visibility": 1,
+          "diagnostics_backed_support_visibility": 1,
+          "evidence_backed_support": 1,
+          "explainability_backed_support_visibility": 1,
+          "partially_evidenced_support": 1,
+          "unsupported_evidence_states": 1
+        },
+        "experimental_counts": {
+          "blocked_surfaces": 1,
+          "blocked_systems": 1,
+          "deprecated_surfaces": 1,
+          "deprecated_systems": 1,
+          "experimental_surfaces": 1,
+          "experimental_systems": 1,
+          "unknown_support_states": 1
+        },
+        "explainability_counts": {
+          "continuity_explainability_visibility": 1,
+          "explainability_supported_states": 1,
+          "fail_visible_explainability_diagnostics": 1,
+          "partially_explainable_states": 1,
+          "unsupported_explainability_states": 1
+        },
+        "missing_classifications": [],
+        "missing_continuity_support": [],
+        "missing_diagnostics": [],
+        "missing_evidence_support": [],
+        "missing_experimental_deprecated": [],
+        "missing_explainability_support": [],
+        "missing_summaries": [],
+        "missing_surfaces": [],
+        "missing_unsupported_operational_states": [],
+        "missing_unsupported_states": [],
+        "summary_counts": {
+          "continuity_support_summary": 1,
+          "diagnostics_support_summary": 1,
+          "evidence_based_support_summary": 1,
+          "experimental_deprecated_summary": 1,
+          "explainability_support_summary": 1,
+          "support_classification_summary": 1,
+          "surface_support_summary": 1,
+          "unsupported_state_summary": 1
+        },
+        "surface_counts": {
+          "continuity_surfaces": 1,
+          "data_sources": 1,
+          "diagnostics_surfaces": 1,
+          "evidence_chains": 1,
+          "explainability_surfaces": 1,
+          "mechanics": 1,
+          "planner_sections": 1,
+          "systems": 1
+        },
+        "unsupported_counts": {
+          "unsupported_continuity_surfaces": 1,
+          "unsupported_diagnostics_surfaces": 1,
+          "unsupported_evidence_chains": 1,
+          "unsupported_explainability_surfaces": 1,
+          "unsupported_mechanics": 1,
+          "unsupported_operational_states": 1,
+          "unsupported_planner_sections": 1
+        },
+        "unsupported_operational_counts": {
+          "automated_correction": 1,
+          "automated_mitigation": 1,
+          "automated_remediation": 1,
+          "automated_repair": 1,
+          "implicit_operational_behavior": 1,
+          "operational_mutation": 1,
+          "orchestration_approval": 1,
+          "orchestration_authorization": 1,
+          "orchestration_decisions": 1,
+          "orchestration_dispatch": 1,
+          "orchestration_execution": 1,
+          "orchestration_recommendations": 1,
+          "orchestration_routing": 1,
+          "orchestration_scheduling": 1,
+          "orchestration_sequencing": 1,
+          "orchestration_traversal": 1,
+          "planner_integration": 1,
+          "production_consumption": 1,
+          "runtime_mutation": 1,
+          "support_based_approval": 1,
+          "support_based_authorization": 1,
+          "support_based_ranking": 1,
+          "support_based_recommendation": 1
+        },
+        "valid": true
+      },
+      "serialization_hashing": {
+        "hashing_stable": true,
+        "rebuilt_support_status_hash": "03b919155f02aff9629f0a5769c8d31cb32f61d5bcfde7aee6dd48a7aea773b8",
+        "serialization_length": 53789,
+        "serialization_stable": true,
+        "support_status_hash": "03b919155f02aff9629f0a5769c8d31cb32f61d5bcfde7aee6dd48a7aea773b8",
+        "valid": true
+      },
+      "support_classification": {
+        "missing_classifications": [],
+        "support_classification_count": 7,
+        "unsafe_classification_ids": [],
+        "valid": true
+      },
+      "support_summary": {
+        "missing_summary_types": [],
+        "support_summary_count": 8,
+        "unsafe_summary_ids": [],
+        "valid": true
+      },
+      "support_surface": {
+        "missing_surfaces": [],
+        "support_surface_count": 8,
+        "unsafe_surface_ids": [],
+        "valid": true
+      },
+      "unsupported_state_visibility": {
+        "missing_unsupported_state_types": [],
+        "unsafe_unsupported_state_ids": [],
+        "unsupported_state_visibility_count": 7,
+        "valid": true
+      }
+    }
+  },
+  "visibility": {
+    "continuity_support": [
+      {
+        "authorization_enabled": false,
+        "continuity_reference_id": "continuity_reference_continuity_supported_states",
+        "continuity_support_id": "continuity_support_continuity_supported_states",
+        "continuity_support_type": "continuity_supported_states",
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_continuity_supported_states"
+        ],
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "restoration_enabled": false
+      },
+      {
+        "authorization_enabled": false,
+        "continuity_reference_id": "continuity_reference_partially_continuous_states",
+        "continuity_support_id": "continuity_support_partially_continuous_states",
+        "continuity_support_type": "partially_continuous_states",
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_partially_continuous_states"
+        ],
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "restoration_enabled": false
+      },
+      {
+        "authorization_enabled": false,
+        "continuity_reference_id": "continuity_reference_unsupported_continuity_states",
+        "continuity_support_id": "continuity_support_unsupported_continuity_states",
+        "continuity_support_type": "unsupported_continuity_states",
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_continuity_states"
+        ],
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "restoration_enabled": false
+      },
+      {
+        "authorization_enabled": false,
+        "continuity_reference_id": "continuity_reference_evidence_continuity_visibility",
+        "continuity_support_id": "continuity_support_evidence_continuity_visibility",
+        "continuity_support_type": "evidence_continuity_visibility",
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_evidence_continuity_visibility"
+        ],
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "restoration_enabled": false
+      },
+      {
+        "authorization_enabled": false,
+        "continuity_reference_id": "continuity_reference_fail_visible_continuity_diagnostics",
+        "continuity_support_id": "continuity_support_fail_visible_continuity_diagnostics",
+        "continuity_support_type": "fail_visible_continuity_diagnostics",
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_fail_visible_continuity_diagnostics"
+        ],
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "restoration_enabled": false
+      }
+    ],
+    "descriptive_only": {
+      "descriptive_only": true,
+      "non_approving": true,
+      "non_authorizing": true,
+      "non_executing": true,
+      "non_operational": true,
+      "non_ranking": true,
+      "non_recommending": true,
+      "non_remediating": true,
+      "non_runtime_mutating": true,
+      "operational_mutation_enabled": false,
+      "planner_integration_enabled": false,
+      "production_consumption_enabled": false,
+      "publicly_transparent": true,
+      "runtime_mutation_enabled": false,
+      "support_approval_enabled": false,
+      "support_authorization_enabled": false,
+      "support_classification_non_authority_statement": "Support classifications do NOT imply authorization, approval, operational readiness, execution safety, or production enablement.",
+      "support_ranking_enabled": false,
+      "support_recommendation_enabled": false,
+      "support_status_visibility_statement": "Support status visibility is descriptive-only."
+    },
+    "evidence_based_support": [
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_evidence_backed_support"
+        ],
+        "evidence_support_id": "evidence_based_support_evidence_backed_support",
+        "evidence_support_type": "evidence_backed_support",
+        "provenance_safe": true,
+        "replay_safe": true,
+        "trust_scoring_enabled": false
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_partially_evidenced_support"
+        ],
+        "evidence_support_id": "evidence_based_support_partially_evidenced_support",
+        "evidence_support_type": "partially_evidenced_support",
+        "provenance_safe": true,
+        "replay_safe": true,
+        "trust_scoring_enabled": false
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_evidence_states"
+        ],
+        "evidence_support_id": "evidence_based_support_unsupported_evidence_states",
+        "evidence_support_type": "unsupported_evidence_states",
+        "provenance_safe": true,
+        "replay_safe": true,
+        "trust_scoring_enabled": false
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_continuity_backed_support_visibility"
+        ],
+        "evidence_support_id": "evidence_based_support_continuity_backed_support_visibility",
+        "evidence_support_type": "continuity_backed_support_visibility",
+        "provenance_safe": true,
+        "replay_safe": true,
+        "trust_scoring_enabled": false
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_explainability_backed_support_visibility"
+        ],
+        "evidence_support_id": "evidence_based_support_explainability_backed_support_visibility",
+        "evidence_support_type": "explainability_backed_support_visibility",
+        "provenance_safe": true,
+        "replay_safe": true,
+        "trust_scoring_enabled": false
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_diagnostics_backed_support_visibility"
+        ],
+        "evidence_support_id": "evidence_based_support_diagnostics_backed_support_visibility",
+        "evidence_support_type": "diagnostics_backed_support_visibility",
+        "provenance_safe": true,
+        "replay_safe": true,
+        "trust_scoring_enabled": false
+      }
+    ],
+    "experimental_deprecated": [
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automatic_migration_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_experimental_systems"
+        ],
+        "experimental_deprecated_id": "experimental_deprecated_experimental_systems",
+        "operational_fallback_enabled": false,
+        "visibility_type": "experimental_systems"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automatic_migration_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_experimental_surfaces"
+        ],
+        "experimental_deprecated_id": "experimental_deprecated_experimental_surfaces",
+        "operational_fallback_enabled": false,
+        "visibility_type": "experimental_surfaces"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automatic_migration_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_deprecated_systems"
+        ],
+        "experimental_deprecated_id": "experimental_deprecated_deprecated_systems",
+        "operational_fallback_enabled": false,
+        "visibility_type": "deprecated_systems"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automatic_migration_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_deprecated_surfaces"
+        ],
+        "experimental_deprecated_id": "experimental_deprecated_deprecated_surfaces",
+        "operational_fallback_enabled": false,
+        "visibility_type": "deprecated_surfaces"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automatic_migration_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_blocked_systems"
+        ],
+        "experimental_deprecated_id": "experimental_deprecated_blocked_systems",
+        "operational_fallback_enabled": false,
+        "visibility_type": "blocked_systems"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automatic_migration_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_blocked_surfaces"
+        ],
+        "experimental_deprecated_id": "experimental_deprecated_blocked_surfaces",
+        "operational_fallback_enabled": false,
+        "visibility_type": "blocked_surfaces"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automatic_migration_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unknown_support_states"
+        ],
+        "experimental_deprecated_id": "experimental_deprecated_unknown_support_states",
+        "operational_fallback_enabled": false,
+        "visibility_type": "unknown_support_states"
+      }
+    ],
+    "explainability_support": [
+      {
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_explainability_supported_states"
+        ],
+        "explainability_support_id": "explainability_support_explainability_supported_states",
+        "explainability_support_type": "explainability_supported_states",
+        "operational_semantics_enabled": false,
+        "recommendation_enabled": false
+      },
+      {
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_partially_explainable_states"
+        ],
+        "explainability_support_id": "explainability_support_partially_explainable_states",
+        "explainability_support_type": "partially_explainable_states",
+        "operational_semantics_enabled": false,
+        "recommendation_enabled": false
+      },
+      {
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_explainability_states"
+        ],
+        "explainability_support_id": "explainability_support_unsupported_explainability_states",
+        "explainability_support_type": "unsupported_explainability_states",
+        "operational_semantics_enabled": false,
+        "recommendation_enabled": false
+      },
+      {
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_continuity_explainability_visibility"
+        ],
+        "explainability_support_id": "explainability_support_continuity_explainability_visibility",
+        "explainability_support_type": "continuity_explainability_visibility",
+        "operational_semantics_enabled": false,
+        "recommendation_enabled": false
+      },
+      {
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_fail_visible_explainability_diagnostics"
+        ],
+        "explainability_support_id": "explainability_support_fail_visible_explainability_diagnostics",
+        "explainability_support_type": "fail_visible_explainability_diagnostics",
+        "operational_semantics_enabled": false,
+        "recommendation_enabled": false
+      }
+    ],
+    "support_classifications": [
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "classification_visibility_id": "support_classification_supported",
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_supported_classification"
+        ],
+        "execution_semantics_enabled": false,
+        "operational_approval_enabled": false,
+        "support_classification": "supported"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "classification_visibility_id": "support_classification_partially_supported",
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_partially_supported_classification"
+        ],
+        "execution_semantics_enabled": false,
+        "operational_approval_enabled": false,
+        "support_classification": "partially_supported"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "classification_visibility_id": "support_classification_unsupported",
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_classification"
+        ],
+        "execution_semantics_enabled": false,
+        "operational_approval_enabled": false,
+        "support_classification": "unsupported"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "classification_visibility_id": "support_classification_experimental",
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_experimental_classification"
+        ],
+        "execution_semantics_enabled": false,
+        "operational_approval_enabled": false,
+        "support_classification": "experimental"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "classification_visibility_id": "support_classification_deprecated",
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_deprecated_classification"
+        ],
+        "execution_semantics_enabled": false,
+        "operational_approval_enabled": false,
+        "support_classification": "deprecated"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "classification_visibility_id": "support_classification_blocked",
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_blocked_classification"
+        ],
+        "execution_semantics_enabled": false,
+        "operational_approval_enabled": false,
+        "support_classification": "blocked"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "classification_visibility_id": "support_classification_unknown",
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unknown_classification"
+        ],
+        "execution_semantics_enabled": false,
+        "operational_approval_enabled": false,
+        "support_classification": "unknown"
+      }
+    ],
+    "support_diagnostics": [
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "auto_correction_enabled": false,
+        "descriptive_only": true,
+        "diagnostic_id": "support_diagnostic_missing_support_evidence",
+        "diagnostic_type": "missing_support_evidence",
+        "evidence_reference_ids": [
+          "evidence_missing_support_evidence"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "message": "missing_support_evidence remains explicit, fail-visible, and descriptive-only for support status visibility.",
+        "mitigation_enabled": false,
+        "orchestration_response_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "silent_fallback_enabled": false
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "auto_correction_enabled": false,
+        "descriptive_only": true,
+        "diagnostic_id": "support_diagnostic_unsupported_visibility_gaps",
+        "diagnostic_type": "unsupported_visibility_gaps",
+        "evidence_reference_ids": [
+          "evidence_unsupported_visibility_gaps"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "message": "unsupported_visibility_gaps remains explicit, fail-visible, and descriptive-only for support status visibility.",
+        "mitigation_enabled": false,
+        "orchestration_response_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "silent_fallback_enabled": false
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "auto_correction_enabled": false,
+        "descriptive_only": true,
+        "diagnostic_id": "support_diagnostic_unsupported_explainability_gaps",
+        "diagnostic_type": "unsupported_explainability_gaps",
+        "evidence_reference_ids": [
+          "evidence_unsupported_explainability_gaps"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "message": "unsupported_explainability_gaps remains explicit, fail-visible, and descriptive-only for support status visibility.",
+        "mitigation_enabled": false,
+        "orchestration_response_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "silent_fallback_enabled": false
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "auto_correction_enabled": false,
+        "descriptive_only": true,
+        "diagnostic_id": "support_diagnostic_unsupported_continuity_gaps",
+        "diagnostic_type": "unsupported_continuity_gaps",
+        "evidence_reference_ids": [
+          "evidence_unsupported_continuity_gaps"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "message": "unsupported_continuity_gaps remains explicit, fail-visible, and descriptive-only for support status visibility.",
+        "mitigation_enabled": false,
+        "orchestration_response_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "silent_fallback_enabled": false
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "auto_correction_enabled": false,
+        "descriptive_only": true,
+        "diagnostic_id": "support_diagnostic_blocked_visibility_states",
+        "diagnostic_type": "blocked_visibility_states",
+        "evidence_reference_ids": [
+          "evidence_blocked_visibility_states"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "message": "blocked_visibility_states remains explicit, fail-visible, and descriptive-only for support status visibility.",
+        "mitigation_enabled": false,
+        "orchestration_response_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "silent_fallback_enabled": false
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "auto_correction_enabled": false,
+        "descriptive_only": true,
+        "diagnostic_id": "support_diagnostic_deprecated_visibility_states",
+        "diagnostic_type": "deprecated_visibility_states",
+        "evidence_reference_ids": [
+          "evidence_deprecated_visibility_states"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "message": "deprecated_visibility_states remains explicit, fail-visible, and descriptive-only for support status visibility.",
+        "mitigation_enabled": false,
+        "orchestration_response_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "silent_fallback_enabled": false
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "auto_correction_enabled": false,
+        "descriptive_only": true,
+        "diagnostic_id": "support_diagnostic_unknown_support_states",
+        "diagnostic_type": "unknown_support_states",
+        "evidence_reference_ids": [
+          "evidence_unknown_support_states"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "message": "unknown_support_states remains explicit, fail-visible, and descriptive-only for support status visibility.",
+        "mitigation_enabled": false,
+        "orchestration_response_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "silent_fallback_enabled": false
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "auto_correction_enabled": false,
+        "descriptive_only": true,
+        "diagnostic_id": "support_diagnostic_inherited_limitation_visibility_gaps",
+        "diagnostic_type": "inherited_limitation_visibility_gaps",
+        "evidence_reference_ids": [
+          "evidence_inherited_limitation_visibility_gaps"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "message": "inherited_limitation_visibility_gaps remains explicit, fail-visible, and descriptive-only for support status visibility.",
+        "mitigation_enabled": false,
+        "orchestration_response_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "silent_fallback_enabled": false
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "auto_correction_enabled": false,
+        "descriptive_only": true,
+        "diagnostic_id": "support_diagnostic_inherited_prohibition_visibility_gaps",
+        "diagnostic_type": "inherited_prohibition_visibility_gaps",
+        "evidence_reference_ids": [
+          "evidence_inherited_prohibition_visibility_gaps"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "message": "inherited_prohibition_visibility_gaps remains explicit, fail-visible, and descriptive-only for support status visibility.",
+        "mitigation_enabled": false,
+        "orchestration_response_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "silent_fallback_enabled": false
+      }
+    ],
+    "support_status": [
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "continuity_reference_id": "continuity::v4_5b_2.public_support",
+        "descriptive_only": true,
+        "diagnostics_reference_id": "diagnostics::v4_5b_2.public_support",
+        "evidence_reference_id": "evidence::v4_5b_2.public_support",
+        "explainability_reference_id": "explainability::v4_5b_2.public_support",
+        "fail_visible": true,
+        "lineage_reference_id": "lineage::v4_5b_2.public_support",
+        "provenance_reference_id": "provenance::v4_5b_2.public_support",
+        "publicly_transparent": true,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "support_authority_enabled": false,
+        "support_record_id": "public_support_status_visibility_foundation",
+        "support_reference_id": "support::v4_5b_2.public_support",
+        "support_scope_id": "scope::v4_5b_2.public_support",
+        "support_status_id": "v4_5b_2_support_status_visibility",
+        "support_summary_id": "v4_5b_2_support_summary"
+      }
+    ],
+    "support_summaries": [
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_support_classification_summary"
+        ],
+        "execution_enablement_enabled": false,
+        "production_enablement_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "summary_state": "support_summary_descriptive_only",
+        "summary_type": "support_classification_summary",
+        "support_summary_id": "v4_5b_2_support_summary",
+        "support_summary_record_id": "support_summary_support_classification_summary"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_surface_support_summary"
+        ],
+        "execution_enablement_enabled": false,
+        "production_enablement_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "summary_state": "support_summary_descriptive_only",
+        "summary_type": "surface_support_summary",
+        "support_summary_id": "v4_5b_2_support_summary",
+        "support_summary_record_id": "support_summary_surface_support_summary"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_state_summary"
+        ],
+        "execution_enablement_enabled": false,
+        "production_enablement_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "summary_state": "support_summary_descriptive_only",
+        "summary_type": "unsupported_state_summary",
+        "support_summary_id": "v4_5b_2_support_summary",
+        "support_summary_record_id": "support_summary_unsupported_state_summary"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_experimental_deprecated_summary"
+        ],
+        "execution_enablement_enabled": false,
+        "production_enablement_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "summary_state": "support_summary_descriptive_only",
+        "summary_type": "experimental_deprecated_summary",
+        "support_summary_id": "v4_5b_2_support_summary",
+        "support_summary_record_id": "support_summary_experimental_deprecated_summary"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_evidence_based_support_summary"
+        ],
+        "execution_enablement_enabled": false,
+        "production_enablement_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "summary_state": "support_summary_descriptive_only",
+        "summary_type": "evidence_based_support_summary",
+        "support_summary_id": "v4_5b_2_support_summary",
+        "support_summary_record_id": "support_summary_evidence_based_support_summary"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_explainability_support_summary"
+        ],
+        "execution_enablement_enabled": false,
+        "production_enablement_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "summary_state": "support_summary_descriptive_only",
+        "summary_type": "explainability_support_summary",
+        "support_summary_id": "v4_5b_2_support_summary",
+        "support_summary_record_id": "support_summary_explainability_support_summary"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_continuity_support_summary"
+        ],
+        "execution_enablement_enabled": false,
+        "production_enablement_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "summary_state": "support_summary_descriptive_only",
+        "summary_type": "continuity_support_summary",
+        "support_summary_id": "v4_5b_2_support_summary",
+        "support_summary_record_id": "support_summary_continuity_support_summary"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_diagnostics_support_summary"
+        ],
+        "execution_enablement_enabled": false,
+        "production_enablement_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "summary_state": "support_summary_descriptive_only",
+        "summary_type": "diagnostics_support_summary",
+        "support_summary_id": "v4_5b_2_support_summary",
+        "support_summary_record_id": "support_summary_diagnostics_support_summary"
+      }
+    ],
+    "support_surfaces": [
+      {
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_mechanics_support_surface"
+        ],
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "support_classification": "supported",
+        "support_surface": "mechanics",
+        "surface_visibility_id": "support_surface_mechanics"
+      },
+      {
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_systems_support_surface"
+        ],
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "support_classification": "partially_supported",
+        "support_surface": "systems",
+        "surface_visibility_id": "support_surface_systems"
+      },
+      {
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_planner_sections_support_surface"
+        ],
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "support_classification": "unsupported",
+        "support_surface": "planner_sections",
+        "surface_visibility_id": "support_surface_planner_sections"
+      },
+      {
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_data_sources_support_surface"
+        ],
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "support_classification": "experimental",
+        "support_surface": "data_sources",
+        "surface_visibility_id": "support_surface_data_sources"
+      },
+      {
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_evidence_chains_support_surface"
+        ],
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "support_classification": "deprecated",
+        "support_surface": "evidence_chains",
+        "surface_visibility_id": "support_surface_evidence_chains"
+      },
+      {
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_explainability_surfaces_support_surface"
+        ],
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "support_classification": "blocked",
+        "support_surface": "explainability_surfaces",
+        "surface_visibility_id": "support_surface_explainability_surfaces"
+      },
+      {
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_continuity_surfaces_support_surface"
+        ],
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "support_classification": "unknown",
+        "support_surface": "continuity_surfaces",
+        "surface_visibility_id": "support_surface_continuity_surfaces"
+      },
+      {
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_diagnostics_surfaces_support_surface"
+        ],
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "support_classification": "partially_supported",
+        "support_surface": "diagnostics_surfaces",
+        "surface_visibility_id": "support_surface_diagnostics_surfaces"
+      }
+    ],
+    "unsupported_operational_states": [
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_support_operational_states"
+        ],
+        "explicit_reason": "orchestration_execution remains unsupported for v4.5B.2 support status visibility.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_support_operational_state_orchestration_execution",
+        "suppression_enabled": false,
+        "unsupported_state": "orchestration_execution"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_support_operational_states"
+        ],
+        "explicit_reason": "orchestration_authorization remains unsupported for v4.5B.2 support status visibility.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_support_operational_state_orchestration_authorization",
+        "suppression_enabled": false,
+        "unsupported_state": "orchestration_authorization"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_support_operational_states"
+        ],
+        "explicit_reason": "orchestration_approval remains unsupported for v4.5B.2 support status visibility.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_support_operational_state_orchestration_approval",
+        "suppression_enabled": false,
+        "unsupported_state": "orchestration_approval"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_support_operational_states"
+        ],
+        "explicit_reason": "orchestration_dispatch remains unsupported for v4.5B.2 support status visibility.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_support_operational_state_orchestration_dispatch",
+        "suppression_enabled": false,
+        "unsupported_state": "orchestration_dispatch"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_support_operational_states"
+        ],
+        "explicit_reason": "orchestration_routing remains unsupported for v4.5B.2 support status visibility.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_support_operational_state_orchestration_routing",
+        "suppression_enabled": false,
+        "unsupported_state": "orchestration_routing"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_support_operational_states"
+        ],
+        "explicit_reason": "orchestration_traversal remains unsupported for v4.5B.2 support status visibility.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_support_operational_state_orchestration_traversal",
+        "suppression_enabled": false,
+        "unsupported_state": "orchestration_traversal"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_support_operational_states"
+        ],
+        "explicit_reason": "orchestration_scheduling remains unsupported for v4.5B.2 support status visibility.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_support_operational_state_orchestration_scheduling",
+        "suppression_enabled": false,
+        "unsupported_state": "orchestration_scheduling"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_support_operational_states"
+        ],
+        "explicit_reason": "orchestration_sequencing remains unsupported for v4.5B.2 support status visibility.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_support_operational_state_orchestration_sequencing",
+        "suppression_enabled": false,
+        "unsupported_state": "orchestration_sequencing"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_support_operational_states"
+        ],
+        "explicit_reason": "orchestration_decisions remains unsupported for v4.5B.2 support status visibility.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_support_operational_state_orchestration_decisions",
+        "suppression_enabled": false,
+        "unsupported_state": "orchestration_decisions"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_support_operational_states"
+        ],
+        "explicit_reason": "orchestration_recommendations remains unsupported for v4.5B.2 support status visibility.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_support_operational_state_orchestration_recommendations",
+        "suppression_enabled": false,
+        "unsupported_state": "orchestration_recommendations"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_support_operational_states"
+        ],
+        "explicit_reason": "support_based_authorization remains unsupported for v4.5B.2 support status visibility.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_support_operational_state_support_based_authorization",
+        "suppression_enabled": false,
+        "unsupported_state": "support_based_authorization"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_support_operational_states"
+        ],
+        "explicit_reason": "support_based_approval remains unsupported for v4.5B.2 support status visibility.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_support_operational_state_support_based_approval",
+        "suppression_enabled": false,
+        "unsupported_state": "support_based_approval"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_support_operational_states"
+        ],
+        "explicit_reason": "support_based_ranking remains unsupported for v4.5B.2 support status visibility.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_support_operational_state_support_based_ranking",
+        "suppression_enabled": false,
+        "unsupported_state": "support_based_ranking"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_support_operational_states"
+        ],
+        "explicit_reason": "support_based_recommendation remains unsupported for v4.5B.2 support status visibility.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_support_operational_state_support_based_recommendation",
+        "suppression_enabled": false,
+        "unsupported_state": "support_based_recommendation"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_support_operational_states"
+        ],
+        "explicit_reason": "automated_remediation remains unsupported for v4.5B.2 support status visibility.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_support_operational_state_automated_remediation",
+        "suppression_enabled": false,
+        "unsupported_state": "automated_remediation"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_support_operational_states"
+        ],
+        "explicit_reason": "automated_repair remains unsupported for v4.5B.2 support status visibility.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_support_operational_state_automated_repair",
+        "suppression_enabled": false,
+        "unsupported_state": "automated_repair"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_support_operational_states"
+        ],
+        "explicit_reason": "automated_mitigation remains unsupported for v4.5B.2 support status visibility.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_support_operational_state_automated_mitigation",
+        "suppression_enabled": false,
+        "unsupported_state": "automated_mitigation"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_support_operational_states"
+        ],
+        "explicit_reason": "automated_correction remains unsupported for v4.5B.2 support status visibility.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_support_operational_state_automated_correction",
+        "suppression_enabled": false,
+        "unsupported_state": "automated_correction"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_support_operational_states"
+        ],
+        "explicit_reason": "planner_integration remains unsupported for v4.5B.2 support status visibility.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_support_operational_state_planner_integration",
+        "suppression_enabled": false,
+        "unsupported_state": "planner_integration"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_support_operational_states"
+        ],
+        "explicit_reason": "production_consumption remains unsupported for v4.5B.2 support status visibility.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_support_operational_state_production_consumption",
+        "suppression_enabled": false,
+        "unsupported_state": "production_consumption"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_support_operational_states"
+        ],
+        "explicit_reason": "runtime_mutation remains unsupported for v4.5B.2 support status visibility.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_support_operational_state_runtime_mutation",
+        "suppression_enabled": false,
+        "unsupported_state": "runtime_mutation"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_support_operational_states"
+        ],
+        "explicit_reason": "operational_mutation remains unsupported for v4.5B.2 support status visibility.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_support_operational_state_operational_mutation",
+        "suppression_enabled": false,
+        "unsupported_state": "operational_mutation"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_support_operational_states"
+        ],
+        "explicit_reason": "implicit_operational_behavior remains unsupported for v4.5B.2 support status visibility.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_support_operational_state_implicit_operational_behavior",
+        "suppression_enabled": false,
+        "unsupported_state": "implicit_operational_behavior"
+      }
+    ],
+    "unsupported_states": [
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_mechanics"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "remediation_enabled": false,
+        "suppression_enabled": false,
+        "unsupported_state_type": "unsupported_mechanics",
+        "unsupported_visibility_id": "unsupported_support_state_unsupported_mechanics"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_planner_sections"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "remediation_enabled": false,
+        "suppression_enabled": false,
+        "unsupported_state_type": "unsupported_planner_sections",
+        "unsupported_visibility_id": "unsupported_support_state_unsupported_planner_sections"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_evidence_chains"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "remediation_enabled": false,
+        "suppression_enabled": false,
+        "unsupported_state_type": "unsupported_evidence_chains",
+        "unsupported_visibility_id": "unsupported_support_state_unsupported_evidence_chains"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_explainability_surfaces"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "remediation_enabled": false,
+        "suppression_enabled": false,
+        "unsupported_state_type": "unsupported_explainability_surfaces",
+        "unsupported_visibility_id": "unsupported_support_state_unsupported_explainability_surfaces"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_continuity_surfaces"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "remediation_enabled": false,
+        "suppression_enabled": false,
+        "unsupported_state_type": "unsupported_continuity_surfaces",
+        "unsupported_visibility_id": "unsupported_support_state_unsupported_continuity_surfaces"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_diagnostics_surfaces"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "remediation_enabled": false,
+        "suppression_enabled": false,
+        "unsupported_state_type": "unsupported_diagnostics_surfaces",
+        "unsupported_visibility_id": "unsupported_support_state_unsupported_diagnostics_surfaces"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_operational_states"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "remediation_enabled": false,
+        "suppression_enabled": false,
+        "unsupported_state_type": "unsupported_operational_states",
+        "unsupported_visibility_id": "unsupported_support_state_unsupported_operational_states"
+      }
+    ]
+  }
+}

--- a/docs/migration/V4_5B_2_SUPPORT_STATUS_VISIBILITY.md
+++ b/docs/migration/V4_5B_2_SUPPORT_STATUS_VISIBILITY.md
@@ -1,0 +1,131 @@
+# V4.5B.2 Support Status Visibility
+
+## Architectural Purpose
+
+v4.5B.2 establishes deterministic governance-safe support status visibility on
+top of v4.5A governance intelligence and v4.5B.1 public trust visibility
+foundations. The phase models public support states across systems, mechanics,
+planner sections, data sources, evidence chains, explainability surfaces,
+continuity surfaces, and diagnostics surfaces.
+
+This phase is descriptive-only support visibility infrastructure. Support
+status visibility is descriptive-only. Support classifications do NOT imply
+authorization, approval, operational readiness, execution safety, or production
+enablement.
+
+## Deterministic Support Visibility Philosophy
+
+The implementation preserves deterministic, governance-safe, replay-safe,
+rollback-safe, lineage-safe, provenance-safe, integrity-safe,
+explainability-first, fail-visible, descriptive-only, publicly transparent
+constraints.
+
+Support visibility is modeled as explicit records and summaries. It is not a
+support score, ranking, recommendation, approval, authorization, correctness
+guarantee, operational guarantee, production readiness claim, execution safety
+claim, or runtime enablement signal.
+
+## Support Classification Philosophy
+
+The supported, partially_supported, unsupported, experimental, deprecated,
+blocked, and unknown classifications remain deterministic descriptive
+visibility. They do not authorize, approve, execute, recommend, rank, or imply
+operational support.
+
+## Unsupported-State Visibility Philosophy
+
+Unsupported mechanics, planner sections, evidence chains, explainability
+surfaces, continuity surfaces, diagnostics surfaces, and operational states
+remain explicit and fail-visible. Unsupported states are not suppressed,
+remediated, repaired, backfilled, or treated as fallback behavior.
+
+## Experimental and Deprecated Visibility Philosophy
+
+Experimental systems, experimental surfaces, deprecated systems, deprecated
+surfaces, blocked systems, blocked surfaces, and unknown support states remain
+descriptive visibility only. They do not trigger automatic migration,
+operational fallback, approval, authorization, ranking, or recommendation.
+
+## Explainability Support Philosophy
+
+Explainability-supported states, partially explainable states, unsupported
+explainability states, continuity explainability visibility, and fail-visible
+explainability diagnostics remain public visibility records. They do not create
+recommendation behavior or operational semantics.
+
+## Continuity Support Philosophy
+
+Continuity support visibility preserves support visibility for continuity
+surfaces and evidence continuity. It does not restore, repair, remediate, route,
+traverse, authorize, approve, or execute.
+
+## Fail-Visible Support Diagnostics Philosophy
+
+Diagnostics remain explicit for missing support evidence, unsupported
+visibility gaps, unsupported explainability gaps, unsupported continuity gaps,
+blocked visibility states, deprecated visibility states, unknown support
+states, inherited limitation visibility gaps, and inherited prohibition
+visibility gaps.
+
+No diagnostic silently falls back, suppresses unsupported states, ranks,
+recommends, remediates, authorizes, approves, or triggers operational behavior.
+
+## Hashing Guarantees
+
+Support visibility records, support classification records, unsupported-state
+records, support summaries, diagnostics records, explainability support records,
+and continuity support records use deterministic SHA-256 hashes over canonical
+JSON serialization. Hashes are stable, replay-safe, provenance-safe, and
+integrity-safe.
+
+## Serialization Guarantees
+
+Serialization preserves deterministic ordering, replayability, provenance
+continuity, lineage continuity, evidence continuity, and explicit
+unsupported-state visibility. Serialization does not add operational meaning.
+
+## Inherited Prohibitions
+
+The repository remains:
+
+- NON-operational
+- NON-authorizing
+- NON-approving
+- NON-executing
+- NON-remediating
+- NON-runtime-mutating
+- NON-ranking
+- NON-recommending
+
+This phase preserves prohibitions against orchestration execution,
+authorization, approval, dispatch, routing, traversal, scheduling, sequencing,
+decisions, recommendations, support-based authorization, support-based
+approval, support-based ranking, support-based recommendation, automated
+remediation, automated repair, automated mitigation, automated correction,
+planner integration, production consumption, runtime mutation, operational
+mutation, and implicit operational behavior.
+
+## Unsupported Operational States
+
+Unsupported operational states are represented as fail-visible support status
+visibility records. They do not enable fallback behavior, suppression behavior,
+support scoring, support ranking, support recommendation, authorization,
+approval, execution, planner integration, production consumption, runtime
+mutation, or operational mutation.
+
+## Intentionally Preserved Limitations
+
+v4.5B.2 intentionally preserves these limitations:
+
+- Support visibility does not authorize or approve.
+- Support visibility does not rank or recommend.
+- Support visibility does not execute.
+- Support visibility does not enable production.
+- Support visibility does not imply correctness guarantees.
+- Support visibility does not imply execution safety.
+- Support visibility does not remediate, repair, mitigate, or correct.
+- Support visibility does not integrate planners.
+- Support visibility does not mutate runtime state.
+
+The phase is a deterministic descriptive support visibility foundation for
+later public trust work only.


### PR DESCRIPTION
Implement governance-safe deterministic support status visibility including support classifications, unsupported-state visibility, experimental and deprecated visibility, explainability support visibility, continuity support visibility, fail-visible support diagnostics, hashing, serialization, reporting, and descriptive-only public trust guarantees without introducing authorization, approval, recommendation, execution, or operational behavior.