### PR TITLE
v4.5B.3: implement explainability surfaces

### DIFF
--- a/backend/app/public_trust_visibility/v4_5b_3_explainability_surface_audit.py
+++ b/backend/app/public_trust_visibility/v4_5b_3_explainability_surface_audit.py
@@ -1,0 +1,1053 @@
+"""Audit for deterministic v4.5B.3 explainability surfaces.
+
+The audit validates descriptive public explainability surfaces only. It does
+not authorize, approve, execute, dispatch, route, traverse, schedule, sequence,
+decide, recommend, rank, remediate, repair, mitigate, correct, integrate
+planners, consume production paths, or mutate runtime or operational state.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import is_dataclass, replace
+from pathlib import Path
+from typing import Any, Iterable
+
+from .v4_5b_3_explainability_surface_hashing import (
+    deterministic_v4_5b_3_explainability_surface_hash,
+    hash_continuity_explanation_visibility,
+    hash_evidence_to_explanation_mapping,
+    hash_explainability_surface_identity,
+    hash_explainability_surface_record,
+    hash_explanation_diagnostic_record,
+    hash_explanation_summary_record,
+    hash_limitation_explanation_visibility,
+    hash_public_trust_explanation_visibility,
+    hash_support_state_explanation_surface,
+    hash_unsupported_explanation_operational_state_visibility,
+    hash_unsupported_state_explanation_visibility,
+    hash_v4_5b_3_explainability_surfaces,
+)
+from .v4_5b_3_explainability_surface_models import (
+    CONTINUITY_EXPLANATION_TYPES,
+    EVIDENCE_TO_EXPLANATION_MAPPING_TYPES,
+    EXPLANATION_DIAGNOSTIC_TYPES,
+    EXPLANATION_SUMMARY_TYPES,
+    EXPLAINABILITY_SURFACE_STATEMENT,
+    EXPLAINABILITY_VISIBILITY_NON_AUTHORITY_STATEMENT,
+    LIMITATION_EXPLANATION_TYPES,
+    SUPPORT_STATE_EXPLANATION_TYPES,
+    TRUST_EXPLANATION_TYPES,
+    UNSUPPORTED_EXPLANATION_OPERATIONAL_STATES,
+    UNSUPPORTED_STATE_EXPLANATION_TYPES,
+    V4_5B_3_EXPLAINABILITY_SURFACE_DISABLED_COUNTER_NAMES,
+    V4_5B_3_EXPLAINABILITY_SURFACE_GENERATED_AT,
+    V4_5B_3_EXPLAINABILITY_SURFACE_PHASE_ID,
+    V4_5B_3_EXPLAINABILITY_SURFACE_PURPOSE,
+    V4_5B_3_EXPLAINABILITY_SURFACE_REPORT_SCHEMA_VERSION,
+    V4_5B_3_EXPLAINABILITY_SURFACE_STATUS_BLOCKED,
+    V4_5B_3_EXPLAINABILITY_SURFACE_STATUS_STABLE,
+    ExplainabilitySurfaceIntelligence,
+    default_v4_5b_3_explainability_surfaces,
+)
+from .v4_5b_3_explainability_surface_serialization import (
+    export_v4_5b_3_explainability_surfaces,
+    serialize_v4_5b_3_explainability_surfaces,
+)
+from .v4_5b_3_explainability_surface_visibility import (
+    continuity_explanation_summary,
+    descriptive_only_explainability_surface_summary,
+    evidence_to_explanation_mapping_summary,
+    explanation_diagnostic_summary,
+    explanation_summary_visibility,
+    explanation_surface_summary,
+    limitation_explanation_summary,
+    support_state_explanation_summary,
+    trust_explanation_summary,
+    unsupported_operational_state_summary,
+    unsupported_state_explanation_summary,
+    validate_required_explainability_surfaces,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+CAPABILITY_COUNTER_FIELD_MAP: dict[str, tuple[str, ...]] = {
+    "enabled_runtime_execution_count": (
+        "runtime_execution_enabled",
+        "orchestration_execution_enabled",
+        "planner_execution_enabled",
+        "execution_enabled",
+        "execution_enablement_enabled",
+        "execution_semantics_enabled",
+        "execution_safety_enabled",
+    ),
+    "enabled_orchestration_authorization_count": (
+        "orchestration_authorization_enabled",
+        "authorization_enabled",
+    ),
+    "enabled_orchestration_approval_count": (
+        "orchestration_approval_enabled",
+        "approval_enabled",
+    ),
+    "enabled_orchestration_dispatch_count": (
+        "orchestration_dispatch_enabled",
+        "dispatch_enabled",
+    ),
+    "enabled_orchestration_routing_count": (
+        "orchestration_routing_enabled",
+        "routing_enabled",
+    ),
+    "enabled_orchestration_traversal_count": (
+        "orchestration_traversal_enabled",
+        "traversal_enabled",
+    ),
+    "enabled_orchestration_scheduling_count": (
+        "orchestration_scheduling_enabled",
+        "scheduling_enabled",
+    ),
+    "enabled_orchestration_sequencing_count": (
+        "orchestration_sequencing_enabled",
+        "sequencing_enabled",
+    ),
+    "enabled_orchestration_decision_count": (
+        "orchestration_decision_enabled",
+        "decision_enabled",
+    ),
+    "enabled_orchestration_recommendation_count": (
+        "orchestration_recommendation_enabled",
+        "orchestration_response_enabled",
+    ),
+    "enabled_explainability_authorization_count": (
+        "explainability_authorization_enabled",
+        "explainability_authority_enabled",
+        "authorization_enabled",
+    ),
+    "enabled_explainability_approval_count": (
+        "explainability_approval_enabled",
+        "approval_enabled",
+        "operational_approval_enabled",
+    ),
+    "enabled_explainability_ranking_count": (
+        "explainability_ranking_enabled",
+        "ranking_enabled",
+        "trust_scoring_enabled",
+    ),
+    "enabled_explainability_recommendation_count": (
+        "explainability_recommendation_enabled",
+        "recommendation_enabled",
+    ),
+    "enabled_remediation_count": ("remediation_enabled",),
+    "enabled_repair_count": ("repair_enabled",),
+    "enabled_mitigation_count": ("mitigation_enabled",),
+    "enabled_auto_correction_count": (
+        "auto_correction_enabled",
+        "automated_correction_enabled",
+    ),
+    "enabled_planner_integration_count": ("planner_integration_enabled",),
+    "enabled_production_consumption_count": (
+        "production_consumption_enabled",
+        "production_enablement_enabled",
+    ),
+    "enabled_runtime_mutation_count": (
+        "runtime_mutation_enabled",
+        "runtime_enablement_enabled",
+    ),
+    "enabled_operational_mutation_count": (
+        "operational_mutation_enabled",
+        "operational_behavior_enabled",
+        "operational_semantics_enabled",
+        "operational_enabled",
+        "operational_fallback_enabled",
+        "operational_readiness_enabled",
+    ),
+}
+
+PROHIBITED_BOOLEAN_FIELD_NAMES: tuple[str, ...] = tuple(
+    sorted({field for fields in CAPABILITY_COUNTER_FIELD_MAP.values() for field in fields})
+)
+
+
+def build_v4_5b_3_explainability_surfaces() -> ExplainabilitySurfaceIntelligence:
+    return default_v4_5b_3_explainability_surfaces()
+
+
+def _iter_dataclass_objects(value: Any) -> Iterable[Any]:
+    if is_dataclass(value) and not isinstance(value, type):
+        yield value
+        for item in value.__dict__.values():
+            yield from _iter_dataclass_objects(item)
+    elif isinstance(value, dict):
+        for item in value.values():
+            yield from _iter_dataclass_objects(item)
+    elif isinstance(value, tuple | list | set):
+        for item in value:
+            yield from _iter_dataclass_objects(item)
+
+
+def _relative_path_exists(reference: str) -> bool:
+    return (REPO_ROOT / reference).exists()
+
+
+def _report_hash_matches(reference: str, expected_hash: str) -> bool:
+    path = REPO_ROOT / reference
+    if not path.exists():
+        return False
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return False
+    return payload.get("deterministic_report_hash") == expected_hash
+
+
+def _record_id(item: object) -> str:
+    return str(
+        getattr(item, "surface_record_id", None)
+        or getattr(item, "support_state_explanation_id", None)
+        or getattr(item, "evidence_mapping_id", None)
+        or getattr(item, "limitation_explanation_id", None)
+        or getattr(item, "trust_explanation_id", None)
+        or getattr(item, "continuity_explanation_id", None)
+        or getattr(item, "unsupported_explanation_id", None)
+        or getattr(item, "explanation_summary_record_id", None)
+        or getattr(item, "diagnostic_id", None)
+        or getattr(item, "state_id", None)
+        or getattr(item, "explainability_surface_id", item.__class__.__name__)
+    )
+
+
+def enabled_explainability_surface_capability_flags(
+    intelligence: ExplainabilitySurfaceIntelligence,
+) -> dict[str, list[str]]:
+    enabled: dict[str, list[str]] = {}
+    for item in _iter_dataclass_objects(intelligence):
+        for field_name in PROHIBITED_BOOLEAN_FIELD_NAMES:
+            if bool(getattr(item, field_name, False)):
+                enabled.setdefault(_record_id(item), []).append(field_name)
+    return {key: sorted(values) for key, values in sorted(enabled.items())}
+
+
+def explainability_surface_capability_counter_values(
+    intelligence: ExplainabilitySurfaceIntelligence,
+) -> dict[str, int]:
+    objects = tuple(_iter_dataclass_objects(intelligence))
+    counters: dict[str, int] = {}
+    for counter_name, field_names in CAPABILITY_COUNTER_FIELD_MAP.items():
+        counters[counter_name] = sum(
+            1
+            for item in objects
+            for field_name in field_names
+            if bool(getattr(item, field_name, False))
+        )
+    return counters
+
+
+def explainability_surface_equal(
+    left: ExplainabilitySurfaceIntelligence,
+    right: ExplainabilitySurfaceIntelligence,
+) -> bool:
+    return serialize_v4_5b_3_explainability_surfaces(
+        left
+    ) == serialize_v4_5b_3_explainability_surfaces(right)
+
+
+def validate_explainability_surface_ordering_stability(
+    intelligence: ExplainabilitySurfaceIntelligence,
+) -> dict[str, Any]:
+    order_groups = {
+        "surface_records": tuple(
+            record.deterministic_order for record in intelligence.surface_records
+        ),
+        "support_state_explanations": tuple(
+            record.deterministic_order
+            for record in intelligence.support_state_explanations
+        ),
+        "evidence_to_explanation_mappings": tuple(
+            record.deterministic_order
+            for record in intelligence.evidence_to_explanation_mappings
+        ),
+        "limitation_explanations": tuple(
+            record.deterministic_order
+            for record in intelligence.limitation_explanations
+        ),
+        "trust_explanations": tuple(
+            record.deterministic_order for record in intelligence.trust_explanations
+        ),
+        "continuity_explanations": tuple(
+            record.deterministic_order
+            for record in intelligence.continuity_explanations
+        ),
+        "unsupported_state_explanations": tuple(
+            record.deterministic_order
+            for record in intelligence.unsupported_state_explanations
+        ),
+        "explanation_summaries": tuple(
+            record.deterministic_order for record in intelligence.explanation_summaries
+        ),
+        "explanation_diagnostics": tuple(
+            record.deterministic_order for record in intelligence.explanation_diagnostics
+        ),
+        "unsupported_operational_state_visibility": tuple(
+            record.deterministic_order
+            for record in intelligence.unsupported_operational_state_visibility
+        ),
+    }
+    unordered_groups = sorted(
+        key for key, values in order_groups.items() if tuple(sorted(values)) != values
+    )
+    return {
+        "valid": not unordered_groups,
+        "order_groups": {key: list(values) for key, values in order_groups.items()},
+        "unordered_groups": unordered_groups,
+    }
+
+
+def validate_explainability_identity_integrity(
+    intelligence: ExplainabilitySurfaceIntelligence,
+) -> dict[str, Any]:
+    identity = intelligence.surface_identity
+    required_values = {
+        "explainability_surface_id": identity.explainability_surface_id,
+        "explanation_summary_id": identity.explanation_summary_id,
+        "support_visibility_reference_id": identity.support_visibility_reference_id,
+        "evidence_reference_id": identity.evidence_reference_id,
+        "continuity_reference_id": identity.continuity_reference_id,
+        "trust_summary_reference_id": identity.trust_summary_reference_id,
+        "diagnostics_reference_id": identity.diagnostics_reference_id,
+        "lineage_reference_id": identity.lineage_reference_id,
+        "provenance_reference_id": identity.provenance_reference_id,
+    }
+    missing_fields = sorted(key for key, value in required_values.items() if not value)
+    source_report_present = _relative_path_exists(
+        identity.source_support_status_report_reference
+    )
+    source_report_hash_matches = _report_hash_matches(
+        identity.source_support_status_report_reference,
+        identity.source_support_status_hash_reference,
+    )
+    return {
+        "valid": not missing_fields
+        and identity.phase_id == V4_5B_3_EXPLAINABILITY_SURFACE_PHASE_ID
+        and source_report_present
+        and source_report_hash_matches,
+        "missing_identity_fields": missing_fields,
+        "phase_id": identity.phase_id,
+        "schema_version": identity.schema_version,
+        "source_report_present": source_report_present,
+        "source_report_hash_matches": source_report_hash_matches,
+    }
+
+
+def validate_support_state_explanation_visibility(
+    intelligence: ExplainabilitySurfaceIntelligence,
+) -> dict[str, Any]:
+    records = intelligence.support_state_explanations
+    present = {record.explanation_type for record in records}
+    missing_types = sorted(set(SUPPORT_STATE_EXPLANATION_TYPES) - present)
+    unsafe_ids = sorted(
+        record.support_state_explanation_id
+        for record in records
+        if (
+            not record.descriptive_only
+            or record.recommendation_enabled
+            or record.ranking_enabled
+            or record.authorization_enabled
+            or record.approval_enabled
+            or record.correctness_guarantee_enabled
+            or record.operational_readiness_enabled
+            or record.execution_safety_enabled
+        )
+    )
+    return {
+        "valid": not (missing_types or unsafe_ids),
+        "support_state_explanation_count": len(records),
+        "missing_support_state_explanation_types": missing_types,
+        "unsafe_support_state_explanation_ids": unsafe_ids,
+    }
+
+
+def validate_evidence_to_explanation_mapping_stability(
+    intelligence: ExplainabilitySurfaceIntelligence,
+) -> dict[str, Any]:
+    records = intelligence.evidence_to_explanation_mappings
+    present = {record.mapping_type for record in records}
+    missing_types = sorted(set(EVIDENCE_TO_EXPLANATION_MAPPING_TYPES) - present)
+    unsafe_ids = sorted(
+        record.evidence_mapping_id
+        for record in records
+        if (
+            not record.descriptive_only
+            or not record.replay_safe
+            or not record.provenance_safe
+            or not record.evidence_reference_ids
+            or not record.explanation_reference_ids
+            or record.trust_scoring_enabled
+            or record.authorization_enabled
+            or record.approval_enabled
+            or record.ranking_enabled
+            or record.recommendation_enabled
+        )
+    )
+    return {
+        "valid": not (missing_types or unsafe_ids),
+        "evidence_mapping_count": len(records),
+        "missing_evidence_mapping_types": missing_types,
+        "unsafe_evidence_mapping_ids": unsafe_ids,
+    }
+
+
+def validate_limitation_explanation_preservation(
+    intelligence: ExplainabilitySurfaceIntelligence,
+) -> dict[str, Any]:
+    records = intelligence.limitation_explanations
+    present = {record.limitation_type for record in records}
+    missing_types = sorted(set(LIMITATION_EXPLANATION_TYPES) - present)
+    unsafe_ids = sorted(
+        record.limitation_explanation_id
+        for record in records
+        if (
+            not record.descriptive_only
+            or record.operational_fallback_enabled
+            or record.authorization_enabled
+            or record.approval_enabled
+            or record.recommendation_enabled
+        )
+    )
+    return {
+        "valid": not (missing_types or unsafe_ids),
+        "limitation_explanation_count": len(records),
+        "missing_limitation_explanation_types": missing_types,
+        "unsafe_limitation_explanation_ids": unsafe_ids,
+    }
+
+
+def validate_trust_explanation_visibility(
+    intelligence: ExplainabilitySurfaceIntelligence,
+) -> dict[str, Any]:
+    records = intelligence.trust_explanations
+    present = {record.trust_explanation_type for record in records}
+    missing_types = sorted(set(TRUST_EXPLANATION_TYPES) - present)
+    unsafe_ids = sorted(
+        record.trust_explanation_id
+        for record in records
+        if (
+            not record.descriptive_only
+            or record.authorization_enabled
+            or record.approval_enabled
+            or record.execution_semantics_enabled
+            or record.operational_enabled
+        )
+    )
+    return {
+        "valid": not (missing_types or unsafe_ids),
+        "trust_explanation_count": len(records),
+        "missing_trust_explanation_types": missing_types,
+        "unsafe_trust_explanation_ids": unsafe_ids,
+    }
+
+
+def validate_continuity_explanation_visibility(
+    intelligence: ExplainabilitySurfaceIntelligence,
+) -> dict[str, Any]:
+    records = intelligence.continuity_explanations
+    present = {record.continuity_explanation_type for record in records}
+    missing_types = sorted(set(CONTINUITY_EXPLANATION_TYPES) - present)
+    unsafe_ids = sorted(
+        record.continuity_explanation_id
+        for record in records
+        if (
+            not record.continuity_reference_id
+            or not record.descriptive_only
+            or record.restoration_enabled
+            or record.remediation_enabled
+            or record.repair_enabled
+            or record.authorization_enabled
+        )
+    )
+    return {
+        "valid": not (missing_types or unsafe_ids),
+        "continuity_explanation_count": len(records),
+        "missing_continuity_explanation_types": missing_types,
+        "unsafe_continuity_explanation_ids": unsafe_ids,
+    }
+
+
+def validate_unsupported_state_explanation_preservation(
+    intelligence: ExplainabilitySurfaceIntelligence,
+) -> dict[str, Any]:
+    records = intelligence.unsupported_state_explanations
+    present = {record.unsupported_state_type for record in records}
+    missing_types = sorted(set(UNSUPPORTED_STATE_EXPLANATION_TYPES) - present)
+    unsafe_ids = sorted(
+        record.unsupported_explanation_id
+        for record in records
+        if (
+            not record.descriptive_only
+            or not record.fail_visible
+            or record.suppression_enabled
+            or record.hidden_fallback_enabled
+            or record.authorization_enabled
+            or record.approval_enabled
+            or record.remediation_enabled
+        )
+    )
+    return {
+        "valid": not (missing_types or unsafe_ids),
+        "unsupported_state_explanation_count": len(records),
+        "missing_unsupported_state_explanation_types": missing_types,
+        "unsafe_unsupported_state_explanation_ids": unsafe_ids,
+    }
+
+
+def validate_explanation_summary_stability(
+    intelligence: ExplainabilitySurfaceIntelligence,
+) -> dict[str, Any]:
+    records = intelligence.explanation_summaries
+    present = {record.summary_type for record in records}
+    missing_types = sorted(set(EXPLANATION_SUMMARY_TYPES) - present)
+    unsafe_ids = sorted(
+        record.explanation_summary_record_id
+        for record in records
+        if (
+            not record.descriptive_only
+            or record.authorization_enabled
+            or record.approval_enabled
+            or record.ranking_enabled
+            or record.recommendation_enabled
+            or record.execution_enablement_enabled
+            or record.production_enablement_enabled
+        )
+    )
+    return {
+        "valid": not (missing_types or unsafe_ids),
+        "explanation_summary_count": len(records),
+        "missing_explanation_summary_types": missing_types,
+        "unsafe_explanation_summary_ids": unsafe_ids,
+    }
+
+
+def validate_lineage_and_provenance_preservation(
+    intelligence: ExplainabilitySurfaceIntelligence,
+) -> dict[str, Any]:
+    identity = intelligence.surface_identity
+    records_with_evidence = (
+        intelligence.support_state_explanations
+        + intelligence.evidence_to_explanation_mappings
+        + intelligence.limitation_explanations
+        + intelligence.trust_explanations
+        + intelligence.continuity_explanations
+        + intelligence.unsupported_state_explanations
+        + intelligence.explanation_summaries
+        + intelligence.explanation_diagnostics
+        + intelligence.unsupported_operational_state_visibility
+    )
+    records_missing_evidence = sorted(
+        _record_id(record)
+        for record in records_with_evidence
+        if not getattr(record, "evidence_reference_ids", ())
+    )
+    continuity_missing = sorted(
+        record.continuity_explanation_id
+        for record in intelligence.continuity_explanations
+        if not record.continuity_reference_id
+    )
+    return {
+        "valid": not records_missing_evidence
+        and not continuity_missing
+        and bool(identity.lineage_reference_id)
+        and bool(identity.provenance_reference_id)
+        and bool(identity.evidence_reference_id)
+        and bool(identity.continuity_reference_id),
+        "lineage_continuity_preserved": bool(identity.lineage_reference_id),
+        "provenance_continuity_preserved": bool(identity.provenance_reference_id),
+        "evidence_continuity_preserved": not records_missing_evidence,
+        "continuity_reference_preserved": not continuity_missing,
+        "records_missing_evidence": records_missing_evidence,
+        "continuity_records_missing_references": continuity_missing,
+    }
+
+
+def validate_explainability_surface_serialization_and_hashing(
+    intelligence: ExplainabilitySurfaceIntelligence,
+) -> dict[str, Any]:
+    first_serialization = serialize_v4_5b_3_explainability_surfaces(intelligence)
+    second_serialization = serialize_v4_5b_3_explainability_surfaces(intelligence)
+    first_hash = hash_v4_5b_3_explainability_surfaces(intelligence)
+    second_hash = hash_v4_5b_3_explainability_surfaces(intelligence)
+    return {
+        "valid": first_serialization == second_serialization
+        and first_hash == second_hash
+        and len(first_hash) == 64,
+        "serialization_stable": first_serialization == second_serialization,
+        "hashing_stable": first_hash == second_hash,
+        "explainability_surface_hash": first_hash,
+    }
+
+
+def validate_fail_visible_explanation_diagnostics(
+    intelligence: ExplainabilitySurfaceIntelligence,
+) -> dict[str, Any]:
+    diagnostics = intelligence.explanation_diagnostics
+    unsupported = intelligence.unsupported_operational_state_visibility
+    diagnostic_types = {record.diagnostic_type for record in diagnostics}
+    unsupported_states = {record.unsupported_state for record in unsupported}
+    missing_diagnostic_types = sorted(set(EXPLANATION_DIAGNOSTIC_TYPES) - diagnostic_types)
+    missing_unsupported_states = sorted(
+        set(UNSUPPORTED_EXPLANATION_OPERATIONAL_STATES) - unsupported_states
+    )
+    unsafe_diagnostic_ids = sorted(
+        record.diagnostic_id
+        for record in diagnostics
+        if (
+            not record.fail_visible
+            or not record.descriptive_only
+            or record.silent_fallback_enabled
+            or record.hidden_fallback_enabled
+            or record.authorization_enabled
+            or record.approval_enabled
+            or record.remediation_enabled
+            or record.repair_enabled
+            or record.mitigation_enabled
+            or record.auto_correction_enabled
+            or record.ranking_enabled
+            or record.recommendation_enabled
+            or record.orchestration_response_enabled
+        )
+    )
+    unsafe_unsupported_ids = sorted(
+        record.state_id
+        for record in unsupported
+        if (
+            not record.fail_visible
+            or not record.descriptive_only
+            or record.authorization_enabled
+            or record.approval_enabled
+            or record.operational_enabled
+            or record.remediation_enabled
+            or record.repair_enabled
+            or record.mitigation_enabled
+            or record.automated_correction_enabled
+            or record.ranking_enabled
+            or record.recommendation_enabled
+            or record.suppression_enabled
+        )
+    )
+    return {
+        "valid": not (
+            missing_diagnostic_types
+            or missing_unsupported_states
+            or unsafe_diagnostic_ids
+            or unsafe_unsupported_ids
+        ),
+        "explanation_diagnostic_count": len(diagnostics),
+        "unsupported_operational_state_count": len(unsupported),
+        "missing_diagnostic_types": missing_diagnostic_types,
+        "missing_unsupported_states": missing_unsupported_states,
+        "unsafe_diagnostic_ids": unsafe_diagnostic_ids,
+        "unsafe_unsupported_ids": unsafe_unsupported_ids,
+        "fail_visible": all(record.fail_visible for record in diagnostics)
+        and all(record.fail_visible for record in unsupported),
+        "silent_fallback_enabled_count": sum(
+            1 for record in diagnostics if record.silent_fallback_enabled
+        ),
+        "hidden_fallback_enabled_count": sum(
+            1 for record in diagnostics if record.hidden_fallback_enabled
+        ),
+        "authorization_enabled_count": sum(
+            1 for record in diagnostics if record.authorization_enabled
+        )
+        + sum(1 for record in unsupported if record.authorization_enabled),
+        "approval_enabled_count": sum(
+            1 for record in diagnostics if record.approval_enabled
+        )
+        + sum(1 for record in unsupported if record.approval_enabled),
+        "ranking_enabled_count": sum(
+            1 for record in diagnostics if record.ranking_enabled
+        )
+        + sum(1 for record in unsupported if record.ranking_enabled),
+        "recommendation_enabled_count": sum(
+            1 for record in diagnostics if record.recommendation_enabled
+        )
+        + sum(1 for record in unsupported if record.recommendation_enabled),
+    }
+
+
+def validate_descriptive_only_explainability_guarantees(
+    intelligence: ExplainabilitySurfaceIntelligence,
+) -> dict[str, Any]:
+    counters = explainability_surface_capability_counter_values(intelligence)
+    enabled_flags = enabled_explainability_surface_capability_flags(intelligence)
+    descriptive_failures = sorted(
+        _record_id(item)
+        for item in _iter_dataclass_objects(intelligence)
+        if hasattr(item, "descriptive_only") and not getattr(item, "descriptive_only")
+    )
+    missing_disabled_counters = sorted(
+        set(V4_5B_3_EXPLAINABILITY_SURFACE_DISABLED_COUNTER_NAMES) - set(counters)
+    )
+    required_repository_states = {
+        "NON-operational": intelligence.non_operational,
+        "NON-authorizing": intelligence.non_authorizing,
+        "NON-approving": intelligence.non_approving,
+        "NON-executing": intelligence.non_executing,
+        "NON-remediating": intelligence.non_remediating,
+        "NON-runtime-mutating": intelligence.non_runtime_mutating,
+        "NON-ranking": intelligence.non_ranking,
+        "NON-recommending": intelligence.non_recommending,
+    }
+    statement_valid = (
+        intelligence.explainability_surface_statement
+        == EXPLAINABILITY_SURFACE_STATEMENT
+        and intelligence.explainability_visibility_non_authority_statement
+        == EXPLAINABILITY_VISIBILITY_NON_AUTHORITY_STATEMENT
+    )
+    return {
+        "valid": (
+            not enabled_flags
+            and all(value == 0 for value in counters.values())
+            and not descriptive_failures
+            and not missing_disabled_counters
+            and all(required_repository_states.values())
+            and intelligence.publicly_transparent
+            and statement_valid
+        ),
+        "enabled_flags": enabled_flags,
+        "counters": counters,
+        "descriptive_failures": descriptive_failures,
+        "missing_disabled_counters": missing_disabled_counters,
+        "repository_remains": required_repository_states,
+        "publicly_transparent": intelligence.publicly_transparent,
+        "explainability_surface_statement": (
+            intelligence.explainability_surface_statement
+        ),
+        "explainability_visibility_non_authority_statement": (
+            intelligence.explainability_visibility_non_authority_statement
+        ),
+        "statement_valid": statement_valid,
+        "inherited_prohibition_count": len(intelligence.inherited_prohibitions),
+        "inherited_constraint_count": len(intelligence.inherited_constraints),
+        "explicit_limitation_count": len(intelligence.explicit_limitations),
+    }
+
+
+def validate_v4_5b_3_explainability_surfaces(
+    intelligence: ExplainabilitySurfaceIntelligence | None = None,
+) -> dict[str, Any]:
+    if intelligence is None:
+        intelligence = build_v4_5b_3_explainability_surfaces()
+    validations = {
+        "required_visibility": validate_required_explainability_surfaces(intelligence),
+        "ordering_stability": validate_explainability_surface_ordering_stability(
+            intelligence
+        ),
+        "identity_integrity": validate_explainability_identity_integrity(intelligence),
+        "support_state_explanations": validate_support_state_explanation_visibility(
+            intelligence
+        ),
+        "evidence_to_explanation_mapping": (
+            validate_evidence_to_explanation_mapping_stability(intelligence)
+        ),
+        "limitation_explanations": validate_limitation_explanation_preservation(
+            intelligence
+        ),
+        "trust_explanations": validate_trust_explanation_visibility(intelligence),
+        "continuity_explanations": validate_continuity_explanation_visibility(
+            intelligence
+        ),
+        "unsupported_state_explanations": (
+            validate_unsupported_state_explanation_preservation(intelligence)
+        ),
+        "explanation_summary": validate_explanation_summary_stability(intelligence),
+        "lineage_and_provenance": validate_lineage_and_provenance_preservation(
+            intelligence
+        ),
+        "serialization_hashing": (
+            validate_explainability_surface_serialization_and_hashing(intelligence)
+        ),
+        "fail_visible_explanations": validate_fail_visible_explanation_diagnostics(
+            intelligence
+        ),
+        "descriptive_only_guarantees": (
+            validate_descriptive_only_explainability_guarantees(intelligence)
+        ),
+    }
+    failed_validations = sorted(
+        name for name, result in validations.items() if not result["valid"]
+    )
+    return {
+        "valid": not failed_validations,
+        "foundation_status": (
+            V4_5B_3_EXPLAINABILITY_SURFACE_STATUS_STABLE
+            if not failed_validations
+            else V4_5B_3_EXPLAINABILITY_SURFACE_STATUS_BLOCKED
+        ),
+        "validation_error_count": len(failed_validations),
+        "failed_validations": failed_validations,
+        "validations": validations,
+    }
+
+
+def build_v4_5b_3_explainability_surfaces_report() -> dict[str, Any]:
+    intelligence = build_v4_5b_3_explainability_surfaces()
+    exported = export_v4_5b_3_explainability_surfaces(intelligence)
+    validation = validate_v4_5b_3_explainability_surfaces(intelligence)
+    required_visibility = validation["validations"]["required_visibility"]
+    serialization_hashing = validation["validations"]["serialization_hashing"]
+    support = validation["validations"]["support_state_explanations"]
+    mapping = validation["validations"]["evidence_to_explanation_mapping"]
+    limitation = validation["validations"]["limitation_explanations"]
+    trust = validation["validations"]["trust_explanations"]
+    continuity = validation["validations"]["continuity_explanations"]
+    unsupported = validation["validations"]["unsupported_state_explanations"]
+    lineage_provenance = validation["validations"]["lineage_and_provenance"]
+    fail_visible = validation["validations"]["fail_visible_explanations"]
+    descriptive_only = validation["validations"]["descriptive_only_guarantees"]
+    counters = descriptive_only["counters"]
+
+    deterministic_hash_evidence = {
+        "surface_identity_hash": hash_explainability_surface_identity(
+            intelligence.surface_identity
+        ),
+        "explainability_surface_hash": hash_v4_5b_3_explainability_surfaces(
+            intelligence
+        ),
+        "surface_record_hashes": {
+            record.surface_record_id: hash_explainability_surface_record(record)
+            for record in sorted(
+                intelligence.surface_records,
+                key=lambda item: (item.deterministic_order, item.surface_record_id),
+            )
+        },
+        "support_state_explanation_hashes": {
+            record.support_state_explanation_id: (
+                hash_support_state_explanation_surface(record)
+            )
+            for record in sorted(
+                intelligence.support_state_explanations,
+                key=lambda item: (
+                    item.deterministic_order,
+                    item.support_state_explanation_id,
+                ),
+            )
+        },
+        "evidence_to_explanation_mapping_hashes": {
+            record.evidence_mapping_id: hash_evidence_to_explanation_mapping(record)
+            for record in sorted(
+                intelligence.evidence_to_explanation_mappings,
+                key=lambda item: (item.deterministic_order, item.evidence_mapping_id),
+            )
+        },
+        "limitation_explanation_hashes": {
+            record.limitation_explanation_id: hash_limitation_explanation_visibility(
+                record
+            )
+            for record in sorted(
+                intelligence.limitation_explanations,
+                key=lambda item: (item.deterministic_order, item.limitation_explanation_id),
+            )
+        },
+        "trust_explanation_hashes": {
+            record.trust_explanation_id: hash_public_trust_explanation_visibility(
+                record
+            )
+            for record in sorted(
+                intelligence.trust_explanations,
+                key=lambda item: (item.deterministic_order, item.trust_explanation_id),
+            )
+        },
+        "continuity_explanation_hashes": {
+            record.continuity_explanation_id: hash_continuity_explanation_visibility(
+                record
+            )
+            for record in sorted(
+                intelligence.continuity_explanations,
+                key=lambda item: (
+                    item.deterministic_order,
+                    item.continuity_explanation_id,
+                ),
+            )
+        },
+        "unsupported_state_explanation_hashes": {
+            record.unsupported_explanation_id: (
+                hash_unsupported_state_explanation_visibility(record)
+            )
+            for record in sorted(
+                intelligence.unsupported_state_explanations,
+                key=lambda item: (
+                    item.deterministic_order,
+                    item.unsupported_explanation_id,
+                ),
+            )
+        },
+        "explanation_summary_hashes": {
+            record.explanation_summary_record_id: hash_explanation_summary_record(record)
+            for record in sorted(
+                intelligence.explanation_summaries,
+                key=lambda item: (
+                    item.deterministic_order,
+                    item.explanation_summary_record_id,
+                ),
+            )
+        },
+        "explanation_diagnostic_hashes": {
+            record.diagnostic_id: hash_explanation_diagnostic_record(record)
+            for record in sorted(
+                intelligence.explanation_diagnostics,
+                key=lambda item: (item.deterministic_order, item.diagnostic_id),
+            )
+        },
+        "unsupported_operational_hashes": {
+            record.state_id: hash_unsupported_explanation_operational_state_visibility(
+                record
+            )
+            for record in sorted(
+                intelligence.unsupported_operational_state_visibility,
+                key=lambda item: (item.deterministic_order, item.state_id),
+            )
+        },
+    }
+    summary = {
+        "surface_record_count": len(intelligence.surface_records),
+        "support_state_explanation_count": len(
+            intelligence.support_state_explanations
+        ),
+        "evidence_to_explanation_mapping_count": len(
+            intelligence.evidence_to_explanation_mappings
+        ),
+        "limitation_explanation_count": len(intelligence.limitation_explanations),
+        "trust_explanation_count": len(intelligence.trust_explanations),
+        "continuity_explanation_count": len(intelligence.continuity_explanations),
+        "unsupported_state_explanation_count": len(
+            intelligence.unsupported_state_explanations
+        ),
+        "explanation_summary_count": len(intelligence.explanation_summaries),
+        "explanation_diagnostic_count": len(intelligence.explanation_diagnostics),
+        "unsupported_operational_state_count": len(
+            intelligence.unsupported_operational_state_visibility
+        ),
+        "support_counts": required_visibility["support_counts"],
+        "mapping_counts": required_visibility["mapping_counts"],
+        "limitation_counts": required_visibility["limitation_counts"],
+        "trust_counts": required_visibility["trust_counts"],
+        "continuity_counts": required_visibility["continuity_counts"],
+        "unsupported_counts": required_visibility["unsupported_counts"],
+        "summary_counts": required_visibility["summary_counts"],
+        "diagnostic_counts": required_visibility["diagnostic_counts"],
+        "unsupported_operational_counts": required_visibility[
+            "unsupported_operational_counts"
+        ],
+        "deterministic_serialization_verified": serialization_hashing[
+            "serialization_stable"
+        ],
+        "deterministic_hashing_verified": serialization_hashing["hashing_stable"],
+        "support_state_explanations_stable": support["valid"],
+        "evidence_to_explanation_mapping_stable": mapping["valid"],
+        "limitation_explanation_preserved": limitation["valid"],
+        "trust_explanation_visibility_stable": trust["valid"],
+        "continuity_explanation_visibility_stable": continuity["valid"],
+        "unsupported_state_explanation_preserved": unsupported["valid"],
+        "lineage_continuity_preserved": lineage_provenance[
+            "lineage_continuity_preserved"
+        ],
+        "provenance_continuity_preserved": lineage_provenance[
+            "provenance_continuity_preserved"
+        ],
+        "evidence_continuity_preserved": lineage_provenance[
+            "evidence_continuity_preserved"
+        ],
+        "fail_visible_explanation_diagnostics_verified": fail_visible["valid"],
+        "descriptive_only_guarantees_verified": descriptive_only["valid"],
+        "publicly_transparent": descriptive_only["publicly_transparent"],
+        "explainability_surface_statement": (
+            descriptive_only["explainability_surface_statement"]
+        ),
+        "explainability_visibility_non_authority_statement": (
+            descriptive_only["explainability_visibility_non_authority_statement"]
+        ),
+        "inherited_prohibition_count": descriptive_only[
+            "inherited_prohibition_count"
+        ],
+        "inherited_constraint_count": descriptive_only["inherited_constraint_count"],
+        "explicit_limitation_count": descriptive_only["explicit_limitation_count"],
+        "validation_error_count": validation["validation_error_count"],
+        "repository_remains": [
+            "NON-operational",
+            "NON-authorizing",
+            "NON-approving",
+            "NON-executing",
+            "NON-remediating",
+            "NON-runtime-mutating",
+            "NON-ranking",
+            "NON-recommending",
+        ],
+    }
+    summary.update(counters)
+    report = {
+        "phase_id": V4_5B_3_EXPLAINABILITY_SURFACE_PHASE_ID,
+        "schema_version": V4_5B_3_EXPLAINABILITY_SURFACE_REPORT_SCHEMA_VERSION,
+        "generated_at": V4_5B_3_EXPLAINABILITY_SURFACE_GENERATED_AT,
+        "purpose": V4_5B_3_EXPLAINABILITY_SURFACE_PURPOSE,
+        "foundation_status": validation["foundation_status"],
+        "summary": summary,
+        "visibility": {
+            "explainability_surfaces": explanation_surface_summary(
+                intelligence.surface_records
+            ),
+            "support_state_explanations": support_state_explanation_summary(
+                intelligence.support_state_explanations
+            ),
+            "evidence_to_explanation_mappings": (
+                evidence_to_explanation_mapping_summary(
+                    intelligence.evidence_to_explanation_mappings
+                )
+            ),
+            "limitation_explanations": limitation_explanation_summary(
+                intelligence.limitation_explanations
+            ),
+            "trust_explanations": trust_explanation_summary(
+                intelligence.trust_explanations
+            ),
+            "continuity_explanations": continuity_explanation_summary(
+                intelligence.continuity_explanations
+            ),
+            "unsupported_state_explanations": unsupported_state_explanation_summary(
+                intelligence.unsupported_state_explanations
+            ),
+            "explanation_summaries": explanation_summary_visibility(
+                intelligence.explanation_summaries
+            ),
+            "explanation_diagnostics": explanation_diagnostic_summary(
+                intelligence.explanation_diagnostics
+            ),
+            "unsupported_operational_states": unsupported_operational_state_summary(
+                intelligence.unsupported_operational_state_visibility
+            ),
+            "descriptive_only": descriptive_only_explainability_surface_summary(
+                intelligence
+            ),
+        },
+        "deterministic_hash_evidence": deterministic_hash_evidence,
+        "validation": validation,
+        "exported_intelligence": exported,
+    }
+    report["deterministic_report_hash"] = (
+        deterministic_v4_5b_3_explainability_surface_hash(report)
+    )
+    return report
+
+
+def contaminate_v4_5b_3_explainability_surfaces_for_non_operational_validation(
+    intelligence: ExplainabilitySurfaceIntelligence | None = None,
+) -> ExplainabilitySurfaceIntelligence:
+    if intelligence is None:
+        intelligence = build_v4_5b_3_explainability_surfaces()
+    return replace(
+        intelligence,
+        runtime_execution_enabled=True,
+        explainability_authorization_enabled=True,
+        explainability_approval_enabled=True,
+        explainability_ranking_enabled=True,
+        explainability_recommendation_enabled=True,
+        remediation_enabled=True,
+        planner_integration_enabled=True,
+    )

--- a/backend/app/public_trust_visibility/v4_5b_3_explainability_surface_hashing.py
+++ b/backend/app/public_trust_visibility/v4_5b_3_explainability_surface_hashing.py
@@ -1,0 +1,130 @@
+"""Deterministic hashing for v4.5B.3 explainability surfaces."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+from .v4_5b_3_explainability_surface_models import (
+    ContinuityExplanationVisibility,
+    EvidenceToExplanationMapping,
+    ExplainabilitySurfaceIdentity,
+    ExplainabilitySurfaceIntelligence,
+    ExplainabilitySurfaceRecord,
+    ExplanationDiagnosticRecord,
+    ExplanationSummaryRecord,
+    LimitationExplanationVisibility,
+    PublicTrustExplanationVisibility,
+    SupportStateExplanationSurface,
+    UnsupportedExplanationOperationalStateVisibility,
+    UnsupportedStateExplanationVisibility,
+)
+from .v4_5b_3_explainability_surface_serialization import (
+    export_continuity_explanation_visibility,
+    export_evidence_to_explanation_mapping,
+    export_explainability_surface_identity,
+    export_explainability_surface_record,
+    export_explanation_diagnostic_record,
+    export_explanation_summary_record,
+    export_limitation_explanation_visibility,
+    export_public_trust_explanation_visibility,
+    export_support_state_explanation_surface,
+    export_unsupported_explanation_operational_state_visibility,
+    export_unsupported_state_explanation_visibility,
+    export_v4_5b_3_explainability_surfaces,
+    stable_serialize_v4_5b_3_explainability_surfaces,
+)
+
+
+def deterministic_v4_5b_3_explainability_surface_hash(payload: Any) -> str:
+    return hashlib.sha256(
+        stable_serialize_v4_5b_3_explainability_surfaces(payload).encode("utf-8")
+    ).hexdigest()
+
+
+def hash_explainability_surface_identity(
+    identity: ExplainabilitySurfaceIdentity,
+) -> str:
+    return deterministic_v4_5b_3_explainability_surface_hash(
+        export_explainability_surface_identity(identity)
+    )
+
+
+def hash_explainability_surface_record(record: ExplainabilitySurfaceRecord) -> str:
+    return deterministic_v4_5b_3_explainability_surface_hash(
+        export_explainability_surface_record(record)
+    )
+
+
+def hash_support_state_explanation_surface(
+    record: SupportStateExplanationSurface,
+) -> str:
+    return deterministic_v4_5b_3_explainability_surface_hash(
+        export_support_state_explanation_surface(record)
+    )
+
+
+def hash_evidence_to_explanation_mapping(record: EvidenceToExplanationMapping) -> str:
+    return deterministic_v4_5b_3_explainability_surface_hash(
+        export_evidence_to_explanation_mapping(record)
+    )
+
+
+def hash_limitation_explanation_visibility(
+    record: LimitationExplanationVisibility,
+) -> str:
+    return deterministic_v4_5b_3_explainability_surface_hash(
+        export_limitation_explanation_visibility(record)
+    )
+
+
+def hash_public_trust_explanation_visibility(
+    record: PublicTrustExplanationVisibility,
+) -> str:
+    return deterministic_v4_5b_3_explainability_surface_hash(
+        export_public_trust_explanation_visibility(record)
+    )
+
+
+def hash_continuity_explanation_visibility(
+    record: ContinuityExplanationVisibility,
+) -> str:
+    return deterministic_v4_5b_3_explainability_surface_hash(
+        export_continuity_explanation_visibility(record)
+    )
+
+
+def hash_unsupported_state_explanation_visibility(
+    record: UnsupportedStateExplanationVisibility,
+) -> str:
+    return deterministic_v4_5b_3_explainability_surface_hash(
+        export_unsupported_state_explanation_visibility(record)
+    )
+
+
+def hash_explanation_summary_record(record: ExplanationSummaryRecord) -> str:
+    return deterministic_v4_5b_3_explainability_surface_hash(
+        export_explanation_summary_record(record)
+    )
+
+
+def hash_explanation_diagnostic_record(record: ExplanationDiagnosticRecord) -> str:
+    return deterministic_v4_5b_3_explainability_surface_hash(
+        export_explanation_diagnostic_record(record)
+    )
+
+
+def hash_unsupported_explanation_operational_state_visibility(
+    record: UnsupportedExplanationOperationalStateVisibility,
+) -> str:
+    return deterministic_v4_5b_3_explainability_surface_hash(
+        export_unsupported_explanation_operational_state_visibility(record)
+    )
+
+
+def hash_v4_5b_3_explainability_surfaces(
+    intelligence: ExplainabilitySurfaceIntelligence,
+) -> str:
+    return deterministic_v4_5b_3_explainability_surface_hash(
+        export_v4_5b_3_explainability_surfaces(intelligence)
+    )

