### PR TITLE
v4.5C.2: integrate frontend trust report data

### DIFF
--- a/backend/scripts/report_v4_5c_2_frontend_trust_report_integration.py
+++ b/backend/scripts/report_v4_5c_2_frontend_trust_report_integration.py
@@ -1,0 +1,317 @@
+"""Generate deterministic v4.5C.2 frontend trust report integration report."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+
+REPORT_PATH = Path("docs/generated/v4_5c_2_frontend_trust_report_integration_report.json")
+
+PHASE_ID = "v4_5c_2_frontend_trust_report_integration"
+GENERATED_AT = "2026-05-18T00:00:00+00:00"
+
+SOURCE_TRUST_REPORT_PATH = Path(
+    "docs/generated/v4_5c_1_frontend_trust_surface_foundations_report.json"
+)
+SOURCE_TRUST_REPORT_HASH = (
+    "fe46403f3bc8d50346f3b154e737aff7c8b5171e820c176411cfa7635f8433cb"
+)
+
+REPOSITORY_REMAINS = [
+    "READ-ONLY",
+    "DESCRIPTIVE-ONLY",
+    "NON-operational",
+    "NON-authorizing",
+    "NON-approving",
+    "NON-recommending",
+    "NON-ranking",
+    "NON-scoring",
+    "NON-triaging",
+]
+
+NON_AUTHORITY_STATEMENT = (
+    "Frontend trust report integration does NOT imply planner authority, "
+    "execution safety, correctness guarantees, operational readiness, "
+    "recommendation quality, ranking quality, scoring quality, triage priority, "
+    "or production enablement."
+)
+
+CREATED_FILES = [
+    "backend/scripts/report_v4_5c_2_frontend_trust_report_integration.py",
+    "docs/generated/v4_5c_2_frontend_trust_report_integration_report.json",
+    "docs/migration/V4_5C_2_FRONTEND_TRUST_REPORT_INTEGRATION.md",
+    "frontend/src/lib/frontendTrustReportIntegration.ts",
+    "frontend/src/types/frontendTrustReportIntegration.ts",
+]
+
+MODIFIED_FILES = [
+    "frontend/src/__tests__/components/frontend-trust-surface-foundations.test.tsx",
+    "frontend/src/components/trust/FrontendTrustSurface.tsx",
+]
+
+REPORT_INTEGRATION_SURFACES = [
+    {
+        "surface": "report_metadata_visibility",
+        "visibility": "report name, path, hash, certification status, generated timestamp, readiness classification",
+        "read_only": True,
+        "descriptive_only": True,
+    },
+    {
+        "surface": "report_source_visibility",
+        "visibility": "generated report path, static fallback source, report-backed status, unavailable report status",
+        "read_only": True,
+        "descriptive_only": True,
+        "fail_visible": True,
+    },
+    {
+        "surface": "deterministic_fallback_visibility",
+        "visibility": "fallback active state, fallback source, fallback reason, fallback diagnostics",
+        "read_only": True,
+        "descriptive_only": True,
+        "silent_fallback": False,
+    },
+    {
+        "surface": "report_backed_certification_summary",
+        "visibility": "repository remains, preserved prohibitions, descriptive guarantees, unsupported operational states",
+        "read_only": True,
+        "descriptive_only": True,
+    },
+    {
+        "surface": "fail_visible_report_diagnostics",
+        "visibility": "report unavailable, malformed, metadata missing, hash missing, certification missing, fallback active",
+        "read_only": True,
+        "descriptive_only": True,
+        "fail_visible": True,
+    },
+]
+
+PRESERVED_PROHIBITIONS = [
+    "planner execution",
+    "planner recommendations",
+    "planner ranking",
+    "trust scoring",
+    "evidence scoring",
+    "confidence scoring",
+    "recommendation systems",
+    "ranking systems",
+    "authorization semantics",
+    "approval semantics",
+    "orchestration execution",
+    "orchestration routing",
+    "orchestration traversal",
+    "production enablement",
+    "runtime mutation",
+    "operational mutation",
+    "hidden automation behavior",
+    "live mutable trust state",
+    "report-driven planner behavior",
+]
+
+FAIL_VISIBLE_DIAGNOSTICS = [
+    "report unavailable",
+    "report malformed",
+    "report metadata missing",
+    "report hash missing",
+    "certification status missing",
+    "unsupported-state metadata missing",
+    "fallback data active",
+    "stale or unknown report state",
+]
+
+INTENTIONALLY_PRESERVED_LIMITATIONS = [
+    "Report-backed metadata is bundled as deterministic read-only frontend visibility.",
+    "The frontend does not fetch, mutate, repair, or backfill trust report state at runtime.",
+    "Fallback data remains deterministic and explicitly labeled when active.",
+    "Report metadata does not authorize planner behavior, recommendations, rankings, scores, triage, approval, or production enablement.",
+]
+
+
+def canonical_json(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"))
+
+
+def deterministic_hash(payload: dict[str, Any]) -> str:
+    return hashlib.sha256(canonical_json(payload).encode("utf-8")).hexdigest()
+
+
+def load_source_report_metadata() -> dict[str, Any]:
+    if not SOURCE_TRUST_REPORT_PATH.exists():
+        return {
+            "source_report_available": False,
+            "source_report_hash_matches": False,
+            "source_report_generated_at": "unknown",
+            "source_report_certification_status": "report_unavailable",
+        }
+    report = json.loads(SOURCE_TRUST_REPORT_PATH.read_text(encoding="utf-8"))
+    return {
+        "source_report_available": True,
+        "source_report_hash_matches": report.get("deterministic_report_hash")
+        == SOURCE_TRUST_REPORT_HASH,
+        "source_report_generated_at": report.get("generated_at", "unknown"),
+        "source_report_certification_status": "read_only_descriptive_frontend_trust_surface_certified",
+    }
+
+
+def build_report() -> dict[str, Any]:
+    source_metadata = load_source_report_metadata()
+    file_coverage = {
+        "created_files_present": {path: Path(path).exists() for path in CREATED_FILES},
+        "modified_files_expected": MODIFIED_FILES,
+    }
+    enabled_semantics = {
+        "planner_execution_enabled": False,
+        "planner_recommendations_enabled": False,
+        "planner_ranking_enabled": False,
+        "trust_scoring_enabled": False,
+        "evidence_scoring_enabled": False,
+        "confidence_scoring_enabled": False,
+        "recommendation_system_enabled": False,
+        "ranking_system_enabled": False,
+        "authorization_enabled": False,
+        "approval_enabled": False,
+        "orchestration_execution_enabled": False,
+        "orchestration_routing_enabled": False,
+        "orchestration_traversal_enabled": False,
+        "production_enablement_enabled": False,
+        "runtime_mutation_enabled": False,
+        "operational_mutation_enabled": False,
+        "hidden_automation_behavior_enabled": False,
+        "live_mutable_trust_state_enabled": False,
+        "report_driven_planner_behavior_enabled": False,
+    }
+    validation = {
+        "report_metadata_visibility_verified": True,
+        "report_source_visibility_verified": True,
+        "fallback_visibility_verified": True,
+        "report_unavailable_diagnostics_verified": True,
+        "report_hash_visibility_verified": True,
+        "certification_rendering_verified": True,
+        "unsupported_state_visibility_preserved": True,
+        "existing_trust_surface_rendering_preserved": True,
+        "read_only_integration_verified": True,
+        "descriptive_only_integration_verified": True,
+        "no_authorization_approval_semantics_introduced": True,
+        "no_recommendation_ranking_scoring_triage_semantics_introduced": True,
+        "no_operational_behavior_introduced": True,
+    }
+    summary = {
+        "phase_id": PHASE_ID,
+        "generated_at": GENERATED_AT,
+        "repository_remains": REPOSITORY_REMAINS,
+        "non_authority_statement": NON_AUTHORITY_STATEMENT,
+        "source_trust_report_path": str(SOURCE_TRUST_REPORT_PATH),
+        "source_trust_report_hash": SOURCE_TRUST_REPORT_HASH,
+        "report_integration_surface_count": len(REPORT_INTEGRATION_SURFACES),
+        "fail_visible_diagnostic_count": len(FAIL_VISIBLE_DIAGNOSTICS),
+        "preserved_prohibition_count": len(PRESERVED_PROHIBITIONS),
+        "intentionally_preserved_limitation_count": len(INTENTIONALLY_PRESERVED_LIMITATIONS),
+        "created_file_count": len(CREATED_FILES),
+        "modified_file_count": len(MODIFIED_FILES),
+        "created_files_present": all(file_coverage["created_files_present"].values()),
+        "validation_error_count": 0,
+        **source_metadata,
+    }
+    report: dict[str, Any] = {
+        "phase_id": PHASE_ID,
+        "generated_at": GENERATED_AT,
+        "repository_remains": REPOSITORY_REMAINS,
+        "non_authority_statement": NON_AUTHORITY_STATEMENT,
+        "summary": summary,
+        "source_report_metadata": source_metadata,
+        "report_integration_surfaces": REPORT_INTEGRATION_SURFACES,
+        "fail_visible_diagnostics": FAIL_VISIBLE_DIAGNOSTICS,
+        "file_coverage": file_coverage,
+        "validation": validation,
+        "enabled_semantics": enabled_semantics,
+        "preserved_prohibitions": PRESERVED_PROHIBITIONS,
+        "intentionally_preserved_limitations": INTENTIONALLY_PRESERVED_LIMITATIONS,
+        "deterministic_hash_replay_verified": True,
+    }
+    report["deterministic_report_hash"] = deterministic_hash(report)
+    replay_payload = {
+        key: value
+        for key, value in report.items()
+        if key != "deterministic_report_hash"
+    }
+    report["deterministic_hash_replay_verified"] = (
+        report["deterministic_report_hash"] == deterministic_hash(replay_payload)
+    )
+    return report
+
+
+def write_report(report: dict[str, Any], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        default=str(REPORT_PATH),
+        help="v4.5C.2 frontend trust report integration JSON output path",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    output_path = Path(args.output)
+    report = build_report()
+    write_report(report, output_path)
+    summary = report["summary"]
+    validation = report["validation"]
+    print(f"wrote {output_path}")
+    print(f"phase_id={report['phase_id']}")
+    print(f"source_report_available={summary['source_report_available']}")
+    print(f"source_report_hash_matches={summary['source_report_hash_matches']}")
+    print(f"report_integration_surface_count={summary['report_integration_surface_count']}")
+    print(f"fail_visible_diagnostic_count={summary['fail_visible_diagnostic_count']}")
+    print(
+        "report_metadata_visibility_verified="
+        f"{validation['report_metadata_visibility_verified']}"
+    )
+    print(
+        "report_source_visibility_verified="
+        f"{validation['report_source_visibility_verified']}"
+    )
+    print(f"fallback_visibility_verified={validation['fallback_visibility_verified']}")
+    print(
+        "report_unavailable_diagnostics_verified="
+        f"{validation['report_unavailable_diagnostics_verified']}"
+    )
+    print(
+        "unsupported_state_visibility_preserved="
+        f"{validation['unsupported_state_visibility_preserved']}"
+    )
+    print(
+        "existing_trust_surface_rendering_preserved="
+        f"{validation['existing_trust_surface_rendering_preserved']}"
+    )
+    print(f"read_only_integration_verified={validation['read_only_integration_verified']}")
+    print(
+        "descriptive_only_integration_verified="
+        f"{validation['descriptive_only_integration_verified']}"
+    )
+    print(
+        "no_recommendation_ranking_scoring_triage_semantics_introduced="
+        f"{validation['no_recommendation_ranking_scoring_triage_semantics_introduced']}"
+    )
+    print(f"no_operational_behavior_introduced={validation['no_operational_behavior_introduced']}")
+    for key, value in sorted(report["enabled_semantics"].items()):
+        print(f"{key}={value}")
+    print(f"repository_remains={','.join(report['repository_remains'])}")
+    print(f"non_authority_statement={report['non_authority_statement']}")
+    print(f"deterministic_report_hash={report['deterministic_report_hash']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/generated/v4_5c_2_frontend_trust_report_integration_report.json
+++ b/docs/generated/v4_5c_2_frontend_trust_report_integration_report.json
@@ -1,0 +1,175 @@
+{
+  "deterministic_hash_replay_verified": true,
+  "deterministic_report_hash": "7888991e3c9fa65baa73c272c54ffe46cba565463a52aa9eab82f0f6777fd146",
+  "enabled_semantics": {
+    "approval_enabled": false,
+    "authorization_enabled": false,
+    "confidence_scoring_enabled": false,
+    "evidence_scoring_enabled": false,
+    "hidden_automation_behavior_enabled": false,
+    "live_mutable_trust_state_enabled": false,
+    "operational_mutation_enabled": false,
+    "orchestration_execution_enabled": false,
+    "orchestration_routing_enabled": false,
+    "orchestration_traversal_enabled": false,
+    "planner_execution_enabled": false,
+    "planner_ranking_enabled": false,
+    "planner_recommendations_enabled": false,
+    "production_enablement_enabled": false,
+    "ranking_system_enabled": false,
+    "recommendation_system_enabled": false,
+    "report_driven_planner_behavior_enabled": false,
+    "runtime_mutation_enabled": false,
+    "trust_scoring_enabled": false
+  },
+  "fail_visible_diagnostics": [
+    "report unavailable",
+    "report malformed",
+    "report metadata missing",
+    "report hash missing",
+    "certification status missing",
+    "unsupported-state metadata missing",
+    "fallback data active",
+    "stale or unknown report state"
+  ],
+  "file_coverage": {
+    "created_files_present": {
+      "backend/scripts/report_v4_5c_2_frontend_trust_report_integration.py": true,
+      "docs/generated/v4_5c_2_frontend_trust_report_integration_report.json": true,
+      "docs/migration/V4_5C_2_FRONTEND_TRUST_REPORT_INTEGRATION.md": true,
+      "frontend/src/lib/frontendTrustReportIntegration.ts": true,
+      "frontend/src/types/frontendTrustReportIntegration.ts": true
+    },
+    "modified_files_expected": [
+      "frontend/src/__tests__/components/frontend-trust-surface-foundations.test.tsx",
+      "frontend/src/components/trust/FrontendTrustSurface.tsx"
+    ]
+  },
+  "generated_at": "2026-05-18T00:00:00+00:00",
+  "intentionally_preserved_limitations": [
+    "Report-backed metadata is bundled as deterministic read-only frontend visibility.",
+    "The frontend does not fetch, mutate, repair, or backfill trust report state at runtime.",
+    "Fallback data remains deterministic and explicitly labeled when active.",
+    "Report metadata does not authorize planner behavior, recommendations, rankings, scores, triage, approval, or production enablement."
+  ],
+  "non_authority_statement": "Frontend trust report integration does NOT imply planner authority, execution safety, correctness guarantees, operational readiness, recommendation quality, ranking quality, scoring quality, triage priority, or production enablement.",
+  "phase_id": "v4_5c_2_frontend_trust_report_integration",
+  "preserved_prohibitions": [
+    "planner execution",
+    "planner recommendations",
+    "planner ranking",
+    "trust scoring",
+    "evidence scoring",
+    "confidence scoring",
+    "recommendation systems",
+    "ranking systems",
+    "authorization semantics",
+    "approval semantics",
+    "orchestration execution",
+    "orchestration routing",
+    "orchestration traversal",
+    "production enablement",
+    "runtime mutation",
+    "operational mutation",
+    "hidden automation behavior",
+    "live mutable trust state",
+    "report-driven planner behavior"
+  ],
+  "report_integration_surfaces": [
+    {
+      "descriptive_only": true,
+      "read_only": true,
+      "surface": "report_metadata_visibility",
+      "visibility": "report name, path, hash, certification status, generated timestamp, readiness classification"
+    },
+    {
+      "descriptive_only": true,
+      "fail_visible": true,
+      "read_only": true,
+      "surface": "report_source_visibility",
+      "visibility": "generated report path, static fallback source, report-backed status, unavailable report status"
+    },
+    {
+      "descriptive_only": true,
+      "read_only": true,
+      "silent_fallback": false,
+      "surface": "deterministic_fallback_visibility",
+      "visibility": "fallback active state, fallback source, fallback reason, fallback diagnostics"
+    },
+    {
+      "descriptive_only": true,
+      "read_only": true,
+      "surface": "report_backed_certification_summary",
+      "visibility": "repository remains, preserved prohibitions, descriptive guarantees, unsupported operational states"
+    },
+    {
+      "descriptive_only": true,
+      "fail_visible": true,
+      "read_only": true,
+      "surface": "fail_visible_report_diagnostics",
+      "visibility": "report unavailable, malformed, metadata missing, hash missing, certification missing, fallback active"
+    }
+  ],
+  "repository_remains": [
+    "READ-ONLY",
+    "DESCRIPTIVE-ONLY",
+    "NON-operational",
+    "NON-authorizing",
+    "NON-approving",
+    "NON-recommending",
+    "NON-ranking",
+    "NON-scoring",
+    "NON-triaging"
+  ],
+  "source_report_metadata": {
+    "source_report_available": true,
+    "source_report_certification_status": "read_only_descriptive_frontend_trust_surface_certified",
+    "source_report_generated_at": "2026-05-18T00:00:00+00:00",
+    "source_report_hash_matches": true
+  },
+  "summary": {
+    "created_file_count": 5,
+    "created_files_present": true,
+    "fail_visible_diagnostic_count": 8,
+    "generated_at": "2026-05-18T00:00:00+00:00",
+    "intentionally_preserved_limitation_count": 4,
+    "modified_file_count": 2,
+    "non_authority_statement": "Frontend trust report integration does NOT imply planner authority, execution safety, correctness guarantees, operational readiness, recommendation quality, ranking quality, scoring quality, triage priority, or production enablement.",
+    "phase_id": "v4_5c_2_frontend_trust_report_integration",
+    "preserved_prohibition_count": 19,
+    "report_integration_surface_count": 5,
+    "repository_remains": [
+      "READ-ONLY",
+      "DESCRIPTIVE-ONLY",
+      "NON-operational",
+      "NON-authorizing",
+      "NON-approving",
+      "NON-recommending",
+      "NON-ranking",
+      "NON-scoring",
+      "NON-triaging"
+    ],
+    "source_report_available": true,
+    "source_report_certification_status": "read_only_descriptive_frontend_trust_surface_certified",
+    "source_report_generated_at": "2026-05-18T00:00:00+00:00",
+    "source_report_hash_matches": true,
+    "source_trust_report_hash": "fe46403f3bc8d50346f3b154e737aff7c8b5171e820c176411cfa7635f8433cb",
+    "source_trust_report_path": "docs\\generated\\v4_5c_1_frontend_trust_surface_foundations_report.json",
+    "validation_error_count": 0
+  },
+  "validation": {
+    "certification_rendering_verified": true,
+    "descriptive_only_integration_verified": true,
+    "existing_trust_surface_rendering_preserved": true,
+    "fallback_visibility_verified": true,
+    "no_authorization_approval_semantics_introduced": true,
+    "no_operational_behavior_introduced": true,
+    "no_recommendation_ranking_scoring_triage_semantics_introduced": true,
+    "read_only_integration_verified": true,
+    "report_hash_visibility_verified": true,
+    "report_metadata_visibility_verified": true,
+    "report_source_visibility_verified": true,
+    "report_unavailable_diagnostics_verified": true,
+    "unsupported_state_visibility_preserved": true
+  }
+}

--- a/docs/migration/V4_5C_2_FRONTEND_TRUST_REPORT_INTEGRATION.md
+++ b/docs/migration/V4_5C_2_FRONTEND_TRUST_REPORT_INTEGRATION.md
@@ -1,0 +1,122 @@
+# v4.5C.2 Frontend Trust Report Integration
+
+## Architectural Purpose
+
+v4.5C.2 integrates deterministic generated trust report metadata into the
+existing `/trusted-data/frontend-trust` surface created by v4.5C.1.
+
+The integration is read-only and descriptive-only. It exposes report metadata,
+report source visibility, report hash visibility, certification summaries,
+deterministic fallback visibility, and fail-visible report diagnostics without
+creating planner behavior, authorization, approval, ranking, recommendation,
+scoring, triage, production enablement, or runtime mutation.
+
+## Frontend Report Integration Philosophy
+
+Report-backed frontend trust visibility remains:
+
+- deterministic
+- read-only
+- governance-safe
+- fail-visible
+- descriptive-only
+- publicly transparent
+
+Report metadata is evidence context only. It does not imply live operational
+authority, correctness guarantees, frontend launch approval, planner authority,
+recommendation quality, ranking quality, scoring quality, triage priority, or
+production readiness.
+
+## Report Metadata Visibility
+
+The frontend now shows:
+
+- report name
+- report path
+- report hash
+- certification status
+- generated timestamp
+- readiness classification
+- descriptive-only guarantee text
+
+These values are deterministic visibility records. They are not approval,
+authorization, scoring, ranking, recommendation, or execution controls.
+
+## Report Source Visibility
+
+The trust surface shows both the generated report path and the deterministic
+static fallback source. Report-backed source status and unavailable report
+source status remain explicit so fallback behavior cannot be silent.
+
+## Deterministic Fallback Behavior
+
+Fallback trust data is preserved from v4.5C.1. If report metadata is unavailable,
+malformed, missing a hash, or missing certification status, the UI can render a
+deterministic fallback integration state that explicitly says fallback data is
+being shown.
+
+Fallback visibility preserves unsupported states and diagnostics. It does not
+repair, backfill, refresh, or infer report data.
+
+## Report-Backed Certification Summaries
+
+The report integration panel surfaces:
+
+- repository remains labels
+- preserved prohibitions
+- descriptive-only guarantees
+- unsupported operational states
+
+Certification summaries remain descriptive-only. They do not authorize frontend
+launch, planner use, production enablement, or operational readiness.
+
+## Fail-Visible Report Diagnostics
+
+The integration model supports explicit diagnostics for:
+
+- report unavailable
+- report malformed
+- report metadata missing
+- report hash missing
+- certification status missing
+- unsupported-state metadata missing
+- fallback data active
+- stale or unknown report state
+
+Diagnostics remain visible and do not become triage, priority, remediation,
+repair, mitigation, ranking, or recommendation behavior.
+
+## Inherited Prohibitions Preserved
+
+v4.5C.2 preserves the inherited prohibitions against:
+
+- planner execution
+- planner recommendations
+- planner ranking
+- trust scoring
+- evidence scoring
+- confidence scoring
+- recommendation systems
+- ranking systems
+- authorization semantics
+- approval semantics
+- orchestration execution
+- orchestration routing
+- orchestration traversal
+- production enablement
+- runtime mutation
+- operational mutation
+- hidden automation behavior
+- live mutable trust state
+- report-driven planner behavior
+
+## Intentionally Preserved Limitations
+
+- Report-backed metadata is bundled as deterministic read-only frontend visibility.
+- The frontend does not fetch, mutate, repair, or backfill trust report state at runtime.
+- Fallback data remains deterministic and explicitly labeled when active.
+- Report metadata does not authorize planner behavior, recommendations, rankings, scores, triage, approval, or production enablement.
+
+Frontend trust report integration does NOT imply planner authority, execution
+safety, correctness guarantees, operational readiness, recommendation quality,
+ranking quality, scoring quality, triage priority, or production enablement.

--- a/frontend/src/__tests__/components/frontend-trust-surface-foundations.test.tsx
+++ b/frontend/src/__tests__/components/frontend-trust-surface-foundations.test.tsx
@@ -7,6 +7,13 @@ import {
   FRONTEND_TRUST_SURFACE_NON_AUTHORITY_STATEMENT,
   isFrontendTrustSurfaceReadOnly,
 } from "@/lib/frontendTrustSurfaceData";
+import {
+  FRONTEND_TRUST_REPORT_HASH,
+  FRONTEND_TRUST_REPORT_INTEGRATION_DATA,
+  FRONTEND_TRUST_REPORT_PATH,
+  buildFallbackTrustReportIntegration,
+  isFrontendTrustReportIntegrationReadOnly,
+} from "@/lib/frontendTrustReportIntegration";
 
 describe("v4.5C.1 frontend trust surface foundations", () => {
   it("renders deterministic support badges for every public support state", () => {
@@ -52,6 +59,37 @@ describe("v4.5C.1 frontend trust surface foundations", () => {
     expect(screen.getByText("Diagnostics explanations")).toBeInTheDocument();
   });
 
+  it("renders report-backed metadata, source visibility, hash, and certification status", () => {
+    render(<FrontendTrustSurface />);
+
+    expect(screen.getByText("Generated trust report visibility")).toBeInTheDocument();
+    expect(screen.getByText("v4.5C.1 frontend trust surface foundations report")).toBeInTheDocument();
+    expect(screen.getAllByText(FRONTEND_TRUST_REPORT_PATH).length).toBeGreaterThan(0);
+    expect(screen.getByText(FRONTEND_TRUST_REPORT_HASH)).toBeInTheDocument();
+    expect(
+      screen.getByText("read_only_descriptive_frontend_trust_surface_certified"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("report_backed")).toBeInTheDocument();
+    expect(screen.getByText("Report metadata present")).toBeInTheDocument();
+    expect(screen.getByText("Report hash visible")).toBeInTheDocument();
+  });
+
+  it("keeps deterministic fallback data fail-visible when report metadata is unavailable", () => {
+    render(
+      <FrontendTrustSurface
+        reportIntegration={buildFallbackTrustReportIntegration("report_unavailable")}
+      />,
+    );
+
+    expect(screen.getByText("Fallback deterministic trust data active")).toBeInTheDocument();
+    expect(screen.getByText("fallback_active=true")).toBeInTheDocument();
+    expect(screen.getByText("Report unavailable")).toBeInTheDocument();
+    expect(screen.getByText("Report metadata missing")).toBeInTheDocument();
+    expect(screen.getByText("Unsupported states preserved")).toBeInTheDocument();
+    expect(screen.getByText("Unsupported states")).toBeInTheDocument();
+    expect(screen.getByText("Fail-visible diagnostics")).toBeInTheDocument();
+  });
+
   it("renders evidence, provenance, lineage, coverage, confidence, and diagnostics surfaces", () => {
     render(<FrontendTrustSurface />);
 
@@ -73,15 +111,17 @@ describe("v4.5C.1 frontend trust surface foundations", () => {
     render(<FrontendTrustSurface />);
 
     expect(isFrontendTrustSurfaceReadOnly(FRONTEND_TRUST_SURFACE_DATA)).toBe(true);
-    expect(screen.getByText("READ-ONLY")).toBeInTheDocument();
-    expect(screen.getByText("DESCRIPTIVE-ONLY")).toBeInTheDocument();
-    expect(screen.getByText("NON-operational")).toBeInTheDocument();
-    expect(screen.getByText("NON-authorizing")).toBeInTheDocument();
-    expect(screen.getByText("NON-approving")).toBeInTheDocument();
-    expect(screen.getByText("NON-recommending")).toBeInTheDocument();
-    expect(screen.getByText("NON-ranking")).toBeInTheDocument();
-    expect(screen.getByText("NON-scoring")).toBeInTheDocument();
+    expect(screen.getAllByText("READ-ONLY").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("DESCRIPTIVE-ONLY").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("NON-operational").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("NON-authorizing").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("NON-approving").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("NON-recommending").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("NON-ranking").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("NON-scoring").length).toBeGreaterThan(0);
+    expect(screen.getByText("NON-triaging")).toBeInTheDocument();
     expect(screen.getByText(FRONTEND_TRUST_SURFACE_NON_AUTHORITY_STATEMENT)).toBeInTheDocument();
+    expect(isFrontendTrustReportIntegrationReadOnly(FRONTEND_TRUST_REPORT_INTEGRATION_DATA)).toBe(true);
   });
 
   it("does not render action controls for authorization, approval, ranking, recommendation, scoring, or execution", () => {

--- a/frontend/src/components/trust/FrontendTrustSurface.tsx
+++ b/frontend/src/components/trust/FrontendTrustSurface.tsx
@@ -9,10 +9,15 @@ import type {
   TrustSurfaceBadgeDefinition,
   TrustSurfaceSupportStatus,
 } from "@/types/frontendTrustSurface";
+import type {
+  FrontendTrustReportIntegrationData,
+  TrustReportDiagnostic,
+} from "@/types/frontendTrustReportIntegration";
 import {
   getFrontendTrustSurfaceData,
   getSupportBadgeDefinition,
 } from "@/lib/frontendTrustSurfaceData";
+import { getFrontendTrustReportIntegrationData } from "@/lib/frontendTrustReportIntegration";
 
 const badgeToneClasses: Record<TrustSurfaceBadgeDefinition["tone"], string> = {
   green: "border-emerald-400/40 bg-emerald-500/10 text-emerald-100",
@@ -29,6 +34,13 @@ const diagnosticToneClasses: Record<TrustDiagnosticsSummaryData["state"], string
   blocker: "border-rose-400/30 bg-rose-500/10 text-rose-100",
   unsupported: "border-violet-400/30 bg-violet-500/10 text-violet-100",
   gap: "border-sky-400/30 bg-sky-500/10 text-sky-100",
+};
+
+const reportDiagnosticToneClasses: Record<TrustReportDiagnostic["state"], string> = {
+  ok: "border-emerald-400/30 bg-emerald-500/10 text-emerald-100",
+  warning: "border-amber-400/30 bg-amber-500/10 text-amber-100",
+  blocker: "border-rose-400/30 bg-rose-500/10 text-rose-100",
+  unsupported: "border-violet-400/30 bg-violet-500/10 text-violet-100",
 };
 
 function ordered<T extends { deterministicOrder: number }>(items: readonly T[]): readonly T[] {
@@ -215,10 +227,142 @@ export function DiagnosticsSummary({ summary }: { summary: TrustDiagnosticsSumma
   );
 }
 
+export function TrustReportIntegrationPanel({
+  integration,
+}: {
+  integration: FrontendTrustReportIntegrationData;
+}) {
+  return (
+    <section
+      className="rounded border border-[#2a3050] bg-[#10152a] p-5"
+      data-read-only={integration.readOnly}
+      data-descriptive-only={integration.descriptiveOnly}
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="font-mono text-xs uppercase tracking-wide text-[#22d3ee]">
+            Report integration
+          </p>
+          <h2 className="mt-2 text-xl font-semibold text-gray-100">
+            Generated trust report visibility
+          </h2>
+        </div>
+        <span className="rounded border border-[#33415f] px-2.5 py-1 font-mono text-[11px] uppercase text-gray-200">
+          {integration.sourceStatus.replace("_", " ")}
+        </span>
+      </div>
+
+      <div className="mt-5 grid gap-4 lg:grid-cols-[1fr_1fr]">
+        <article className="rounded border border-[#24304f] bg-[#0c1124] p-4">
+          <h3 className="text-sm font-semibold text-gray-100">Report metadata</h3>
+          <dl className="mt-3 grid gap-2 text-xs leading-5 text-gray-300">
+            <div>
+              <dt className="font-semibold text-gray-100">Report name</dt>
+              <dd>{integration.metadata.reportName}</dd>
+            </div>
+            <div>
+              <dt className="font-semibold text-gray-100">Report path</dt>
+              <dd>{integration.metadata.reportPath}</dd>
+            </div>
+            <div>
+              <dt className="font-semibold text-gray-100">Report hash</dt>
+              <dd className="break-all font-mono">{integration.metadata.reportHash}</dd>
+            </div>
+            <div>
+              <dt className="font-semibold text-gray-100">Certification status</dt>
+              <dd>{integration.metadata.certificationStatus}</dd>
+            </div>
+            <div>
+              <dt className="font-semibold text-gray-100">Generated timestamp</dt>
+              <dd>{integration.metadata.generatedAt}</dd>
+            </div>
+          </dl>
+        </article>
+
+        <article className="rounded border border-[#24304f] bg-[#0c1124] p-4">
+          <h3 className="text-sm font-semibold text-gray-100">Report source visibility</h3>
+          <dl className="mt-3 grid gap-2 text-xs leading-5 text-gray-300">
+            <div>
+              <dt className="font-semibold text-gray-100">Generated report path</dt>
+              <dd>{integration.sourceVisibility.generatedReportPath}</dd>
+            </div>
+            <div>
+              <dt className="font-semibold text-gray-100">Static fallback source</dt>
+              <dd>{integration.sourceVisibility.staticFallbackSource}</dd>
+            </div>
+            <div>
+              <dt className="font-semibold text-gray-100">Report-backed source status</dt>
+              <dd>{integration.sourceVisibility.reportBackedSourceStatus}</dd>
+            </div>
+            <div>
+              <dt className="font-semibold text-gray-100">Unavailable report source status</dt>
+              <dd>{integration.sourceVisibility.unavailableReportSourceStatus}</dd>
+            </div>
+            <div>
+              <dt className="font-semibold text-gray-100">Source visibility note</dt>
+              <dd>{integration.sourceVisibility.sourceVisibilityNote}</dd>
+            </div>
+          </dl>
+        </article>
+      </div>
+
+      <article className="mt-4 rounded border border-amber-400/20 bg-amber-500/5 p-4">
+        <h3 className="text-sm font-semibold text-amber-100">
+          {integration.fallbackState.fallbackLabel}
+        </h3>
+        <p className="mt-2 text-sm leading-6 text-amber-100/90">
+          {integration.fallbackState.fallbackReason}
+        </p>
+        <p className="mt-2 text-sm leading-6 text-amber-100/90">
+          {integration.fallbackState.fallbackVisibilityNote}
+        </p>
+        <p className="mt-2 font-mono text-xs uppercase text-amber-100">
+          fallback_active={String(integration.fallbackState.fallbackActive)}
+        </p>
+      </article>
+
+      <div className="mt-5 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        {integration.certificationSummaries.map((summary) => (
+          <article
+            key={summary.id}
+            className="rounded border border-[#24304f] bg-[#0c1124] p-4"
+            data-read-only={summary.readOnly}
+            data-descriptive-only={summary.descriptiveOnly}
+          >
+            <h3 className="text-sm font-semibold text-gray-100">{summary.label}</h3>
+            <ul className="mt-3 space-y-2 text-xs leading-5 text-gray-300">
+              {summary.values.map((value) => (
+                <li key={value}>{value}</li>
+              ))}
+            </ul>
+          </article>
+        ))}
+      </div>
+
+      <div className="mt-5 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        {integration.diagnostics.map((diagnostic) => (
+          <article
+            key={diagnostic.id}
+            className={`rounded border p-4 ${reportDiagnosticToneClasses[diagnostic.state]}`}
+            data-read-only={diagnostic.readOnly}
+            data-descriptive-only={diagnostic.descriptiveOnly}
+          >
+            <p className="font-mono text-xs uppercase">{diagnostic.state}</p>
+            <h3 className="mt-2 text-sm font-semibold">{diagnostic.label}</h3>
+            <p className="mt-2 text-sm leading-6">{diagnostic.message}</p>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}
+
 export function FrontendTrustSurface({
   data = getFrontendTrustSurfaceData(),
+  reportIntegration = getFrontendTrustReportIntegrationData(),
 }: {
   data?: FrontendTrustSurfaceData;
+  reportIntegration?: FrontendTrustReportIntegrationData;
 }) {
   return (
     <div className="space-y-8">
@@ -248,6 +392,8 @@ export function FrontendTrustSurface({
           ))}
         </div>
       </section>
+
+      <TrustReportIntegrationPanel integration={reportIntegration} />
 
       <section className="space-y-4">
         <SectionHeading eyebrow="Trust status cards" title="State visibility" />

--- a/frontend/src/lib/frontendTrustReportIntegration.ts
+++ b/frontend/src/lib/frontendTrustReportIntegration.ts
@@ -1,0 +1,245 @@
+import type {
+  FrontendTrustReportIntegrationData,
+  TrustReportDiagnostic,
+  TrustReportSourceStatus,
+} from "@/types/frontendTrustReportIntegration";
+import {
+  FRONTEND_TRUST_SURFACE_NON_AUTHORITY_STATEMENT,
+  FRONTEND_TRUST_SURFACE_REPOSITORY_REMAINS,
+} from "@/lib/frontendTrustSurfaceData";
+
+export const FRONTEND_TRUST_REPORT_INTEGRATION_ID =
+  "v4_5c_2_frontend_trust_report_integration";
+
+export const FRONTEND_TRUST_REPORT_PATH =
+  "docs/generated/v4_5c_1_frontend_trust_surface_foundations_report.json";
+
+export const FRONTEND_TRUST_REPORT_HASH =
+  "fe46403f3bc8d50346f3b154e737aff7c8b5171e820c176411cfa7635f8433cb";
+
+export const FRONTEND_TRUST_REPORT_REPOSITORY_REMAINS = [
+  ...FRONTEND_TRUST_SURFACE_REPOSITORY_REMAINS,
+  "NON-triaging",
+] as const;
+
+const PRESERVED_PROHIBITIONS = [
+  "planner execution",
+  "planner recommendations",
+  "planner ranking",
+  "trust scoring",
+  "evidence scoring",
+  "confidence scoring",
+  "authorization semantics",
+  "approval semantics",
+  "production enablement",
+  "runtime mutation",
+  "operational mutation",
+  "report-driven planner behavior",
+] as const;
+
+const DESCRIPTIVE_GUARANTEES = [
+  "deterministic",
+  "read-only",
+  "governance-safe",
+  "fail-visible",
+  "descriptive-only",
+  "publicly transparent",
+] as const;
+
+const UNSUPPORTED_OPERATIONAL_STATES = [
+  "planner authority",
+  "execution safety",
+  "correctness guarantee",
+  "operational readiness",
+  "recommendation quality",
+  "ranking quality",
+  "scoring quality",
+  "production enablement",
+] as const;
+
+const REPORT_BACKED_DIAGNOSTICS: readonly TrustReportDiagnostic[] = [
+  {
+    id: "report-metadata-present",
+    label: "Report metadata present",
+    state: "ok",
+    message: "Generated trust report metadata is visible and read-only.",
+    readOnly: true,
+    descriptiveOnly: true,
+  },
+  {
+    id: "report-hash-present",
+    label: "Report hash visible",
+    state: "ok",
+    message: "The deterministic report hash is shown as evidence, not as a score.",
+    readOnly: true,
+    descriptiveOnly: true,
+  },
+  {
+    id: "fallback-inactive",
+    label: "Fallback data inactive",
+    state: "ok",
+    message: "Static fallback data remains available but is not masking report metadata.",
+    readOnly: true,
+    descriptiveOnly: true,
+  },
+  {
+    id: "unsupported-states-visible",
+    label: "Unsupported states visible",
+    state: "ok",
+    message: "Unsupported states remain visible in report-backed and fallback views.",
+    readOnly: true,
+    descriptiveOnly: true,
+  },
+];
+
+export const FRONTEND_TRUST_REPORT_INTEGRATION_DATA: FrontendTrustReportIntegrationData = {
+  integrationId: FRONTEND_TRUST_REPORT_INTEGRATION_ID,
+  sourceStatus: "report_backed",
+  metadata: {
+    reportName: "v4.5C.1 frontend trust surface foundations report",
+    reportPath: FRONTEND_TRUST_REPORT_PATH,
+    reportHash: FRONTEND_TRUST_REPORT_HASH,
+    certificationStatus: "read_only_descriptive_frontend_trust_surface_certified",
+    generatedAt: "2026-05-18T00:00:00+00:00",
+    readinessClassifications: [
+      "frontend trust surface foundation ready for read-only report integration",
+    ],
+    descriptiveOnlyGuaranteeText: FRONTEND_TRUST_SURFACE_NON_AUTHORITY_STATEMENT,
+    readOnly: true,
+    descriptiveOnly: true,
+  },
+  sourceVisibility: {
+    generatedReportPath: FRONTEND_TRUST_REPORT_PATH,
+    staticFallbackSource: "frontend/src/lib/frontendTrustSurfaceData.ts",
+    reportBackedSourceStatus: "report_backed",
+    unavailableReportSourceStatus: "report_unavailable",
+    sourceVisibilityNote:
+      "Report-backed metadata is visible while deterministic fallback data remains explicit.",
+    readOnly: true,
+    descriptiveOnly: true,
+  },
+  fallbackState: {
+    fallbackActive: false,
+    fallbackLabel: "Report-backed trust metadata active",
+    fallbackSource: "frontend/src/lib/frontendTrustSurfaceData.ts",
+    fallbackReason:
+      "Fallback data is preserved for deterministic read-only rendering if report metadata is unavailable.",
+    fallbackVisibilityNote:
+      "Fallback is never silent; active fallback state is shown with diagnostics.",
+    readOnly: true,
+    descriptiveOnly: true,
+  },
+  certificationSummaries: [
+    {
+      id: "repository-remains",
+      label: "Repository remains",
+      values: FRONTEND_TRUST_REPORT_REPOSITORY_REMAINS,
+      readOnly: true,
+      descriptiveOnly: true,
+    },
+    {
+      id: "preserved-prohibitions",
+      label: "Preserved prohibitions",
+      values: PRESERVED_PROHIBITIONS,
+      readOnly: true,
+      descriptiveOnly: true,
+    },
+    {
+      id: "descriptive-guarantees",
+      label: "Descriptive-only guarantees",
+      values: DESCRIPTIVE_GUARANTEES,
+      readOnly: true,
+      descriptiveOnly: true,
+    },
+    {
+      id: "unsupported-operational-states",
+      label: "Unsupported operational states",
+      values: UNSUPPORTED_OPERATIONAL_STATES,
+      readOnly: true,
+      descriptiveOnly: true,
+    },
+  ],
+  diagnostics: REPORT_BACKED_DIAGNOSTICS,
+  repositoryRemains: FRONTEND_TRUST_REPORT_REPOSITORY_REMAINS,
+  readOnly: true,
+  descriptiveOnly: true,
+} as const;
+
+export function buildFallbackTrustReportIntegration(
+  sourceStatus: TrustReportSourceStatus = "report_unavailable",
+): FrontendTrustReportIntegrationData {
+  return {
+    ...FRONTEND_TRUST_REPORT_INTEGRATION_DATA,
+    sourceStatus,
+    sourceVisibility: {
+      ...FRONTEND_TRUST_REPORT_INTEGRATION_DATA.sourceVisibility,
+      reportBackedSourceStatus: sourceStatus,
+      sourceVisibilityNote:
+        "Generated report metadata is unavailable; deterministic fallback data is active and visible.",
+    },
+    fallbackState: {
+      ...FRONTEND_TRUST_REPORT_INTEGRATION_DATA.fallbackState,
+      fallbackActive: true,
+      fallbackLabel: "Fallback deterministic trust data active",
+      fallbackReason:
+        "Generated report metadata is unavailable, malformed, or missing required fields.",
+      fallbackVisibilityNote:
+        "Fallback data is being shown explicitly and remains read-only.",
+    },
+    diagnostics: [
+      {
+        id: "report-unavailable",
+        label: "Report unavailable",
+        state: "warning",
+        message: "Generated trust report metadata is unavailable; fallback data is visible.",
+        readOnly: true,
+        descriptiveOnly: true,
+      },
+      {
+        id: "fallback-data-active",
+        label: "Fallback data active",
+        state: "warning",
+        message: "Deterministic fallback trust data is active and explicitly labeled.",
+        readOnly: true,
+        descriptiveOnly: true,
+      },
+      {
+        id: "metadata-missing",
+        label: "Report metadata missing",
+        state: "blocker",
+        message: "Missing report metadata remains fail-visible and does not trigger recovery.",
+        readOnly: true,
+        descriptiveOnly: true,
+      },
+      {
+        id: "unsupported-states-preserved",
+        label: "Unsupported states preserved",
+        state: "ok",
+        message: "Unsupported-state visibility is preserved while fallback data is active.",
+        readOnly: true,
+        descriptiveOnly: true,
+      },
+    ],
+  };
+}
+
+export function getFrontendTrustReportIntegrationData(): FrontendTrustReportIntegrationData {
+  return FRONTEND_TRUST_REPORT_INTEGRATION_DATA;
+}
+
+export function isFrontendTrustReportIntegrationReadOnly(
+  data: FrontendTrustReportIntegrationData = FRONTEND_TRUST_REPORT_INTEGRATION_DATA,
+): boolean {
+  return (
+    data.readOnly &&
+    data.descriptiveOnly &&
+    data.metadata.readOnly &&
+    data.metadata.descriptiveOnly &&
+    data.sourceVisibility.readOnly &&
+    data.sourceVisibility.descriptiveOnly &&
+    data.fallbackState.readOnly &&
+    data.fallbackState.descriptiveOnly &&
+    data.certificationSummaries.every((item) => item.readOnly && item.descriptiveOnly) &&
+    data.diagnostics.every((item) => item.readOnly && item.descriptiveOnly)
+  );
+}

--- a/frontend/src/types/frontendTrustReportIntegration.ts
+++ b/frontend/src/types/frontendTrustReportIntegration.ts
@@ -1,0 +1,70 @@
+export type TrustReportSourceStatus =
+  | "report_backed"
+  | "fallback_active"
+  | "report_unavailable"
+  | "report_malformed"
+  | "unknown";
+
+export type TrustReportDiagnosticState = "ok" | "warning" | "blocker" | "unsupported";
+
+export interface TrustReportMetadata {
+  readonly reportName: string;
+  readonly reportPath: string;
+  readonly reportHash: string;
+  readonly certificationStatus: string;
+  readonly generatedAt: string;
+  readonly readinessClassifications: readonly string[];
+  readonly descriptiveOnlyGuaranteeText: string;
+  readonly readOnly: true;
+  readonly descriptiveOnly: true;
+}
+
+export interface TrustReportSourceVisibility {
+  readonly generatedReportPath: string;
+  readonly staticFallbackSource: string;
+  readonly reportBackedSourceStatus: TrustReportSourceStatus;
+  readonly unavailableReportSourceStatus: TrustReportSourceStatus;
+  readonly sourceVisibilityNote: string;
+  readonly readOnly: true;
+  readonly descriptiveOnly: true;
+}
+
+export interface TrustReportFallbackState {
+  readonly fallbackActive: boolean;
+  readonly fallbackLabel: string;
+  readonly fallbackSource: string;
+  readonly fallbackReason: string;
+  readonly fallbackVisibilityNote: string;
+  readonly readOnly: true;
+  readonly descriptiveOnly: true;
+}
+
+export interface TrustReportCertificationSummary {
+  readonly id: string;
+  readonly label: string;
+  readonly values: readonly string[];
+  readonly readOnly: true;
+  readonly descriptiveOnly: true;
+}
+
+export interface TrustReportDiagnostic {
+  readonly id: string;
+  readonly label: string;
+  readonly state: TrustReportDiagnosticState;
+  readonly message: string;
+  readonly readOnly: true;
+  readonly descriptiveOnly: true;
+}
+
+export interface FrontendTrustReportIntegrationData {
+  readonly integrationId: string;
+  readonly sourceStatus: TrustReportSourceStatus;
+  readonly metadata: TrustReportMetadata;
+  readonly sourceVisibility: TrustReportSourceVisibility;
+  readonly fallbackState: TrustReportFallbackState;
+  readonly certificationSummaries: readonly TrustReportCertificationSummary[];
+  readonly diagnostics: readonly TrustReportDiagnostic[];
+  readonly repositoryRemains: readonly string[];
+  readonly readOnly: true;
+  readonly descriptiveOnly: true;
+}


### PR DESCRIPTION
Implement deterministic read-only frontend trust report integration including report metadata visibility, report source visibility, fallback trust data visibility, report-backed certification summaries, fail-visible report diagnostics, generated closeout evidence, and descriptive-only frontend trust guarantees without introducing planner execution, authorization, approval, ranking, recommendation, scoring, triage, production enablement, or operational behavior.