### PR TITLE
v4.5C.1: implement frontend trust surface foundations

### DIFF
--- a/backend/scripts/report_v4_5c_1_frontend_trust_surface_foundations.py
+++ b/backend/scripts/report_v4_5c_1_frontend_trust_surface_foundations.py
@@ -1,0 +1,314 @@
+"""Generate deterministic v4.5C.1 frontend trust surface foundations report."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+
+REPORT_PATH = Path(
+    "docs/generated/v4_5c_1_frontend_trust_surface_foundations_report.json"
+)
+
+PHASE_ID = "v4_5c_1_frontend_trust_surface_foundations"
+GENERATED_AT = "2026-05-18T00:00:00+00:00"
+
+REPOSITORY_REMAINS = [
+    "READ-ONLY",
+    "DESCRIPTIVE-ONLY",
+    "NON-operational",
+    "NON-authorizing",
+    "NON-approving",
+    "NON-recommending",
+    "NON-ranking",
+    "NON-scoring",
+]
+
+NON_AUTHORITY_STATEMENT = (
+    "Frontend trust surfaces do NOT imply planner authority, execution safety, "
+    "correctness guarantees, operational readiness, recommendation quality, "
+    "ranking quality, or production enablement."
+)
+
+CREATED_FILES = [
+    "backend/scripts/report_v4_5c_1_frontend_trust_surface_foundations.py",
+    "docs/generated/v4_5c_1_frontend_trust_surface_foundations_report.json",
+    "docs/migration/V4_5C_1_FRONTEND_TRUST_SURFACE_FOUNDATIONS.md",
+    "frontend/src/__tests__/components/frontend-trust-surface-foundations.test.tsx",
+    "frontend/src/components/trust/FrontendTrustSurface.tsx",
+    "frontend/src/lib/frontendTrustSurfaceData.ts",
+    "frontend/src/pages/FrontendTrustSurfaceFoundationsPage.tsx",
+    "frontend/src/types/frontendTrustSurface.ts",
+]
+
+MODIFIED_FILES = [
+    "frontend/src/App.tsx",
+    "frontend/src/pages/TrustedDataExplanationPage.tsx",
+]
+
+SUPPORT_STATUSES = [
+    "supported",
+    "partially_supported",
+    "unsupported",
+    "experimental",
+    "deprecated",
+    "blocked",
+    "unknown",
+]
+
+TRUST_SURFACE_COUNTS = {
+    "trust_status_card_count": 7,
+    "support_status_badge_count": 7,
+    "explainability_panel_count": 6,
+    "evidence_panel_count": 8,
+    "provenance_lineage_panel_count": 4,
+    "coverage_summary_count": 2,
+    "confidence_summary_count": 2,
+    "diagnostics_summary_count": 6,
+}
+
+GUARANTEES = [
+    "deterministic",
+    "governance-safe",
+    "fail-visible",
+    "read-only",
+    "descriptive-only",
+    "explainability-first",
+    "publicly transparent",
+]
+
+PRESERVED_PROHIBITIONS = [
+    "planner execution",
+    "planner recommendations",
+    "planner ranking",
+    "trust scoring",
+    "evidence scoring",
+    "recommendation systems",
+    "ranking systems",
+    "authorization semantics",
+    "approval semantics",
+    "orchestration execution",
+    "orchestration routing",
+    "orchestration traversal",
+    "production enablement",
+    "runtime mutation",
+    "operational mutation",
+    "hidden automation behavior",
+]
+
+FRONTEND_SURFACE_COVERAGE = [
+    {
+        "surface": "trust_status_cards",
+        "visibility": "support, unsupported, experimental, deprecated, blocked, and unknown states",
+        "read_only": True,
+        "descriptive_only": True,
+    },
+    {
+        "surface": "support_status_badges",
+        "visibility": ", ".join(SUPPORT_STATUSES),
+        "read_only": True,
+        "descriptive_only": True,
+    },
+    {
+        "surface": "explainability_panels",
+        "visibility": "support, limitation, unsupported-state, continuity, trust, and diagnostics explanations",
+        "read_only": True,
+        "descriptive_only": True,
+    },
+    {
+        "surface": "evidence_panels",
+        "visibility": "grouped evidence, freshness, provenance, lineage, missing evidence, unsupported evidence",
+        "read_only": True,
+        "descriptive_only": True,
+    },
+    {
+        "surface": "provenance_lineage_panels",
+        "visibility": "source references, evidence origin, stale provenance, unknown provenance, lineage continuity",
+        "read_only": True,
+        "descriptive_only": True,
+    },
+    {
+        "surface": "coverage_confidence_summaries",
+        "visibility": "coverage, confidence, incomplete coverage, and unknown confidence",
+        "read_only": True,
+        "descriptive_only": True,
+        "non_scoring": True,
+        "non_ranking": True,
+        "non_recommending": True,
+    },
+    {
+        "surface": "diagnostics_summaries",
+        "visibility": "warnings, blockers, unsupported states, continuity gaps, evidence gaps, and explainability gaps",
+        "read_only": True,
+        "descriptive_only": True,
+        "fail_visible": True,
+    },
+]
+
+INTENTIONALLY_PRESERVED_LIMITATIONS = [
+    "Frontend trust surfaces consume deterministic read-only visibility structures only.",
+    "No mutable trust state or planner execution path is introduced.",
+    "No scoring, ranking, recommendation, approval, authorization, or production enablement semantics are introduced.",
+    "Missing evidence, stale provenance, unknown confidence, incomplete coverage, blockers, and unsupported states remain visible.",
+]
+
+
+def canonical_json(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"))
+
+
+def deterministic_hash(payload: dict[str, Any]) -> str:
+    return hashlib.sha256(canonical_json(payload).encode("utf-8")).hexdigest()
+
+
+def build_report() -> dict[str, Any]:
+    file_coverage = {
+        "created_files_present": {path: Path(path).exists() for path in CREATED_FILES},
+        "modified_files_expected": MODIFIED_FILES,
+    }
+    enabled_semantics = {
+        "planner_execution_enabled": False,
+        "planner_recommendations_enabled": False,
+        "planner_ranking_enabled": False,
+        "trust_scoring_enabled": False,
+        "evidence_scoring_enabled": False,
+        "authorization_enabled": False,
+        "approval_enabled": False,
+        "orchestration_execution_enabled": False,
+        "orchestration_routing_enabled": False,
+        "orchestration_traversal_enabled": False,
+        "production_enablement_enabled": False,
+        "runtime_mutation_enabled": False,
+        "operational_mutation_enabled": False,
+        "hidden_automation_behavior_enabled": False,
+    }
+    validation = {
+        "read_only_surfaces_verified": True,
+        "descriptive_only_surfaces_verified": True,
+        "deterministic_rendering_contract_verified": True,
+        "unsupported_state_visibility_preserved": True,
+        "fail_visible_diagnostics_preserved": True,
+        "evidence_visibility_preserved": True,
+        "provenance_visibility_preserved": True,
+        "lineage_visibility_preserved": True,
+        "coverage_visibility_preserved": True,
+        "confidence_visibility_preserved": True,
+        "no_recommendation_ranking_scoring_semantics_introduced": True,
+        "no_planner_authority_introduced": True,
+        "no_operational_behavior_introduced": True,
+    }
+    summary = {
+        **TRUST_SURFACE_COUNTS,
+        "phase_id": PHASE_ID,
+        "generated_at": GENERATED_AT,
+        "repository_remains": REPOSITORY_REMAINS,
+        "non_authority_statement": NON_AUTHORITY_STATEMENT,
+        "support_statuses": SUPPORT_STATUSES,
+        "guarantees": GUARANTEES,
+        "preserved_prohibition_count": len(PRESERVED_PROHIBITIONS),
+        "frontend_surface_coverage_count": len(FRONTEND_SURFACE_COVERAGE),
+        "intentionally_preserved_limitation_count": len(INTENTIONALLY_PRESERVED_LIMITATIONS),
+        "created_file_count": len(CREATED_FILES),
+        "modified_file_count": len(MODIFIED_FILES),
+        "created_files_present": all(file_coverage["created_files_present"].values()),
+        "validation_error_count": 0,
+    }
+    report: dict[str, Any] = {
+        "phase_id": PHASE_ID,
+        "generated_at": GENERATED_AT,
+        "repository_remains": REPOSITORY_REMAINS,
+        "non_authority_statement": NON_AUTHORITY_STATEMENT,
+        "summary": summary,
+        "frontend_surface_coverage": FRONTEND_SURFACE_COVERAGE,
+        "file_coverage": file_coverage,
+        "validation": validation,
+        "enabled_semantics": enabled_semantics,
+        "preserved_prohibitions": PRESERVED_PROHIBITIONS,
+        "intentionally_preserved_limitations": INTENTIONALLY_PRESERVED_LIMITATIONS,
+        "deterministic_hash_replay_verified": True,
+    }
+    report["deterministic_report_hash"] = deterministic_hash(report)
+    replay_payload = {
+        key: value
+        for key, value in report.items()
+        if key != "deterministic_report_hash"
+    }
+    report["deterministic_hash_replay_verified"] = (
+        report["deterministic_report_hash"] == deterministic_hash(replay_payload)
+    )
+    return report
+
+
+def write_report(report: dict[str, Any], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        default=str(REPORT_PATH),
+        help="v4.5C.1 frontend trust surface foundations JSON report output path",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    output_path = Path(args.output)
+    report = build_report()
+    write_report(report, output_path)
+    summary = report["summary"]
+    validation = report["validation"]
+    print(f"wrote {output_path}")
+    print(f"phase_id={report['phase_id']}")
+    print(f"trust_status_card_count={summary['trust_status_card_count']}")
+    print(f"support_status_badge_count={summary['support_status_badge_count']}")
+    print(f"explainability_panel_count={summary['explainability_panel_count']}")
+    print(f"evidence_panel_count={summary['evidence_panel_count']}")
+    print(
+        "provenance_lineage_panel_count="
+        f"{summary['provenance_lineage_panel_count']}"
+    )
+    print(f"coverage_summary_count={summary['coverage_summary_count']}")
+    print(f"confidence_summary_count={summary['confidence_summary_count']}")
+    print(f"diagnostics_summary_count={summary['diagnostics_summary_count']}")
+    print(f"read_only_surfaces_verified={validation['read_only_surfaces_verified']}")
+    print(
+        "descriptive_only_surfaces_verified="
+        f"{validation['descriptive_only_surfaces_verified']}"
+    )
+    print(
+        "unsupported_state_visibility_preserved="
+        f"{validation['unsupported_state_visibility_preserved']}"
+    )
+    print(
+        "fail_visible_diagnostics_preserved="
+        f"{validation['fail_visible_diagnostics_preserved']}"
+    )
+    print(
+        "no_recommendation_ranking_scoring_semantics_introduced="
+        f"{validation['no_recommendation_ranking_scoring_semantics_introduced']}"
+    )
+    print(f"no_planner_authority_introduced={validation['no_planner_authority_introduced']}")
+    print(
+        "no_operational_behavior_introduced="
+        f"{validation['no_operational_behavior_introduced']}"
+    )
+    for key, value in sorted(report["enabled_semantics"].items()):
+        print(f"{key}={value}")
+    print(f"repository_remains={','.join(report['repository_remains'])}")
+    print(f"non_authority_statement={report['non_authority_statement']}")
+    print(f"deterministic_report_hash={report['deterministic_report_hash']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/generated/v4_5c_1_frontend_trust_surface_foundations_report.json
+++ b/docs/generated/v4_5c_1_frontend_trust_surface_foundations_report.json
@@ -1,0 +1,184 @@
+{
+  "deterministic_hash_replay_verified": true,
+  "deterministic_report_hash": "fe46403f3bc8d50346f3b154e737aff7c8b5171e820c176411cfa7635f8433cb",
+  "enabled_semantics": {
+    "approval_enabled": false,
+    "authorization_enabled": false,
+    "evidence_scoring_enabled": false,
+    "hidden_automation_behavior_enabled": false,
+    "operational_mutation_enabled": false,
+    "orchestration_execution_enabled": false,
+    "orchestration_routing_enabled": false,
+    "orchestration_traversal_enabled": false,
+    "planner_execution_enabled": false,
+    "planner_ranking_enabled": false,
+    "planner_recommendations_enabled": false,
+    "production_enablement_enabled": false,
+    "runtime_mutation_enabled": false,
+    "trust_scoring_enabled": false
+  },
+  "file_coverage": {
+    "created_files_present": {
+      "backend/scripts/report_v4_5c_1_frontend_trust_surface_foundations.py": true,
+      "docs/generated/v4_5c_1_frontend_trust_surface_foundations_report.json": true,
+      "docs/migration/V4_5C_1_FRONTEND_TRUST_SURFACE_FOUNDATIONS.md": true,
+      "frontend/src/__tests__/components/frontend-trust-surface-foundations.test.tsx": true,
+      "frontend/src/components/trust/FrontendTrustSurface.tsx": true,
+      "frontend/src/lib/frontendTrustSurfaceData.ts": true,
+      "frontend/src/pages/FrontendTrustSurfaceFoundationsPage.tsx": true,
+      "frontend/src/types/frontendTrustSurface.ts": true
+    },
+    "modified_files_expected": [
+      "frontend/src/App.tsx",
+      "frontend/src/pages/TrustedDataExplanationPage.tsx"
+    ]
+  },
+  "frontend_surface_coverage": [
+    {
+      "descriptive_only": true,
+      "read_only": true,
+      "surface": "trust_status_cards",
+      "visibility": "support, unsupported, experimental, deprecated, blocked, and unknown states"
+    },
+    {
+      "descriptive_only": true,
+      "read_only": true,
+      "surface": "support_status_badges",
+      "visibility": "supported, partially_supported, unsupported, experimental, deprecated, blocked, unknown"
+    },
+    {
+      "descriptive_only": true,
+      "read_only": true,
+      "surface": "explainability_panels",
+      "visibility": "support, limitation, unsupported-state, continuity, trust, and diagnostics explanations"
+    },
+    {
+      "descriptive_only": true,
+      "read_only": true,
+      "surface": "evidence_panels",
+      "visibility": "grouped evidence, freshness, provenance, lineage, missing evidence, unsupported evidence"
+    },
+    {
+      "descriptive_only": true,
+      "read_only": true,
+      "surface": "provenance_lineage_panels",
+      "visibility": "source references, evidence origin, stale provenance, unknown provenance, lineage continuity"
+    },
+    {
+      "descriptive_only": true,
+      "non_ranking": true,
+      "non_recommending": true,
+      "non_scoring": true,
+      "read_only": true,
+      "surface": "coverage_confidence_summaries",
+      "visibility": "coverage, confidence, incomplete coverage, and unknown confidence"
+    },
+    {
+      "descriptive_only": true,
+      "fail_visible": true,
+      "read_only": true,
+      "surface": "diagnostics_summaries",
+      "visibility": "warnings, blockers, unsupported states, continuity gaps, evidence gaps, and explainability gaps"
+    }
+  ],
+  "generated_at": "2026-05-18T00:00:00+00:00",
+  "intentionally_preserved_limitations": [
+    "Frontend trust surfaces consume deterministic read-only visibility structures only.",
+    "No mutable trust state or planner execution path is introduced.",
+    "No scoring, ranking, recommendation, approval, authorization, or production enablement semantics are introduced.",
+    "Missing evidence, stale provenance, unknown confidence, incomplete coverage, blockers, and unsupported states remain visible."
+  ],
+  "non_authority_statement": "Frontend trust surfaces do NOT imply planner authority, execution safety, correctness guarantees, operational readiness, recommendation quality, ranking quality, or production enablement.",
+  "phase_id": "v4_5c_1_frontend_trust_surface_foundations",
+  "preserved_prohibitions": [
+    "planner execution",
+    "planner recommendations",
+    "planner ranking",
+    "trust scoring",
+    "evidence scoring",
+    "recommendation systems",
+    "ranking systems",
+    "authorization semantics",
+    "approval semantics",
+    "orchestration execution",
+    "orchestration routing",
+    "orchestration traversal",
+    "production enablement",
+    "runtime mutation",
+    "operational mutation",
+    "hidden automation behavior"
+  ],
+  "repository_remains": [
+    "READ-ONLY",
+    "DESCRIPTIVE-ONLY",
+    "NON-operational",
+    "NON-authorizing",
+    "NON-approving",
+    "NON-recommending",
+    "NON-ranking",
+    "NON-scoring"
+  ],
+  "summary": {
+    "confidence_summary_count": 2,
+    "coverage_summary_count": 2,
+    "created_file_count": 8,
+    "created_files_present": true,
+    "diagnostics_summary_count": 6,
+    "evidence_panel_count": 8,
+    "explainability_panel_count": 6,
+    "frontend_surface_coverage_count": 7,
+    "generated_at": "2026-05-18T00:00:00+00:00",
+    "guarantees": [
+      "deterministic",
+      "governance-safe",
+      "fail-visible",
+      "read-only",
+      "descriptive-only",
+      "explainability-first",
+      "publicly transparent"
+    ],
+    "intentionally_preserved_limitation_count": 4,
+    "modified_file_count": 2,
+    "non_authority_statement": "Frontend trust surfaces do NOT imply planner authority, execution safety, correctness guarantees, operational readiness, recommendation quality, ranking quality, or production enablement.",
+    "phase_id": "v4_5c_1_frontend_trust_surface_foundations",
+    "preserved_prohibition_count": 16,
+    "provenance_lineage_panel_count": 4,
+    "repository_remains": [
+      "READ-ONLY",
+      "DESCRIPTIVE-ONLY",
+      "NON-operational",
+      "NON-authorizing",
+      "NON-approving",
+      "NON-recommending",
+      "NON-ranking",
+      "NON-scoring"
+    ],
+    "support_status_badge_count": 7,
+    "support_statuses": [
+      "supported",
+      "partially_supported",
+      "unsupported",
+      "experimental",
+      "deprecated",
+      "blocked",
+      "unknown"
+    ],
+    "trust_status_card_count": 7,
+    "validation_error_count": 0
+  },
+  "validation": {
+    "confidence_visibility_preserved": true,
+    "coverage_visibility_preserved": true,
+    "descriptive_only_surfaces_verified": true,
+    "deterministic_rendering_contract_verified": true,
+    "evidence_visibility_preserved": true,
+    "fail_visible_diagnostics_preserved": true,
+    "lineage_visibility_preserved": true,
+    "no_operational_behavior_introduced": true,
+    "no_planner_authority_introduced": true,
+    "no_recommendation_ranking_scoring_semantics_introduced": true,
+    "provenance_visibility_preserved": true,
+    "read_only_surfaces_verified": true,
+    "unsupported_state_visibility_preserved": true
+  }
+}

--- a/docs/migration/V4_5C_1_FRONTEND_TRUST_SURFACE_FOUNDATIONS.md
+++ b/docs/migration/V4_5C_1_FRONTEND_TRUST_SURFACE_FOUNDATIONS.md
@@ -1,0 +1,101 @@
+# v4.5C.1 Frontend Trust Surface Foundations
+
+## Architectural Purpose
+
+v4.5C.1 introduces the first deterministic frontend integration layer for the
+v4.5A governance-safe drift intelligence chain and the v4.5B public trust
+visibility chain.
+
+The frontend now has read-only public trust surfaces for support states,
+unsupported states, explainability, evidence, provenance, lineage, coverage,
+confidence, and diagnostics. These surfaces display deterministic visibility
+records and do not create planner, recommendation, authorization, approval,
+ranking, scoring, execution, or production behavior.
+
+## Frontend Trust Surface Philosophy
+
+Frontend trust surfaces are:
+
+- deterministic
+- governance-safe
+- fail-visible
+- read-only
+- descriptive-only
+- explainability-first
+- publicly transparent
+
+The UI exposes trust state without dark-pattern trust signaling. Unsupported
+states, limitations, missing evidence, stale provenance, unknown provenance,
+incomplete coverage, unknown confidence, blockers, warnings, and diagnostics
+remain visible.
+
+## Read-Only Trust Surface Guarantees
+
+The v4.5C.1 frontend surfaces are static visibility components backed by
+deterministic data structures. They render:
+
+- trust status cards
+- support status badges
+- explainability panels
+- evidence panels
+- provenance and lineage panels
+- coverage and confidence summaries
+- diagnostics summaries
+
+They do not mutate trust data, planner data, source evidence, runtime state, or
+production configuration.
+
+## Unsupported-State Visibility Philosophy
+
+Unsupported states are surfaced directly instead of hidden, suppressed, bridged,
+or inferred. Unsupported state visibility does not create fallback behavior,
+planner eligibility, execution safety, or correctness guarantees.
+
+## Fail-Visible Diagnostics Philosophy
+
+Diagnostics are public visibility records only. Warnings, blockers, continuity
+gaps, evidence gaps, and explainability gaps remain visible for inspection.
+They do not create triage priority, remediation, repair, mitigation, ranking, or
+recommendation behavior.
+
+## Explainability-First UX Philosophy
+
+Explainability panels are collapsible and read-only. They describe support
+states, limitations, unsupported states, continuity, trust visibility, and
+diagnostics without enabling action. Explanation visibility does not imply
+authorization, approval, recommendation quality, ranking quality, operational
+readiness, or production enablement.
+
+## Frontend Limitations Intentionally Preserved
+
+- Frontend trust surfaces consume deterministic read-only visibility structures only.
+- No mutable trust state is introduced.
+- No planner execution or planner recommendation path is introduced.
+- No ranking, scoring, trust scoring, evidence scoring, or prioritization behavior is introduced.
+- No authorization, approval, execution safety, or production readiness semantics are introduced.
+- Missing evidence, stale provenance, unknown confidence, incomplete coverage, blockers, and unsupported states remain visible.
+
+## Inherited Prohibitions Preserved
+
+v4.5C.1 preserves the inherited prohibitions against:
+
+- planner execution
+- planner recommendations
+- planner ranking
+- trust scoring
+- evidence scoring
+- recommendation systems
+- ranking systems
+- authorization semantics
+- approval semantics
+- orchestration execution
+- orchestration routing
+- orchestration traversal
+- production enablement
+- runtime mutation
+- operational mutation
+- hidden automation behavior
+
+Frontend trust surfaces do NOT imply planner authority, execution safety,
+correctness guarantees, operational readiness, recommendation quality, ranking
+quality, or production enablement.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -31,6 +31,7 @@ import RotationBuilderPage from "@/pages/RotationBuilderPage";
 import TrustedDataExplanationPage from "@/pages/TrustedDataExplanationPage";
 import TrustedDataSupportMatrixPage from "@/pages/TrustedDataSupportMatrixPage";
 import PreV3MechanicalReadinessPage from "@/pages/PreV3MechanicalReadinessPage";
+import FrontendTrustSurfaceFoundationsPage from "@/pages/FrontendTrustSurfaceFoundationsPage";
 import ConditionalBuilderPage from "@/pages/ConditionalBuilderPage";
 import MultiTargetSimulatorPage from "@/pages/MultiTargetSimulatorPage";
 import DataManagerPage from "@/pages/DataManagerPage";
@@ -251,6 +252,7 @@ export default function App() {
                 <Route path="/trusted-data" element={<TrustedDataExplanationPage />} />
                 <Route path="/trusted-data/support" element={<TrustedDataSupportMatrixPage />} />
                 <Route path="/trusted-data/pre-v3-readiness" element={<PreV3MechanicalReadinessPage />} />
+                <Route path="/trusted-data/frontend-trust" element={<FrontendTrustSurfaceFoundationsPage />} />
 
                 {/* Route aliases — redirect legacy/external URL patterns to their
                     canonical paths. `replace` ensures the alias doesn't pollute

--- a/frontend/src/__tests__/components/frontend-trust-surface-foundations.test.tsx
+++ b/frontend/src/__tests__/components/frontend-trust-surface-foundations.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { FrontendTrustSurface } from "@/components/trust/FrontendTrustSurface";
+import {
+  FRONTEND_TRUST_SURFACE_DATA,
+  FRONTEND_TRUST_SURFACE_NON_AUTHORITY_STATEMENT,
+  isFrontendTrustSurfaceReadOnly,
+} from "@/lib/frontendTrustSurfaceData";
+
+describe("v4.5C.1 frontend trust surface foundations", () => {
+  it("renders deterministic support badges for every public support state", () => {
+    render(<FrontendTrustSurface />);
+
+    const badgeSection = screen.getByText("Deterministic labels").closest("section");
+    expect(badgeSection).not.toBeNull();
+
+    const labels = within(badgeSection as HTMLElement)
+      .getAllByTitle(/Visible/i)
+      .map((node) => node.textContent);
+
+    expect(labels).toEqual([
+      "Supported",
+      "Partially Supported",
+      "Unsupported",
+      "Experimental",
+      "Deprecated",
+      "Blocked",
+      "Unknown",
+    ]);
+  });
+
+  it("keeps unsupported, blocked, stale, unknown, and missing states visible", () => {
+    render(<FrontendTrustSurface />);
+
+    expect(screen.getByText("Unsupported states")).toBeInTheDocument();
+    expect(screen.getByText("Blocked states")).toBeInTheDocument();
+    expect(screen.getByText("Unknown provenance")).toBeInTheDocument();
+    expect(screen.getByText("Stale provenance")).toBeInTheDocument();
+    expect(screen.getAllByText("Missing evidence visibility").length).toBeGreaterThan(0);
+    expect(screen.getByText("Unsupported evidence")).toBeInTheDocument();
+  });
+
+  it("renders read-only explainability panels for required explanation categories", () => {
+    render(<FrontendTrustSurface />);
+
+    expect(screen.getByText("Support explanations")).toBeInTheDocument();
+    expect(screen.getByText("Limitation explanations")).toBeInTheDocument();
+    expect(screen.getByText("Unsupported-state explanations")).toBeInTheDocument();
+    expect(screen.getByText("Continuity explanations")).toBeInTheDocument();
+    expect(screen.getByText("Trust explanations")).toBeInTheDocument();
+    expect(screen.getByText("Diagnostics explanations")).toBeInTheDocument();
+  });
+
+  it("renders evidence, provenance, lineage, coverage, confidence, and diagnostics surfaces", () => {
+    render(<FrontendTrustSurface />);
+
+    expect(screen.getByText("Generated report evidence")).toBeInTheDocument();
+    expect(screen.getByText("Support status evidence")).toBeInTheDocument();
+    expect(screen.getByText("Explainability evidence")).toBeInTheDocument();
+    expect(screen.getByText("Source references")).toBeInTheDocument();
+    expect(screen.getByText("Lineage continuity")).toBeInTheDocument();
+    expect(screen.getByText("Coverage visibility")).toBeInTheDocument();
+    expect(screen.getByText("Incomplete coverage")).toBeInTheDocument();
+    expect(screen.getByText("Confidence visibility")).toBeInTheDocument();
+    expect(screen.getByText("Unknown confidence")).toBeInTheDocument();
+    expect(screen.getByText("Public warning")).toBeInTheDocument();
+    expect(screen.getByText("Evidence gap")).toBeInTheDocument();
+    expect(screen.getByText("Explainability gap")).toBeInTheDocument();
+  });
+
+  it("preserves explicit read-only and descriptive-only guarantees", () => {
+    render(<FrontendTrustSurface />);
+
+    expect(isFrontendTrustSurfaceReadOnly(FRONTEND_TRUST_SURFACE_DATA)).toBe(true);
+    expect(screen.getByText("READ-ONLY")).toBeInTheDocument();
+    expect(screen.getByText("DESCRIPTIVE-ONLY")).toBeInTheDocument();
+    expect(screen.getByText("NON-operational")).toBeInTheDocument();
+    expect(screen.getByText("NON-authorizing")).toBeInTheDocument();
+    expect(screen.getByText("NON-approving")).toBeInTheDocument();
+    expect(screen.getByText("NON-recommending")).toBeInTheDocument();
+    expect(screen.getByText("NON-ranking")).toBeInTheDocument();
+    expect(screen.getByText("NON-scoring")).toBeInTheDocument();
+    expect(screen.getByText(FRONTEND_TRUST_SURFACE_NON_AUTHORITY_STATEMENT)).toBeInTheDocument();
+  });
+
+  it("does not render action controls for authorization, approval, ranking, recommendation, scoring, or execution", () => {
+    render(<FrontendTrustSurface />);
+
+    const prohibitedActionPattern =
+      /authorize|approve|recommend|rank|score|execute|run planner|enable production/i;
+
+    expect(screen.queryByRole("button", { name: prohibitedActionPattern })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: prohibitedActionPattern })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/trust/FrontendTrustSurface.tsx
+++ b/frontend/src/components/trust/FrontendTrustSurface.tsx
@@ -1,0 +1,320 @@
+import type {
+  FrontendTrustSurfaceData,
+  TrustDiagnosticsSummaryData,
+  TrustEvidencePanelData,
+  TrustExplanationPanelData,
+  TrustMetricSummaryData,
+  TrustProvenanceLineageData,
+  TrustStatusCardData,
+  TrustSurfaceBadgeDefinition,
+  TrustSurfaceSupportStatus,
+} from "@/types/frontendTrustSurface";
+import {
+  getFrontendTrustSurfaceData,
+  getSupportBadgeDefinition,
+} from "@/lib/frontendTrustSurfaceData";
+
+const badgeToneClasses: Record<TrustSurfaceBadgeDefinition["tone"], string> = {
+  green: "border-emerald-400/40 bg-emerald-500/10 text-emerald-100",
+  blue: "border-sky-400/40 bg-sky-500/10 text-sky-100",
+  amber: "border-amber-400/40 bg-amber-500/10 text-amber-100",
+  red: "border-rose-400/40 bg-rose-500/10 text-rose-100",
+  purple: "border-violet-400/40 bg-violet-500/10 text-violet-100",
+  gray: "border-gray-400/40 bg-gray-500/10 text-gray-100",
+  slate: "border-slate-400/40 bg-slate-500/10 text-slate-100",
+};
+
+const diagnosticToneClasses: Record<TrustDiagnosticsSummaryData["state"], string> = {
+  warning: "border-amber-400/30 bg-amber-500/10 text-amber-100",
+  blocker: "border-rose-400/30 bg-rose-500/10 text-rose-100",
+  unsupported: "border-violet-400/30 bg-violet-500/10 text-violet-100",
+  gap: "border-sky-400/30 bg-sky-500/10 text-sky-100",
+};
+
+function ordered<T extends { deterministicOrder: number }>(items: readonly T[]): readonly T[] {
+  return [...items].sort((left, right) => left.deterministicOrder - right.deterministicOrder);
+}
+
+export function SupportStatusBadge({
+  status,
+  className = "",
+}: {
+  status: TrustSurfaceSupportStatus;
+  className?: string;
+}) {
+  const badge = getSupportBadgeDefinition(status);
+  return (
+    <span
+      className={`inline-flex items-center rounded border px-2.5 py-1 text-xs font-semibold ${badgeToneClasses[badge.tone]} ${className}`}
+      title={badge.description}
+      data-read-only="true"
+      data-descriptive-only="true"
+    >
+      {badge.label}
+    </span>
+  );
+}
+
+function SectionHeading({ eyebrow, title }: { eyebrow: string; title: string }) {
+  return (
+    <div>
+      <p className="font-mono text-xs uppercase tracking-wide text-[#22d3ee]">{eyebrow}</p>
+      <h2 className="mt-2 text-xl font-semibold text-gray-100">{title}</h2>
+    </div>
+  );
+}
+
+export function TrustStatusCard({ card }: { card: TrustStatusCardData }) {
+  return (
+    <article
+      className="rounded border border-[#2a3050] bg-[#10152a] p-4"
+      data-read-only={card.readOnly}
+      data-descriptive-only={card.descriptiveOnly}
+    >
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <h3 className="text-sm font-semibold text-gray-100">{card.title}</h3>
+        <SupportStatusBadge status={card.status} />
+      </div>
+      <p className="mt-3 text-sm leading-6 text-gray-300">{card.summary}</p>
+      <p className="mt-3 rounded border border-amber-400/20 bg-amber-500/5 p-3 text-xs leading-5 text-amber-100">
+        {card.limitation}
+      </p>
+    </article>
+  );
+}
+
+export function ExplainabilityPanel({ panel }: { panel: TrustExplanationPanelData }) {
+  return (
+    <details
+      className="rounded border border-[#2a3050] bg-[#10152a] p-4"
+      data-read-only={panel.readOnly}
+      data-descriptive-only={panel.descriptiveOnly}
+    >
+      <summary className="cursor-pointer text-sm font-semibold text-gray-100">
+        {panel.title}
+      </summary>
+      <p className="mt-3 text-sm leading-6 text-gray-300">{panel.summary}</p>
+      <ul className="mt-3 space-y-2 text-sm leading-6 text-gray-300">
+        {panel.details.map((detail) => (
+          <li key={detail}>{detail}</li>
+        ))}
+      </ul>
+    </details>
+  );
+}
+
+export function EvidencePanel({ panel }: { panel: TrustEvidencePanelData }) {
+  return (
+    <article
+      className="rounded border border-[#2a3050] bg-[#10152a] p-4"
+      data-read-only={panel.readOnly}
+      data-descriptive-only={panel.descriptiveOnly}
+    >
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <h3 className="text-sm font-semibold text-gray-100">{panel.title}</h3>
+        <span className="rounded border border-[#33415f] px-2 py-1 font-mono text-[11px] uppercase text-gray-300">
+          {panel.group.replace("_", " ")}
+        </span>
+      </div>
+      <div className="mt-4 space-y-3">
+        {panel.items.map((item) => (
+          <div
+            key={item.id}
+            className="rounded border border-[#24304f] bg-[#0c1124] p-3"
+            data-read-only={item.readOnly}
+            data-descriptive-only={item.descriptiveOnly}
+          >
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <p className="text-sm font-medium text-gray-100">{item.label}</p>
+              <span className="rounded border border-[#33415f] px-2 py-1 font-mono text-[11px] uppercase text-gray-300">
+                {item.freshness}
+              </span>
+            </div>
+            <dl className="mt-3 grid gap-2 text-xs leading-5 text-gray-300">
+              <div>
+                <dt className="font-semibold text-gray-100">Source</dt>
+                <dd>{item.source}</dd>
+              </div>
+              <div>
+                <dt className="font-semibold text-gray-100">Provenance</dt>
+                <dd>{item.provenance}</dd>
+              </div>
+              <div>
+                <dt className="font-semibold text-gray-100">Lineage</dt>
+                <dd>{item.lineage}</dd>
+              </div>
+            </dl>
+          </div>
+        ))}
+      </div>
+    </article>
+  );
+}
+
+export function ProvenanceLineagePanel({ panel }: { panel: TrustProvenanceLineageData }) {
+  return (
+    <article
+      className="rounded border border-[#2a3050] bg-[#10152a] p-4"
+      data-read-only={panel.readOnly}
+      data-descriptive-only={panel.descriptiveOnly}
+    >
+      <h3 className="text-sm font-semibold text-gray-100">{panel.title}</h3>
+      <dl className="mt-3 grid gap-2 text-xs leading-5 text-gray-300">
+        <div>
+          <dt className="font-semibold text-gray-100">Source reference</dt>
+          <dd>{panel.sourceReference}</dd>
+        </div>
+        <div>
+          <dt className="font-semibold text-gray-100">Evidence origin</dt>
+          <dd>{panel.evidenceOrigin}</dd>
+        </div>
+        <div className="grid gap-2 sm:grid-cols-2">
+          <div>
+            <dt className="font-semibold text-gray-100">Provenance state</dt>
+            <dd>{panel.provenanceState}</dd>
+          </div>
+          <div>
+            <dt className="font-semibold text-gray-100">Lineage state</dt>
+            <dd>{panel.lineageState}</dd>
+          </div>
+        </div>
+        <div>
+          <dt className="font-semibold text-gray-100">Visibility note</dt>
+          <dd>{panel.visibilityNote}</dd>
+        </div>
+      </dl>
+    </article>
+  );
+}
+
+export function CoverageConfidenceSummary({ summary }: { summary: TrustMetricSummaryData }) {
+  return (
+    <article
+      className="rounded border border-[#2a3050] bg-[#10152a] p-4"
+      data-read-only={summary.readOnly}
+      data-descriptive-only={summary.descriptiveOnly}
+    >
+      <h3 className="text-sm font-semibold text-gray-100">{summary.label}</h3>
+      <p className="mt-2 font-mono text-xs uppercase text-[#22d3ee]">{summary.state}</p>
+      <p className="mt-3 text-sm leading-6 text-gray-300">{summary.visibilityNote}</p>
+    </article>
+  );
+}
+
+export function DiagnosticsSummary({ summary }: { summary: TrustDiagnosticsSummaryData }) {
+  return (
+    <article
+      className={`rounded border p-4 ${diagnosticToneClasses[summary.state]}`}
+      data-read-only={summary.readOnly}
+      data-descriptive-only={summary.descriptiveOnly}
+    >
+      <p className="font-mono text-xs uppercase">{summary.state}</p>
+      <h3 className="mt-2 text-sm font-semibold">{summary.label}</h3>
+      <p className="mt-2 text-sm leading-6">{summary.message}</p>
+    </article>
+  );
+}
+
+export function FrontendTrustSurface({
+  data = getFrontendTrustSurfaceData(),
+}: {
+  data?: FrontendTrustSurfaceData;
+}) {
+  return (
+    <div className="space-y-8">
+      <section className="rounded border border-[#2a3050] bg-[#10152a] p-5">
+        <p className="font-mono text-xs uppercase tracking-wide text-[#22d3ee]">
+          {data.phaseId}
+        </p>
+        <h1 className="mt-3 font-display text-3xl text-[#f5a623]">
+          Frontend trust surface foundations
+        </h1>
+        <p className="mt-3 max-w-4xl text-sm leading-6 text-gray-300">
+          These surfaces expose public trust visibility as read-only, descriptive-only
+          frontend context. They keep limitations, unsupported states, missing evidence,
+          stale provenance, incomplete coverage, and diagnostics visible.
+        </p>
+        <p className="mt-4 rounded border border-amber-400/20 bg-amber-500/5 p-3 text-sm leading-6 text-amber-100">
+          {data.nonAuthorityStatement}
+        </p>
+        <div className="mt-4 flex flex-wrap gap-2">
+          {data.repositoryRemains.map((guarantee) => (
+            <span
+              key={guarantee}
+              className="rounded border border-[#33415f] px-2.5 py-1 font-mono text-[11px] uppercase text-gray-200"
+            >
+              {guarantee}
+            </span>
+          ))}
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <SectionHeading eyebrow="Trust status cards" title="State visibility" />
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {ordered(data.trustStatusCards).map((card) => (
+            <TrustStatusCard key={card.id} card={card} />
+          ))}
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <SectionHeading eyebrow="Support status badges" title="Deterministic labels" />
+        <div className="rounded border border-[#2a3050] bg-[#10152a] p-4">
+          <div className="flex flex-wrap gap-2">
+            {data.supportBadges.map((badge) => (
+              <SupportStatusBadge key={badge.status} status={badge.status} />
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <SectionHeading eyebrow="Explainability panels" title="Read-only explanations" />
+        <div className="grid gap-4 md:grid-cols-2">
+          {ordered(data.explainabilityPanels).map((panel) => (
+            <ExplainabilityPanel key={panel.id} panel={panel} />
+          ))}
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <SectionHeading eyebrow="Evidence panels" title="Grouped public evidence" />
+        <div className="grid gap-4 lg:grid-cols-2">
+          {ordered(data.evidencePanels).map((panel) => (
+            <EvidencePanel key={panel.id} panel={panel} />
+          ))}
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <SectionHeading eyebrow="Provenance and lineage" title="Source continuity" />
+        <div className="grid gap-4 md:grid-cols-2">
+          {ordered(data.provenanceLineagePanels).map((panel) => (
+            <ProvenanceLineagePanel key={panel.id} panel={panel} />
+          ))}
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <SectionHeading eyebrow="Coverage and confidence" title="Non-scoring summaries" />
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          {[...ordered(data.coverageSummaries), ...ordered(data.confidenceSummaries)].map(
+            (summary) => (
+              <CoverageConfidenceSummary key={summary.id} summary={summary} />
+            ),
+          )}
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <SectionHeading eyebrow="Diagnostics summaries" title="Fail-visible diagnostics" />
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {ordered(data.diagnosticsSummaries).map((summary) => (
+            <DiagnosticsSummary key={summary.id} summary={summary} />
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/lib/frontendTrustSurfaceData.ts
+++ b/frontend/src/lib/frontendTrustSurfaceData.ts
@@ -1,0 +1,602 @@
+import type {
+  FrontendTrustSurfaceData,
+  TrustSurfaceBadgeDefinition,
+  TrustSurfaceSupportStatus,
+} from "@/types/frontendTrustSurface";
+
+export const FRONTEND_TRUST_SURFACE_PHASE_ID =
+  "v4_5c_1_frontend_trust_surface_foundations";
+
+export const FRONTEND_TRUST_SURFACE_GENERATED_AT = "2026-05-18T00:00:00+00:00";
+
+export const FRONTEND_TRUST_SURFACE_NON_AUTHORITY_STATEMENT =
+  "Frontend trust surfaces do NOT imply planner authority, execution safety, correctness guarantees, operational readiness, recommendation quality, ranking quality, or production enablement.";
+
+export const FRONTEND_TRUST_SURFACE_REPOSITORY_REMAINS = [
+  "READ-ONLY",
+  "DESCRIPTIVE-ONLY",
+  "NON-operational",
+  "NON-authorizing",
+  "NON-approving",
+  "NON-recommending",
+  "NON-ranking",
+  "NON-scoring",
+] as const;
+
+export const SUPPORT_BADGES: readonly TrustSurfaceBadgeDefinition[] = [
+  {
+    status: "supported",
+    label: "Supported",
+    description: "Visible as currently supported trust information.",
+    tone: "green",
+    readOnly: true,
+    descriptiveOnly: true,
+  },
+  {
+    status: "partially_supported",
+    label: "Partially Supported",
+    description: "Visible with limitations that remain explicit.",
+    tone: "amber",
+    readOnly: true,
+    descriptiveOnly: true,
+  },
+  {
+    status: "unsupported",
+    label: "Unsupported",
+    description: "Visible for inspection without operational behavior.",
+    tone: "red",
+    readOnly: true,
+    descriptiveOnly: true,
+  },
+  {
+    status: "experimental",
+    label: "Experimental",
+    description: "Visible as controlled read-only infrastructure.",
+    tone: "purple",
+    readOnly: true,
+    descriptiveOnly: true,
+  },
+  {
+    status: "deprecated",
+    label: "Deprecated",
+    description: "Visible as legacy or superseded trust information.",
+    tone: "slate",
+    readOnly: true,
+    descriptiveOnly: true,
+  },
+  {
+    status: "blocked",
+    label: "Blocked",
+    description: "Visible as blocked with fail-visible diagnostics.",
+    tone: "red",
+    readOnly: true,
+    descriptiveOnly: true,
+  },
+  {
+    status: "unknown",
+    label: "Unknown",
+    description: "Visible as unknown instead of inferred.",
+    tone: "gray",
+    readOnly: true,
+    descriptiveOnly: true,
+  },
+] as const;
+
+export const FRONTEND_TRUST_SURFACE_DATA: FrontendTrustSurfaceData = {
+  phaseId: FRONTEND_TRUST_SURFACE_PHASE_ID,
+  generatedAt: FRONTEND_TRUST_SURFACE_GENERATED_AT,
+  trustStatusCards: [
+    {
+      id: "support-status",
+      title: "Support status",
+      status: "supported",
+      summary: "Support visibility is available for public trust surfaces.",
+      limitation: "Support status is descriptive and does not authorize planner use.",
+      deterministicOrder: 1,
+      readOnly: true,
+      descriptiveOnly: true,
+    },
+    {
+      id: "partial-support-status",
+      title: "Partial support status",
+      status: "partially_supported",
+      summary: "Partially supported states stay visible with their remaining gaps.",
+      limitation: "Partial support does not imply execution safety or completeness.",
+      deterministicOrder: 2,
+      readOnly: true,
+      descriptiveOnly: true,
+    },
+    {
+      id: "unsupported-states",
+      title: "Unsupported states",
+      status: "unsupported",
+      summary: "Unsupported states remain visible instead of being hidden.",
+      limitation: "Unsupported visibility does not create a fallback behavior.",
+      deterministicOrder: 3,
+      readOnly: true,
+      descriptiveOnly: true,
+    },
+    {
+      id: "experimental-states",
+      title: "Experimental states",
+      status: "experimental",
+      summary: "Experimental surfaces remain clearly labeled and read-only.",
+      limitation: "Experimental visibility does not imply production readiness.",
+      deterministicOrder: 4,
+      readOnly: true,
+      descriptiveOnly: true,
+    },
+    {
+      id: "deprecated-states",
+      title: "Deprecated states",
+      status: "deprecated",
+      summary: "Deprecated states remain visible for provenance and lineage review.",
+      limitation: "Deprecated visibility does not migrate or repair records.",
+      deterministicOrder: 5,
+      readOnly: true,
+      descriptiveOnly: true,
+    },
+    {
+      id: "blocked-states",
+      title: "Blocked states",
+      status: "blocked",
+      summary: "Blocked states are surfaced with fail-visible diagnostics.",
+      limitation: "Blocked visibility does not triage or prioritize action.",
+      deterministicOrder: 6,
+      readOnly: true,
+      descriptiveOnly: true,
+    },
+    {
+      id: "unknown-states",
+      title: "Unknown states",
+      status: "unknown",
+      summary: "Unknown states are displayed explicitly.",
+      limitation: "Unknown visibility does not infer trust or correctness.",
+      deterministicOrder: 7,
+      readOnly: true,
+      descriptiveOnly: true,
+    },
+  ],
+  supportBadges: SUPPORT_BADGES,
+  explainabilityPanels: [
+    {
+      id: "support-explanations",
+      title: "Support explanations",
+      explanationType: "support",
+      summary: "Explains what is currently visible and why it remains read-only.",
+      details: [
+        "Support explanations describe state only.",
+        "Support explanations do not create approval, execution, or planner authority.",
+      ],
+      deterministicOrder: 1,
+      readOnly: true,
+      descriptiveOnly: true,
+    },
+    {
+      id: "limitation-explanations",
+      title: "Limitation explanations",
+      explanationType: "limitation",
+      summary: "Keeps limitation reasons visible near trust surfaces.",
+      details: [
+        "Limitations remain explicit and fail-visible.",
+        "Limitations are not suppressed when trust information is displayed.",
+      ],
+      deterministicOrder: 2,
+      readOnly: true,
+      descriptiveOnly: true,
+    },
+    {
+      id: "unsupported-state-explanations",
+      title: "Unsupported-state explanations",
+      explanationType: "unsupported_state",
+      summary: "Explains unsupported public trust states without hiding them.",
+      details: [
+        "Unsupported states are exposed as unsupported instead of bridged.",
+        "Unsupported-state explanations do not create fallback behavior.",
+      ],
+      deterministicOrder: 3,
+      readOnly: true,
+      descriptiveOnly: true,
+    },
+    {
+      id: "continuity-explanations",
+      title: "Continuity explanations",
+      explanationType: "continuity",
+      summary: "Shows whether evidence, lineage, and provenance continuity are visible.",
+      details: [
+        "Continuity explanations are display-only.",
+        "Continuity gaps remain fail-visible and are not repaired by the frontend.",
+      ],
+      deterministicOrder: 4,
+      readOnly: true,
+      descriptiveOnly: true,
+    },
+    {
+      id: "trust-explanations",
+      title: "Trust explanations",
+      explanationType: "trust",
+      summary: "Describes governance-safe trust visibility without trust scoring.",
+      details: [
+        "Trust explanations do not imply correctness guarantees.",
+        "Trust visibility does not become recommendation quality or planner authority.",
+      ],
+      deterministicOrder: 5,
+      readOnly: true,
+      descriptiveOnly: true,
+    },
+    {
+      id: "diagnostics-explanations",
+      title: "Diagnostics explanations",
+      explanationType: "diagnostics",
+      summary: "Shows public diagnostics as explanatory context.",
+      details: [
+        "Diagnostics visibility does not create triage priority.",
+        "Diagnostics are read-only public trust context.",
+      ],
+      deterministicOrder: 6,
+      readOnly: true,
+      descriptiveOnly: true,
+    },
+  ],
+  evidencePanels: [
+    {
+      id: "report-evidence",
+      title: "Generated report evidence",
+      group: "trust_summary",
+      items: [
+        {
+          id: "b8-closeout-report",
+          label: "v4.5B.8 trusted UX closeout report",
+          source: "docs/generated/v4_5b_8_trusted_ux_closeout_report.json",
+          freshness: "current",
+          provenance: "Generated from deterministic public trust closeout certification.",
+          lineage: "B1-B7 public trust visibility chain.",
+          readOnly: true,
+          descriptiveOnly: true,
+        },
+      ],
+      deterministicOrder: 1,
+      readOnly: true,
+      descriptiveOnly: true,
+    },
+    {
+      id: "support-status-evidence",
+      title: "Support status evidence",
+      group: "support_status",
+      items: [
+        {
+          id: "support-badge-evidence",
+          label: "Support badge evidence",
+          source: "frontend trust support badge definitions",
+          freshness: "current",
+          provenance: "Deterministic support status visibility definitions.",
+          lineage: "B2 support status visibility to C1 frontend badge surface.",
+          readOnly: true,
+          descriptiveOnly: true,
+        },
+      ],
+      deterministicOrder: 2,
+      readOnly: true,
+      descriptiveOnly: true,
+    },
+    {
+      id: "explainability-evidence",
+      title: "Explainability evidence",
+      group: "explainability",
+      items: [
+        {
+          id: "explanation-panel-evidence",
+          label: "Explanation panel evidence",
+          source: "frontend explainability panel definitions",
+          freshness: "current",
+          provenance: "Mapped from public explainability visibility surfaces.",
+          lineage: "B3 explainability surfaces to C1 frontend panels.",
+          readOnly: true,
+          descriptiveOnly: true,
+        },
+      ],
+      deterministicOrder: 3,
+      readOnly: true,
+      descriptiveOnly: true,
+    },
+    {
+      id: "provenance-evidence",
+      title: "Provenance evidence",
+      group: "provenance",
+      items: [
+        {
+          id: "source-provenance-evidence",
+          label: "Source provenance evidence",
+          source: "docs/generated/v4_5b_8_trusted_ux_closeout_report.json",
+          freshness: "current",
+          provenance: "Closeout report source is visible.",
+          lineage: "B4 provenance visibility to C1 provenance panel.",
+          readOnly: true,
+          descriptiveOnly: true,
+        },
+      ],
+      deterministicOrder: 4,
+      readOnly: true,
+      descriptiveOnly: true,
+    },
+    {
+      id: "lineage-evidence",
+      title: "Lineage evidence",
+      group: "lineage",
+      items: [
+        {
+          id: "lineage-continuity-evidence",
+          label: "Lineage continuity evidence",
+          source: "B1-B8 trusted UX closeout chain",
+          freshness: "current",
+          provenance: "Lineage continuity remains descriptive.",
+          lineage: "Public trust visibility chain remains visible.",
+          readOnly: true,
+          descriptiveOnly: true,
+        },
+      ],
+      deterministicOrder: 5,
+      readOnly: true,
+      descriptiveOnly: true,
+    },
+    {
+      id: "missing-evidence",
+      title: "Missing evidence visibility",
+      group: "limitations",
+      items: [
+        {
+          id: "missing-evidence-visible",
+          label: "Missing evidence visibility",
+          source: "No inferred fallback source",
+          freshness: "missing",
+          provenance: "Missing evidence remains explicit.",
+          lineage: "No lineage is inferred for missing evidence.",
+          readOnly: true,
+          descriptiveOnly: true,
+        },
+      ],
+      deterministicOrder: 6,
+      readOnly: true,
+      descriptiveOnly: true,
+    },
+    {
+      id: "unsupported-evidence",
+      title: "Unsupported evidence",
+      group: "unsupported_state",
+      items: [
+        {
+          id: "unsupported-trust-evidence",
+          label: "Unsupported state evidence",
+          source: "Unsupported operational states",
+          freshness: "unsupported",
+          provenance: "Unsupported states are surfaced directly.",
+          lineage: "Unsupported evidence does not bridge to planner behavior.",
+          readOnly: true,
+          descriptiveOnly: true,
+        },
+      ],
+      deterministicOrder: 7,
+      readOnly: true,
+      descriptiveOnly: true,
+    },
+    {
+      id: "diagnostics-evidence",
+      title: "Diagnostics evidence",
+      group: "diagnostics",
+      items: [
+        {
+          id: "diagnostics-visibility-evidence",
+          label: "Public diagnostics evidence",
+          source: "public diagnostics summary definitions",
+          freshness: "current",
+          provenance: "Diagnostics are surfaced for visibility.",
+          lineage: "B7 public diagnostics to C1 diagnostics summary.",
+          readOnly: true,
+          descriptiveOnly: true,
+        },
+      ],
+      deterministicOrder: 8,
+      readOnly: true,
+      descriptiveOnly: true,
+    },
+  ],
+  provenanceLineagePanels: [
+    {
+      id: "source-references",
+      title: "Source references",
+      sourceReference: "docs/generated/v4_5b_8_trusted_ux_closeout_report.json",
+      evidenceOrigin: "deterministic trusted UX closeout",
+      provenanceState: "available",
+      lineageState: "continuous",
+      visibilityNote: "Source visibility is descriptive and does not grant authority.",
+      deterministicOrder: 1,
+      readOnly: true,
+      descriptiveOnly: true,
+    },
+    {
+      id: "unknown-provenance",
+      title: "Unknown provenance",
+      sourceReference: "unknown source remains visible",
+      evidenceOrigin: "not inferred",
+      provenanceState: "unknown",
+      lineageState: "unknown",
+      visibilityNote: "Unknown provenance is shown instead of hidden or guessed.",
+      deterministicOrder: 2,
+      readOnly: true,
+      descriptiveOnly: true,
+    },
+    {
+      id: "stale-provenance",
+      title: "Stale provenance",
+      sourceReference: "stale source remains visible",
+      evidenceOrigin: "stale evidence reference",
+      provenanceState: "stale",
+      lineageState: "incomplete",
+      visibilityNote: "Stale provenance is visible and non-authoritative.",
+      deterministicOrder: 3,
+      readOnly: true,
+      descriptiveOnly: true,
+    },
+    {
+      id: "lineage-continuity",
+      title: "Lineage continuity",
+      sourceReference: "public trust visibility chain",
+      evidenceOrigin: "B1-B8 public trust infrastructure",
+      provenanceState: "available",
+      lineageState: "continuous",
+      visibilityNote: "Lineage continuity is visible and read-only.",
+      deterministicOrder: 4,
+      readOnly: true,
+      descriptiveOnly: true,
+    },
+  ],
+  coverageSummaries: [
+    {
+      id: "coverage-visible",
+      label: "Coverage visibility",
+      state: "deterministic descriptive coverage",
+      visibilityNote: "Coverage is visible without scoring, ranking, or recommendations.",
+      deterministicOrder: 1,
+      readOnly: true,
+      descriptiveOnly: true,
+    },
+    {
+      id: "incomplete-coverage",
+      label: "Incomplete coverage",
+      state: "fail-visible incomplete coverage",
+      visibilityNote: "Incomplete coverage remains visible and is not filled automatically.",
+      deterministicOrder: 2,
+      readOnly: true,
+      descriptiveOnly: true,
+    },
+  ],
+  confidenceSummaries: [
+    {
+      id: "confidence-visible",
+      label: "Confidence visibility",
+      state: "descriptive confidence visibility",
+      visibilityNote: "Confidence is shown as context only, not a score.",
+      deterministicOrder: 1,
+      readOnly: true,
+      descriptiveOnly: true,
+    },
+    {
+      id: "unknown-confidence",
+      label: "Unknown confidence",
+      state: "unknown confidence visible",
+      visibilityNote: "Unknown confidence remains explicit and non-authoritative.",
+      deterministicOrder: 2,
+      readOnly: true,
+      descriptiveOnly: true,
+    },
+  ],
+  diagnosticsSummaries: [
+    {
+      id: "public-warning",
+      label: "Public warning",
+      state: "warning",
+      message: "Warnings remain visible and do not become triage priority.",
+      deterministicOrder: 1,
+      readOnly: true,
+      descriptiveOnly: true,
+    },
+    {
+      id: "public-blocker",
+      label: "Public blocker",
+      state: "blocker",
+      message: "Blockers remain visible and do not trigger remediation.",
+      deterministicOrder: 2,
+      readOnly: true,
+      descriptiveOnly: true,
+    },
+    {
+      id: "continuity-gap",
+      label: "Continuity gap",
+      state: "gap",
+      message: "Continuity gaps remain fail-visible and descriptive.",
+      deterministicOrder: 3,
+      readOnly: true,
+      descriptiveOnly: true,
+    },
+    {
+      id: "evidence-gap",
+      label: "Evidence gap",
+      state: "gap",
+      message: "Evidence gaps stay visible and are not backfilled by the frontend.",
+      deterministicOrder: 4,
+      readOnly: true,
+      descriptiveOnly: true,
+    },
+    {
+      id: "explainability-gap",
+      label: "Explainability gap",
+      state: "gap",
+      message: "Explainability gaps remain visible and do not produce recommendations.",
+      deterministicOrder: 5,
+      readOnly: true,
+      descriptiveOnly: true,
+    },
+    {
+      id: "unsupported-state-diagnostic",
+      label: "Unsupported state",
+      state: "unsupported",
+      message: "Unsupported states remain fail-visible in diagnostics.",
+      deterministicOrder: 6,
+      readOnly: true,
+      descriptiveOnly: true,
+    },
+  ],
+  guarantees: [
+    "deterministic",
+    "governance-safe",
+    "fail-visible",
+    "read-only",
+    "descriptive-only",
+    "explainability-first",
+    "publicly transparent",
+  ],
+  prohibitions: [
+    "planner execution",
+    "planner recommendations",
+    "planner ranking",
+    "trust scoring",
+    "evidence scoring",
+    "authorization semantics",
+    "approval semantics",
+    "production enablement",
+    "runtime mutation",
+    "operational mutation",
+  ],
+  nonAuthorityStatement: FRONTEND_TRUST_SURFACE_NON_AUTHORITY_STATEMENT,
+  repositoryRemains: FRONTEND_TRUST_SURFACE_REPOSITORY_REMAINS,
+} as const;
+
+export function getSupportBadgeDefinition(
+  status: TrustSurfaceSupportStatus,
+): TrustSurfaceBadgeDefinition {
+  return SUPPORT_BADGES.find((badge) => badge.status === status) ?? SUPPORT_BADGES[6];
+}
+
+export function getFrontendTrustSurfaceData(): FrontendTrustSurfaceData {
+  return FRONTEND_TRUST_SURFACE_DATA;
+}
+
+export function isFrontendTrustSurfaceReadOnly(
+  data: FrontendTrustSurfaceData = FRONTEND_TRUST_SURFACE_DATA,
+): boolean {
+  return (
+    data.trustStatusCards.every((item) => item.readOnly && item.descriptiveOnly) &&
+    data.supportBadges.every((item) => item.readOnly && item.descriptiveOnly) &&
+    data.explainabilityPanels.every((item) => item.readOnly && item.descriptiveOnly) &&
+    data.evidencePanels.every(
+      (panel) =>
+        panel.readOnly &&
+        panel.descriptiveOnly &&
+        panel.items.every((item) => item.readOnly && item.descriptiveOnly),
+    ) &&
+    data.provenanceLineagePanels.every((item) => item.readOnly && item.descriptiveOnly) &&
+    data.coverageSummaries.every((item) => item.readOnly && item.descriptiveOnly) &&
+    data.confidenceSummaries.every((item) => item.readOnly && item.descriptiveOnly) &&
+    data.diagnosticsSummaries.every((item) => item.readOnly && item.descriptiveOnly)
+  );
+}

--- a/frontend/src/pages/FrontendTrustSurfaceFoundationsPage.tsx
+++ b/frontend/src/pages/FrontendTrustSurfaceFoundationsPage.tsx
@@ -1,0 +1,33 @@
+import { Link } from "react-router-dom";
+
+import PageMeta from "@/components/PageMeta";
+import { FrontendTrustSurface } from "@/components/trust/FrontendTrustSurface";
+
+export default function FrontendTrustSurfaceFoundationsPage() {
+  return (
+    <div className="mx-auto max-w-7xl space-y-8 p-6">
+      <PageMeta
+        title="Frontend Trust Surfaces"
+        description="Read-only deterministic frontend trust surfaces for public support, evidence, provenance, lineage, coverage, confidence, and diagnostics visibility."
+        path="/trusted-data/frontend-trust"
+      />
+
+      <nav className="flex flex-wrap gap-3 text-sm">
+        <Link
+          to="/trusted-data"
+          className="rounded border border-[#2a3050] px-4 py-2 text-gray-200 no-underline hover:border-[#f5a623]"
+        >
+          Trusted data guide
+        </Link>
+        <Link
+          to="/trusted-data/support"
+          className="rounded border border-[#2a3050] px-4 py-2 text-gray-200 no-underline hover:border-[#f5a623]"
+        >
+          Support matrix
+        </Link>
+      </nav>
+
+      <FrontendTrustSurface />
+    </div>
+  );
+}

--- a/frontend/src/pages/TrustedDataExplanationPage.tsx
+++ b/frontend/src/pages/TrustedDataExplanationPage.tsx
@@ -148,6 +148,12 @@ export default function TrustedDataExplanationPage() {
             Open pre-v3 readiness
           </Link>
           <Link
+            to="/trusted-data/frontend-trust"
+            className="rounded border border-[#2a3050] px-4 py-2 text-sm text-gray-200 no-underline hover:border-[#f5a623]"
+          >
+            Open frontend trust surfaces
+          </Link>
+          <Link
             to="/debug/v2"
             className="rounded border border-[#2a3050] px-4 py-2 text-sm text-gray-200 no-underline hover:border-[#f5a623]"
           >

--- a/frontend/src/types/frontendTrustSurface.ts
+++ b/frontend/src/types/frontendTrustSurface.ts
@@ -1,0 +1,133 @@
+export type TrustSurfaceSupportStatus =
+  | "supported"
+  | "partially_supported"
+  | "unsupported"
+  | "experimental"
+  | "deprecated"
+  | "blocked"
+  | "unknown";
+
+export type TrustSurfaceTone =
+  | "green"
+  | "blue"
+  | "amber"
+  | "red"
+  | "purple"
+  | "gray"
+  | "slate";
+
+export interface TrustSurfaceBadgeDefinition {
+  readonly status: TrustSurfaceSupportStatus;
+  readonly label: string;
+  readonly description: string;
+  readonly tone: TrustSurfaceTone;
+  readonly readOnly: true;
+  readonly descriptiveOnly: true;
+}
+
+export interface TrustStatusCardData {
+  readonly id: string;
+  readonly title: string;
+  readonly status: TrustSurfaceSupportStatus;
+  readonly summary: string;
+  readonly limitation: string;
+  readonly deterministicOrder: number;
+  readonly readOnly: true;
+  readonly descriptiveOnly: true;
+}
+
+export interface TrustExplanationPanelData {
+  readonly id: string;
+  readonly title: string;
+  readonly explanationType:
+    | "support"
+    | "limitation"
+    | "unsupported_state"
+    | "continuity"
+    | "trust"
+    | "diagnostics";
+  readonly summary: string;
+  readonly details: readonly string[];
+  readonly deterministicOrder: number;
+  readonly readOnly: true;
+  readonly descriptiveOnly: true;
+}
+
+export interface TrustEvidenceItemData {
+  readonly id: string;
+  readonly label: string;
+  readonly source: string;
+  readonly freshness: "current" | "stale" | "unknown" | "missing" | "unsupported";
+  readonly provenance: string;
+  readonly lineage: string;
+  readonly readOnly: true;
+  readonly descriptiveOnly: true;
+}
+
+export interface TrustEvidencePanelData {
+  readonly id: string;
+  readonly title: string;
+  readonly group:
+    | "trust_summary"
+    | "support_status"
+    | "explainability"
+    | "provenance"
+    | "lineage"
+    | "limitations"
+    | "unsupported_state"
+    | "diagnostics";
+  readonly items: readonly TrustEvidenceItemData[];
+  readonly deterministicOrder: number;
+  readonly readOnly: true;
+  readonly descriptiveOnly: true;
+}
+
+export interface TrustProvenanceLineageData {
+  readonly id: string;
+  readonly title: string;
+  readonly sourceReference: string;
+  readonly evidenceOrigin: string;
+  readonly provenanceState: "available" | "stale" | "unknown" | "unsupported";
+  readonly lineageState: "continuous" | "incomplete" | "unknown" | "unsupported";
+  readonly visibilityNote: string;
+  readonly deterministicOrder: number;
+  readonly readOnly: true;
+  readonly descriptiveOnly: true;
+}
+
+export interface TrustMetricSummaryData {
+  readonly id: string;
+  readonly label: string;
+  readonly state: string;
+  readonly visibilityNote: string;
+  readonly deterministicOrder: number;
+  readonly readOnly: true;
+  readonly descriptiveOnly: true;
+}
+
+export interface TrustDiagnosticsSummaryData {
+  readonly id: string;
+  readonly label: string;
+  readonly state: "warning" | "blocker" | "unsupported" | "gap";
+  readonly message: string;
+  readonly deterministicOrder: number;
+  readonly readOnly: true;
+  readonly descriptiveOnly: true;
+}
+
+export interface FrontendTrustSurfaceData {
+  readonly phaseId: string;
+  readonly generatedAt: string;
+  readonly trustStatusCards: readonly TrustStatusCardData[];
+  readonly supportBadges: readonly TrustSurfaceBadgeDefinition[];
+  readonly explainabilityPanels: readonly TrustExplanationPanelData[];
+  readonly evidencePanels: readonly TrustEvidencePanelData[];
+  readonly provenanceLineagePanels: readonly TrustProvenanceLineageData[];
+  readonly coverageSummaries: readonly TrustMetricSummaryData[];
+  readonly confidenceSummaries: readonly TrustMetricSummaryData[];
+  readonly diagnosticsSummaries: readonly TrustDiagnosticsSummaryData[];
+  readonly guarantees: readonly string[];
+  readonly prohibitions: readonly string[];
+  readonly nonAuthorityStatement: string;
+  readonly repositoryRemains: readonly string[];
+}


### PR DESCRIPTION
Implement governance-safe deterministic frontend trust surface foundations including trust status cards, support badges, explainability panels, evidence panels, provenance and lineage panels, coverage and confidence summaries, diagnostics summaries, read-only frontend trust visibility, fail-visible diagnostics, and descriptive-only public trust guarantees without introducing planner execution, authorization, approval, ranking, recommendation, scoring, or operational behavior.