--- a/backend/app/public_trust_visibility/v4_5b_3_explainability_surface_models.py
+++ b/backend/app/public_trust_visibility/v4_5b_3_explainability_surface_models.py
@@ -1,0 +1,782 @@
+"""Deterministic v4.5B.3 public explainability surface models.
+
+The v4.5B.3 layer models public-facing explanation surfaces without enabling
+explainability authority, approval, authorization, ranking, recommendation,
+execution, remediation, runtime mutation, planner integration, production
+consumption, or operational behavior.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+V4_5B_3_EXPLAINABILITY_SURFACE_PHASE_ID = "v4_5b_3_explainability_surfaces"
+V4_5B_3_EXPLAINABILITY_SURFACE_SCHEMA_VERSION = (
+    "v4_5b_3.explainability_surfaces.1"
+)
+V4_5B_3_EXPLAINABILITY_SURFACE_REPORT_SCHEMA_VERSION = (
+    "v4_5b_3.explainability_surfaces_report.1"
+)
+V4_5B_3_EXPLAINABILITY_SURFACE_GENERATED_AT = "2026-05-18T00:00:00+00:00"
+V4_5B_3_EXPLAINABILITY_SURFACE_STATUS_STABLE = (
+    "v4_5b_3_explainability_surfaces_stable"
+)
+V4_5B_3_EXPLAINABILITY_SURFACE_STATUS_BLOCKED = (
+    "v4_5b_3_explainability_surfaces_blocked"
+)
+V4_5B_3_EXPLAINABILITY_SURFACE_PURPOSE = (
+    "deterministic_governance_safe_public_explainability_surfaces_descriptive_only"
+)
+V4_5B_3_EXPLAINABILITY_SURFACE_CLASSIFICATION = (
+    "governance_safe_public_explainability_surfaces_descriptive_only"
+)
+
+V4_5B_2_SUPPORT_STATUS_VISIBILITY_REPORT_REFERENCE = (
+    "docs/generated/v4_5b_2_support_status_visibility_report.json"
+)
+V4_5B_2_SUPPORT_STATUS_VISIBILITY_REPORT_HASH_REFERENCE = (
+    "c716c22d2907e6f5d6d9eac4e5d3db7102b9b4411547dfe0b361dfedc5e2434e"
+)
+
+EXPLAINABILITY_SURFACE_STATEMENT = "Explainability surfaces are descriptive-only."
+EXPLAINABILITY_VISIBILITY_NON_AUTHORITY_STATEMENT = (
+    "Explainability visibility does NOT imply authorization, approval, operational "
+    "readiness, execution safety, or production enablement."
+)
+
+SUPPORT_STATE_EXPLANATION_TYPES: tuple[str, ...] = (
+    "supported_explanations",
+    "partially_supported_explanations",
+    "unsupported_explanations",
+    "experimental_explanations",
+    "deprecated_explanations",
+    "blocked_explanations",
+    "unknown_state_explanations",
+)
+
+EVIDENCE_TO_EXPLANATION_MAPPING_TYPES: tuple[str, ...] = (
+    "evidence_backed_explanations",
+    "partially_evidenced_explanations",
+    "unsupported_evidence_explanations",
+    "continuity_backed_explanations",
+    "explainability_backed_explanations",
+    "diagnostics_backed_explanations",
+)
+
+LIMITATION_EXPLANATION_TYPES: tuple[str, ...] = (
+    "unsupported_limitation_explanations",
+    "experimental_limitation_explanations",
+    "deprecated_limitation_explanations",
+    "blocked_limitation_explanations",
+    "governance_limitation_explanations",
+    "continuity_limitation_explanations",
+    "evidence_limitation_explanations",
+)
+
+TRUST_EXPLANATION_TYPES: tuple[str, ...] = (
+    "governance_transparency_explanations",
+    "deterministic_guarantee_explanations",
+    "explainability_continuity_explanations",
+    "integrity_continuity_explanations",
+    "fail_visible_diagnostic_explanations",
+    "unsupported_state_explanations",
+)
+
+CONTINUITY_EXPLANATION_TYPES: tuple[str, ...] = (
+    "evidence_continuity_explanations",
+    "lineage_continuity_explanations",
+    "provenance_continuity_explanations",
+    "integrity_continuity_explanations",
+    "diagnostics_continuity_explanations",
+)
+
+UNSUPPORTED_STATE_EXPLANATION_TYPES: tuple[str, ...] = (
+    "unsupported_systems",
+    "unsupported_planner_sections",
+    "unsupported_evidence_chains",
+    "unsupported_continuity_chains",
+    "unsupported_operational_states",
+    "unsupported_trust_states",
+)
+
+EXPLANATION_SUMMARY_TYPES: tuple[str, ...] = (
+    "explanation_surface_summary",
+    "support_state_explanation_summary",
+    "evidence_mapping_summary",
+    "limitation_explanation_summary",
+    "trust_explanation_summary",
+    "continuity_explanation_summary",
+    "unsupported_state_explanation_summary",
+    "diagnostics_explanation_summary",
+)
+
+EXPLANATION_DIAGNOSTIC_TYPES: tuple[str, ...] = (
+    "missing_explanation_evidence",
+    "unsupported_explanation_gaps",
+    "incomplete_continuity_explanations",
+    "incomplete_integrity_explanations",
+    "unsupported_trust_explanations",
+    "unsupported_operational_explanations",
+    "inherited_limitation_explanation_gaps",
+    "inherited_prohibition_explanation_gaps",
+)
+
+UNSUPPORTED_EXPLANATION_OPERATIONAL_STATES: tuple[str, ...] = (
+    "orchestration_execution",
+    "orchestration_authorization",
+    "orchestration_approval",
+    "orchestration_dispatch",
+    "orchestration_routing",
+    "orchestration_traversal",
+    "orchestration_scheduling",
+    "orchestration_sequencing",
+    "orchestration_decisions",
+    "orchestration_recommendations",
+    "explainability_based_authorization",
+    "explainability_based_approval",
+    "explainability_based_ranking",
+    "explainability_based_recommendation",
+    "automated_remediation",
+    "automated_repair",
+    "automated_mitigation",
+    "automated_correction",
+    "planner_integration",
+    "production_consumption",
+    "runtime_mutation",
+    "operational_mutation",
+    "implicit_operational_behavior",
+)
+
+V4_5B_3_EXPLAINABILITY_SURFACE_DISABLED_COUNTER_NAMES: tuple[str, ...] = (
+    "enabled_runtime_execution_count",
+    "enabled_orchestration_authorization_count",
+    "enabled_orchestration_approval_count",
+    "enabled_orchestration_dispatch_count",
+    "enabled_orchestration_routing_count",
+    "enabled_orchestration_traversal_count",
+    "enabled_orchestration_scheduling_count",
+    "enabled_orchestration_sequencing_count",
+    "enabled_orchestration_decision_count",
+    "enabled_orchestration_recommendation_count",
+    "enabled_explainability_authorization_count",
+    "enabled_explainability_approval_count",
+    "enabled_explainability_ranking_count",
+    "enabled_explainability_recommendation_count",
+    "enabled_remediation_count",
+    "enabled_repair_count",
+    "enabled_mitigation_count",
+    "enabled_auto_correction_count",
+    "enabled_planner_integration_count",
+    "enabled_production_consumption_count",
+    "enabled_runtime_mutation_count",
+    "enabled_operational_mutation_count",
+)
+
+V4_5B_3_EXPLAINABILITY_SURFACE_DETERMINISTIC_GUARANTEES: tuple[str, ...] = (
+    "deterministic_explainability_surface_identity",
+    "deterministic_support_state_explanation_visibility",
+    "deterministic_evidence_to_explanation_mapping",
+    "deterministic_limitation_explanation_visibility",
+    "deterministic_public_trust_explanation_visibility",
+    "deterministic_continuity_explanation_visibility",
+    "deterministic_unsupported_state_explanation_visibility",
+    "stable_replay_safe_serialization",
+    "stable_replay_safe_hashing",
+    "lineage_continuity_preserved",
+    "provenance_continuity_preserved",
+    "publicly_transparent_descriptive_only_explainability_surfaces",
+)
+
+V4_5B_3_EXPLAINABILITY_SURFACE_INHERITED_PROHIBITIONS: tuple[str, ...] = (
+    "orchestration_execution_prohibited",
+    "orchestration_authorization_prohibited",
+    "orchestration_approval_prohibited",
+    "orchestration_dispatch_prohibited",
+    "orchestration_routing_prohibited",
+    "orchestration_traversal_prohibited",
+    "orchestration_scheduling_prohibited",
+    "orchestration_sequencing_prohibited",
+    "orchestration_decisions_prohibited",
+    "orchestration_recommendations_prohibited",
+    "explainability_based_authorization_prohibited",
+    "explainability_based_approval_prohibited",
+    "explainability_based_ranking_prohibited",
+    "explainability_based_recommendation_prohibited",
+    "automated_remediation_prohibited",
+    "automated_repair_prohibited",
+    "automated_mitigation_prohibited",
+    "automated_correction_prohibited",
+    "planner_integration_prohibited",
+    "production_consumption_prohibited",
+    "runtime_mutation_prohibited",
+    "operational_mutation_prohibited",
+    "implicit_operational_behavior_prohibited",
+)
+
+V4_5B_3_EXPLAINABILITY_SURFACE_INHERITED_CONSTRAINTS: tuple[str, ...] = (
+    "deterministic",
+    "governance-safe",
+    "replay-safe",
+    "rollback-safe",
+    "lineage-safe",
+    "provenance-safe",
+    "integrity-safe",
+    "explainability-first",
+    "fail-visible",
+    "descriptive-only",
+    "publicly transparent",
+    "NON-operational",
+    "NON-authorizing",
+    "NON-approving",
+    "NON-executing",
+    "NON-remediating",
+    "NON-runtime-mutating",
+    "NON-ranking",
+    "NON-recommending",
+)
+
+V4_5B_3_EXPLAINABILITY_SURFACE_EXPLICIT_LIMITATIONS: tuple[str, ...] = (
+    "explainability_surfaces_do_not_authorize",
+    "explainability_surfaces_do_not_approve",
+    "explainability_surfaces_do_not_rank",
+    "explainability_surfaces_do_not_recommend",
+    "explainability_surfaces_do_not_execute",
+    "explainability_surfaces_do_not_enable_production",
+    "explainability_surfaces_do_not_imply_correctness_guarantees",
+    "explainability_surfaces_do_not_imply_execution_safety",
+    "explainability_surfaces_do_not_remediate_or_repair",
+    "explainability_surfaces_do_not_mitigate_or_correct",
+    "explainability_surfaces_do_not_integrate_planners",
+    "explainability_surfaces_do_not_mutate_runtime_state",
+)
+
+
+def _set_tuple_field(instance: object, field_name: str) -> None:
+    object.__setattr__(instance, field_name, tuple(getattr(instance, field_name)))
+
+
+@dataclass(frozen=True)
+class ExplainabilitySurfaceIdentity:
+    explainability_surface_id: str
+    explanation_summary_id: str
+    support_visibility_reference_id: str
+    evidence_reference_id: str
+    continuity_reference_id: str
+    trust_summary_reference_id: str
+    diagnostics_reference_id: str
+    lineage_reference_id: str
+    provenance_reference_id: str
+    phase_id: str
+    schema_version: str
+    generated_at: str
+    classification: str
+    source_support_status_report_reference: str
+    source_support_status_hash_reference: str
+
+
+@dataclass(frozen=True)
+class ExplainabilitySurfaceRecord:
+    surface_record_id: str
+    explainability_surface_id: str
+    explanation_summary_id: str
+    support_visibility_reference_id: str
+    evidence_reference_id: str
+    continuity_reference_id: str
+    trust_summary_reference_id: str
+    diagnostics_reference_id: str
+    lineage_reference_id: str
+    provenance_reference_id: str
+    visibility_state: str
+    deterministic_order: int
+    descriptive_only: bool = True
+    publicly_transparent: bool = True
+    fail_visible: bool = True
+    non_authorizing: bool = True
+    non_approving: bool = True
+    explainability_authority_enabled: bool = False
+    authorization_enabled: bool = False
+    approval_enabled: bool = False
+    ranking_enabled: bool = False
+    recommendation_enabled: bool = False
+    execution_enabled: bool = False
+    production_enablement_enabled: bool = False
+
+
+@dataclass(frozen=True)
+class SupportStateExplanationSurface:
+    support_state_explanation_id: str
+    explanation_type: str
+    evidence_reference_ids: tuple[str, ...]
+    explanation_visibility_state: str
+    deterministic_order: int
+    descriptive_only: bool = True
+    recommendation_enabled: bool = False
+    ranking_enabled: bool = False
+    authorization_enabled: bool = False
+    approval_enabled: bool = False
+    correctness_guarantee_enabled: bool = False
+    operational_readiness_enabled: bool = False
+    execution_safety_enabled: bool = False
+
+    def __post_init__(self) -> None:
+        _set_tuple_field(self, "evidence_reference_ids")
+
+
+@dataclass(frozen=True)
+class EvidenceToExplanationMapping:
+    evidence_mapping_id: str
+    mapping_type: str
+    evidence_reference_ids: tuple[str, ...]
+    explanation_reference_ids: tuple[str, ...]
+    mapping_state: str
+    deterministic_order: int
+    descriptive_only: bool = True
+    replay_safe: bool = True
+    provenance_safe: bool = True
+    trust_scoring_enabled: bool = False
+    authorization_enabled: bool = False
+    approval_enabled: bool = False
+    ranking_enabled: bool = False
+    recommendation_enabled: bool = False
+
+    def __post_init__(self) -> None:
+        _set_tuple_field(self, "evidence_reference_ids")
+        _set_tuple_field(self, "explanation_reference_ids")
+
+
+@dataclass(frozen=True)
+class LimitationExplanationVisibility:
+    limitation_explanation_id: str
+    limitation_type: str
+    evidence_reference_ids: tuple[str, ...]
+    explanation_visibility_state: str
+    deterministic_order: int
+    descriptive_only: bool = True
+    operational_fallback_enabled: bool = False
+    authorization_enabled: bool = False
+    approval_enabled: bool = False
+    recommendation_enabled: bool = False
+
+    def __post_init__(self) -> None:
+        _set_tuple_field(self, "evidence_reference_ids")
+
+
+@dataclass(frozen=True)
+class PublicTrustExplanationVisibility:
+    trust_explanation_id: str
+    trust_explanation_type: str
+    evidence_reference_ids: tuple[str, ...]
+    explanation_visibility_state: str
+    deterministic_order: int
+    descriptive_only: bool = True
+    authorization_enabled: bool = False
+    approval_enabled: bool = False
+    execution_semantics_enabled: bool = False
+    operational_enabled: bool = False
+
+    def __post_init__(self) -> None:
+        _set_tuple_field(self, "evidence_reference_ids")
+
+
+@dataclass(frozen=True)
+class ContinuityExplanationVisibility:
+    continuity_explanation_id: str
+    continuity_explanation_type: str
+    continuity_reference_id: str
+    evidence_reference_ids: tuple[str, ...]
+    explanation_visibility_state: str
+    deterministic_order: int
+    descriptive_only: bool = True
+    restoration_enabled: bool = False
+    remediation_enabled: bool = False
+    repair_enabled: bool = False
+    authorization_enabled: bool = False
+
+    def __post_init__(self) -> None:
+        _set_tuple_field(self, "evidence_reference_ids")
+
+
+@dataclass(frozen=True)
+class UnsupportedStateExplanationVisibility:
+    unsupported_explanation_id: str
+    unsupported_state_type: str
+    evidence_reference_ids: tuple[str, ...]
+    explanation_visibility_state: str
+    deterministic_order: int
+    descriptive_only: bool = True
+    fail_visible: bool = True
+    suppression_enabled: bool = False
+    hidden_fallback_enabled: bool = False
+    authorization_enabled: bool = False
+    approval_enabled: bool = False
+    remediation_enabled: bool = False
+
+    def __post_init__(self) -> None:
+        _set_tuple_field(self, "evidence_reference_ids")
+
+
+@dataclass(frozen=True)
+class ExplanationSummaryRecord:
+    explanation_summary_record_id: str
+    explanation_summary_id: str
+    summary_type: str
+    evidence_reference_ids: tuple[str, ...]
+    summary_state: str
+    deterministic_order: int
+    descriptive_only: bool = True
+    authorization_enabled: bool = False
+    approval_enabled: bool = False
+    ranking_enabled: bool = False
+    recommendation_enabled: bool = False
+    execution_enablement_enabled: bool = False
+    production_enablement_enabled: bool = False
+
+    def __post_init__(self) -> None:
+        _set_tuple_field(self, "evidence_reference_ids")
+
+
+@dataclass(frozen=True)
+class ExplanationDiagnosticRecord:
+    diagnostic_id: str
+    diagnostic_type: str
+    evidence_reference_ids: tuple[str, ...]
+    message: str
+    visibility_state: str
+    deterministic_order: int
+    fail_visible: bool = True
+    descriptive_only: bool = True
+    silent_fallback_enabled: bool = False
+    hidden_fallback_enabled: bool = False
+    authorization_enabled: bool = False
+    approval_enabled: bool = False
+    remediation_enabled: bool = False
+    repair_enabled: bool = False
+    mitigation_enabled: bool = False
+    auto_correction_enabled: bool = False
+    ranking_enabled: bool = False
+    recommendation_enabled: bool = False
+    orchestration_response_enabled: bool = False
+
+    def __post_init__(self) -> None:
+        _set_tuple_field(self, "evidence_reference_ids")
+
+
+@dataclass(frozen=True)
+class UnsupportedExplanationOperationalStateVisibility:
+    state_id: str
+    unsupported_state: str
+    explicit_reason: str
+    evidence_reference_ids: tuple[str, ...]
+    visibility_state: str
+    deterministic_order: int
+    fail_visible: bool = True
+    descriptive_only: bool = True
+    authorization_enabled: bool = False
+    approval_enabled: bool = False
+    operational_enabled: bool = False
+    remediation_enabled: bool = False
+    repair_enabled: bool = False
+    mitigation_enabled: bool = False
+    automated_correction_enabled: bool = False
+    ranking_enabled: bool = False
+    recommendation_enabled: bool = False
+    suppression_enabled: bool = False
+
+    def __post_init__(self) -> None:
+        _set_tuple_field(self, "evidence_reference_ids")
+
+
+@dataclass(frozen=True)
+class ExplainabilitySurfaceIntelligence:
+    surface_identity: ExplainabilitySurfaceIdentity
+    surface_records: tuple[ExplainabilitySurfaceRecord, ...]
+    support_state_explanations: tuple[SupportStateExplanationSurface, ...]
+    evidence_to_explanation_mappings: tuple[EvidenceToExplanationMapping, ...]
+    limitation_explanations: tuple[LimitationExplanationVisibility, ...]
+    trust_explanations: tuple[PublicTrustExplanationVisibility, ...]
+    continuity_explanations: tuple[ContinuityExplanationVisibility, ...]
+    unsupported_state_explanations: tuple[UnsupportedStateExplanationVisibility, ...]
+    explanation_summaries: tuple[ExplanationSummaryRecord, ...]
+    explanation_diagnostics: tuple[ExplanationDiagnosticRecord, ...]
+    unsupported_operational_state_visibility: tuple[
+        UnsupportedExplanationOperationalStateVisibility, ...
+    ]
+    deterministic_guarantees: tuple[str, ...]
+    inherited_prohibitions: tuple[str, ...]
+    inherited_constraints: tuple[str, ...]
+    explicit_limitations: tuple[str, ...]
+    explainability_surface_statement: str = EXPLAINABILITY_SURFACE_STATEMENT
+    explainability_visibility_non_authority_statement: str = (
+        EXPLAINABILITY_VISIBILITY_NON_AUTHORITY_STATEMENT
+    )
+    descriptive_only: bool = True
+    publicly_transparent: bool = True
+    non_operational: bool = True
+    non_authorizing: bool = True
+    non_approving: bool = True
+    non_executing: bool = True
+    non_remediating: bool = True
+    non_runtime_mutating: bool = True
+    non_ranking: bool = True
+    non_recommending: bool = True
+    runtime_execution_enabled: bool = False
+    orchestration_execution_enabled: bool = False
+    orchestration_authorization_enabled: bool = False
+    orchestration_approval_enabled: bool = False
+    orchestration_dispatch_enabled: bool = False
+    orchestration_routing_enabled: bool = False
+    orchestration_traversal_enabled: bool = False
+    orchestration_scheduling_enabled: bool = False
+    orchestration_sequencing_enabled: bool = False
+    orchestration_decision_enabled: bool = False
+    orchestration_recommendation_enabled: bool = False
+    explainability_authorization_enabled: bool = False
+    explainability_approval_enabled: bool = False
+    explainability_ranking_enabled: bool = False
+    explainability_recommendation_enabled: bool = False
+    remediation_enabled: bool = False
+    repair_enabled: bool = False
+    mitigation_enabled: bool = False
+    auto_correction_enabled: bool = False
+    ranking_enabled: bool = False
+    recommendation_enabled: bool = False
+    planner_integration_enabled: bool = False
+    planner_execution_enabled: bool = False
+    production_consumption_enabled: bool = False
+    runtime_mutation_enabled: bool = False
+    operational_mutation_enabled: bool = False
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "surface_records",
+            "support_state_explanations",
+            "evidence_to_explanation_mappings",
+            "limitation_explanations",
+            "trust_explanations",
+            "continuity_explanations",
+            "unsupported_state_explanations",
+            "explanation_summaries",
+            "explanation_diagnostics",
+            "unsupported_operational_state_visibility",
+            "deterministic_guarantees",
+            "inherited_prohibitions",
+            "inherited_constraints",
+            "explicit_limitations",
+        ):
+            object.__setattr__(self, field_name, tuple(getattr(self, field_name)))
+
+
+def default_explainability_surface_identity() -> ExplainabilitySurfaceIdentity:
+    return ExplainabilitySurfaceIdentity(
+        explainability_surface_id="v4_5b_3_explainability_surfaces",
+        explanation_summary_id="v4_5b_3_explanation_summary",
+        support_visibility_reference_id="support::v4_5b_2.public_support",
+        evidence_reference_id="evidence::v4_5b_3.explainability_surfaces",
+        continuity_reference_id="continuity::v4_5b_3.explainability_surfaces",
+        trust_summary_reference_id="trust::v4_5b_3.explainability_surfaces",
+        diagnostics_reference_id="diagnostics::v4_5b_3.explainability_surfaces",
+        lineage_reference_id="lineage::v4_5b_3.explainability_surfaces",
+        provenance_reference_id="provenance::v4_5b_3.explainability_surfaces",
+        phase_id=V4_5B_3_EXPLAINABILITY_SURFACE_PHASE_ID,
+        schema_version=V4_5B_3_EXPLAINABILITY_SURFACE_SCHEMA_VERSION,
+        generated_at=V4_5B_3_EXPLAINABILITY_SURFACE_GENERATED_AT,
+        classification=V4_5B_3_EXPLAINABILITY_SURFACE_CLASSIFICATION,
+        source_support_status_report_reference=(
+            V4_5B_2_SUPPORT_STATUS_VISIBILITY_REPORT_REFERENCE
+        ),
+        source_support_status_hash_reference=(
+            V4_5B_2_SUPPORT_STATUS_VISIBILITY_REPORT_HASH_REFERENCE
+        ),
+    )
+
+
+def default_surface_records() -> tuple[ExplainabilitySurfaceRecord, ...]:
+    identity = default_explainability_surface_identity()
+    return (
+        ExplainabilitySurfaceRecord(
+            surface_record_id="public_explainability_surface_foundation",
+            explainability_surface_id=identity.explainability_surface_id,
+            explanation_summary_id=identity.explanation_summary_id,
+            support_visibility_reference_id=identity.support_visibility_reference_id,
+            evidence_reference_id=identity.evidence_reference_id,
+            continuity_reference_id=identity.continuity_reference_id,
+            trust_summary_reference_id=identity.trust_summary_reference_id,
+            diagnostics_reference_id=identity.diagnostics_reference_id,
+            lineage_reference_id=identity.lineage_reference_id,
+            provenance_reference_id=identity.provenance_reference_id,
+            visibility_state="public_explainability_surface_visible",
+            deterministic_order=1,
+        ),
+    )
+
+
+def default_support_state_explanations() -> tuple[
+    SupportStateExplanationSurface, ...
+]:
+    return tuple(
+        SupportStateExplanationSurface(
+            support_state_explanation_id=f"support_state_explanation_{item}",
+            explanation_type=item,
+            evidence_reference_ids=(f"evidence_{item}",),
+            explanation_visibility_state="support_state_explanation_visible",
+            deterministic_order=order,
+        )
+        for order, item in enumerate(SUPPORT_STATE_EXPLANATION_TYPES, start=1)
+    )
+
+
+def default_evidence_to_explanation_mappings() -> tuple[
+    EvidenceToExplanationMapping, ...
+]:
+    return tuple(
+        EvidenceToExplanationMapping(
+            evidence_mapping_id=f"evidence_to_explanation_{item}",
+            mapping_type=item,
+            evidence_reference_ids=(f"evidence_{item}",),
+            explanation_reference_ids=(f"explanation_{item}",),
+            mapping_state="evidence_to_explanation_mapping_replay_safe",
+            deterministic_order=order,
+        )
+        for order, item in enumerate(
+            EVIDENCE_TO_EXPLANATION_MAPPING_TYPES,
+            start=1,
+        )
+    )
+
+
+def default_limitation_explanations() -> tuple[LimitationExplanationVisibility, ...]:
+    return tuple(
+        LimitationExplanationVisibility(
+            limitation_explanation_id=f"limitation_explanation_{item}",
+            limitation_type=item,
+            evidence_reference_ids=(f"evidence_{item}",),
+            explanation_visibility_state="limitation_explanation_visible",
+            deterministic_order=order,
+        )
+        for order, item in enumerate(LIMITATION_EXPLANATION_TYPES, start=1)
+    )
+
+
+def default_trust_explanations() -> tuple[PublicTrustExplanationVisibility, ...]:
+    return tuple(
+        PublicTrustExplanationVisibility(
+            trust_explanation_id=f"trust_explanation_{item}",
+            trust_explanation_type=item,
+            evidence_reference_ids=(f"evidence_{item}",),
+            explanation_visibility_state="public_trust_explanation_visible",
+            deterministic_order=order,
+        )
+        for order, item in enumerate(TRUST_EXPLANATION_TYPES, start=1)
+    )
+
+
+def default_continuity_explanations() -> tuple[ContinuityExplanationVisibility, ...]:
+    return tuple(
+        ContinuityExplanationVisibility(
+            continuity_explanation_id=f"continuity_explanation_{item}",
+            continuity_explanation_type=item,
+            continuity_reference_id=f"continuity_reference_{item}",
+            evidence_reference_ids=(f"evidence_{item}",),
+            explanation_visibility_state="continuity_explanation_visible",
+            deterministic_order=order,
+        )
+        for order, item in enumerate(CONTINUITY_EXPLANATION_TYPES, start=1)
+    )
+
+
+def default_unsupported_state_explanations() -> tuple[
+    UnsupportedStateExplanationVisibility, ...
+]:
+    return tuple(
+        UnsupportedStateExplanationVisibility(
+            unsupported_explanation_id=f"unsupported_state_explanation_{item}",
+            unsupported_state_type=item,
+            evidence_reference_ids=(f"evidence_{item}",),
+            explanation_visibility_state="unsupported_state_explanation_fail_visible",
+            deterministic_order=order,
+        )
+        for order, item in enumerate(UNSUPPORTED_STATE_EXPLANATION_TYPES, start=1)
+    )
+
+
+def default_explanation_summaries() -> tuple[ExplanationSummaryRecord, ...]:
+    identity = default_explainability_surface_identity()
+    return tuple(
+        ExplanationSummaryRecord(
+            explanation_summary_record_id=f"explanation_summary_{item}",
+            explanation_summary_id=identity.explanation_summary_id,
+            summary_type=item,
+            evidence_reference_ids=(f"evidence_{item}",),
+            summary_state="explanation_summary_descriptive_only",
+            deterministic_order=order,
+        )
+        for order, item in enumerate(EXPLANATION_SUMMARY_TYPES, start=1)
+    )
+
+
+def default_explanation_diagnostics() -> tuple[ExplanationDiagnosticRecord, ...]:
+    return tuple(
+        ExplanationDiagnosticRecord(
+            diagnostic_id=f"explanation_diagnostic_{item}",
+            diagnostic_type=item,
+            evidence_reference_ids=(f"evidence_{item}",),
+            message=(
+                f"{item} remains explicit, fail-visible, and descriptive-only "
+                "for public explainability surfaces."
+            ),
+            visibility_state="fail_visible_explanation_diagnostic_visible",
+            deterministic_order=order,
+        )
+        for order, item in enumerate(EXPLANATION_DIAGNOSTIC_TYPES, start=1)
+    )
+
+
+def default_unsupported_operational_state_visibility() -> tuple[
+    UnsupportedExplanationOperationalStateVisibility, ...
+]:
+    return tuple(
+        UnsupportedExplanationOperationalStateVisibility(
+            state_id=f"unsupported_explanation_operational_state_{item}",
+            unsupported_state=item,
+            explicit_reason=(
+                f"{item} remains unsupported for v4.5B.3 public "
+                "explainability surfaces."
+            ),
+            evidence_reference_ids=(
+                "evidence_unsupported_explanation_operational_states",
+            ),
+            visibility_state="unsupported_explanation_operational_state_fail_visible",
+            deterministic_order=order,
+        )
+        for order, item in enumerate(
+            UNSUPPORTED_EXPLANATION_OPERATIONAL_STATES,
+            start=1,
+        )
+    )
+
+
+def default_v4_5b_3_explainability_surfaces() -> ExplainabilitySurfaceIntelligence:
+    return ExplainabilitySurfaceIntelligence(
+        surface_identity=default_explainability_surface_identity(),
+        surface_records=default_surface_records(),
+        support_state_explanations=default_support_state_explanations(),
+        evidence_to_explanation_mappings=default_evidence_to_explanation_mappings(),
+        limitation_explanations=default_limitation_explanations(),
+        trust_explanations=default_trust_explanations(),
+        continuity_explanations=default_continuity_explanations(),
+        unsupported_state_explanations=default_unsupported_state_explanations(),
+        explanation_summaries=default_explanation_summaries(),
+        explanation_diagnostics=default_explanation_diagnostics(),
+        unsupported_operational_state_visibility=(
+            default_unsupported_operational_state_visibility()
+        ),
+        deterministic_guarantees=(
+            V4_5B_3_EXPLAINABILITY_SURFACE_DETERMINISTIC_GUARANTEES
+        ),
+        inherited_prohibitions=(
+            V4_5B_3_EXPLAINABILITY_SURFACE_INHERITED_PROHIBITIONS
+        ),
+        inherited_constraints=V4_5B_3_EXPLAINABILITY_SURFACE_INHERITED_CONSTRAINTS,
+        explicit_limitations=V4_5B_3_EXPLAINABILITY_SURFACE_EXPLICIT_LIMITATIONS,
+    )

--- a/backend/app/public_trust_visibility/v4_5b_3_explainability_surface_serialization.py
+++ b/backend/app/public_trust_visibility/v4_5b_3_explainability_surface_serialization.py
@@ -1,0 +1,230 @@
+"""Deterministic serialization for v4.5B.3 explainability surfaces."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, is_dataclass
+from typing import Any, Mapping
+
+from .v4_5b_3_explainability_surface_models import (
+    ContinuityExplanationVisibility,
+    EvidenceToExplanationMapping,
+    ExplainabilitySurfaceIdentity,
+    ExplainabilitySurfaceIntelligence,
+    ExplainabilitySurfaceRecord,
+    ExplanationDiagnosticRecord,
+    ExplanationSummaryRecord,
+    LimitationExplanationVisibility,
+    PublicTrustExplanationVisibility,
+    SupportStateExplanationSurface,
+    UnsupportedExplanationOperationalStateVisibility,
+    UnsupportedStateExplanationVisibility,
+)
+
+
+def _sorted_tuple(values: tuple[str, ...] | list[str]) -> list[str]:
+    return sorted(tuple(values or ()))
+
+
+def canonicalize_v4_5b_3_explainability_surface_evidence(payload: Any) -> Any:
+    if is_dataclass(payload) and not isinstance(payload, type):
+        return canonicalize_v4_5b_3_explainability_surface_evidence(asdict(payload))
+    if isinstance(payload, Mapping):
+        return {
+            str(key): canonicalize_v4_5b_3_explainability_surface_evidence(value)
+            for key, value in sorted(payload.items(), key=lambda item: str(item[0]))
+        }
+    if isinstance(payload, tuple | list):
+        return [
+            canonicalize_v4_5b_3_explainability_surface_evidence(value)
+            for value in payload
+        ]
+    return payload
+
+
+def stable_serialize_v4_5b_3_explainability_surfaces(payload: Any) -> str:
+    return json.dumps(
+        canonicalize_v4_5b_3_explainability_surface_evidence(payload),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        default=str,
+    )
+
+
+def _export_with_sorted_references(record: object) -> dict[str, Any]:
+    data = asdict(record)
+    if "evidence_reference_ids" in data:
+        data["evidence_reference_ids"] = _sorted_tuple(data["evidence_reference_ids"])
+    if "explanation_reference_ids" in data:
+        data["explanation_reference_ids"] = _sorted_tuple(
+            data["explanation_reference_ids"]
+        )
+    return data
+
+
+def export_explainability_surface_identity(
+    identity: ExplainabilitySurfaceIdentity,
+) -> dict[str, Any]:
+    return asdict(identity)
+
+
+def export_explainability_surface_record(
+    record: ExplainabilitySurfaceRecord,
+) -> dict[str, Any]:
+    return asdict(record)
+
+
+def export_support_state_explanation_surface(
+    record: SupportStateExplanationSurface,
+) -> dict[str, Any]:
+    return _export_with_sorted_references(record)
+
+
+def export_evidence_to_explanation_mapping(
+    record: EvidenceToExplanationMapping,
+) -> dict[str, Any]:
+    return _export_with_sorted_references(record)
+
+
+def export_limitation_explanation_visibility(
+    record: LimitationExplanationVisibility,
+) -> dict[str, Any]:
+    return _export_with_sorted_references(record)
+
+
+def export_public_trust_explanation_visibility(
+    record: PublicTrustExplanationVisibility,
+) -> dict[str, Any]:
+    return _export_with_sorted_references(record)
+
+
+def export_continuity_explanation_visibility(
+    record: ContinuityExplanationVisibility,
+) -> dict[str, Any]:
+    return _export_with_sorted_references(record)
+
+
+def export_unsupported_state_explanation_visibility(
+    record: UnsupportedStateExplanationVisibility,
+) -> dict[str, Any]:
+    return _export_with_sorted_references(record)
+
+
+def export_explanation_summary_record(record: ExplanationSummaryRecord) -> dict[str, Any]:
+    return _export_with_sorted_references(record)
+
+
+def export_explanation_diagnostic_record(
+    record: ExplanationDiagnosticRecord,
+) -> dict[str, Any]:
+    return _export_with_sorted_references(record)
+
+
+def export_unsupported_explanation_operational_state_visibility(
+    record: UnsupportedExplanationOperationalStateVisibility,
+) -> dict[str, Any]:
+    return _export_with_sorted_references(record)
+
+
+def export_v4_5b_3_explainability_surfaces(
+    intelligence: ExplainabilitySurfaceIntelligence,
+) -> dict[str, Any]:
+    data = asdict(intelligence)
+    data["surface_identity"] = export_explainability_surface_identity(
+        intelligence.surface_identity
+    )
+    data["surface_records"] = [
+        export_explainability_surface_record(record)
+        for record in sorted(
+            intelligence.surface_records,
+            key=lambda item: (item.deterministic_order, item.surface_record_id),
+        )
+    ]
+    data["support_state_explanations"] = [
+        export_support_state_explanation_surface(record)
+        for record in sorted(
+            intelligence.support_state_explanations,
+            key=lambda item: (item.deterministic_order, item.support_state_explanation_id),
+        )
+    ]
+    data["evidence_to_explanation_mappings"] = [
+        export_evidence_to_explanation_mapping(record)
+        for record in sorted(
+            intelligence.evidence_to_explanation_mappings,
+            key=lambda item: (item.deterministic_order, item.evidence_mapping_id),
+        )
+    ]
+    data["limitation_explanations"] = [
+        export_limitation_explanation_visibility(record)
+        for record in sorted(
+            intelligence.limitation_explanations,
+            key=lambda item: (item.deterministic_order, item.limitation_explanation_id),
+        )
+    ]
+    data["trust_explanations"] = [
+        export_public_trust_explanation_visibility(record)
+        for record in sorted(
+            intelligence.trust_explanations,
+            key=lambda item: (item.deterministic_order, item.trust_explanation_id),
+        )
+    ]
+    data["continuity_explanations"] = [
+        export_continuity_explanation_visibility(record)
+        for record in sorted(
+            intelligence.continuity_explanations,
+            key=lambda item: (item.deterministic_order, item.continuity_explanation_id),
+        )
+    ]
+    data["unsupported_state_explanations"] = [
+        export_unsupported_state_explanation_visibility(record)
+        for record in sorted(
+            intelligence.unsupported_state_explanations,
+            key=lambda item: (item.deterministic_order, item.unsupported_explanation_id),
+        )
+    ]
+    data["explanation_summaries"] = [
+        export_explanation_summary_record(record)
+        for record in sorted(
+            intelligence.explanation_summaries,
+            key=lambda item: (
+                item.deterministic_order,
+                item.explanation_summary_record_id,
+            ),
+        )
+    ]
+    data["explanation_diagnostics"] = [
+        export_explanation_diagnostic_record(record)
+        for record in sorted(
+            intelligence.explanation_diagnostics,
+            key=lambda item: (item.deterministic_order, item.diagnostic_id),
+        )
+    ]
+    data["unsupported_operational_state_visibility"] = [
+        export_unsupported_explanation_operational_state_visibility(record)
+        for record in sorted(
+            intelligence.unsupported_operational_state_visibility,
+            key=lambda item: (item.deterministic_order, item.state_id),
+        )
+    ]
+    data["deterministic_guarantees"] = _sorted_tuple(data["deterministic_guarantees"])
+    data["inherited_prohibitions"] = _sorted_tuple(data["inherited_prohibitions"])
+    data["inherited_constraints"] = _sorted_tuple(data["inherited_constraints"])
+    data["explicit_limitations"] = _sorted_tuple(data["explicit_limitations"])
+    return data
+
+
+def serialize_explainability_surface_identity(
+    identity: ExplainabilitySurfaceIdentity,
+) -> str:
+    return stable_serialize_v4_5b_3_explainability_surfaces(
+        export_explainability_surface_identity(identity)
+    )
+
+
+def serialize_v4_5b_3_explainability_surfaces(
+    intelligence: ExplainabilitySurfaceIntelligence,
+) -> str:
+    return stable_serialize_v4_5b_3_explainability_surfaces(
+        export_v4_5b_3_explainability_surfaces(intelligence)
+    )

--- a/backend/app/public_trust_visibility/v4_5b_3_explainability_surface_visibility.py
+++ b/backend/app/public_trust_visibility/v4_5b_3_explainability_surface_visibility.py
@@ -1,0 +1,470 @@
+"""Visibility helpers for v4.5B.3 explainability surfaces."""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any, Iterable
+
+from .v4_5b_3_explainability_surface_models import (
+    CONTINUITY_EXPLANATION_TYPES,
+    EVIDENCE_TO_EXPLANATION_MAPPING_TYPES,
+    EXPLANATION_DIAGNOSTIC_TYPES,
+    EXPLANATION_SUMMARY_TYPES,
+    LIMITATION_EXPLANATION_TYPES,
+    SUPPORT_STATE_EXPLANATION_TYPES,
+    TRUST_EXPLANATION_TYPES,
+    UNSUPPORTED_EXPLANATION_OPERATIONAL_STATES,
+    UNSUPPORTED_STATE_EXPLANATION_TYPES,
+    ContinuityExplanationVisibility,
+    EvidenceToExplanationMapping,
+    ExplainabilitySurfaceIntelligence,
+    ExplainabilitySurfaceRecord,
+    ExplanationDiagnosticRecord,
+    ExplanationSummaryRecord,
+    LimitationExplanationVisibility,
+    PublicTrustExplanationVisibility,
+    SupportStateExplanationSurface,
+    UnsupportedExplanationOperationalStateVisibility,
+    UnsupportedStateExplanationVisibility,
+)
+
+
+def _ordered_ids(values: Iterable[str]) -> list[str]:
+    return sorted(tuple(values or ()))
+
+
+def _count(items: Iterable[str], expected: tuple[str, ...]) -> dict[str, int]:
+    counts = Counter(items)
+    return {item: int(counts.get(item, 0)) for item in expected}
+
+
+def count_support_state_explanation_types(
+    records: Iterable[SupportStateExplanationSurface],
+) -> dict[str, int]:
+    return _count(
+        (record.explanation_type for record in records),
+        SUPPORT_STATE_EXPLANATION_TYPES,
+    )
+
+
+def count_evidence_mapping_types(
+    records: Iterable[EvidenceToExplanationMapping],
+) -> dict[str, int]:
+    return _count(
+        (record.mapping_type for record in records),
+        EVIDENCE_TO_EXPLANATION_MAPPING_TYPES,
+    )
+
+
+def count_limitation_explanation_types(
+    records: Iterable[LimitationExplanationVisibility],
+) -> dict[str, int]:
+    return _count((record.limitation_type for record in records), LIMITATION_EXPLANATION_TYPES)
+
+
+def count_trust_explanation_types(
+    records: Iterable[PublicTrustExplanationVisibility],
+) -> dict[str, int]:
+    return _count((record.trust_explanation_type for record in records), TRUST_EXPLANATION_TYPES)
+
+
+def count_continuity_explanation_types(
+    records: Iterable[ContinuityExplanationVisibility],
+) -> dict[str, int]:
+    return _count(
+        (record.continuity_explanation_type for record in records),
+        CONTINUITY_EXPLANATION_TYPES,
+    )
+
+
+def count_unsupported_state_explanation_types(
+    records: Iterable[UnsupportedStateExplanationVisibility],
+) -> dict[str, int]:
+    return _count(
+        (record.unsupported_state_type for record in records),
+        UNSUPPORTED_STATE_EXPLANATION_TYPES,
+    )
+
+
+def count_explanation_summary_types(
+    records: Iterable[ExplanationSummaryRecord],
+) -> dict[str, int]:
+    return _count((record.summary_type for record in records), EXPLANATION_SUMMARY_TYPES)
+
+
+def count_explanation_diagnostic_types(
+    records: Iterable[ExplanationDiagnosticRecord],
+) -> dict[str, int]:
+    return _count((record.diagnostic_type for record in records), EXPLANATION_DIAGNOSTIC_TYPES)
+
+
+def count_unsupported_operational_states(
+    records: Iterable[UnsupportedExplanationOperationalStateVisibility],
+) -> dict[str, int]:
+    return _count(
+        (record.unsupported_state for record in records),
+        UNSUPPORTED_EXPLANATION_OPERATIONAL_STATES,
+    )
+
+
+def explanation_surface_summary(
+    records: Iterable[ExplainabilitySurfaceRecord],
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "surface_record_id": record.surface_record_id,
+            "explainability_surface_id": record.explainability_surface_id,
+            "explanation_summary_id": record.explanation_summary_id,
+            "support_visibility_reference_id": record.support_visibility_reference_id,
+            "evidence_reference_id": record.evidence_reference_id,
+            "continuity_reference_id": record.continuity_reference_id,
+            "trust_summary_reference_id": record.trust_summary_reference_id,
+            "diagnostics_reference_id": record.diagnostics_reference_id,
+            "lineage_reference_id": record.lineage_reference_id,
+            "provenance_reference_id": record.provenance_reference_id,
+            "descriptive_only": record.descriptive_only,
+            "publicly_transparent": record.publicly_transparent,
+            "fail_visible": record.fail_visible,
+            "explainability_authority_enabled": (
+                record.explainability_authority_enabled
+            ),
+            "authorization_enabled": record.authorization_enabled,
+            "approval_enabled": record.approval_enabled,
+            "ranking_enabled": record.ranking_enabled,
+            "recommendation_enabled": record.recommendation_enabled,
+        }
+        for record in sorted(
+            records,
+            key=lambda item: (item.deterministic_order, item.surface_record_id),
+        )
+    ]
+
+
+def support_state_explanation_summary(
+    records: Iterable[SupportStateExplanationSurface],
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "support_state_explanation_id": record.support_state_explanation_id,
+            "explanation_type": record.explanation_type,
+            "evidence_reference_ids": _ordered_ids(record.evidence_reference_ids),
+            "descriptive_only": record.descriptive_only,
+            "recommendation_enabled": record.recommendation_enabled,
+            "ranking_enabled": record.ranking_enabled,
+            "authorization_enabled": record.authorization_enabled,
+            "approval_enabled": record.approval_enabled,
+            "correctness_guarantee_enabled": record.correctness_guarantee_enabled,
+            "operational_readiness_enabled": record.operational_readiness_enabled,
+            "execution_safety_enabled": record.execution_safety_enabled,
+        }
+        for record in sorted(
+            records,
+            key=lambda item: (item.deterministic_order, item.support_state_explanation_id),
+        )
+    ]
+
+
+def evidence_to_explanation_mapping_summary(
+    records: Iterable[EvidenceToExplanationMapping],
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "evidence_mapping_id": record.evidence_mapping_id,
+            "mapping_type": record.mapping_type,
+            "evidence_reference_ids": _ordered_ids(record.evidence_reference_ids),
+            "explanation_reference_ids": _ordered_ids(record.explanation_reference_ids),
+            "descriptive_only": record.descriptive_only,
+            "replay_safe": record.replay_safe,
+            "provenance_safe": record.provenance_safe,
+            "trust_scoring_enabled": record.trust_scoring_enabled,
+            "authorization_enabled": record.authorization_enabled,
+            "approval_enabled": record.approval_enabled,
+            "ranking_enabled": record.ranking_enabled,
+            "recommendation_enabled": record.recommendation_enabled,
+        }
+        for record in sorted(
+            records,
+            key=lambda item: (item.deterministic_order, item.evidence_mapping_id),
+        )
+    ]
+
+
+def limitation_explanation_summary(
+    records: Iterable[LimitationExplanationVisibility],
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "limitation_explanation_id": record.limitation_explanation_id,
+            "limitation_type": record.limitation_type,
+            "evidence_reference_ids": _ordered_ids(record.evidence_reference_ids),
+            "descriptive_only": record.descriptive_only,
+            "operational_fallback_enabled": record.operational_fallback_enabled,
+            "authorization_enabled": record.authorization_enabled,
+            "approval_enabled": record.approval_enabled,
+            "recommendation_enabled": record.recommendation_enabled,
+        }
+        for record in sorted(
+            records,
+            key=lambda item: (item.deterministic_order, item.limitation_explanation_id),
+        )
+    ]
+
+
+def trust_explanation_summary(
+    records: Iterable[PublicTrustExplanationVisibility],
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "trust_explanation_id": record.trust_explanation_id,
+            "trust_explanation_type": record.trust_explanation_type,
+            "evidence_reference_ids": _ordered_ids(record.evidence_reference_ids),
+            "descriptive_only": record.descriptive_only,
+            "authorization_enabled": record.authorization_enabled,
+            "approval_enabled": record.approval_enabled,
+            "execution_semantics_enabled": record.execution_semantics_enabled,
+            "operational_enabled": record.operational_enabled,
+        }
+        for record in sorted(
+            records,
+            key=lambda item: (item.deterministic_order, item.trust_explanation_id),
+        )
+    ]
+
+
+def continuity_explanation_summary(
+    records: Iterable[ContinuityExplanationVisibility],
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "continuity_explanation_id": record.continuity_explanation_id,
+            "continuity_explanation_type": record.continuity_explanation_type,
+            "continuity_reference_id": record.continuity_reference_id,
+            "evidence_reference_ids": _ordered_ids(record.evidence_reference_ids),
+            "descriptive_only": record.descriptive_only,
+            "restoration_enabled": record.restoration_enabled,
+            "remediation_enabled": record.remediation_enabled,
+            "repair_enabled": record.repair_enabled,
+            "authorization_enabled": record.authorization_enabled,
+        }
+        for record in sorted(
+            records,
+            key=lambda item: (item.deterministic_order, item.continuity_explanation_id),
+        )
+    ]
+
+
+def unsupported_state_explanation_summary(
+    records: Iterable[UnsupportedStateExplanationVisibility],
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "unsupported_explanation_id": record.unsupported_explanation_id,
+            "unsupported_state_type": record.unsupported_state_type,
+            "evidence_reference_ids": _ordered_ids(record.evidence_reference_ids),
+            "descriptive_only": record.descriptive_only,
+            "fail_visible": record.fail_visible,
+            "suppression_enabled": record.suppression_enabled,
+            "hidden_fallback_enabled": record.hidden_fallback_enabled,
+            "authorization_enabled": record.authorization_enabled,
+            "approval_enabled": record.approval_enabled,
+            "remediation_enabled": record.remediation_enabled,
+        }
+        for record in sorted(
+            records,
+            key=lambda item: (item.deterministic_order, item.unsupported_explanation_id),
+        )
+    ]
+
+
+def explanation_summary_visibility(
+    records: Iterable[ExplanationSummaryRecord],
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "explanation_summary_record_id": record.explanation_summary_record_id,
+            "explanation_summary_id": record.explanation_summary_id,
+            "summary_type": record.summary_type,
+            "evidence_reference_ids": _ordered_ids(record.evidence_reference_ids),
+            "summary_state": record.summary_state,
+            "descriptive_only": record.descriptive_only,
+            "authorization_enabled": record.authorization_enabled,
+            "approval_enabled": record.approval_enabled,
+            "ranking_enabled": record.ranking_enabled,
+            "recommendation_enabled": record.recommendation_enabled,
+            "execution_enablement_enabled": record.execution_enablement_enabled,
+            "production_enablement_enabled": record.production_enablement_enabled,
+        }
+        for record in sorted(
+            records,
+            key=lambda item: (
+                item.deterministic_order,
+                item.explanation_summary_record_id,
+            ),
+        )
+    ]
+
+
+def explanation_diagnostic_summary(
+    records: Iterable[ExplanationDiagnosticRecord],
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "diagnostic_id": record.diagnostic_id,
+            "diagnostic_type": record.diagnostic_type,
+            "evidence_reference_ids": _ordered_ids(record.evidence_reference_ids),
+            "message": record.message,
+            "fail_visible": record.fail_visible,
+            "descriptive_only": record.descriptive_only,
+            "silent_fallback_enabled": record.silent_fallback_enabled,
+            "hidden_fallback_enabled": record.hidden_fallback_enabled,
+            "authorization_enabled": record.authorization_enabled,
+            "approval_enabled": record.approval_enabled,
+            "remediation_enabled": record.remediation_enabled,
+            "repair_enabled": record.repair_enabled,
+            "mitigation_enabled": record.mitigation_enabled,
+            "auto_correction_enabled": record.auto_correction_enabled,
+            "ranking_enabled": record.ranking_enabled,
+            "recommendation_enabled": record.recommendation_enabled,
+            "orchestration_response_enabled": record.orchestration_response_enabled,
+        }
+        for record in sorted(
+            records,
+            key=lambda item: (item.deterministic_order, item.diagnostic_id),
+        )
+    ]
+
+
+def unsupported_operational_state_summary(
+    records: Iterable[UnsupportedExplanationOperationalStateVisibility],
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "state_id": record.state_id,
+            "unsupported_state": record.unsupported_state,
+            "explicit_reason": record.explicit_reason,
+            "evidence_reference_ids": _ordered_ids(record.evidence_reference_ids),
+            "fail_visible": record.fail_visible,
+            "descriptive_only": record.descriptive_only,
+            "authorization_enabled": record.authorization_enabled,
+            "approval_enabled": record.approval_enabled,
+            "operational_enabled": record.operational_enabled,
+            "remediation_enabled": record.remediation_enabled,
+            "repair_enabled": record.repair_enabled,
+            "mitigation_enabled": record.mitigation_enabled,
+            "automated_correction_enabled": record.automated_correction_enabled,
+            "ranking_enabled": record.ranking_enabled,
+            "recommendation_enabled": record.recommendation_enabled,
+            "suppression_enabled": record.suppression_enabled,
+        }
+        for record in sorted(
+            records,
+            key=lambda item: (item.deterministic_order, item.state_id),
+        )
+    ]
+
+
+def validate_required_explainability_surfaces(
+    intelligence: ExplainabilitySurfaceIntelligence,
+) -> dict[str, Any]:
+    support_counts = count_support_state_explanation_types(
+        intelligence.support_state_explanations
+    )
+    mapping_counts = count_evidence_mapping_types(
+        intelligence.evidence_to_explanation_mappings
+    )
+    limitation_counts = count_limitation_explanation_types(
+        intelligence.limitation_explanations
+    )
+    trust_counts = count_trust_explanation_types(intelligence.trust_explanations)
+    continuity_counts = count_continuity_explanation_types(
+        intelligence.continuity_explanations
+    )
+    unsupported_counts = count_unsupported_state_explanation_types(
+        intelligence.unsupported_state_explanations
+    )
+    summary_counts = count_explanation_summary_types(
+        intelligence.explanation_summaries
+    )
+    diagnostic_counts = count_explanation_diagnostic_types(
+        intelligence.explanation_diagnostics
+    )
+    unsupported_operational_counts = count_unsupported_operational_states(
+        intelligence.unsupported_operational_state_visibility
+    )
+    missing = {
+        "missing_support_state_explanations": sorted(
+            key for key, value in support_counts.items() if value < 1
+        ),
+        "missing_evidence_mappings": sorted(
+            key for key, value in mapping_counts.items() if value < 1
+        ),
+        "missing_limitation_explanations": sorted(
+            key for key, value in limitation_counts.items() if value < 1
+        ),
+        "missing_trust_explanations": sorted(
+            key for key, value in trust_counts.items() if value < 1
+        ),
+        "missing_continuity_explanations": sorted(
+            key for key, value in continuity_counts.items() if value < 1
+        ),
+        "missing_unsupported_state_explanations": sorted(
+            key for key, value in unsupported_counts.items() if value < 1
+        ),
+        "missing_summaries": sorted(
+            key for key, value in summary_counts.items() if value < 1
+        ),
+        "missing_diagnostics": sorted(
+            key for key, value in diagnostic_counts.items() if value < 1
+        ),
+        "missing_unsupported_operational_states": sorted(
+            key for key, value in unsupported_operational_counts.items() if value < 1
+        ),
+    }
+    return {
+        "valid": not any(missing.values()),
+        "support_counts": support_counts,
+        "mapping_counts": mapping_counts,
+        "limitation_counts": limitation_counts,
+        "trust_counts": trust_counts,
+        "continuity_counts": continuity_counts,
+        "unsupported_counts": unsupported_counts,
+        "summary_counts": summary_counts,
+        "diagnostic_counts": diagnostic_counts,
+        "unsupported_operational_counts": unsupported_operational_counts,
+        **missing,
+    }
+
+
+def descriptive_only_explainability_surface_summary(
+    intelligence: ExplainabilitySurfaceIntelligence,
+) -> dict[str, Any]:
+    return {
+        "descriptive_only": intelligence.descriptive_only,
+        "publicly_transparent": intelligence.publicly_transparent,
+        "explainability_surface_statement": (
+            intelligence.explainability_surface_statement
+        ),
+        "explainability_visibility_non_authority_statement": (
+            intelligence.explainability_visibility_non_authority_statement
+        ),
+        "non_operational": intelligence.non_operational,
+        "non_authorizing": intelligence.non_authorizing,
+        "non_approving": intelligence.non_approving,
+        "non_executing": intelligence.non_executing,
+        "non_remediating": intelligence.non_remediating,
+        "non_runtime_mutating": intelligence.non_runtime_mutating,
+        "non_ranking": intelligence.non_ranking,
+        "non_recommending": intelligence.non_recommending,
+        "explainability_authorization_enabled": (
+            intelligence.explainability_authorization_enabled
+        ),
+        "explainability_approval_enabled": intelligence.explainability_approval_enabled,
+        "explainability_ranking_enabled": intelligence.explainability_ranking_enabled,
+        "explainability_recommendation_enabled": (
+            intelligence.explainability_recommendation_enabled
+        ),
+        "planner_integration_enabled": intelligence.planner_integration_enabled,
+        "production_consumption_enabled": intelligence.production_consumption_enabled,
+        "runtime_mutation_enabled": intelligence.runtime_mutation_enabled,
+        "operational_mutation_enabled": intelligence.operational_mutation_enabled,
+    }

--- a/backend/scripts/report_v4_5b_3_explainability_surfaces.py
+++ b/backend/scripts/report_v4_5b_3_explainability_surfaces.py
@@ -1,0 +1,138 @@
+"""Generate deterministic v4.5B.3 explainability surfaces report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+APP_ROOT = BACKEND_ROOT / "app"
+if str(APP_ROOT) not in sys.path:
+    sys.path.insert(0, str(APP_ROOT))
+
+from public_trust_visibility.v4_5b_3_explainability_surface_audit import (  # noqa: E402
+    build_v4_5b_3_explainability_surfaces_report,
+)
+
+
+REPORT_PATH = Path("docs/generated/v4_5b_3_explainability_surfaces_report.json")
+
+
+def write_report(report: dict[str, object], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        default=str(REPORT_PATH),
+        help="v4.5B.3 explainability surfaces JSON report output path",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    output_path = Path(args.output)
+    report = build_v4_5b_3_explainability_surfaces_report()
+    write_report(report, output_path)
+    summary = report["summary"]
+    print(f"wrote {output_path}")
+    print(f"foundation_status={report['foundation_status']}")
+    print(f"surface_record_count={summary['surface_record_count']}")
+    print(
+        "support_state_explanation_count="
+        f"{summary['support_state_explanation_count']}"
+    )
+    print(
+        "evidence_to_explanation_mapping_count="
+        f"{summary['evidence_to_explanation_mapping_count']}"
+    )
+    print(f"limitation_explanation_count={summary['limitation_explanation_count']}")
+    print(f"trust_explanation_count={summary['trust_explanation_count']}")
+    print(f"continuity_explanation_count={summary['continuity_explanation_count']}")
+    print(
+        "unsupported_state_explanation_count="
+        f"{summary['unsupported_state_explanation_count']}"
+    )
+    print(f"explanation_summary_count={summary['explanation_summary_count']}")
+    print(f"explanation_diagnostic_count={summary['explanation_diagnostic_count']}")
+    print(
+        "unsupported_operational_state_count="
+        f"{summary['unsupported_operational_state_count']}"
+    )
+    print(
+        "deterministic_serialization_verified="
+        f"{summary['deterministic_serialization_verified']}"
+    )
+    print(f"deterministic_hashing_verified={summary['deterministic_hashing_verified']}")
+    print(
+        "support_state_explanations_stable="
+        f"{summary['support_state_explanations_stable']}"
+    )
+    print(
+        "evidence_to_explanation_mapping_stable="
+        f"{summary['evidence_to_explanation_mapping_stable']}"
+    )
+    print(
+        "limitation_explanation_preserved="
+        f"{summary['limitation_explanation_preserved']}"
+    )
+    print(
+        "trust_explanation_visibility_stable="
+        f"{summary['trust_explanation_visibility_stable']}"
+    )
+    print(
+        "continuity_explanation_visibility_stable="
+        f"{summary['continuity_explanation_visibility_stable']}"
+    )
+    print(
+        "unsupported_state_explanation_preserved="
+        f"{summary['unsupported_state_explanation_preserved']}"
+    )
+    print(f"lineage_continuity_preserved={summary['lineage_continuity_preserved']}")
+    print(
+        "provenance_continuity_preserved="
+        f"{summary['provenance_continuity_preserved']}"
+    )
+    print(f"evidence_continuity_preserved={summary['evidence_continuity_preserved']}")
+    print(
+        "fail_visible_explanation_diagnostics_verified="
+        f"{summary['fail_visible_explanation_diagnostics_verified']}"
+    )
+    print(
+        "descriptive_only_guarantees_verified="
+        f"{summary['descriptive_only_guarantees_verified']}"
+    )
+    print(f"publicly_transparent={summary['publicly_transparent']}")
+    print(
+        "explainability_surface_statement="
+        f"{summary['explainability_surface_statement']}"
+    )
+    print(
+        "explainability_visibility_non_authority_statement="
+        f"{summary['explainability_visibility_non_authority_statement']}"
+    )
+    print(f"inherited_prohibition_count={summary['inherited_prohibition_count']}")
+    print(f"inherited_constraint_count={summary['inherited_constraint_count']}")
+    print(f"explicit_limitation_count={summary['explicit_limitation_count']}")
+    print(f"validation_error_count={summary['validation_error_count']}")
+    for key in sorted(k for k in summary if k.startswith("enabled_")):
+        print(f"{key}={summary[key]}")
+    print(f"repository_remains={','.join(summary['repository_remains'])}")
+    print(f"deterministic_report_hash={report['deterministic_report_hash']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_v4_5b_3_explainability_surfaces.py
+++ b/backend/tests/test_v4_5b_3_explainability_surfaces.py
@@ -1,0 +1,362 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError, replace
+from pathlib import Path
+import sys
+
+import pytest
+
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+APP_ROOT = BACKEND_ROOT / "app"
+if str(APP_ROOT) not in sys.path:
+    sys.path.insert(0, str(APP_ROOT))
+
+from public_trust_visibility.v4_5b_3_explainability_surface_audit import (  # noqa: E402
+    build_v4_5b_3_explainability_surfaces,
+    build_v4_5b_3_explainability_surfaces_report,
+    contaminate_v4_5b_3_explainability_surfaces_for_non_operational_validation,
+    enabled_explainability_surface_capability_flags,
+    explainability_surface_capability_counter_values,
+    explainability_surface_equal,
+    validate_continuity_explanation_visibility,
+    validate_descriptive_only_explainability_guarantees,
+    validate_evidence_to_explanation_mapping_stability,
+    validate_explainability_identity_integrity,
+    validate_explainability_surface_ordering_stability,
+    validate_explainability_surface_serialization_and_hashing,
+    validate_fail_visible_explanation_diagnostics,
+    validate_limitation_explanation_preservation,
+    validate_lineage_and_provenance_preservation,
+    validate_support_state_explanation_visibility,
+    validate_trust_explanation_visibility,
+    validate_unsupported_state_explanation_preservation,
+    validate_v4_5b_3_explainability_surfaces,
+)
+from public_trust_visibility.v4_5b_3_explainability_surface_hashing import (  # noqa: E402
+    hash_evidence_to_explanation_mapping,
+    hash_explainability_surface_identity,
+    hash_explainability_surface_record,
+    hash_explanation_diagnostic_record,
+    hash_explanation_summary_record,
+    hash_limitation_explanation_visibility,
+    hash_support_state_explanation_surface,
+    hash_v4_5b_3_explainability_surfaces,
+)
+from public_trust_visibility.v4_5b_3_explainability_surface_models import (  # noqa: E402
+    CONTINUITY_EXPLANATION_TYPES,
+    EVIDENCE_TO_EXPLANATION_MAPPING_TYPES,
+    EXPLANATION_DIAGNOSTIC_TYPES,
+    EXPLANATION_SUMMARY_TYPES,
+    EXPLAINABILITY_SURFACE_STATEMENT,
+    EXPLAINABILITY_VISIBILITY_NON_AUTHORITY_STATEMENT,
+    LIMITATION_EXPLANATION_TYPES,
+    SUPPORT_STATE_EXPLANATION_TYPES,
+    TRUST_EXPLANATION_TYPES,
+    UNSUPPORTED_EXPLANATION_OPERATIONAL_STATES,
+    UNSUPPORTED_STATE_EXPLANATION_TYPES,
+    V4_5B_3_EXPLAINABILITY_SURFACE_SCHEMA_VERSION,
+    V4_5B_3_EXPLAINABILITY_SURFACE_STATUS_STABLE,
+)
+from public_trust_visibility.v4_5b_3_explainability_surface_serialization import (  # noqa: E402
+    serialize_v4_5b_3_explainability_surfaces,
+)
+from public_trust_visibility.v4_5b_3_explainability_surface_visibility import (  # noqa: E402
+    continuity_explanation_summary,
+    descriptive_only_explainability_surface_summary,
+    evidence_to_explanation_mapping_summary,
+    explanation_diagnostic_summary,
+    explanation_summary_visibility,
+    explanation_surface_summary,
+    limitation_explanation_summary,
+    support_state_explanation_summary,
+    trust_explanation_summary,
+    unsupported_operational_state_summary,
+    unsupported_state_explanation_summary,
+    validate_required_explainability_surfaces,
+)
+
+
+def test_v4_5b_3_models_are_immutable_and_descriptive_only():
+    intelligence = build_v4_5b_3_explainability_surfaces()
+
+    with pytest.raises(FrozenInstanceError):
+        intelligence.explainability_authorization_enabled = True
+
+    assert (
+        intelligence.surface_identity.schema_version
+        == V4_5B_3_EXPLAINABILITY_SURFACE_SCHEMA_VERSION
+    )
+    assert intelligence.descriptive_only is True
+    assert intelligence.publicly_transparent is True
+    assert intelligence.non_operational is True
+    assert intelligence.non_executing is True
+    assert intelligence.non_authorizing is True
+    assert intelligence.non_approving is True
+    assert intelligence.non_remediating is True
+    assert intelligence.non_runtime_mutating is True
+    assert intelligence.non_ranking is True
+    assert intelligence.non_recommending is True
+    assert intelligence.explainability_authorization_enabled is False
+    assert intelligence.explainability_approval_enabled is False
+    assert intelligence.explainability_ranking_enabled is False
+    assert intelligence.explainability_recommendation_enabled is False
+    assert intelligence.production_consumption_enabled is False
+    assert enabled_explainability_surface_capability_flags(intelligence) == {}
+    assert all(
+        value == 0
+        for value in explainability_surface_capability_counter_values(
+            intelligence
+        ).values()
+    )
+
+
+def test_v4_5b_3_required_visibility_sets_are_complete():
+    intelligence = build_v4_5b_3_explainability_surfaces()
+    visibility = validate_required_explainability_surfaces(intelligence)
+
+    assert visibility["valid"] is True
+    assert set(visibility["support_counts"]) == set(SUPPORT_STATE_EXPLANATION_TYPES)
+    assert set(visibility["mapping_counts"]) == set(
+        EVIDENCE_TO_EXPLANATION_MAPPING_TYPES
+    )
+    assert set(visibility["limitation_counts"]) == set(LIMITATION_EXPLANATION_TYPES)
+    assert set(visibility["trust_counts"]) == set(TRUST_EXPLANATION_TYPES)
+    assert set(visibility["continuity_counts"]) == set(CONTINUITY_EXPLANATION_TYPES)
+    assert set(visibility["unsupported_counts"]) == set(
+        UNSUPPORTED_STATE_EXPLANATION_TYPES
+    )
+    assert set(visibility["summary_counts"]) == set(EXPLANATION_SUMMARY_TYPES)
+    assert set(visibility["diagnostic_counts"]) == set(EXPLANATION_DIAGNOSTIC_TYPES)
+    assert set(visibility["unsupported_operational_counts"]) == set(
+        UNSUPPORTED_EXPLANATION_OPERATIONAL_STATES
+    )
+    assert visibility["missing_support_state_explanations"] == []
+    assert visibility["missing_evidence_mappings"] == []
+    assert visibility["missing_limitation_explanations"] == []
+    assert visibility["missing_trust_explanations"] == []
+    assert visibility["missing_continuity_explanations"] == []
+    assert visibility["missing_unsupported_state_explanations"] == []
+    assert visibility["missing_diagnostics"] == []
+    assert visibility["missing_unsupported_operational_states"] == []
+
+
+def test_v4_5b_3_serialization_hashing_and_equality_are_stable():
+    first = build_v4_5b_3_explainability_surfaces()
+    second = build_v4_5b_3_explainability_surfaces()
+    serialization = validate_explainability_surface_serialization_and_hashing(first)
+
+    assert first == second
+    assert explainability_surface_equal(first, second)
+    assert serialize_v4_5b_3_explainability_surfaces(first) == (
+        serialize_v4_5b_3_explainability_surfaces(second)
+    )
+    assert hash_v4_5b_3_explainability_surfaces(first) == (
+        hash_v4_5b_3_explainability_surfaces(second)
+    )
+    assert serialization["valid"] is True
+    assert len(hash_explainability_surface_identity(first.surface_identity)) == 64
+    assert len(hash_explainability_surface_record(first.surface_records[0])) == 64
+    assert len(
+        hash_support_state_explanation_surface(first.support_state_explanations[0])
+    ) == 64
+    assert len(
+        hash_evidence_to_explanation_mapping(
+            first.evidence_to_explanation_mappings[0]
+        )
+    ) == 64
+    assert len(
+        hash_limitation_explanation_visibility(first.limitation_explanations[0])
+    ) == 64
+    assert len(hash_explanation_summary_record(first.explanation_summaries[0])) == 64
+    assert len(
+        hash_explanation_diagnostic_record(first.explanation_diagnostics[0])
+    ) == 64
+
+
+def test_v4_5b_3_ordering_survives_reordered_collections():
+    intelligence = build_v4_5b_3_explainability_surfaces()
+    reordered = replace(
+        intelligence,
+        surface_records=tuple(reversed(intelligence.surface_records)),
+        support_state_explanations=tuple(
+            reversed(intelligence.support_state_explanations)
+        ),
+        evidence_to_explanation_mappings=tuple(
+            reversed(intelligence.evidence_to_explanation_mappings)
+        ),
+        limitation_explanations=tuple(
+            reversed(intelligence.limitation_explanations)
+        ),
+        trust_explanations=tuple(reversed(intelligence.trust_explanations)),
+        continuity_explanations=tuple(
+            reversed(intelligence.continuity_explanations)
+        ),
+        unsupported_state_explanations=tuple(
+            reversed(intelligence.unsupported_state_explanations)
+        ),
+        explanation_summaries=tuple(reversed(intelligence.explanation_summaries)),
+        explanation_diagnostics=tuple(reversed(intelligence.explanation_diagnostics)),
+        unsupported_operational_state_visibility=tuple(
+            reversed(intelligence.unsupported_operational_state_visibility)
+        ),
+        deterministic_guarantees=tuple(reversed(intelligence.deterministic_guarantees)),
+        inherited_prohibitions=tuple(reversed(intelligence.inherited_prohibitions)),
+        inherited_constraints=tuple(reversed(intelligence.inherited_constraints)),
+        explicit_limitations=tuple(reversed(intelligence.explicit_limitations)),
+    )
+
+    assert (
+        validate_explainability_surface_ordering_stability(intelligence)["valid"]
+        is True
+    )
+    assert serialize_v4_5b_3_explainability_surfaces(
+        intelligence
+    ) == serialize_v4_5b_3_explainability_surfaces(reordered)
+    assert hash_v4_5b_3_explainability_surfaces(
+        intelligence
+    ) == hash_v4_5b_3_explainability_surfaces(reordered)
+
+
+def test_v4_5b_3_explainability_layers_are_stable():
+    intelligence = build_v4_5b_3_explainability_surfaces()
+
+    assert validate_explainability_identity_integrity(intelligence)["valid"] is True
+    assert validate_support_state_explanation_visibility(intelligence)["valid"] is True
+    assert (
+        validate_evidence_to_explanation_mapping_stability(intelligence)["valid"]
+        is True
+    )
+    assert validate_limitation_explanation_preservation(intelligence)["valid"] is True
+    assert validate_trust_explanation_visibility(intelligence)["valid"] is True
+    assert validate_continuity_explanation_visibility(intelligence)["valid"] is True
+    assert (
+        validate_unsupported_state_explanation_preservation(intelligence)["valid"]
+        is True
+    )
+
+
+def test_v4_5b_3_lineage_provenance_and_fail_visible_diagnostics_are_preserved():
+    intelligence = build_v4_5b_3_explainability_surfaces()
+    lineage = validate_lineage_and_provenance_preservation(intelligence)
+    fail_visible = validate_fail_visible_explanation_diagnostics(intelligence)
+
+    assert lineage["valid"] is True
+    assert lineage["lineage_continuity_preserved"] is True
+    assert lineage["provenance_continuity_preserved"] is True
+    assert lineage["evidence_continuity_preserved"] is True
+    assert fail_visible["valid"] is True
+    assert fail_visible["fail_visible"] is True
+    assert fail_visible["silent_fallback_enabled_count"] == 0
+    assert fail_visible["hidden_fallback_enabled_count"] == 0
+    assert fail_visible["authorization_enabled_count"] == 0
+    assert fail_visible["approval_enabled_count"] == 0
+    assert fail_visible["ranking_enabled_count"] == 0
+    assert fail_visible["recommendation_enabled_count"] == 0
+    assert fail_visible["missing_diagnostic_types"] == []
+    assert fail_visible["missing_unsupported_states"] == []
+
+
+def test_v4_5b_3_visibility_helpers_are_non_operational():
+    intelligence = build_v4_5b_3_explainability_surfaces()
+
+    assert len(explanation_surface_summary(intelligence.surface_records)) == 1
+    assert len(
+        support_state_explanation_summary(intelligence.support_state_explanations)
+    ) == len(SUPPORT_STATE_EXPLANATION_TYPES)
+    assert len(
+        evidence_to_explanation_mapping_summary(
+            intelligence.evidence_to_explanation_mappings
+        )
+    ) == len(EVIDENCE_TO_EXPLANATION_MAPPING_TYPES)
+    assert len(limitation_explanation_summary(intelligence.limitation_explanations)) == len(
+        LIMITATION_EXPLANATION_TYPES
+    )
+    assert len(trust_explanation_summary(intelligence.trust_explanations)) == len(
+        TRUST_EXPLANATION_TYPES
+    )
+    assert len(
+        continuity_explanation_summary(intelligence.continuity_explanations)
+    ) == len(CONTINUITY_EXPLANATION_TYPES)
+    assert len(
+        unsupported_state_explanation_summary(
+            intelligence.unsupported_state_explanations
+        )
+    ) == len(UNSUPPORTED_STATE_EXPLANATION_TYPES)
+    assert len(explanation_summary_visibility(intelligence.explanation_summaries)) == len(
+        EXPLANATION_SUMMARY_TYPES
+    )
+    assert len(explanation_diagnostic_summary(intelligence.explanation_diagnostics)) == len(
+        EXPLANATION_DIAGNOSTIC_TYPES
+    )
+    assert len(
+        unsupported_operational_state_summary(
+            intelligence.unsupported_operational_state_visibility
+        )
+    ) == len(UNSUPPORTED_EXPLANATION_OPERATIONAL_STATES)
+    summary = descriptive_only_explainability_surface_summary(intelligence)
+    assert summary["explainability_surface_statement"] == (
+        EXPLAINABILITY_SURFACE_STATEMENT
+    )
+    assert summary["explainability_visibility_non_authority_statement"] == (
+        EXPLAINABILITY_VISIBILITY_NON_AUTHORITY_STATEMENT
+    )
+    assert summary["explainability_authorization_enabled"] is False
+    assert summary["explainability_approval_enabled"] is False
+    assert summary["explainability_ranking_enabled"] is False
+    assert summary["explainability_recommendation_enabled"] is False
+
+
+def test_v4_5b_3_contamination_is_fail_visible():
+    contaminated = (
+        contaminate_v4_5b_3_explainability_surfaces_for_non_operational_validation()
+    )
+    validation = validate_v4_5b_3_explainability_surfaces(contaminated)
+    descriptive = validate_descriptive_only_explainability_guarantees(contaminated)
+
+    assert validation["valid"] is False
+    assert "descriptive_only_guarantees" in validation["failed_validations"]
+    assert descriptive["valid"] is False
+    assert descriptive["counters"]["enabled_runtime_execution_count"] > 0
+    assert descriptive["counters"]["enabled_explainability_authorization_count"] > 0
+    assert descriptive["counters"]["enabled_explainability_approval_count"] > 0
+    assert descriptive["counters"]["enabled_explainability_ranking_count"] > 0
+    assert descriptive["counters"]["enabled_explainability_recommendation_count"] > 0
+    assert descriptive["counters"]["enabled_remediation_count"] > 0
+
+
+def test_v4_5b_3_report_is_replay_safe_and_certifies_explainability_boundary():
+    first = build_v4_5b_3_explainability_surfaces_report()
+    second = build_v4_5b_3_explainability_surfaces_report()
+    summary = first["summary"]
+
+    assert first == second
+    assert first["foundation_status"] == V4_5B_3_EXPLAINABILITY_SURFACE_STATUS_STABLE
+    assert first["deterministic_report_hash"] == second["deterministic_report_hash"]
+    assert len(first["deterministic_report_hash"]) == 64
+    assert summary["validation_error_count"] == 0
+    assert summary["deterministic_serialization_verified"] is True
+    assert summary["deterministic_hashing_verified"] is True
+    assert summary["evidence_to_explanation_mapping_stable"] is True
+    assert summary["descriptive_only_guarantees_verified"] is True
+    assert summary["explainability_surface_statement"] == (
+        EXPLAINABILITY_SURFACE_STATEMENT
+    )
+    assert summary["explainability_visibility_non_authority_statement"] == (
+        EXPLAINABILITY_VISIBILITY_NON_AUTHORITY_STATEMENT
+    )
+    assert summary["repository_remains"] == [
+        "NON-operational",
+        "NON-authorizing",
+        "NON-approving",
+        "NON-executing",
+        "NON-remediating",
+        "NON-runtime-mutating",
+        "NON-ranking",
+        "NON-recommending",
+    ]
+    assert all(
+        value == 0 for key, value in summary.items() if key.startswith("enabled_")
+    )

--- a/docs/generated/v4_5b_3_explainability_surfaces_report.json
+++ b/docs/generated/v4_5b_3_explainability_surfaces_report.json
@@ -1,0 +1,3545 @@
+{
+  "deterministic_hash_evidence": {
+    "continuity_explanation_hashes": {
+      "continuity_explanation_diagnostics_continuity_explanations": "2249ad2c7d327702327d8580fa3b4755316623701c4da1b1244bfaa8aa1f2c69",
+      "continuity_explanation_evidence_continuity_explanations": "f435b95e589267c4a9a1ced14c6140d2352be050ea1090118f303004e4f37883",
+      "continuity_explanation_integrity_continuity_explanations": "7c3a71597ed4ad1d887330bcf6a302c0b739a751e44b5a1e6eb41e0cf294960c",
+      "continuity_explanation_lineage_continuity_explanations": "3e8c8710daa08fb8c9cff834857ad69fab0bb8e43a489538b58a96e9dda10b1a",
+      "continuity_explanation_provenance_continuity_explanations": "83ebef8982383f5ab4f0629833dc8838ccfc435700261579a282fccda83ca871"
+    },
+    "evidence_to_explanation_mapping_hashes": {
+      "evidence_to_explanation_continuity_backed_explanations": "ff40e4600e315df3bd0285646fbe327f980179b7449f9df1759d3f7a09f254ef",
+      "evidence_to_explanation_diagnostics_backed_explanations": "80a3339c02ecd53023f8f181f2211cb55778358cb02e0a12e4a5fa5077e1ad9d",
+      "evidence_to_explanation_evidence_backed_explanations": "c1ced7cf30d68e0be9347de1a6c935f7b008b5eaec9a73204bd148e43528fb29",
+      "evidence_to_explanation_explainability_backed_explanations": "360ce6640b48bbd14d1eecdd8e81192301daa633e2f575a1a72ede476bcf3f96",
+      "evidence_to_explanation_partially_evidenced_explanations": "be0c5aada065aca8e62a1dd5044b8e955cd4c43205915d87357baffefc9b3638",
+      "evidence_to_explanation_unsupported_evidence_explanations": "f634227016dcd56c98f83ae5dc876751604ff88ffce65dd2b75fd6b11267b6b0"
+    },
+    "explainability_surface_hash": "7491594afcddcd2c762e75d7cf9772eaca79a219dd64327257644bf1eee19808",
+    "explanation_diagnostic_hashes": {
+      "explanation_diagnostic_incomplete_continuity_explanations": "1c14e554691c0381f47ee890842bc370f69160c68900cae3c16618f76b143d77",
+      "explanation_diagnostic_incomplete_integrity_explanations": "98ed3119a9aedf1eaf4e6c2c82faf7561c20031584f7bdb0836e666bf0e807b1",
+      "explanation_diagnostic_inherited_limitation_explanation_gaps": "5b25cf1f76cd9387457dcf2ea1b43a9db24b496d3f6b8c1f041c48ff3058dfc1",
+      "explanation_diagnostic_inherited_prohibition_explanation_gaps": "23edfd6a0a46f39725095509068398a4886d2dbb07da0e2c178be185efc155a1",
+      "explanation_diagnostic_missing_explanation_evidence": "7bfc585ebb4cc5f9ffb22b17d2a8610bf910129ba75ea037a246323579f8bdfd",
+      "explanation_diagnostic_unsupported_explanation_gaps": "254fa4a252f4e266fc3f2d1cfa2284d7d4b464c1aef88e4308c0cc48507b2567",
+      "explanation_diagnostic_unsupported_operational_explanations": "caaca896db6d3c6a4078f2b8b5612c5d45e66a49887dcb958bb712bd34b604f8",
+      "explanation_diagnostic_unsupported_trust_explanations": "83fcd69476a1bc3aabb27e6792c9b6e7baf194c033b140cde508fca3a957a4ee"
+    },
+    "explanation_summary_hashes": {
+      "explanation_summary_continuity_explanation_summary": "81a890ceb5e4d23fad14dca6416f01dca2596b94ba40a4999b4a958fbae7e989",
+      "explanation_summary_diagnostics_explanation_summary": "823eb6fc893dd461bdd205de455093531f5924f3f03e9a4bd56c87d0640c54ac",
+      "explanation_summary_evidence_mapping_summary": "919853a3d9ba0d518dd671ae5a6215ee1505c09ec7bb37639440f2fd70f1e041",
+      "explanation_summary_explanation_surface_summary": "554d073ee01afa60ab6bf3aef2f6260a4ddd701509febf75a5461fccbdbde360",
+      "explanation_summary_limitation_explanation_summary": "21d7703a1ec295875659899a494d956d5a80ac159d68fd741f3fbe3142bf3c9e",
+      "explanation_summary_support_state_explanation_summary": "beca14fadd8593f3dee733d547c904071a8436e5bb4d2d1b34625173bf072272",
+      "explanation_summary_trust_explanation_summary": "c44bd0a3d8b3c4ca4ed92a752d52a7a7b87c2d5eb4a9ecd65b217bc5daec0a47",
+      "explanation_summary_unsupported_state_explanation_summary": "1f1c6ba5c9ee5356db3a97984318abb4e17441dfcca06d18c667ed50d914e575"
+    },
+    "limitation_explanation_hashes": {
+      "limitation_explanation_blocked_limitation_explanations": "00544a85eab18e185050221d66bc6ed6371f4f7ac13838cbab7357c55517d0df",
+      "limitation_explanation_continuity_limitation_explanations": "a9097de5c063b19166395d250817026a85372ea8e5a5a24a0ef2124733ee59f2",
+      "limitation_explanation_deprecated_limitation_explanations": "9528d5a0d0ec13ce50e2bc9c2a8c9117a3320148a2ccbe8bd1564de81ab33170",
+      "limitation_explanation_evidence_limitation_explanations": "bf0405de6a4ae98cf36798d366d702c2a9c4601a05a1a79bba3fca54077e7989",
+      "limitation_explanation_experimental_limitation_explanations": "1667efff02c14db437d833e6092688d6be1f817ad4b93c0b79317d7c79a06088",
+      "limitation_explanation_governance_limitation_explanations": "4ace341ba3ffcc3da88941d1303dc28e72226b4c94654b951d976add5a4e8775",
+      "limitation_explanation_unsupported_limitation_explanations": "bb5953c68c5cfc35b2def4ca932a20a83e7d0ffd416983fea4d6ff69228b2af6"
+    },
+    "support_state_explanation_hashes": {
+      "support_state_explanation_blocked_explanations": "009171e89333e774edc0c3fc02bef5fe2351193dcb3c954e27799e7907d9abc0",
+      "support_state_explanation_deprecated_explanations": "aedae55fc8a2551928b73c8be3ab826f5a74e205bf747ea3560d13c39a584ca8",
+      "support_state_explanation_experimental_explanations": "a19fe1930cb042f0d1e6a63941e5561fb2a2240bc863ae412614443eeafd3143",
+      "support_state_explanation_partially_supported_explanations": "8a8f2e4e7194972a39d4779f0d592f0438156c92162a0d98d2be59df5ad463c1",
+      "support_state_explanation_supported_explanations": "8427f1b70652c06a877b8d84d1fd6735b3f9f6ad73b4f24d51f78d351e020408",
+      "support_state_explanation_unknown_state_explanations": "58ac540770adb5f21114cc0a624fc07ab034adce83bea4359cc762bf74b50f6e",
+      "support_state_explanation_unsupported_explanations": "882fb7fe961c57f90cc635d447a707b94b9d9a30f08a525f04e23a32e52cee03"
+    },
+    "surface_identity_hash": "827e7b793103f3ee0e4cb617fb551e4dfd66593478503c8d1331f471d8415bcc",
+    "surface_record_hashes": {
+      "public_explainability_surface_foundation": "3db2d4f82004044a3da89e0781b1ded2f13a2e2f94121d098fe924129c4695d5"
+    },
+    "trust_explanation_hashes": {
+      "trust_explanation_deterministic_guarantee_explanations": "4c4a65e2054e33de3b739ec5b0196d905833d5118796c8f15c1d0ceab96b02d0",
+      "trust_explanation_explainability_continuity_explanations": "f36bcf9b433f1bd1cdde86e3141e46e5712ab4b3dd8bb536fe9b32161432f0b8",
+      "trust_explanation_fail_visible_diagnostic_explanations": "288cab3598ec04f77fc18b24509979d7ec43a7879be58c34b02c38edde7f8f0b",
+      "trust_explanation_governance_transparency_explanations": "4e1fa9052ef4c1e874626c632522570f105ce02827c3ce6593e63ab72a72d12d",
+      "trust_explanation_integrity_continuity_explanations": "d1a9d28359a32ee40d2b5492dd62afab16583980a3016d01de63fc42a3ae977a",
+      "trust_explanation_unsupported_state_explanations": "93e6fb037f67771ea3184ec556c2fbe88b6d178a769df97d5f759684964cdc8e"
+    },
+    "unsupported_operational_hashes": {
+      "unsupported_explanation_operational_state_automated_correction": "9ced05a579aeb6cd30e2f284b4e86e14ef26e94b031e838b8c127437da50e6a3",
+      "unsupported_explanation_operational_state_automated_mitigation": "3a3ae71ae140e22e29305f0de71b84952129b12326c4048e3741f34214e0ef2f",
+      "unsupported_explanation_operational_state_automated_remediation": "50266d6cf35438e468c3758eea26d6d9ab703d726bd159a0cf57ec92c726c07e",
+      "unsupported_explanation_operational_state_automated_repair": "48e71ae8fae1ac0d18a4959907e3e312ea1deec5b357fa7183910a279fc51189",
+      "unsupported_explanation_operational_state_explainability_based_approval": "abb510a5d111c25d61b4c1a0476bbca4384423c7d895db890859c35de7e28a0f",
+      "unsupported_explanation_operational_state_explainability_based_authorization": "e6d413c574bcfa67692bb07b854b97fbeabea342626f1a1decad0ebecd052598",
+      "unsupported_explanation_operational_state_explainability_based_ranking": "14a720dfb99030fb6c6f1ebf84536b1ebdaf638c713ea6ffc627ef00e3267de3",
+      "unsupported_explanation_operational_state_explainability_based_recommendation": "06f3db6c5e4b2006e29f22cef784dec8746c90752cae3af619b73a92668e4bfd",
+      "unsupported_explanation_operational_state_implicit_operational_behavior": "ec557208b762359c18ccfb5584a7640267bc1440091d03158e90d940aab6854d",
+      "unsupported_explanation_operational_state_operational_mutation": "fe1a82a26f4e37bdc479a9628f7f523eb209bc60cc55a9486c75e62c94801f53",
+      "unsupported_explanation_operational_state_orchestration_approval": "1277a97509b55acb070a37a5e2ee41386d07b47760397da1459acd8e8b9ac6f1",
+      "unsupported_explanation_operational_state_orchestration_authorization": "9d6eafbb539c1e16c0d6bc3d341b9cfa79463509764b87fbfd184ab232cc6b66",
+      "unsupported_explanation_operational_state_orchestration_decisions": "ff3a6e7f6da2a8456ca363f769e1b3155b3f4d5364e040411a762771bed8b2bc",
+      "unsupported_explanation_operational_state_orchestration_dispatch": "3b5908d6d1da01b2ea1eedf5fa23cf0ef5306cc4927b678709cdbf06c717d6b1",
+      "unsupported_explanation_operational_state_orchestration_execution": "f9b084bd666b70564efdaa19dcc142bcb03ed8addf4d247089a290ac63e241dd",
+      "unsupported_explanation_operational_state_orchestration_recommendations": "c84f2ead9ceaae3b1d8618759895e96a67946d5c6c7c2cba9a32a64d810e0eaf",
+      "unsupported_explanation_operational_state_orchestration_routing": "bd664009cd6a06b6fee2ff6dee18ce99dc25a86ad7b39f95be9243ff7440e947",
+      "unsupported_explanation_operational_state_orchestration_scheduling": "8ff5cbf7e1872f26f5b6c3644c9825fc7a7b20f297008cef26021cf0ab089e9e",
+      "unsupported_explanation_operational_state_orchestration_sequencing": "448425dc7e99a40c27f7937e2b7c4ea78ba9f56ca03185bd405c86b186193d04",
+      "unsupported_explanation_operational_state_orchestration_traversal": "e9649864f66a9a9d50e9bc6894a590c9ca1ab7e2707afaf4e2c45b155faf6dda",
+      "unsupported_explanation_operational_state_planner_integration": "7223ec09cef0b114bb25522e86f026e112ec19b06ec741cb2112ac13ba65ec88",
+      "unsupported_explanation_operational_state_production_consumption": "81f2b0696b25029c8aa78baeceafd9c07ee1ac4768b0d2ae26f055bbc83b7db2",
+      "unsupported_explanation_operational_state_runtime_mutation": "681e04353a34b9ba83f72d33c47a7652806ba63a45da87913e7aadaad37e3dae"
+    },
+    "unsupported_state_explanation_hashes": {
+      "unsupported_state_explanation_unsupported_continuity_chains": "04b24269714fa4e2cb5b9ca4b7d25bc328e1bc25c6406738acd8a27460ada447",
+      "unsupported_state_explanation_unsupported_evidence_chains": "5f7e655ea416d51f9ca71b90bfab9fd114072a1219256c23d5e4b2666e5c873b",
+      "unsupported_state_explanation_unsupported_operational_states": "3f3a10fee7c01934e07259890b8f65d4af40e39274b99f71c8572ef48cca159a",
+      "unsupported_state_explanation_unsupported_planner_sections": "58093b622239d2d1b3a333d4ec40e346899758fce1400ed50e35d4028eb18f36",
+      "unsupported_state_explanation_unsupported_systems": "ee6b81935c022d837fe77a01904e2172924a1a6df7903cb06813976a03c0d863",
+      "unsupported_state_explanation_unsupported_trust_states": "f06f9593bc66b9fd6834ffd41333cfabf7ba0c29abc7043a6bf7645b52df5898"
+    }
+  },
+  "deterministic_report_hash": "199de43c3e94cfb64397acc5fc10b77fb209476e2a66b57d771e5132462ef382",
+  "exported_intelligence": {
+    "auto_correction_enabled": false,
+    "continuity_explanations": [
+      {
+        "authorization_enabled": false,
+        "continuity_explanation_id": "continuity_explanation_evidence_continuity_explanations",
+        "continuity_explanation_type": "evidence_continuity_explanations",
+        "continuity_reference_id": "continuity_reference_evidence_continuity_explanations",
+        "descriptive_only": true,
+        "deterministic_order": 1,
+        "evidence_reference_ids": [
+          "evidence_evidence_continuity_explanations"
+        ],
+        "explanation_visibility_state": "continuity_explanation_visible",
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "restoration_enabled": false
+      },
+      {
+        "authorization_enabled": false,
+        "continuity_explanation_id": "continuity_explanation_lineage_continuity_explanations",
+        "continuity_explanation_type": "lineage_continuity_explanations",
+        "continuity_reference_id": "continuity_reference_lineage_continuity_explanations",
+        "descriptive_only": true,
+        "deterministic_order": 2,
+        "evidence_reference_ids": [
+          "evidence_lineage_continuity_explanations"
+        ],
+        "explanation_visibility_state": "continuity_explanation_visible",
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "restoration_enabled": false
+      },
+      {
+        "authorization_enabled": false,
+        "continuity_explanation_id": "continuity_explanation_provenance_continuity_explanations",
+        "continuity_explanation_type": "provenance_continuity_explanations",
+        "continuity_reference_id": "continuity_reference_provenance_continuity_explanations",
+        "descriptive_only": true,
+        "deterministic_order": 3,
+        "evidence_reference_ids": [
+          "evidence_provenance_continuity_explanations"
+        ],
+        "explanation_visibility_state": "continuity_explanation_visible",
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "restoration_enabled": false
+      },
+      {
+        "authorization_enabled": false,
+        "continuity_explanation_id": "continuity_explanation_integrity_continuity_explanations",
+        "continuity_explanation_type": "integrity_continuity_explanations",
+        "continuity_reference_id": "continuity_reference_integrity_continuity_explanations",
+        "descriptive_only": true,
+        "deterministic_order": 4,
+        "evidence_reference_ids": [
+          "evidence_integrity_continuity_explanations"
+        ],
+        "explanation_visibility_state": "continuity_explanation_visible",
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "restoration_enabled": false
+      },
+      {
+        "authorization_enabled": false,
+        "continuity_explanation_id": "continuity_explanation_diagnostics_continuity_explanations",
+        "continuity_explanation_type": "diagnostics_continuity_explanations",
+        "continuity_reference_id": "continuity_reference_diagnostics_continuity_explanations",
+        "descriptive_only": true,
+        "deterministic_order": 5,
+        "evidence_reference_ids": [
+          "evidence_diagnostics_continuity_explanations"
+        ],
+        "explanation_visibility_state": "continuity_explanation_visible",
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "restoration_enabled": false
+      }
+    ],
+    "descriptive_only": true,
+    "deterministic_guarantees": [
+      "deterministic_continuity_explanation_visibility",
+      "deterministic_evidence_to_explanation_mapping",
+      "deterministic_explainability_surface_identity",
+      "deterministic_limitation_explanation_visibility",
+      "deterministic_public_trust_explanation_visibility",
+      "deterministic_support_state_explanation_visibility",
+      "deterministic_unsupported_state_explanation_visibility",
+      "lineage_continuity_preserved",
+      "provenance_continuity_preserved",
+      "publicly_transparent_descriptive_only_explainability_surfaces",
+      "stable_replay_safe_hashing",
+      "stable_replay_safe_serialization"
+    ],
+    "evidence_to_explanation_mappings": [
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 1,
+        "evidence_mapping_id": "evidence_to_explanation_evidence_backed_explanations",
+        "evidence_reference_ids": [
+          "evidence_evidence_backed_explanations"
+        ],
+        "explanation_reference_ids": [
+          "explanation_evidence_backed_explanations"
+        ],
+        "mapping_state": "evidence_to_explanation_mapping_replay_safe",
+        "mapping_type": "evidence_backed_explanations",
+        "provenance_safe": true,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "replay_safe": true,
+        "trust_scoring_enabled": false
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 2,
+        "evidence_mapping_id": "evidence_to_explanation_partially_evidenced_explanations",
+        "evidence_reference_ids": [
+          "evidence_partially_evidenced_explanations"
+        ],
+        "explanation_reference_ids": [
+          "explanation_partially_evidenced_explanations"
+        ],
+        "mapping_state": "evidence_to_explanation_mapping_replay_safe",
+        "mapping_type": "partially_evidenced_explanations",
+        "provenance_safe": true,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "replay_safe": true,
+        "trust_scoring_enabled": false
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 3,
+        "evidence_mapping_id": "evidence_to_explanation_unsupported_evidence_explanations",
+        "evidence_reference_ids": [
+          "evidence_unsupported_evidence_explanations"
+        ],
+        "explanation_reference_ids": [
+          "explanation_unsupported_evidence_explanations"
+        ],
+        "mapping_state": "evidence_to_explanation_mapping_replay_safe",
+        "mapping_type": "unsupported_evidence_explanations",
+        "provenance_safe": true,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "replay_safe": true,
+        "trust_scoring_enabled": false
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 4,
+        "evidence_mapping_id": "evidence_to_explanation_continuity_backed_explanations",
+        "evidence_reference_ids": [
+          "evidence_continuity_backed_explanations"
+        ],
+        "explanation_reference_ids": [
+          "explanation_continuity_backed_explanations"
+        ],
+        "mapping_state": "evidence_to_explanation_mapping_replay_safe",
+        "mapping_type": "continuity_backed_explanations",
+        "provenance_safe": true,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "replay_safe": true,
+        "trust_scoring_enabled": false
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 5,
+        "evidence_mapping_id": "evidence_to_explanation_explainability_backed_explanations",
+        "evidence_reference_ids": [
+          "evidence_explainability_backed_explanations"
+        ],
+        "explanation_reference_ids": [
+          "explanation_explainability_backed_explanations"
+        ],
+        "mapping_state": "evidence_to_explanation_mapping_replay_safe",
+        "mapping_type": "explainability_backed_explanations",
+        "provenance_safe": true,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "replay_safe": true,
+        "trust_scoring_enabled": false
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 6,
+        "evidence_mapping_id": "evidence_to_explanation_diagnostics_backed_explanations",
+        "evidence_reference_ids": [
+          "evidence_diagnostics_backed_explanations"
+        ],
+        "explanation_reference_ids": [
+          "explanation_diagnostics_backed_explanations"
+        ],
+        "mapping_state": "evidence_to_explanation_mapping_replay_safe",
+        "mapping_type": "diagnostics_backed_explanations",
+        "provenance_safe": true,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "replay_safe": true,
+        "trust_scoring_enabled": false
+      }
+    ],
+    "explainability_approval_enabled": false,
+    "explainability_authorization_enabled": false,
+    "explainability_ranking_enabled": false,
+    "explainability_recommendation_enabled": false,
+    "explainability_surface_statement": "Explainability surfaces are descriptive-only.",
+    "explainability_visibility_non_authority_statement": "Explainability visibility does NOT imply authorization, approval, operational readiness, execution safety, or production enablement.",
+    "explanation_diagnostics": [
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "auto_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 1,
+        "diagnostic_id": "explanation_diagnostic_missing_explanation_evidence",
+        "diagnostic_type": "missing_explanation_evidence",
+        "evidence_reference_ids": [
+          "evidence_missing_explanation_evidence"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "message": "missing_explanation_evidence remains explicit, fail-visible, and descriptive-only for public explainability surfaces.",
+        "mitigation_enabled": false,
+        "orchestration_response_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "silent_fallback_enabled": false,
+        "visibility_state": "fail_visible_explanation_diagnostic_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "auto_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 2,
+        "diagnostic_id": "explanation_diagnostic_unsupported_explanation_gaps",
+        "diagnostic_type": "unsupported_explanation_gaps",
+        "evidence_reference_ids": [
+          "evidence_unsupported_explanation_gaps"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "message": "unsupported_explanation_gaps remains explicit, fail-visible, and descriptive-only for public explainability surfaces.",
+        "mitigation_enabled": false,
+        "orchestration_response_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "silent_fallback_enabled": false,
+        "visibility_state": "fail_visible_explanation_diagnostic_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "auto_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 3,
+        "diagnostic_id": "explanation_diagnostic_incomplete_continuity_explanations",
+        "diagnostic_type": "incomplete_continuity_explanations",
+        "evidence_reference_ids": [
+          "evidence_incomplete_continuity_explanations"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "message": "incomplete_continuity_explanations remains explicit, fail-visible, and descriptive-only for public explainability surfaces.",
+        "mitigation_enabled": false,
+        "orchestration_response_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "silent_fallback_enabled": false,
+        "visibility_state": "fail_visible_explanation_diagnostic_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "auto_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 4,
+        "diagnostic_id": "explanation_diagnostic_incomplete_integrity_explanations",
+        "diagnostic_type": "incomplete_integrity_explanations",
+        "evidence_reference_ids": [
+          "evidence_incomplete_integrity_explanations"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "message": "incomplete_integrity_explanations remains explicit, fail-visible, and descriptive-only for public explainability surfaces.",
+        "mitigation_enabled": false,
+        "orchestration_response_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "silent_fallback_enabled": false,
+        "visibility_state": "fail_visible_explanation_diagnostic_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "auto_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 5,
+        "diagnostic_id": "explanation_diagnostic_unsupported_trust_explanations",
+        "diagnostic_type": "unsupported_trust_explanations",
+        "evidence_reference_ids": [
+          "evidence_unsupported_trust_explanations"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "message": "unsupported_trust_explanations remains explicit, fail-visible, and descriptive-only for public explainability surfaces.",
+        "mitigation_enabled": false,
+        "orchestration_response_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "silent_fallback_enabled": false,
+        "visibility_state": "fail_visible_explanation_diagnostic_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "auto_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 6,
+        "diagnostic_id": "explanation_diagnostic_unsupported_operational_explanations",
+        "diagnostic_type": "unsupported_operational_explanations",
+        "evidence_reference_ids": [
+          "evidence_unsupported_operational_explanations"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "message": "unsupported_operational_explanations remains explicit, fail-visible, and descriptive-only for public explainability surfaces.",
+        "mitigation_enabled": false,
+        "orchestration_response_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "silent_fallback_enabled": false,
+        "visibility_state": "fail_visible_explanation_diagnostic_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "auto_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 7,
+        "diagnostic_id": "explanation_diagnostic_inherited_limitation_explanation_gaps",
+        "diagnostic_type": "inherited_limitation_explanation_gaps",
+        "evidence_reference_ids": [
+          "evidence_inherited_limitation_explanation_gaps"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "message": "inherited_limitation_explanation_gaps remains explicit, fail-visible, and descriptive-only for public explainability surfaces.",
+        "mitigation_enabled": false,
+        "orchestration_response_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "silent_fallback_enabled": false,
+        "visibility_state": "fail_visible_explanation_diagnostic_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "auto_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 8,
+        "diagnostic_id": "explanation_diagnostic_inherited_prohibition_explanation_gaps",
+        "diagnostic_type": "inherited_prohibition_explanation_gaps",
+        "evidence_reference_ids": [
+          "evidence_inherited_prohibition_explanation_gaps"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "message": "inherited_prohibition_explanation_gaps remains explicit, fail-visible, and descriptive-only for public explainability surfaces.",
+        "mitigation_enabled": false,
+        "orchestration_response_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "silent_fallback_enabled": false,
+        "visibility_state": "fail_visible_explanation_diagnostic_visible"
+      }
+    ],
+    "explanation_summaries": [
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 1,
+        "evidence_reference_ids": [
+          "evidence_explanation_surface_summary"
+        ],
+        "execution_enablement_enabled": false,
+        "explanation_summary_id": "v4_5b_3_explanation_summary",
+        "explanation_summary_record_id": "explanation_summary_explanation_surface_summary",
+        "production_enablement_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "summary_state": "explanation_summary_descriptive_only",
+        "summary_type": "explanation_surface_summary"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 2,
+        "evidence_reference_ids": [
+          "evidence_support_state_explanation_summary"
+        ],
+        "execution_enablement_enabled": false,
+        "explanation_summary_id": "v4_5b_3_explanation_summary",
+        "explanation_summary_record_id": "explanation_summary_support_state_explanation_summary",
+        "production_enablement_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "summary_state": "explanation_summary_descriptive_only",
+        "summary_type": "support_state_explanation_summary"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 3,
+        "evidence_reference_ids": [
+          "evidence_evidence_mapping_summary"
+        ],
+        "execution_enablement_enabled": false,
+        "explanation_summary_id": "v4_5b_3_explanation_summary",
+        "explanation_summary_record_id": "explanation_summary_evidence_mapping_summary",
+        "production_enablement_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "summary_state": "explanation_summary_descriptive_only",
+        "summary_type": "evidence_mapping_summary"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 4,
+        "evidence_reference_ids": [
+          "evidence_limitation_explanation_summary"
+        ],
+        "execution_enablement_enabled": false,
+        "explanation_summary_id": "v4_5b_3_explanation_summary",
+        "explanation_summary_record_id": "explanation_summary_limitation_explanation_summary",
+        "production_enablement_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "summary_state": "explanation_summary_descriptive_only",
+        "summary_type": "limitation_explanation_summary"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 5,
+        "evidence_reference_ids": [
+          "evidence_trust_explanation_summary"
+        ],
+        "execution_enablement_enabled": false,
+        "explanation_summary_id": "v4_5b_3_explanation_summary",
+        "explanation_summary_record_id": "explanation_summary_trust_explanation_summary",
+        "production_enablement_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "summary_state": "explanation_summary_descriptive_only",
+        "summary_type": "trust_explanation_summary"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 6,
+        "evidence_reference_ids": [
+          "evidence_continuity_explanation_summary"
+        ],
+        "execution_enablement_enabled": false,
+        "explanation_summary_id": "v4_5b_3_explanation_summary",
+        "explanation_summary_record_id": "explanation_summary_continuity_explanation_summary",
+        "production_enablement_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "summary_state": "explanation_summary_descriptive_only",
+        "summary_type": "continuity_explanation_summary"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 7,
+        "evidence_reference_ids": [
+          "evidence_unsupported_state_explanation_summary"
+        ],
+        "execution_enablement_enabled": false,
+        "explanation_summary_id": "v4_5b_3_explanation_summary",
+        "explanation_summary_record_id": "explanation_summary_unsupported_state_explanation_summary",
+        "production_enablement_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "summary_state": "explanation_summary_descriptive_only",
+        "summary_type": "unsupported_state_explanation_summary"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 8,
+        "evidence_reference_ids": [
+          "evidence_diagnostics_explanation_summary"
+        ],
+        "execution_enablement_enabled": false,
+        "explanation_summary_id": "v4_5b_3_explanation_summary",
+        "explanation_summary_record_id": "explanation_summary_diagnostics_explanation_summary",
+        "production_enablement_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "summary_state": "explanation_summary_descriptive_only",
+        "summary_type": "diagnostics_explanation_summary"
+      }
+    ],
+    "explicit_limitations": [
+      "explainability_surfaces_do_not_approve",
+      "explainability_surfaces_do_not_authorize",
+      "explainability_surfaces_do_not_enable_production",
+      "explainability_surfaces_do_not_execute",
+      "explainability_surfaces_do_not_imply_correctness_guarantees",
+      "explainability_surfaces_do_not_imply_execution_safety",
+      "explainability_surfaces_do_not_integrate_planners",
+      "explainability_surfaces_do_not_mitigate_or_correct",
+      "explainability_surfaces_do_not_mutate_runtime_state",
+      "explainability_surfaces_do_not_rank",
+      "explainability_surfaces_do_not_recommend",
+      "explainability_surfaces_do_not_remediate_or_repair"
+    ],
+    "inherited_constraints": [
+      "NON-approving",
+      "NON-authorizing",
+      "NON-executing",
+      "NON-operational",
+      "NON-ranking",
+      "NON-recommending",
+      "NON-remediating",
+      "NON-runtime-mutating",
+      "descriptive-only",
+      "deterministic",
+      "explainability-first",
+      "fail-visible",
+      "governance-safe",
+      "integrity-safe",
+      "lineage-safe",
+      "provenance-safe",
+      "publicly transparent",
+      "replay-safe",
+      "rollback-safe"
+    ],
+    "inherited_prohibitions": [
+      "automated_correction_prohibited",
+      "automated_mitigation_prohibited",
+      "automated_remediation_prohibited",
+      "automated_repair_prohibited",
+      "explainability_based_approval_prohibited",
+      "explainability_based_authorization_prohibited",
+      "explainability_based_ranking_prohibited",
+      "explainability_based_recommendation_prohibited",
+      "implicit_operational_behavior_prohibited",
+      "operational_mutation_prohibited",
+      "orchestration_approval_prohibited",
+      "orchestration_authorization_prohibited",
+      "orchestration_decisions_prohibited",
+      "orchestration_dispatch_prohibited",
+      "orchestration_execution_prohibited",
+      "orchestration_recommendations_prohibited",
+      "orchestration_routing_prohibited",
+      "orchestration_scheduling_prohibited",
+      "orchestration_sequencing_prohibited",
+      "orchestration_traversal_prohibited",
+      "planner_integration_prohibited",
+      "production_consumption_prohibited",
+      "runtime_mutation_prohibited"
+    ],
+    "limitation_explanations": [
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 1,
+        "evidence_reference_ids": [
+          "evidence_unsupported_limitation_explanations"
+        ],
+        "explanation_visibility_state": "limitation_explanation_visible",
+        "limitation_explanation_id": "limitation_explanation_unsupported_limitation_explanations",
+        "limitation_type": "unsupported_limitation_explanations",
+        "operational_fallback_enabled": false,
+        "recommendation_enabled": false
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 2,
+        "evidence_reference_ids": [
+          "evidence_experimental_limitation_explanations"
+        ],
+        "explanation_visibility_state": "limitation_explanation_visible",
+        "limitation_explanation_id": "limitation_explanation_experimental_limitation_explanations",
+        "limitation_type": "experimental_limitation_explanations",
+        "operational_fallback_enabled": false,
+        "recommendation_enabled": false
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 3,
+        "evidence_reference_ids": [
+          "evidence_deprecated_limitation_explanations"
+        ],
+        "explanation_visibility_state": "limitation_explanation_visible",
+        "limitation_explanation_id": "limitation_explanation_deprecated_limitation_explanations",
+        "limitation_type": "deprecated_limitation_explanations",
+        "operational_fallback_enabled": false,
+        "recommendation_enabled": false
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 4,
+        "evidence_reference_ids": [
+          "evidence_blocked_limitation_explanations"
+        ],
+        "explanation_visibility_state": "limitation_explanation_visible",
+        "limitation_explanation_id": "limitation_explanation_blocked_limitation_explanations",
+        "limitation_type": "blocked_limitation_explanations",
+        "operational_fallback_enabled": false,
+        "recommendation_enabled": false
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 5,
+        "evidence_reference_ids": [
+          "evidence_governance_limitation_explanations"
+        ],
+        "explanation_visibility_state": "limitation_explanation_visible",
+        "limitation_explanation_id": "limitation_explanation_governance_limitation_explanations",
+        "limitation_type": "governance_limitation_explanations",
+        "operational_fallback_enabled": false,
+        "recommendation_enabled": false
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 6,
+        "evidence_reference_ids": [
+          "evidence_continuity_limitation_explanations"
+        ],
+        "explanation_visibility_state": "limitation_explanation_visible",
+        "limitation_explanation_id": "limitation_explanation_continuity_limitation_explanations",
+        "limitation_type": "continuity_limitation_explanations",
+        "operational_fallback_enabled": false,
+        "recommendation_enabled": false
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 7,
+        "evidence_reference_ids": [
+          "evidence_evidence_limitation_explanations"
+        ],
+        "explanation_visibility_state": "limitation_explanation_visible",
+        "limitation_explanation_id": "limitation_explanation_evidence_limitation_explanations",
+        "limitation_type": "evidence_limitation_explanations",
+        "operational_fallback_enabled": false,
+        "recommendation_enabled": false
+      }
+    ],
+    "mitigation_enabled": false,
+    "non_approving": true,
+    "non_authorizing": true,
+    "non_executing": true,
+    "non_operational": true,
+    "non_ranking": true,
+    "non_recommending": true,
+    "non_remediating": true,
+    "non_runtime_mutating": true,
+    "operational_mutation_enabled": false,
+    "orchestration_approval_enabled": false,
+    "orchestration_authorization_enabled": false,
+    "orchestration_decision_enabled": false,
+    "orchestration_dispatch_enabled": false,
+    "orchestration_execution_enabled": false,
+    "orchestration_recommendation_enabled": false,
+    "orchestration_routing_enabled": false,
+    "orchestration_scheduling_enabled": false,
+    "orchestration_sequencing_enabled": false,
+    "orchestration_traversal_enabled": false,
+    "planner_execution_enabled": false,
+    "planner_integration_enabled": false,
+    "production_consumption_enabled": false,
+    "publicly_transparent": true,
+    "ranking_enabled": false,
+    "recommendation_enabled": false,
+    "remediation_enabled": false,
+    "repair_enabled": false,
+    "runtime_execution_enabled": false,
+    "runtime_mutation_enabled": false,
+    "support_state_explanations": [
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "correctness_guarantee_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 1,
+        "evidence_reference_ids": [
+          "evidence_supported_explanations"
+        ],
+        "execution_safety_enabled": false,
+        "explanation_type": "supported_explanations",
+        "explanation_visibility_state": "support_state_explanation_visible",
+        "operational_readiness_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "support_state_explanation_id": "support_state_explanation_supported_explanations"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "correctness_guarantee_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 2,
+        "evidence_reference_ids": [
+          "evidence_partially_supported_explanations"
+        ],
+        "execution_safety_enabled": false,
+        "explanation_type": "partially_supported_explanations",
+        "explanation_visibility_state": "support_state_explanation_visible",
+        "operational_readiness_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "support_state_explanation_id": "support_state_explanation_partially_supported_explanations"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "correctness_guarantee_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 3,
+        "evidence_reference_ids": [
+          "evidence_unsupported_explanations"
+        ],
+        "execution_safety_enabled": false,
+        "explanation_type": "unsupported_explanations",
+        "explanation_visibility_state": "support_state_explanation_visible",
+        "operational_readiness_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "support_state_explanation_id": "support_state_explanation_unsupported_explanations"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "correctness_guarantee_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 4,
+        "evidence_reference_ids": [
+          "evidence_experimental_explanations"
+        ],
+        "execution_safety_enabled": false,
+        "explanation_type": "experimental_explanations",
+        "explanation_visibility_state": "support_state_explanation_visible",
+        "operational_readiness_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "support_state_explanation_id": "support_state_explanation_experimental_explanations"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "correctness_guarantee_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 5,
+        "evidence_reference_ids": [
+          "evidence_deprecated_explanations"
+        ],
+        "execution_safety_enabled": false,
+        "explanation_type": "deprecated_explanations",
+        "explanation_visibility_state": "support_state_explanation_visible",
+        "operational_readiness_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "support_state_explanation_id": "support_state_explanation_deprecated_explanations"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "correctness_guarantee_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 6,
+        "evidence_reference_ids": [
+          "evidence_blocked_explanations"
+        ],
+        "execution_safety_enabled": false,
+        "explanation_type": "blocked_explanations",
+        "explanation_visibility_state": "support_state_explanation_visible",
+        "operational_readiness_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "support_state_explanation_id": "support_state_explanation_blocked_explanations"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "correctness_guarantee_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 7,
+        "evidence_reference_ids": [
+          "evidence_unknown_state_explanations"
+        ],
+        "execution_safety_enabled": false,
+        "explanation_type": "unknown_state_explanations",
+        "explanation_visibility_state": "support_state_explanation_visible",
+        "operational_readiness_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "support_state_explanation_id": "support_state_explanation_unknown_state_explanations"
+      }
+    ],
+    "surface_identity": {
+      "classification": "governance_safe_public_explainability_surfaces_descriptive_only",
+      "continuity_reference_id": "continuity::v4_5b_3.explainability_surfaces",
+      "diagnostics_reference_id": "diagnostics::v4_5b_3.explainability_surfaces",
+      "evidence_reference_id": "evidence::v4_5b_3.explainability_surfaces",
+      "explainability_surface_id": "v4_5b_3_explainability_surfaces",
+      "explanation_summary_id": "v4_5b_3_explanation_summary",
+      "generated_at": "2026-05-18T00:00:00+00:00",
+      "lineage_reference_id": "lineage::v4_5b_3.explainability_surfaces",
+      "phase_id": "v4_5b_3_explainability_surfaces",
+      "provenance_reference_id": "provenance::v4_5b_3.explainability_surfaces",
+      "schema_version": "v4_5b_3.explainability_surfaces.1",
+      "source_support_status_hash_reference": "c716c22d2907e6f5d6d9eac4e5d3db7102b9b4411547dfe0b361dfedc5e2434e",
+      "source_support_status_report_reference": "docs/generated/v4_5b_2_support_status_visibility_report.json",
+      "support_visibility_reference_id": "support::v4_5b_2.public_support",
+      "trust_summary_reference_id": "trust::v4_5b_3.explainability_surfaces"
+    },
+    "surface_records": [
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "continuity_reference_id": "continuity::v4_5b_3.explainability_surfaces",
+        "descriptive_only": true,
+        "deterministic_order": 1,
+        "diagnostics_reference_id": "diagnostics::v4_5b_3.explainability_surfaces",
+        "evidence_reference_id": "evidence::v4_5b_3.explainability_surfaces",
+        "execution_enabled": false,
+        "explainability_authority_enabled": false,
+        "explainability_surface_id": "v4_5b_3_explainability_surfaces",
+        "explanation_summary_id": "v4_5b_3_explanation_summary",
+        "fail_visible": true,
+        "lineage_reference_id": "lineage::v4_5b_3.explainability_surfaces",
+        "non_approving": true,
+        "non_authorizing": true,
+        "production_enablement_enabled": false,
+        "provenance_reference_id": "provenance::v4_5b_3.explainability_surfaces",
+        "publicly_transparent": true,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "support_visibility_reference_id": "support::v4_5b_2.public_support",
+        "surface_record_id": "public_explainability_surface_foundation",
+        "trust_summary_reference_id": "trust::v4_5b_3.explainability_surfaces",
+        "visibility_state": "public_explainability_surface_visible"
+      }
+    ],
+    "trust_explanations": [
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 1,
+        "evidence_reference_ids": [
+          "evidence_governance_transparency_explanations"
+        ],
+        "execution_semantics_enabled": false,
+        "explanation_visibility_state": "public_trust_explanation_visible",
+        "operational_enabled": false,
+        "trust_explanation_id": "trust_explanation_governance_transparency_explanations",
+        "trust_explanation_type": "governance_transparency_explanations"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 2,
+        "evidence_reference_ids": [
+          "evidence_deterministic_guarantee_explanations"
+        ],
+        "execution_semantics_enabled": false,
+        "explanation_visibility_state": "public_trust_explanation_visible",
+        "operational_enabled": false,
+        "trust_explanation_id": "trust_explanation_deterministic_guarantee_explanations",
+        "trust_explanation_type": "deterministic_guarantee_explanations"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 3,
+        "evidence_reference_ids": [
+          "evidence_explainability_continuity_explanations"
+        ],
+        "execution_semantics_enabled": false,
+        "explanation_visibility_state": "public_trust_explanation_visible",
+        "operational_enabled": false,
+        "trust_explanation_id": "trust_explanation_explainability_continuity_explanations",
+        "trust_explanation_type": "explainability_continuity_explanations"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 4,
+        "evidence_reference_ids": [
+          "evidence_integrity_continuity_explanations"
+        ],
+        "execution_semantics_enabled": false,
+        "explanation_visibility_state": "public_trust_explanation_visible",
+        "operational_enabled": false,
+        "trust_explanation_id": "trust_explanation_integrity_continuity_explanations",
+        "trust_explanation_type": "integrity_continuity_explanations"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 5,
+        "evidence_reference_ids": [
+          "evidence_fail_visible_diagnostic_explanations"
+        ],
+        "execution_semantics_enabled": false,
+        "explanation_visibility_state": "public_trust_explanation_visible",
+        "operational_enabled": false,
+        "trust_explanation_id": "trust_explanation_fail_visible_diagnostic_explanations",
+        "trust_explanation_type": "fail_visible_diagnostic_explanations"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 6,
+        "evidence_reference_ids": [
+          "evidence_unsupported_state_explanations"
+        ],
+        "execution_semantics_enabled": false,
+        "explanation_visibility_state": "public_trust_explanation_visible",
+        "operational_enabled": false,
+        "trust_explanation_id": "trust_explanation_unsupported_state_explanations",
+        "trust_explanation_type": "unsupported_state_explanations"
+      }
+    ],
+    "unsupported_operational_state_visibility": [
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 1,
+        "evidence_reference_ids": [
+          "evidence_unsupported_explanation_operational_states"
+        ],
+        "explicit_reason": "orchestration_execution remains unsupported for v4.5B.3 public explainability surfaces.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_explanation_operational_state_orchestration_execution",
+        "suppression_enabled": false,
+        "unsupported_state": "orchestration_execution",
+        "visibility_state": "unsupported_explanation_operational_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 2,
+        "evidence_reference_ids": [
+          "evidence_unsupported_explanation_operational_states"
+        ],
+        "explicit_reason": "orchestration_authorization remains unsupported for v4.5B.3 public explainability surfaces.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_explanation_operational_state_orchestration_authorization",
+        "suppression_enabled": false,
+        "unsupported_state": "orchestration_authorization",
+        "visibility_state": "unsupported_explanation_operational_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 3,
+        "evidence_reference_ids": [
+          "evidence_unsupported_explanation_operational_states"
+        ],
+        "explicit_reason": "orchestration_approval remains unsupported for v4.5B.3 public explainability surfaces.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_explanation_operational_state_orchestration_approval",
+        "suppression_enabled": false,
+        "unsupported_state": "orchestration_approval",
+        "visibility_state": "unsupported_explanation_operational_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 4,
+        "evidence_reference_ids": [
+          "evidence_unsupported_explanation_operational_states"
+        ],
+        "explicit_reason": "orchestration_dispatch remains unsupported for v4.5B.3 public explainability surfaces.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_explanation_operational_state_orchestration_dispatch",
+        "suppression_enabled": false,
+        "unsupported_state": "orchestration_dispatch",
+        "visibility_state": "unsupported_explanation_operational_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 5,
+        "evidence_reference_ids": [
+          "evidence_unsupported_explanation_operational_states"
+        ],
+        "explicit_reason": "orchestration_routing remains unsupported for v4.5B.3 public explainability surfaces.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_explanation_operational_state_orchestration_routing",
+        "suppression_enabled": false,
+        "unsupported_state": "orchestration_routing",
+        "visibility_state": "unsupported_explanation_operational_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 6,
+        "evidence_reference_ids": [
+          "evidence_unsupported_explanation_operational_states"
+        ],
+        "explicit_reason": "orchestration_traversal remains unsupported for v4.5B.3 public explainability surfaces.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_explanation_operational_state_orchestration_traversal",
+        "suppression_enabled": false,
+        "unsupported_state": "orchestration_traversal",
+        "visibility_state": "unsupported_explanation_operational_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 7,
+        "evidence_reference_ids": [
+          "evidence_unsupported_explanation_operational_states"
+        ],
+        "explicit_reason": "orchestration_scheduling remains unsupported for v4.5B.3 public explainability surfaces.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_explanation_operational_state_orchestration_scheduling",
+        "suppression_enabled": false,
+        "unsupported_state": "orchestration_scheduling",
+        "visibility_state": "unsupported_explanation_operational_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 8,
+        "evidence_reference_ids": [
+          "evidence_unsupported_explanation_operational_states"
+        ],
+        "explicit_reason": "orchestration_sequencing remains unsupported for v4.5B.3 public explainability surfaces.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_explanation_operational_state_orchestration_sequencing",
+        "suppression_enabled": false,
+        "unsupported_state": "orchestration_sequencing",
+        "visibility_state": "unsupported_explanation_operational_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 9,
+        "evidence_reference_ids": [
+          "evidence_unsupported_explanation_operational_states"
+        ],
+        "explicit_reason": "orchestration_decisions remains unsupported for v4.5B.3 public explainability surfaces.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_explanation_operational_state_orchestration_decisions",
+        "suppression_enabled": false,
+        "unsupported_state": "orchestration_decisions",
+        "visibility_state": "unsupported_explanation_operational_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 10,
+        "evidence_reference_ids": [
+          "evidence_unsupported_explanation_operational_states"
+        ],
+        "explicit_reason": "orchestration_recommendations remains unsupported for v4.5B.3 public explainability surfaces.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_explanation_operational_state_orchestration_recommendations",
+        "suppression_enabled": false,
+        "unsupported_state": "orchestration_recommendations",
+        "visibility_state": "unsupported_explanation_operational_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 11,
+        "evidence_reference_ids": [
+          "evidence_unsupported_explanation_operational_states"
+        ],
+        "explicit_reason": "explainability_based_authorization remains unsupported for v4.5B.3 public explainability surfaces.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_explanation_operational_state_explainability_based_authorization",
+        "suppression_enabled": false,
+        "unsupported_state": "explainability_based_authorization",
+        "visibility_state": "unsupported_explanation_operational_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 12,
+        "evidence_reference_ids": [
+          "evidence_unsupported_explanation_operational_states"
+        ],
+        "explicit_reason": "explainability_based_approval remains unsupported for v4.5B.3 public explainability surfaces.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_explanation_operational_state_explainability_based_approval",
+        "suppression_enabled": false,
+        "unsupported_state": "explainability_based_approval",
+        "visibility_state": "unsupported_explanation_operational_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 13,
+        "evidence_reference_ids": [
+          "evidence_unsupported_explanation_operational_states"
+        ],
+        "explicit_reason": "explainability_based_ranking remains unsupported for v4.5B.3 public explainability surfaces.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_explanation_operational_state_explainability_based_ranking",
+        "suppression_enabled": false,
+        "unsupported_state": "explainability_based_ranking",
+        "visibility_state": "unsupported_explanation_operational_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 14,
+        "evidence_reference_ids": [
+          "evidence_unsupported_explanation_operational_states"
+        ],
+        "explicit_reason": "explainability_based_recommendation remains unsupported for v4.5B.3 public explainability surfaces.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_explanation_operational_state_explainability_based_recommendation",
+        "suppression_enabled": false,
+        "unsupported_state": "explainability_based_recommendation",
+        "visibility_state": "unsupported_explanation_operational_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 15,
+        "evidence_reference_ids": [
+          "evidence_unsupported_explanation_operational_states"
+        ],
+        "explicit_reason": "automated_remediation remains unsupported for v4.5B.3 public explainability surfaces.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_explanation_operational_state_automated_remediation",
+        "suppression_enabled": false,
+        "unsupported_state": "automated_remediation",
+        "visibility_state": "unsupported_explanation_operational_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 16,
+        "evidence_reference_ids": [
+          "evidence_unsupported_explanation_operational_states"
+        ],
+        "explicit_reason": "automated_repair remains unsupported for v4.5B.3 public explainability surfaces.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_explanation_operational_state_automated_repair",
+        "suppression_enabled": false,
+        "unsupported_state": "automated_repair",
+        "visibility_state": "unsupported_explanation_operational_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 17,
+        "evidence_reference_ids": [
+          "evidence_unsupported_explanation_operational_states"
+        ],
+        "explicit_reason": "automated_mitigation remains unsupported for v4.5B.3 public explainability surfaces.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_explanation_operational_state_automated_mitigation",
+        "suppression_enabled": false,
+        "unsupported_state": "automated_mitigation",
+        "visibility_state": "unsupported_explanation_operational_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 18,
+        "evidence_reference_ids": [
+          "evidence_unsupported_explanation_operational_states"
+        ],
+        "explicit_reason": "automated_correction remains unsupported for v4.5B.3 public explainability surfaces.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_explanation_operational_state_automated_correction",
+        "suppression_enabled": false,
+        "unsupported_state": "automated_correction",
+        "visibility_state": "unsupported_explanation_operational_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 19,
+        "evidence_reference_ids": [
+          "evidence_unsupported_explanation_operational_states"
+        ],
+        "explicit_reason": "planner_integration remains unsupported for v4.5B.3 public explainability surfaces.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_explanation_operational_state_planner_integration",
+        "suppression_enabled": false,
+        "unsupported_state": "planner_integration",
+        "visibility_state": "unsupported_explanation_operational_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 20,
+        "evidence_reference_ids": [
+          "evidence_unsupported_explanation_operational_states"
+        ],
+        "explicit_reason": "production_consumption remains unsupported for v4.5B.3 public explainability surfaces.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_explanation_operational_state_production_consumption",
+        "suppression_enabled": false,
+        "unsupported_state": "production_consumption",
+        "visibility_state": "unsupported_explanation_operational_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 21,
+        "evidence_reference_ids": [
+          "evidence_unsupported_explanation_operational_states"
+        ],
+        "explicit_reason": "runtime_mutation remains unsupported for v4.5B.3 public explainability surfaces.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_explanation_operational_state_runtime_mutation",
+        "suppression_enabled": false,
+        "unsupported_state": "runtime_mutation",
+        "visibility_state": "unsupported_explanation_operational_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 22,
+        "evidence_reference_ids": [
+          "evidence_unsupported_explanation_operational_states"
+        ],
+        "explicit_reason": "operational_mutation remains unsupported for v4.5B.3 public explainability surfaces.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_explanation_operational_state_operational_mutation",
+        "suppression_enabled": false,
+        "unsupported_state": "operational_mutation",
+        "visibility_state": "unsupported_explanation_operational_state_fail_visible"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 23,
+        "evidence_reference_ids": [
+          "evidence_unsupported_explanation_operational_states"
+        ],
+        "explicit_reason": "implicit_operational_behavior remains unsupported for v4.5B.3 public explainability surfaces.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_explanation_operational_state_implicit_operational_behavior",
+        "suppression_enabled": false,
+        "unsupported_state": "implicit_operational_behavior",
+        "visibility_state": "unsupported_explanation_operational_state_fail_visible"
+      }
+    ],
+    "unsupported_state_explanations": [
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 1,
+        "evidence_reference_ids": [
+          "evidence_unsupported_systems"
+        ],
+        "explanation_visibility_state": "unsupported_state_explanation_fail_visible",
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "remediation_enabled": false,
+        "suppression_enabled": false,
+        "unsupported_explanation_id": "unsupported_state_explanation_unsupported_systems",
+        "unsupported_state_type": "unsupported_systems"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 2,
+        "evidence_reference_ids": [
+          "evidence_unsupported_planner_sections"
+        ],
+        "explanation_visibility_state": "unsupported_state_explanation_fail_visible",
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "remediation_enabled": false,
+        "suppression_enabled": false,
+        "unsupported_explanation_id": "unsupported_state_explanation_unsupported_planner_sections",
+        "unsupported_state_type": "unsupported_planner_sections"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 3,
+        "evidence_reference_ids": [
+          "evidence_unsupported_evidence_chains"
+        ],
+        "explanation_visibility_state": "unsupported_state_explanation_fail_visible",
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "remediation_enabled": false,
+        "suppression_enabled": false,
+        "unsupported_explanation_id": "unsupported_state_explanation_unsupported_evidence_chains",
+        "unsupported_state_type": "unsupported_evidence_chains"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 4,
+        "evidence_reference_ids": [
+          "evidence_unsupported_continuity_chains"
+        ],
+        "explanation_visibility_state": "unsupported_state_explanation_fail_visible",
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "remediation_enabled": false,
+        "suppression_enabled": false,
+        "unsupported_explanation_id": "unsupported_state_explanation_unsupported_continuity_chains",
+        "unsupported_state_type": "unsupported_continuity_chains"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 5,
+        "evidence_reference_ids": [
+          "evidence_unsupported_operational_states"
+        ],
+        "explanation_visibility_state": "unsupported_state_explanation_fail_visible",
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "remediation_enabled": false,
+        "suppression_enabled": false,
+        "unsupported_explanation_id": "unsupported_state_explanation_unsupported_operational_states",
+        "unsupported_state_type": "unsupported_operational_states"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "deterministic_order": 6,
+        "evidence_reference_ids": [
+          "evidence_unsupported_trust_states"
+        ],
+        "explanation_visibility_state": "unsupported_state_explanation_fail_visible",
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "remediation_enabled": false,
+        "suppression_enabled": false,
+        "unsupported_explanation_id": "unsupported_state_explanation_unsupported_trust_states",
+        "unsupported_state_type": "unsupported_trust_states"
+      }
+    ]
+  },
+  "foundation_status": "v4_5b_3_explainability_surfaces_stable",
+  "generated_at": "2026-05-18T00:00:00+00:00",
+  "phase_id": "v4_5b_3_explainability_surfaces",
+  "purpose": "deterministic_governance_safe_public_explainability_surfaces_descriptive_only",
+  "schema_version": "v4_5b_3.explainability_surfaces_report.1",
+  "summary": {
+    "continuity_counts": {
+      "diagnostics_continuity_explanations": 1,
+      "evidence_continuity_explanations": 1,
+      "integrity_continuity_explanations": 1,
+      "lineage_continuity_explanations": 1,
+      "provenance_continuity_explanations": 1
+    },
+    "continuity_explanation_count": 5,
+    "continuity_explanation_visibility_stable": true,
+    "descriptive_only_guarantees_verified": true,
+    "deterministic_hashing_verified": true,
+    "deterministic_serialization_verified": true,
+    "diagnostic_counts": {
+      "incomplete_continuity_explanations": 1,
+      "incomplete_integrity_explanations": 1,
+      "inherited_limitation_explanation_gaps": 1,
+      "inherited_prohibition_explanation_gaps": 1,
+      "missing_explanation_evidence": 1,
+      "unsupported_explanation_gaps": 1,
+      "unsupported_operational_explanations": 1,
+      "unsupported_trust_explanations": 1
+    },
+    "enabled_auto_correction_count": 0,
+    "enabled_explainability_approval_count": 0,
+    "enabled_explainability_authorization_count": 0,
+    "enabled_explainability_ranking_count": 0,
+    "enabled_explainability_recommendation_count": 0,
+    "enabled_mitigation_count": 0,
+    "enabled_operational_mutation_count": 0,
+    "enabled_orchestration_approval_count": 0,
+    "enabled_orchestration_authorization_count": 0,
+    "enabled_orchestration_decision_count": 0,
+    "enabled_orchestration_dispatch_count": 0,
+    "enabled_orchestration_recommendation_count": 0,
+    "enabled_orchestration_routing_count": 0,
+    "enabled_orchestration_scheduling_count": 0,
+    "enabled_orchestration_sequencing_count": 0,
+    "enabled_orchestration_traversal_count": 0,
+    "enabled_planner_integration_count": 0,
+    "enabled_production_consumption_count": 0,
+    "enabled_remediation_count": 0,
+    "enabled_repair_count": 0,
+    "enabled_runtime_execution_count": 0,
+    "enabled_runtime_mutation_count": 0,
+    "evidence_continuity_preserved": true,
+    "evidence_to_explanation_mapping_count": 6,
+    "evidence_to_explanation_mapping_stable": true,
+    "explainability_surface_statement": "Explainability surfaces are descriptive-only.",
+    "explainability_visibility_non_authority_statement": "Explainability visibility does NOT imply authorization, approval, operational readiness, execution safety, or production enablement.",
+    "explanation_diagnostic_count": 8,
+    "explanation_summary_count": 8,
+    "explicit_limitation_count": 12,
+    "fail_visible_explanation_diagnostics_verified": true,
+    "inherited_constraint_count": 19,
+    "inherited_prohibition_count": 23,
+    "limitation_counts": {
+      "blocked_limitation_explanations": 1,
+      "continuity_limitation_explanations": 1,
+      "deprecated_limitation_explanations": 1,
+      "evidence_limitation_explanations": 1,
+      "experimental_limitation_explanations": 1,
+      "governance_limitation_explanations": 1,
+      "unsupported_limitation_explanations": 1
+    },
+    "limitation_explanation_count": 7,
+    "limitation_explanation_preserved": true,
+    "lineage_continuity_preserved": true,
+    "mapping_counts": {
+      "continuity_backed_explanations": 1,
+      "diagnostics_backed_explanations": 1,
+      "evidence_backed_explanations": 1,
+      "explainability_backed_explanations": 1,
+      "partially_evidenced_explanations": 1,
+      "unsupported_evidence_explanations": 1
+    },
+    "provenance_continuity_preserved": true,
+    "publicly_transparent": true,
+    "repository_remains": [
+      "NON-operational",
+      "NON-authorizing",
+      "NON-approving",
+      "NON-executing",
+      "NON-remediating",
+      "NON-runtime-mutating",
+      "NON-ranking",
+      "NON-recommending"
+    ],
+    "summary_counts": {
+      "continuity_explanation_summary": 1,
+      "diagnostics_explanation_summary": 1,
+      "evidence_mapping_summary": 1,
+      "explanation_surface_summary": 1,
+      "limitation_explanation_summary": 1,
+      "support_state_explanation_summary": 1,
+      "trust_explanation_summary": 1,
+      "unsupported_state_explanation_summary": 1
+    },
+    "support_counts": {
+      "blocked_explanations": 1,
+      "deprecated_explanations": 1,
+      "experimental_explanations": 1,
+      "partially_supported_explanations": 1,
+      "supported_explanations": 1,
+      "unknown_state_explanations": 1,
+      "unsupported_explanations": 1
+    },
+    "support_state_explanation_count": 7,
+    "support_state_explanations_stable": true,
+    "surface_record_count": 1,
+    "trust_counts": {
+      "deterministic_guarantee_explanations": 1,
+      "explainability_continuity_explanations": 1,
+      "fail_visible_diagnostic_explanations": 1,
+      "governance_transparency_explanations": 1,
+      "integrity_continuity_explanations": 1,
+      "unsupported_state_explanations": 1
+    },
+    "trust_explanation_count": 6,
+    "trust_explanation_visibility_stable": true,
+    "unsupported_counts": {
+      "unsupported_continuity_chains": 1,
+      "unsupported_evidence_chains": 1,
+      "unsupported_operational_states": 1,
+      "unsupported_planner_sections": 1,
+      "unsupported_systems": 1,
+      "unsupported_trust_states": 1
+    },
+    "unsupported_operational_counts": {
+      "automated_correction": 1,
+      "automated_mitigation": 1,
+      "automated_remediation": 1,
+      "automated_repair": 1,
+      "explainability_based_approval": 1,
+      "explainability_based_authorization": 1,
+      "explainability_based_ranking": 1,
+      "explainability_based_recommendation": 1,
+      "implicit_operational_behavior": 1,
+      "operational_mutation": 1,
+      "orchestration_approval": 1,
+      "orchestration_authorization": 1,
+      "orchestration_decisions": 1,
+      "orchestration_dispatch": 1,
+      "orchestration_execution": 1,
+      "orchestration_recommendations": 1,
+      "orchestration_routing": 1,
+      "orchestration_scheduling": 1,
+      "orchestration_sequencing": 1,
+      "orchestration_traversal": 1,
+      "planner_integration": 1,
+      "production_consumption": 1,
+      "runtime_mutation": 1
+    },
+    "unsupported_operational_state_count": 23,
+    "unsupported_state_explanation_count": 6,
+    "unsupported_state_explanation_preserved": true,
+    "validation_error_count": 0
+  },
+  "validation": {
+    "failed_validations": [],
+    "foundation_status": "v4_5b_3_explainability_surfaces_stable",
+    "valid": true,
+    "validation_error_count": 0,
+    "validations": {
+      "continuity_explanations": {
+        "continuity_explanation_count": 5,
+        "missing_continuity_explanation_types": [],
+        "unsafe_continuity_explanation_ids": [],
+        "valid": true
+      },
+      "descriptive_only_guarantees": {
+        "counters": {
+          "enabled_auto_correction_count": 0,
+          "enabled_explainability_approval_count": 0,
+          "enabled_explainability_authorization_count": 0,
+          "enabled_explainability_ranking_count": 0,
+          "enabled_explainability_recommendation_count": 0,
+          "enabled_mitigation_count": 0,
+          "enabled_operational_mutation_count": 0,
+          "enabled_orchestration_approval_count": 0,
+          "enabled_orchestration_authorization_count": 0,
+          "enabled_orchestration_decision_count": 0,
+          "enabled_orchestration_dispatch_count": 0,
+          "enabled_orchestration_recommendation_count": 0,
+          "enabled_orchestration_routing_count": 0,
+          "enabled_orchestration_scheduling_count": 0,
+          "enabled_orchestration_sequencing_count": 0,
+          "enabled_orchestration_traversal_count": 0,
+          "enabled_planner_integration_count": 0,
+          "enabled_production_consumption_count": 0,
+          "enabled_remediation_count": 0,
+          "enabled_repair_count": 0,
+          "enabled_runtime_execution_count": 0,
+          "enabled_runtime_mutation_count": 0
+        },
+        "descriptive_failures": [],
+        "enabled_flags": {},
+        "explainability_surface_statement": "Explainability surfaces are descriptive-only.",
+        "explainability_visibility_non_authority_statement": "Explainability visibility does NOT imply authorization, approval, operational readiness, execution safety, or production enablement.",
+        "explicit_limitation_count": 12,
+        "inherited_constraint_count": 19,
+        "inherited_prohibition_count": 23,
+        "missing_disabled_counters": [],
+        "publicly_transparent": true,
+        "repository_remains": {
+          "NON-approving": true,
+          "NON-authorizing": true,
+          "NON-executing": true,
+          "NON-operational": true,
+          "NON-ranking": true,
+          "NON-recommending": true,
+          "NON-remediating": true,
+          "NON-runtime-mutating": true
+        },
+        "statement_valid": true,
+        "valid": true
+      },
+      "evidence_to_explanation_mapping": {
+        "evidence_mapping_count": 6,
+        "missing_evidence_mapping_types": [],
+        "unsafe_evidence_mapping_ids": [],
+        "valid": true
+      },
+      "explanation_summary": {
+        "explanation_summary_count": 8,
+        "missing_explanation_summary_types": [],
+        "unsafe_explanation_summary_ids": [],
+        "valid": true
+      },
+      "fail_visible_explanations": {
+        "approval_enabled_count": 0,
+        "authorization_enabled_count": 0,
+        "explanation_diagnostic_count": 8,
+        "fail_visible": true,
+        "hidden_fallback_enabled_count": 0,
+        "missing_diagnostic_types": [],
+        "missing_unsupported_states": [],
+        "ranking_enabled_count": 0,
+        "recommendation_enabled_count": 0,
+        "silent_fallback_enabled_count": 0,
+        "unsafe_diagnostic_ids": [],
+        "unsafe_unsupported_ids": [],
+        "unsupported_operational_state_count": 23,
+        "valid": true
+      },
+      "identity_integrity": {
+        "missing_identity_fields": [],
+        "phase_id": "v4_5b_3_explainability_surfaces",
+        "schema_version": "v4_5b_3.explainability_surfaces.1",
+        "source_report_hash_matches": true,
+        "source_report_present": true,
+        "valid": true
+      },
+      "limitation_explanations": {
+        "limitation_explanation_count": 7,
+        "missing_limitation_explanation_types": [],
+        "unsafe_limitation_explanation_ids": [],
+        "valid": true
+      },
+      "lineage_and_provenance": {
+        "continuity_records_missing_references": [],
+        "continuity_reference_preserved": true,
+        "evidence_continuity_preserved": true,
+        "lineage_continuity_preserved": true,
+        "provenance_continuity_preserved": true,
+        "records_missing_evidence": [],
+        "valid": true
+      },
+      "ordering_stability": {
+        "order_groups": {
+          "continuity_explanations": [
+            1,
+            2,
+            3,
+            4,
+            5
+          ],
+          "evidence_to_explanation_mappings": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6
+          ],
+          "explanation_diagnostics": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8
+          ],
+          "explanation_summaries": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8
+          ],
+          "limitation_explanations": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "support_state_explanations": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "surface_records": [
+            1
+          ],
+          "trust_explanations": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6
+          ],
+          "unsupported_operational_state_visibility": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+            21,
+            22,
+            23
+          ],
+          "unsupported_state_explanations": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6
+          ]
+        },
+        "unordered_groups": [],
+        "valid": true
+      },
+      "required_visibility": {
+        "continuity_counts": {
+          "diagnostics_continuity_explanations": 1,
+          "evidence_continuity_explanations": 1,
+          "integrity_continuity_explanations": 1,
+          "lineage_continuity_explanations": 1,
+          "provenance_continuity_explanations": 1
+        },
+        "diagnostic_counts": {
+          "incomplete_continuity_explanations": 1,
+          "incomplete_integrity_explanations": 1,
+          "inherited_limitation_explanation_gaps": 1,
+          "inherited_prohibition_explanation_gaps": 1,
+          "missing_explanation_evidence": 1,
+          "unsupported_explanation_gaps": 1,
+          "unsupported_operational_explanations": 1,
+          "unsupported_trust_explanations": 1
+        },
+        "limitation_counts": {
+          "blocked_limitation_explanations": 1,
+          "continuity_limitation_explanations": 1,
+          "deprecated_limitation_explanations": 1,
+          "evidence_limitation_explanations": 1,
+          "experimental_limitation_explanations": 1,
+          "governance_limitation_explanations": 1,
+          "unsupported_limitation_explanations": 1
+        },
+        "mapping_counts": {
+          "continuity_backed_explanations": 1,
+          "diagnostics_backed_explanations": 1,
+          "evidence_backed_explanations": 1,
+          "explainability_backed_explanations": 1,
+          "partially_evidenced_explanations": 1,
+          "unsupported_evidence_explanations": 1
+        },
+        "missing_continuity_explanations": [],
+        "missing_diagnostics": [],
+        "missing_evidence_mappings": [],
+        "missing_limitation_explanations": [],
+        "missing_summaries": [],
+        "missing_support_state_explanations": [],
+        "missing_trust_explanations": [],
+        "missing_unsupported_operational_states": [],
+        "missing_unsupported_state_explanations": [],
+        "summary_counts": {
+          "continuity_explanation_summary": 1,
+          "diagnostics_explanation_summary": 1,
+          "evidence_mapping_summary": 1,
+          "explanation_surface_summary": 1,
+          "limitation_explanation_summary": 1,
+          "support_state_explanation_summary": 1,
+          "trust_explanation_summary": 1,
+          "unsupported_state_explanation_summary": 1
+        },
+        "support_counts": {
+          "blocked_explanations": 1,
+          "deprecated_explanations": 1,
+          "experimental_explanations": 1,
+          "partially_supported_explanations": 1,
+          "supported_explanations": 1,
+          "unknown_state_explanations": 1,
+          "unsupported_explanations": 1
+        },
+        "trust_counts": {
+          "deterministic_guarantee_explanations": 1,
+          "explainability_continuity_explanations": 1,
+          "fail_visible_diagnostic_explanations": 1,
+          "governance_transparency_explanations": 1,
+          "integrity_continuity_explanations": 1,
+          "unsupported_state_explanations": 1
+        },
+        "unsupported_counts": {
+          "unsupported_continuity_chains": 1,
+          "unsupported_evidence_chains": 1,
+          "unsupported_operational_states": 1,
+          "unsupported_planner_sections": 1,
+          "unsupported_systems": 1,
+          "unsupported_trust_states": 1
+        },
+        "unsupported_operational_counts": {
+          "automated_correction": 1,
+          "automated_mitigation": 1,
+          "automated_remediation": 1,
+          "automated_repair": 1,
+          "explainability_based_approval": 1,
+          "explainability_based_authorization": 1,
+          "explainability_based_ranking": 1,
+          "explainability_based_recommendation": 1,
+          "implicit_operational_behavior": 1,
+          "operational_mutation": 1,
+          "orchestration_approval": 1,
+          "orchestration_authorization": 1,
+          "orchestration_decisions": 1,
+          "orchestration_dispatch": 1,
+          "orchestration_execution": 1,
+          "orchestration_recommendations": 1,
+          "orchestration_routing": 1,
+          "orchestration_scheduling": 1,
+          "orchestration_sequencing": 1,
+          "orchestration_traversal": 1,
+          "planner_integration": 1,
+          "production_consumption": 1,
+          "runtime_mutation": 1
+        },
+        "valid": true
+      },
+      "serialization_hashing": {
+        "explainability_surface_hash": "7491594afcddcd2c762e75d7cf9772eaca79a219dd64327257644bf1eee19808",
+        "hashing_stable": true,
+        "serialization_stable": true,
+        "valid": true
+      },
+      "support_state_explanations": {
+        "missing_support_state_explanation_types": [],
+        "support_state_explanation_count": 7,
+        "unsafe_support_state_explanation_ids": [],
+        "valid": true
+      },
+      "trust_explanations": {
+        "missing_trust_explanation_types": [],
+        "trust_explanation_count": 6,
+        "unsafe_trust_explanation_ids": [],
+        "valid": true
+      },
+      "unsupported_state_explanations": {
+        "missing_unsupported_state_explanation_types": [],
+        "unsafe_unsupported_state_explanation_ids": [],
+        "unsupported_state_explanation_count": 6,
+        "valid": true
+      }
+    }
+  },
+  "visibility": {
+    "continuity_explanations": [
+      {
+        "authorization_enabled": false,
+        "continuity_explanation_id": "continuity_explanation_evidence_continuity_explanations",
+        "continuity_explanation_type": "evidence_continuity_explanations",
+        "continuity_reference_id": "continuity_reference_evidence_continuity_explanations",
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_evidence_continuity_explanations"
+        ],
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "restoration_enabled": false
+      },
+      {
+        "authorization_enabled": false,
+        "continuity_explanation_id": "continuity_explanation_lineage_continuity_explanations",
+        "continuity_explanation_type": "lineage_continuity_explanations",
+        "continuity_reference_id": "continuity_reference_lineage_continuity_explanations",
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_lineage_continuity_explanations"
+        ],
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "restoration_enabled": false
+      },
+      {
+        "authorization_enabled": false,
+        "continuity_explanation_id": "continuity_explanation_provenance_continuity_explanations",
+        "continuity_explanation_type": "provenance_continuity_explanations",
+        "continuity_reference_id": "continuity_reference_provenance_continuity_explanations",
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_provenance_continuity_explanations"
+        ],
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "restoration_enabled": false
+      },
+      {
+        "authorization_enabled": false,
+        "continuity_explanation_id": "continuity_explanation_integrity_continuity_explanations",
+        "continuity_explanation_type": "integrity_continuity_explanations",
+        "continuity_reference_id": "continuity_reference_integrity_continuity_explanations",
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_integrity_continuity_explanations"
+        ],
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "restoration_enabled": false
+      },
+      {
+        "authorization_enabled": false,
+        "continuity_explanation_id": "continuity_explanation_diagnostics_continuity_explanations",
+        "continuity_explanation_type": "diagnostics_continuity_explanations",
+        "continuity_reference_id": "continuity_reference_diagnostics_continuity_explanations",
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_diagnostics_continuity_explanations"
+        ],
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "restoration_enabled": false
+      }
+    ],
+    "descriptive_only": {
+      "descriptive_only": true,
+      "explainability_approval_enabled": false,
+      "explainability_authorization_enabled": false,
+      "explainability_ranking_enabled": false,
+      "explainability_recommendation_enabled": false,
+      "explainability_surface_statement": "Explainability surfaces are descriptive-only.",
+      "explainability_visibility_non_authority_statement": "Explainability visibility does NOT imply authorization, approval, operational readiness, execution safety, or production enablement.",
+      "non_approving": true,
+      "non_authorizing": true,
+      "non_executing": true,
+      "non_operational": true,
+      "non_ranking": true,
+      "non_recommending": true,
+      "non_remediating": true,
+      "non_runtime_mutating": true,
+      "operational_mutation_enabled": false,
+      "planner_integration_enabled": false,
+      "production_consumption_enabled": false,
+      "publicly_transparent": true,
+      "runtime_mutation_enabled": false
+    },
+    "evidence_to_explanation_mappings": [
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_mapping_id": "evidence_to_explanation_evidence_backed_explanations",
+        "evidence_reference_ids": [
+          "evidence_evidence_backed_explanations"
+        ],
+        "explanation_reference_ids": [
+          "explanation_evidence_backed_explanations"
+        ],
+        "mapping_type": "evidence_backed_explanations",
+        "provenance_safe": true,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "replay_safe": true,
+        "trust_scoring_enabled": false
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_mapping_id": "evidence_to_explanation_partially_evidenced_explanations",
+        "evidence_reference_ids": [
+          "evidence_partially_evidenced_explanations"
+        ],
+        "explanation_reference_ids": [
+          "explanation_partially_evidenced_explanations"
+        ],
+        "mapping_type": "partially_evidenced_explanations",
+        "provenance_safe": true,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "replay_safe": true,
+        "trust_scoring_enabled": false
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_mapping_id": "evidence_to_explanation_unsupported_evidence_explanations",
+        "evidence_reference_ids": [
+          "evidence_unsupported_evidence_explanations"
+        ],
+        "explanation_reference_ids": [
+          "explanation_unsupported_evidence_explanations"
+        ],
+        "mapping_type": "unsupported_evidence_explanations",
+        "provenance_safe": true,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "replay_safe": true,
+        "trust_scoring_enabled": false
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_mapping_id": "evidence_to_explanation_continuity_backed_explanations",
+        "evidence_reference_ids": [
+          "evidence_continuity_backed_explanations"
+        ],
+        "explanation_reference_ids": [
+          "explanation_continuity_backed_explanations"
+        ],
+        "mapping_type": "continuity_backed_explanations",
+        "provenance_safe": true,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "replay_safe": true,
+        "trust_scoring_enabled": false
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_mapping_id": "evidence_to_explanation_explainability_backed_explanations",
+        "evidence_reference_ids": [
+          "evidence_explainability_backed_explanations"
+        ],
+        "explanation_reference_ids": [
+          "explanation_explainability_backed_explanations"
+        ],
+        "mapping_type": "explainability_backed_explanations",
+        "provenance_safe": true,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "replay_safe": true,
+        "trust_scoring_enabled": false
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_mapping_id": "evidence_to_explanation_diagnostics_backed_explanations",
+        "evidence_reference_ids": [
+          "evidence_diagnostics_backed_explanations"
+        ],
+        "explanation_reference_ids": [
+          "explanation_diagnostics_backed_explanations"
+        ],
+        "mapping_type": "diagnostics_backed_explanations",
+        "provenance_safe": true,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "replay_safe": true,
+        "trust_scoring_enabled": false
+      }
+    ],
+    "explainability_surfaces": [
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "continuity_reference_id": "continuity::v4_5b_3.explainability_surfaces",
+        "descriptive_only": true,
+        "diagnostics_reference_id": "diagnostics::v4_5b_3.explainability_surfaces",
+        "evidence_reference_id": "evidence::v4_5b_3.explainability_surfaces",
+        "explainability_authority_enabled": false,
+        "explainability_surface_id": "v4_5b_3_explainability_surfaces",
+        "explanation_summary_id": "v4_5b_3_explanation_summary",
+        "fail_visible": true,
+        "lineage_reference_id": "lineage::v4_5b_3.explainability_surfaces",
+        "provenance_reference_id": "provenance::v4_5b_3.explainability_surfaces",
+        "publicly_transparent": true,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "support_visibility_reference_id": "support::v4_5b_2.public_support",
+        "surface_record_id": "public_explainability_surface_foundation",
+        "trust_summary_reference_id": "trust::v4_5b_3.explainability_surfaces"
+      }
+    ],
+    "explanation_diagnostics": [
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "auto_correction_enabled": false,
+        "descriptive_only": true,
+        "diagnostic_id": "explanation_diagnostic_missing_explanation_evidence",
+        "diagnostic_type": "missing_explanation_evidence",
+        "evidence_reference_ids": [
+          "evidence_missing_explanation_evidence"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "message": "missing_explanation_evidence remains explicit, fail-visible, and descriptive-only for public explainability surfaces.",
+        "mitigation_enabled": false,
+        "orchestration_response_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "silent_fallback_enabled": false
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "auto_correction_enabled": false,
+        "descriptive_only": true,
+        "diagnostic_id": "explanation_diagnostic_unsupported_explanation_gaps",
+        "diagnostic_type": "unsupported_explanation_gaps",
+        "evidence_reference_ids": [
+          "evidence_unsupported_explanation_gaps"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "message": "unsupported_explanation_gaps remains explicit, fail-visible, and descriptive-only for public explainability surfaces.",
+        "mitigation_enabled": false,
+        "orchestration_response_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "silent_fallback_enabled": false
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "auto_correction_enabled": false,
+        "descriptive_only": true,
+        "diagnostic_id": "explanation_diagnostic_incomplete_continuity_explanations",
+        "diagnostic_type": "incomplete_continuity_explanations",
+        "evidence_reference_ids": [
+          "evidence_incomplete_continuity_explanations"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "message": "incomplete_continuity_explanations remains explicit, fail-visible, and descriptive-only for public explainability surfaces.",
+        "mitigation_enabled": false,
+        "orchestration_response_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "silent_fallback_enabled": false
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "auto_correction_enabled": false,
+        "descriptive_only": true,
+        "diagnostic_id": "explanation_diagnostic_incomplete_integrity_explanations",
+        "diagnostic_type": "incomplete_integrity_explanations",
+        "evidence_reference_ids": [
+          "evidence_incomplete_integrity_explanations"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "message": "incomplete_integrity_explanations remains explicit, fail-visible, and descriptive-only for public explainability surfaces.",
+        "mitigation_enabled": false,
+        "orchestration_response_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "silent_fallback_enabled": false
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "auto_correction_enabled": false,
+        "descriptive_only": true,
+        "diagnostic_id": "explanation_diagnostic_unsupported_trust_explanations",
+        "diagnostic_type": "unsupported_trust_explanations",
+        "evidence_reference_ids": [
+          "evidence_unsupported_trust_explanations"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "message": "unsupported_trust_explanations remains explicit, fail-visible, and descriptive-only for public explainability surfaces.",
+        "mitigation_enabled": false,
+        "orchestration_response_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "silent_fallback_enabled": false
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "auto_correction_enabled": false,
+        "descriptive_only": true,
+        "diagnostic_id": "explanation_diagnostic_unsupported_operational_explanations",
+        "diagnostic_type": "unsupported_operational_explanations",
+        "evidence_reference_ids": [
+          "evidence_unsupported_operational_explanations"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "message": "unsupported_operational_explanations remains explicit, fail-visible, and descriptive-only for public explainability surfaces.",
+        "mitigation_enabled": false,
+        "orchestration_response_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "silent_fallback_enabled": false
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "auto_correction_enabled": false,
+        "descriptive_only": true,
+        "diagnostic_id": "explanation_diagnostic_inherited_limitation_explanation_gaps",
+        "diagnostic_type": "inherited_limitation_explanation_gaps",
+        "evidence_reference_ids": [
+          "evidence_inherited_limitation_explanation_gaps"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "message": "inherited_limitation_explanation_gaps remains explicit, fail-visible, and descriptive-only for public explainability surfaces.",
+        "mitigation_enabled": false,
+        "orchestration_response_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "silent_fallback_enabled": false
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "auto_correction_enabled": false,
+        "descriptive_only": true,
+        "diagnostic_id": "explanation_diagnostic_inherited_prohibition_explanation_gaps",
+        "diagnostic_type": "inherited_prohibition_explanation_gaps",
+        "evidence_reference_ids": [
+          "evidence_inherited_prohibition_explanation_gaps"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "message": "inherited_prohibition_explanation_gaps remains explicit, fail-visible, and descriptive-only for public explainability surfaces.",
+        "mitigation_enabled": false,
+        "orchestration_response_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "silent_fallback_enabled": false
+      }
+    ],
+    "explanation_summaries": [
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_explanation_surface_summary"
+        ],
+        "execution_enablement_enabled": false,
+        "explanation_summary_id": "v4_5b_3_explanation_summary",
+        "explanation_summary_record_id": "explanation_summary_explanation_surface_summary",
+        "production_enablement_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "summary_state": "explanation_summary_descriptive_only",
+        "summary_type": "explanation_surface_summary"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_support_state_explanation_summary"
+        ],
+        "execution_enablement_enabled": false,
+        "explanation_summary_id": "v4_5b_3_explanation_summary",
+        "explanation_summary_record_id": "explanation_summary_support_state_explanation_summary",
+        "production_enablement_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "summary_state": "explanation_summary_descriptive_only",
+        "summary_type": "support_state_explanation_summary"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_evidence_mapping_summary"
+        ],
+        "execution_enablement_enabled": false,
+        "explanation_summary_id": "v4_5b_3_explanation_summary",
+        "explanation_summary_record_id": "explanation_summary_evidence_mapping_summary",
+        "production_enablement_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "summary_state": "explanation_summary_descriptive_only",
+        "summary_type": "evidence_mapping_summary"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_limitation_explanation_summary"
+        ],
+        "execution_enablement_enabled": false,
+        "explanation_summary_id": "v4_5b_3_explanation_summary",
+        "explanation_summary_record_id": "explanation_summary_limitation_explanation_summary",
+        "production_enablement_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "summary_state": "explanation_summary_descriptive_only",
+        "summary_type": "limitation_explanation_summary"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_trust_explanation_summary"
+        ],
+        "execution_enablement_enabled": false,
+        "explanation_summary_id": "v4_5b_3_explanation_summary",
+        "explanation_summary_record_id": "explanation_summary_trust_explanation_summary",
+        "production_enablement_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "summary_state": "explanation_summary_descriptive_only",
+        "summary_type": "trust_explanation_summary"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_continuity_explanation_summary"
+        ],
+        "execution_enablement_enabled": false,
+        "explanation_summary_id": "v4_5b_3_explanation_summary",
+        "explanation_summary_record_id": "explanation_summary_continuity_explanation_summary",
+        "production_enablement_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "summary_state": "explanation_summary_descriptive_only",
+        "summary_type": "continuity_explanation_summary"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_state_explanation_summary"
+        ],
+        "execution_enablement_enabled": false,
+        "explanation_summary_id": "v4_5b_3_explanation_summary",
+        "explanation_summary_record_id": "explanation_summary_unsupported_state_explanation_summary",
+        "production_enablement_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "summary_state": "explanation_summary_descriptive_only",
+        "summary_type": "unsupported_state_explanation_summary"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_diagnostics_explanation_summary"
+        ],
+        "execution_enablement_enabled": false,
+        "explanation_summary_id": "v4_5b_3_explanation_summary",
+        "explanation_summary_record_id": "explanation_summary_diagnostics_explanation_summary",
+        "production_enablement_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "summary_state": "explanation_summary_descriptive_only",
+        "summary_type": "diagnostics_explanation_summary"
+      }
+    ],
+    "limitation_explanations": [
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_limitation_explanations"
+        ],
+        "limitation_explanation_id": "limitation_explanation_unsupported_limitation_explanations",
+        "limitation_type": "unsupported_limitation_explanations",
+        "operational_fallback_enabled": false,
+        "recommendation_enabled": false
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_experimental_limitation_explanations"
+        ],
+        "limitation_explanation_id": "limitation_explanation_experimental_limitation_explanations",
+        "limitation_type": "experimental_limitation_explanations",
+        "operational_fallback_enabled": false,
+        "recommendation_enabled": false
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_deprecated_limitation_explanations"
+        ],
+        "limitation_explanation_id": "limitation_explanation_deprecated_limitation_explanations",
+        "limitation_type": "deprecated_limitation_explanations",
+        "operational_fallback_enabled": false,
+        "recommendation_enabled": false
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_blocked_limitation_explanations"
+        ],
+        "limitation_explanation_id": "limitation_explanation_blocked_limitation_explanations",
+        "limitation_type": "blocked_limitation_explanations",
+        "operational_fallback_enabled": false,
+        "recommendation_enabled": false
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_governance_limitation_explanations"
+        ],
+        "limitation_explanation_id": "limitation_explanation_governance_limitation_explanations",
+        "limitation_type": "governance_limitation_explanations",
+        "operational_fallback_enabled": false,
+        "recommendation_enabled": false
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_continuity_limitation_explanations"
+        ],
+        "limitation_explanation_id": "limitation_explanation_continuity_limitation_explanations",
+        "limitation_type": "continuity_limitation_explanations",
+        "operational_fallback_enabled": false,
+        "recommendation_enabled": false
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_evidence_limitation_explanations"
+        ],
+        "limitation_explanation_id": "limitation_explanation_evidence_limitation_explanations",
+        "limitation_type": "evidence_limitation_explanations",
+        "operational_fallback_enabled": false,
+        "recommendation_enabled": false
+      }
+    ],
+    "support_state_explanations": [
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "correctness_guarantee_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_supported_explanations"
+        ],
+        "execution_safety_enabled": false,
+        "explanation_type": "supported_explanations",
+        "operational_readiness_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "support_state_explanation_id": "support_state_explanation_supported_explanations"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "correctness_guarantee_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_partially_supported_explanations"
+        ],
+        "execution_safety_enabled": false,
+        "explanation_type": "partially_supported_explanations",
+        "operational_readiness_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "support_state_explanation_id": "support_state_explanation_partially_supported_explanations"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "correctness_guarantee_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_explanations"
+        ],
+        "execution_safety_enabled": false,
+        "explanation_type": "unsupported_explanations",
+        "operational_readiness_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "support_state_explanation_id": "support_state_explanation_unsupported_explanations"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "correctness_guarantee_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_experimental_explanations"
+        ],
+        "execution_safety_enabled": false,
+        "explanation_type": "experimental_explanations",
+        "operational_readiness_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "support_state_explanation_id": "support_state_explanation_experimental_explanations"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "correctness_guarantee_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_deprecated_explanations"
+        ],
+        "execution_safety_enabled": false,
+        "explanation_type": "deprecated_explanations",
+        "operational_readiness_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "support_state_explanation_id": "support_state_explanation_deprecated_explanations"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "correctness_guarantee_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_blocked_explanations"
+        ],
+        "execution_safety_enabled": false,
+        "explanation_type": "blocked_explanations",
+        "operational_readiness_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "support_state_explanation_id": "support_state_explanation_blocked_explanations"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "correctness_guarantee_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unknown_state_explanations"
+        ],
+        "execution_safety_enabled": false,
+        "explanation_type": "unknown_state_explanations",
+        "operational_readiness_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "support_state_explanation_id": "support_state_explanation_unknown_state_explanations"
+      }
+    ],
+    "trust_explanations": [
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_governance_transparency_explanations"
+        ],
+        "execution_semantics_enabled": false,
+        "operational_enabled": false,
+        "trust_explanation_id": "trust_explanation_governance_transparency_explanations",
+        "trust_explanation_type": "governance_transparency_explanations"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_deterministic_guarantee_explanations"
+        ],
+        "execution_semantics_enabled": false,
+        "operational_enabled": false,
+        "trust_explanation_id": "trust_explanation_deterministic_guarantee_explanations",
+        "trust_explanation_type": "deterministic_guarantee_explanations"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_explainability_continuity_explanations"
+        ],
+        "execution_semantics_enabled": false,
+        "operational_enabled": false,
+        "trust_explanation_id": "trust_explanation_explainability_continuity_explanations",
+        "trust_explanation_type": "explainability_continuity_explanations"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_integrity_continuity_explanations"
+        ],
+        "execution_semantics_enabled": false,
+        "operational_enabled": false,
+        "trust_explanation_id": "trust_explanation_integrity_continuity_explanations",
+        "trust_explanation_type": "integrity_continuity_explanations"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_fail_visible_diagnostic_explanations"
+        ],
+        "execution_semantics_enabled": false,
+        "operational_enabled": false,
+        "trust_explanation_id": "trust_explanation_fail_visible_diagnostic_explanations",
+        "trust_explanation_type": "fail_visible_diagnostic_explanations"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_state_explanations"
+        ],
+        "execution_semantics_enabled": false,
+        "operational_enabled": false,
+        "trust_explanation_id": "trust_explanation_unsupported_state_explanations",
+        "trust_explanation_type": "unsupported_state_explanations"
+      }
+    ],
+    "unsupported_operational_states": [
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_explanation_operational_states"
+        ],
+        "explicit_reason": "orchestration_execution remains unsupported for v4.5B.3 public explainability surfaces.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_explanation_operational_state_orchestration_execution",
+        "suppression_enabled": false,
+        "unsupported_state": "orchestration_execution"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_explanation_operational_states"
+        ],
+        "explicit_reason": "orchestration_authorization remains unsupported for v4.5B.3 public explainability surfaces.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_explanation_operational_state_orchestration_authorization",
+        "suppression_enabled": false,
+        "unsupported_state": "orchestration_authorization"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_explanation_operational_states"
+        ],
+        "explicit_reason": "orchestration_approval remains unsupported for v4.5B.3 public explainability surfaces.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_explanation_operational_state_orchestration_approval",
+        "suppression_enabled": false,
+        "unsupported_state": "orchestration_approval"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_explanation_operational_states"
+        ],
+        "explicit_reason": "orchestration_dispatch remains unsupported for v4.5B.3 public explainability surfaces.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_explanation_operational_state_orchestration_dispatch",
+        "suppression_enabled": false,
+        "unsupported_state": "orchestration_dispatch"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_explanation_operational_states"
+        ],
+        "explicit_reason": "orchestration_routing remains unsupported for v4.5B.3 public explainability surfaces.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_explanation_operational_state_orchestration_routing",
+        "suppression_enabled": false,
+        "unsupported_state": "orchestration_routing"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_explanation_operational_states"
+        ],
+        "explicit_reason": "orchestration_traversal remains unsupported for v4.5B.3 public explainability surfaces.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_explanation_operational_state_orchestration_traversal",
+        "suppression_enabled": false,
+        "unsupported_state": "orchestration_traversal"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_explanation_operational_states"
+        ],
+        "explicit_reason": "orchestration_scheduling remains unsupported for v4.5B.3 public explainability surfaces.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_explanation_operational_state_orchestration_scheduling",
+        "suppression_enabled": false,
+        "unsupported_state": "orchestration_scheduling"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_explanation_operational_states"
+        ],
+        "explicit_reason": "orchestration_sequencing remains unsupported for v4.5B.3 public explainability surfaces.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_explanation_operational_state_orchestration_sequencing",
+        "suppression_enabled": false,
+        "unsupported_state": "orchestration_sequencing"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_explanation_operational_states"
+        ],
+        "explicit_reason": "orchestration_decisions remains unsupported for v4.5B.3 public explainability surfaces.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_explanation_operational_state_orchestration_decisions",
+        "suppression_enabled": false,
+        "unsupported_state": "orchestration_decisions"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_explanation_operational_states"
+        ],
+        "explicit_reason": "orchestration_recommendations remains unsupported for v4.5B.3 public explainability surfaces.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_explanation_operational_state_orchestration_recommendations",
+        "suppression_enabled": false,
+        "unsupported_state": "orchestration_recommendations"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_explanation_operational_states"
+        ],
+        "explicit_reason": "explainability_based_authorization remains unsupported for v4.5B.3 public explainability surfaces.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_explanation_operational_state_explainability_based_authorization",
+        "suppression_enabled": false,
+        "unsupported_state": "explainability_based_authorization"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_explanation_operational_states"
+        ],
+        "explicit_reason": "explainability_based_approval remains unsupported for v4.5B.3 public explainability surfaces.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_explanation_operational_state_explainability_based_approval",
+        "suppression_enabled": false,
+        "unsupported_state": "explainability_based_approval"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_explanation_operational_states"
+        ],
+        "explicit_reason": "explainability_based_ranking remains unsupported for v4.5B.3 public explainability surfaces.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_explanation_operational_state_explainability_based_ranking",
+        "suppression_enabled": false,
+        "unsupported_state": "explainability_based_ranking"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_explanation_operational_states"
+        ],
+        "explicit_reason": "explainability_based_recommendation remains unsupported for v4.5B.3 public explainability surfaces.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_explanation_operational_state_explainability_based_recommendation",
+        "suppression_enabled": false,
+        "unsupported_state": "explainability_based_recommendation"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_explanation_operational_states"
+        ],
+        "explicit_reason": "automated_remediation remains unsupported for v4.5B.3 public explainability surfaces.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_explanation_operational_state_automated_remediation",
+        "suppression_enabled": false,
+        "unsupported_state": "automated_remediation"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_explanation_operational_states"
+        ],
+        "explicit_reason": "automated_repair remains unsupported for v4.5B.3 public explainability surfaces.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_explanation_operational_state_automated_repair",
+        "suppression_enabled": false,
+        "unsupported_state": "automated_repair"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_explanation_operational_states"
+        ],
+        "explicit_reason": "automated_mitigation remains unsupported for v4.5B.3 public explainability surfaces.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_explanation_operational_state_automated_mitigation",
+        "suppression_enabled": false,
+        "unsupported_state": "automated_mitigation"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_explanation_operational_states"
+        ],
+        "explicit_reason": "automated_correction remains unsupported for v4.5B.3 public explainability surfaces.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_explanation_operational_state_automated_correction",
+        "suppression_enabled": false,
+        "unsupported_state": "automated_correction"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_explanation_operational_states"
+        ],
+        "explicit_reason": "planner_integration remains unsupported for v4.5B.3 public explainability surfaces.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_explanation_operational_state_planner_integration",
+        "suppression_enabled": false,
+        "unsupported_state": "planner_integration"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_explanation_operational_states"
+        ],
+        "explicit_reason": "production_consumption remains unsupported for v4.5B.3 public explainability surfaces.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_explanation_operational_state_production_consumption",
+        "suppression_enabled": false,
+        "unsupported_state": "production_consumption"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_explanation_operational_states"
+        ],
+        "explicit_reason": "runtime_mutation remains unsupported for v4.5B.3 public explainability surfaces.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_explanation_operational_state_runtime_mutation",
+        "suppression_enabled": false,
+        "unsupported_state": "runtime_mutation"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_explanation_operational_states"
+        ],
+        "explicit_reason": "operational_mutation remains unsupported for v4.5B.3 public explainability surfaces.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_explanation_operational_state_operational_mutation",
+        "suppression_enabled": false,
+        "unsupported_state": "operational_mutation"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "automated_correction_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_explanation_operational_states"
+        ],
+        "explicit_reason": "implicit_operational_behavior remains unsupported for v4.5B.3 public explainability surfaces.",
+        "fail_visible": true,
+        "mitigation_enabled": false,
+        "operational_enabled": false,
+        "ranking_enabled": false,
+        "recommendation_enabled": false,
+        "remediation_enabled": false,
+        "repair_enabled": false,
+        "state_id": "unsupported_explanation_operational_state_implicit_operational_behavior",
+        "suppression_enabled": false,
+        "unsupported_state": "implicit_operational_behavior"
+      }
+    ],
+    "unsupported_state_explanations": [
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_systems"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "remediation_enabled": false,
+        "suppression_enabled": false,
+        "unsupported_explanation_id": "unsupported_state_explanation_unsupported_systems",
+        "unsupported_state_type": "unsupported_systems"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_planner_sections"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "remediation_enabled": false,
+        "suppression_enabled": false,
+        "unsupported_explanation_id": "unsupported_state_explanation_unsupported_planner_sections",
+        "unsupported_state_type": "unsupported_planner_sections"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_evidence_chains"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "remediation_enabled": false,
+        "suppression_enabled": false,
+        "unsupported_explanation_id": "unsupported_state_explanation_unsupported_evidence_chains",
+        "unsupported_state_type": "unsupported_evidence_chains"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_continuity_chains"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "remediation_enabled": false,
+        "suppression_enabled": false,
+        "unsupported_explanation_id": "unsupported_state_explanation_unsupported_continuity_chains",
+        "unsupported_state_type": "unsupported_continuity_chains"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_operational_states"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "remediation_enabled": false,
+        "suppression_enabled": false,
+        "unsupported_explanation_id": "unsupported_state_explanation_unsupported_operational_states",
+        "unsupported_state_type": "unsupported_operational_states"
+      },
+      {
+        "approval_enabled": false,
+        "authorization_enabled": false,
+        "descriptive_only": true,
+        "evidence_reference_ids": [
+          "evidence_unsupported_trust_states"
+        ],
+        "fail_visible": true,
+        "hidden_fallback_enabled": false,
+        "remediation_enabled": false,
+        "suppression_enabled": false,
+        "unsupported_explanation_id": "unsupported_state_explanation_unsupported_trust_states",
+        "unsupported_state_type": "unsupported_trust_states"
+      }
+    ]
+  }
+}

--- a/docs/migration/V4_5B_3_EXPLAINABILITY_SURFACES.md
+++ b/docs/migration/V4_5B_3_EXPLAINABILITY_SURFACES.md
@@ -1,0 +1,166 @@
+# v4.5B.3 Explainability Surfaces
+
+## Architectural Purpose
+
+v4.5B.3 establishes deterministic governance-safe public explainability
+surfaces on top of the v4.5A drift intelligence chain, v4.5B.1 public trust
+visibility foundations, and v4.5B.2 support status visibility.
+
+The phase exposes public-facing explanations for support states, unsupported
+states, experimental states, deprecated states, blocked states, limitation
+visibility, trust summaries, evidence visibility, continuity visibility, and
+fail-visible diagnostics.
+
+## Deterministic Explainability Philosophy
+
+Explainability surfaces are descriptive-only. They make public explanation
+state visible without creating approval, authorization, recommendation, ranking,
+execution, production enablement, or operational readiness semantics.
+
+The implementation remains:
+
+- deterministic
+- governance-safe
+- replay-safe
+- rollback-safe
+- lineage-safe
+- provenance-safe
+- integrity-safe
+- explainability-first
+- fail-visible
+- descriptive-only
+- publicly transparent
+
+## Support-State Explanation Philosophy
+
+Support-state explanations describe supported, partially supported,
+unsupported, experimental, deprecated, blocked, and unknown states. These labels
+do not approve, authorize, recommend, rank, execute, or certify production use.
+
+## Evidence-to-Explanation Mapping
+
+Evidence-to-explanation mappings are deterministic, replay-safe, and
+provenance-safe. They preserve evidence references and explanation references
+without trust scoring, evidence repair, backfill behavior, or operational
+fallback behavior.
+
+## Limitation Explanation Philosophy
+
+Limitation explanations keep unsupported, experimental, deprecated, blocked,
+governance, continuity, and evidence limitations explicit. These explanations
+are visible only and do not provide automatic migration, fallback, correction,
+mitigation, remediation, or repair behavior.
+
+## Unsupported-State Explanation Philosophy
+
+Unsupported systems, unsupported planner sections, unsupported evidence chains,
+unsupported continuity chains, unsupported operational states, and unsupported
+trust states remain explicit and fail-visible. Unsupported explanations are not
+suppressed and are not converted into runtime behavior.
+
+## Trust Explanation Philosophy
+
+Public trust explanations expose governance transparency, deterministic
+guarantees, explainability continuity, integrity continuity, fail-visible
+diagnostics, and unsupported-state explanations. They do not imply correctness
+guarantees, operational readiness, execution safety, or production enablement.
+
+## Continuity Explanation Philosophy
+
+Continuity explanations preserve evidence, lineage, provenance, integrity, and
+diagnostics continuity visibility. They do not restore continuity, repair
+continuity gaps, remediate gaps, or authorize runtime traversal.
+
+## Fail-Visible Explanation Diagnostics Philosophy
+
+Fail-visible diagnostics explicitly expose missing explanation evidence,
+unsupported explanation gaps, incomplete continuity explanations, incomplete
+integrity explanations, unsupported trust explanations, unsupported operational
+explanations, inherited limitation explanation gaps, and inherited prohibition
+explanation gaps.
+
+No silent fallback behavior is introduced.
+
+## Hashing Guarantees
+
+The hashing layer provides stable SHA-256 hashes for:
+
+- explainability visibility records
+- evidence-to-explanation mapping records
+- unsupported-state explanation records
+- explanation summary records
+- public explanation diagnostics records
+- continuity explanation records
+- trust explanation records
+
+Hashes are stable, deterministic, replay-safe, and integrity-safe.
+
+## Serialization Guarantees
+
+The serialization layer preserves deterministic ordering, replayability,
+provenance continuity, and unsupported-state visibility for:
+
+- explainability visibility records
+- explanation summaries
+- evidence-to-explanation mappings
+- unsupported-state explanations
+- diagnostics visibility
+- continuity explanations
+- trust explanations
+
+## Inherited Prohibitions
+
+v4.5B.3 preserves every inherited prohibition, including:
+
+- orchestration execution
+- orchestration authorization
+- orchestration approval
+- orchestration dispatch
+- orchestration routing
+- orchestration traversal
+- orchestration scheduling
+- orchestration sequencing
+- orchestration decisions
+- orchestration recommendations
+- explainability-based authorization
+- explainability-based approval
+- explainability-based ranking
+- explainability-based recommendation
+- automated remediation
+- automated repair
+- automated mitigation
+- automated correction
+- planner integration
+- production consumption
+- runtime mutation
+- operational mutation
+- implicit operational behavior
+
+## Unsupported Operational States
+
+The generated report explicitly certifies that the repository remains:
+
+- NON-operational
+- NON-authorizing
+- NON-approving
+- NON-executing
+- NON-remediating
+- NON-runtime-mutating
+- NON-ranking
+- NON-recommending
+
+## Intentionally Preserved Limitations
+
+v4.5B.3 intentionally preserves these limitations:
+
+- Explainability surfaces do not authorize.
+- Explainability surfaces do not approve.
+- Explainability surfaces do not rank.
+- Explainability surfaces do not recommend.
+- Explainability surfaces do not execute.
+- Explainability surfaces do not enable production.
+- Explainability surfaces do not imply correctness guarantees.
+- Explainability surfaces do not imply execution safety.
+- Explainability surfaces do not remediate, repair, mitigate, or correct.
+- Explainability surfaces do not integrate planners.
+- Explainability surfaces do not mutate runtime state.


### PR DESCRIPTION
Implement governance-safe deterministic explainability surfaces including support-state explanations, evidence-to-explanation mappings, limitation explanations, unsupported-state explanations, trust explanations, continuity explanations, fail-visible explanation diagnostics, hashing, serialization, reporting, and descriptive-only public trust guarantees without introducing authorization, approval, recommendation, execution, or operational behavior.