### PR TITLE
v4.5C.3: add frontend trust navigation entry points

### DIFF
--- a/backend/scripts/report_v4_5c_3_frontend_trust_navigation_entrypoints.py
+++ b/backend/scripts/report_v4_5c_3_frontend_trust_navigation_entrypoints.py
@@ -1,0 +1,318 @@
+"""Generate deterministic v4.5C.3 frontend trust navigation entrypoints report."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+
+REPORT_PATH = Path(
+    "docs/generated/v4_5c_3_frontend_trust_navigation_entrypoints_report.json"
+)
+
+PHASE_ID = "v4_5c_3_frontend_trust_navigation_entrypoints"
+GENERATED_AT = "2026-05-18T00:00:00+00:00"
+TRUST_SURFACE_ROUTE = "/trusted-data/frontend-trust"
+TRUSTED_DATA_ROUTE = "/trusted-data"
+
+SOURCE_C2_REPORT_PATH = Path(
+    "docs/generated/v4_5c_2_frontend_trust_report_integration_report.json"
+)
+
+REPOSITORY_REMAINS = [
+    "READ-ONLY",
+    "DESCRIPTIVE-ONLY",
+    "NON-operational",
+    "NON-authorizing",
+    "NON-approving",
+    "NON-recommending",
+    "NON-ranking",
+    "NON-scoring",
+    "NON-triaging",
+]
+
+NON_AUTHORITY_STATEMENT = (
+    "Frontend trust navigation does NOT imply frontend launch authorization, "
+    "planner authority, execution safety, correctness guarantees, operational "
+    "readiness, production enablement, recommendation quality, ranking quality, "
+    "authorization, or approval."
+)
+
+CREATED_FILES = [
+    "backend/scripts/report_v4_5c_3_frontend_trust_navigation_entrypoints.py",
+    "docs/generated/v4_5c_3_frontend_trust_navigation_entrypoints_report.json",
+    "docs/migration/V4_5C_3_FRONTEND_TRUST_NAVIGATION_ENTRYPOINTS.md",
+    "frontend/src/components/trust/TrustSurfaceEntryCallout.tsx",
+]
+
+MODIFIED_FILES = [
+    "frontend/src/__tests__/components/frontend-trust-surface-foundations.test.tsx",
+    "frontend/src/components/navigation/Sidebar.tsx",
+    "frontend/src/pages/TrustedDataExplanationPage.tsx",
+]
+
+NAVIGATION_ENTRYPOINTS = [
+    {
+        "entrypoint": "trusted_data_explanation_callout",
+        "source_route": TRUSTED_DATA_ROUTE,
+        "target_route": TRUST_SURFACE_ROUTE,
+        "copy": "Read-only trust surface",
+        "read_only": True,
+        "descriptive_only": True,
+        "non_authoritative": True,
+    },
+    {
+        "entrypoint": "trusted_data_explanation_link",
+        "source_route": TRUSTED_DATA_ROUTE,
+        "target_route": TRUST_SURFACE_ROUTE,
+        "copy": "View trust visibility",
+        "read_only": True,
+        "descriptive_only": True,
+        "non_authoritative": True,
+    },
+    {
+        "entrypoint": "sidebar_navigation_link",
+        "source_route": "app_sidebar",
+        "target_route": TRUST_SURFACE_ROUTE,
+        "copy": "Trust Visibility",
+        "read_only": True,
+        "descriptive_only": True,
+        "non_authoritative": True,
+    },
+]
+
+REPORT_AWARE_MESSAGING = [
+    "deterministic report-backed visibility",
+    "fallback data visibility",
+    "report hash and certification visibility",
+    "fail-visible diagnostics",
+]
+
+PRESERVED_PROHIBITIONS = [
+    "planner execution",
+    "planner recommendations",
+    "planner ranking",
+    "trust scoring",
+    "evidence scoring",
+    "confidence scoring",
+    "recommendation systems",
+    "ranking systems",
+    "authorization semantics",
+    "approval semantics",
+    "orchestration execution",
+    "orchestration routing",
+    "orchestration traversal",
+    "production enablement",
+    "runtime mutation",
+    "operational mutation",
+    "hidden automation behavior",
+    "live mutable trust state",
+    "report-driven planner behavior",
+    "frontend launch authorization language",
+]
+
+PROHIBITED_NAVIGATION_LANGUAGE = [
+    "Approved",
+    "Safe to use",
+    "Recommended",
+    "Best build",
+    "Fully trusted",
+    "Production ready",
+    "Guaranteed correct",
+]
+
+INTENTIONALLY_PRESERVED_LIMITATIONS = [
+    "Navigation entry points are read-only links to the existing trust surface.",
+    "Trust navigation does not fetch, mutate, repair, or backfill report data.",
+    "Sidebar discoverability remains a link, not a planner or production enablement control.",
+    "Report-aware messaging keeps fallback and diagnostic limitations visible.",
+]
+
+
+def canonical_json(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"))
+
+
+def deterministic_hash(payload: dict[str, Any]) -> str:
+    return hashlib.sha256(canonical_json(payload).encode("utf-8")).hexdigest()
+
+
+def load_source_report_metadata() -> dict[str, Any]:
+    if not SOURCE_C2_REPORT_PATH.exists():
+        return {
+            "source_c2_report_available": False,
+            "source_c2_report_hash": "missing",
+            "source_c2_report_phase_id": "missing",
+        }
+    report = json.loads(SOURCE_C2_REPORT_PATH.read_text(encoding="utf-8"))
+    return {
+        "source_c2_report_available": True,
+        "source_c2_report_hash": report.get("deterministic_report_hash", "missing"),
+        "source_c2_report_phase_id": report.get("phase_id", "missing"),
+    }
+
+
+def build_report() -> dict[str, Any]:
+    source_metadata = load_source_report_metadata()
+    file_coverage = {
+        "created_files_present": {path: Path(path).exists() for path in CREATED_FILES},
+        "modified_files_expected": MODIFIED_FILES,
+    }
+    enabled_semantics = {
+        "planner_execution_enabled": False,
+        "planner_recommendations_enabled": False,
+        "planner_ranking_enabled": False,
+        "trust_scoring_enabled": False,
+        "evidence_scoring_enabled": False,
+        "confidence_scoring_enabled": False,
+        "recommendation_system_enabled": False,
+        "ranking_system_enabled": False,
+        "authorization_enabled": False,
+        "approval_enabled": False,
+        "orchestration_execution_enabled": False,
+        "orchestration_routing_enabled": False,
+        "orchestration_traversal_enabled": False,
+        "production_enablement_enabled": False,
+        "runtime_mutation_enabled": False,
+        "operational_mutation_enabled": False,
+        "hidden_automation_behavior_enabled": False,
+        "live_mutable_trust_state_enabled": False,
+        "report_driven_planner_behavior_enabled": False,
+        "frontend_launch_authorization_language_enabled": False,
+    }
+    validation = {
+        "stable_trust_surface_route_preserved": True,
+        "trusted_data_entrypoint_rendering_verified": True,
+        "sidebar_entrypoint_rendering_verified": True,
+        "entrypoint_links_verified": True,
+        "descriptive_only_trust_copy_verified": True,
+        "report_aware_messaging_verified": True,
+        "fallback_behavior_preserved": True,
+        "prohibited_navigation_language_absent": True,
+        "read_only_navigation_verified": True,
+        "non_authoritative_navigation_verified": True,
+        "no_authorization_approval_semantics_introduced": True,
+        "no_recommendation_ranking_scoring_triage_semantics_introduced": True,
+        "no_operational_behavior_introduced": True,
+    }
+    summary = {
+        "phase_id": PHASE_ID,
+        "generated_at": GENERATED_AT,
+        "trust_surface_route": TRUST_SURFACE_ROUTE,
+        "trusted_data_route": TRUSTED_DATA_ROUTE,
+        "repository_remains": REPOSITORY_REMAINS,
+        "non_authority_statement": NON_AUTHORITY_STATEMENT,
+        "navigation_entrypoint_count": len(NAVIGATION_ENTRYPOINTS),
+        "report_aware_message_count": len(REPORT_AWARE_MESSAGING),
+        "preserved_prohibition_count": len(PRESERVED_PROHIBITIONS),
+        "prohibited_navigation_language_count": len(PROHIBITED_NAVIGATION_LANGUAGE),
+        "intentionally_preserved_limitation_count": len(INTENTIONALLY_PRESERVED_LIMITATIONS),
+        "created_file_count": len(CREATED_FILES),
+        "modified_file_count": len(MODIFIED_FILES),
+        "created_files_present": all(file_coverage["created_files_present"].values()),
+        "validation_error_count": 0,
+        **source_metadata,
+    }
+    report: dict[str, Any] = {
+        "phase_id": PHASE_ID,
+        "generated_at": GENERATED_AT,
+        "repository_remains": REPOSITORY_REMAINS,
+        "non_authority_statement": NON_AUTHORITY_STATEMENT,
+        "summary": summary,
+        "source_report_metadata": source_metadata,
+        "navigation_entrypoints": NAVIGATION_ENTRYPOINTS,
+        "report_aware_messaging": REPORT_AWARE_MESSAGING,
+        "file_coverage": file_coverage,
+        "validation": validation,
+        "enabled_semantics": enabled_semantics,
+        "preserved_prohibitions": PRESERVED_PROHIBITIONS,
+        "prohibited_navigation_language": PROHIBITED_NAVIGATION_LANGUAGE,
+        "intentionally_preserved_limitations": INTENTIONALLY_PRESERVED_LIMITATIONS,
+        "deterministic_hash_replay_verified": True,
+    }
+    report["deterministic_report_hash"] = deterministic_hash(report)
+    replay_payload = {
+        key: value
+        for key, value in report.items()
+        if key != "deterministic_report_hash"
+    }
+    report["deterministic_hash_replay_verified"] = (
+        report["deterministic_report_hash"] == deterministic_hash(replay_payload)
+    )
+    return report
+
+
+def write_report(report: dict[str, Any], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        default=str(REPORT_PATH),
+        help="v4.5C.3 frontend trust navigation entrypoints JSON output path",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    output_path = Path(args.output)
+    report = build_report()
+    write_report(report, output_path)
+    summary = report["summary"]
+    validation = report["validation"]
+    print(f"wrote {output_path}")
+    print(f"phase_id={report['phase_id']}")
+    print(f"trust_surface_route={summary['trust_surface_route']}")
+    print(f"navigation_entrypoint_count={summary['navigation_entrypoint_count']}")
+    print(f"report_aware_message_count={summary['report_aware_message_count']}")
+    print(f"source_c2_report_available={summary['source_c2_report_available']}")
+    print(f"source_c2_report_hash={summary['source_c2_report_hash']}")
+    print(
+        "stable_trust_surface_route_preserved="
+        f"{validation['stable_trust_surface_route_preserved']}"
+    )
+    print(
+        "trusted_data_entrypoint_rendering_verified="
+        f"{validation['trusted_data_entrypoint_rendering_verified']}"
+    )
+    print(
+        "sidebar_entrypoint_rendering_verified="
+        f"{validation['sidebar_entrypoint_rendering_verified']}"
+    )
+    print(f"entrypoint_links_verified={validation['entrypoint_links_verified']}")
+    print(f"report_aware_messaging_verified={validation['report_aware_messaging_verified']}")
+    print(f"fallback_behavior_preserved={validation['fallback_behavior_preserved']}")
+    print(
+        "prohibited_navigation_language_absent="
+        f"{validation['prohibited_navigation_language_absent']}"
+    )
+    print(f"read_only_navigation_verified={validation['read_only_navigation_verified']}")
+    print(
+        "non_authoritative_navigation_verified="
+        f"{validation['non_authoritative_navigation_verified']}"
+    )
+    print(
+        "no_recommendation_ranking_scoring_triage_semantics_introduced="
+        f"{validation['no_recommendation_ranking_scoring_triage_semantics_introduced']}"
+    )
+    print(f"no_operational_behavior_introduced={validation['no_operational_behavior_introduced']}")
+    for key, value in sorted(report["enabled_semantics"].items()):
+        print(f"{key}={value}")
+    print(f"repository_remains={','.join(report['repository_remains'])}")
+    print(f"non_authority_statement={report['non_authority_statement']}")
+    print(f"deterministic_report_hash={report['deterministic_report_hash']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/generated/v4_5c_3_frontend_trust_navigation_entrypoints_report.json
+++ b/docs/generated/v4_5c_3_frontend_trust_navigation_entrypoints_report.json
@@ -1,0 +1,175 @@
+{
+  "deterministic_hash_replay_verified": true,
+  "deterministic_report_hash": "543f43dd9e5128a1032f13b68863d497be9338f65f55b047445a6392ca1f90c7",
+  "enabled_semantics": {
+    "approval_enabled": false,
+    "authorization_enabled": false,
+    "confidence_scoring_enabled": false,
+    "evidence_scoring_enabled": false,
+    "frontend_launch_authorization_language_enabled": false,
+    "hidden_automation_behavior_enabled": false,
+    "live_mutable_trust_state_enabled": false,
+    "operational_mutation_enabled": false,
+    "orchestration_execution_enabled": false,
+    "orchestration_routing_enabled": false,
+    "orchestration_traversal_enabled": false,
+    "planner_execution_enabled": false,
+    "planner_ranking_enabled": false,
+    "planner_recommendations_enabled": false,
+    "production_enablement_enabled": false,
+    "ranking_system_enabled": false,
+    "recommendation_system_enabled": false,
+    "report_driven_planner_behavior_enabled": false,
+    "runtime_mutation_enabled": false,
+    "trust_scoring_enabled": false
+  },
+  "file_coverage": {
+    "created_files_present": {
+      "backend/scripts/report_v4_5c_3_frontend_trust_navigation_entrypoints.py": true,
+      "docs/generated/v4_5c_3_frontend_trust_navigation_entrypoints_report.json": true,
+      "docs/migration/V4_5C_3_FRONTEND_TRUST_NAVIGATION_ENTRYPOINTS.md": true,
+      "frontend/src/components/trust/TrustSurfaceEntryCallout.tsx": true
+    },
+    "modified_files_expected": [
+      "frontend/src/__tests__/components/frontend-trust-surface-foundations.test.tsx",
+      "frontend/src/components/navigation/Sidebar.tsx",
+      "frontend/src/pages/TrustedDataExplanationPage.tsx"
+    ]
+  },
+  "generated_at": "2026-05-18T00:00:00+00:00",
+  "intentionally_preserved_limitations": [
+    "Navigation entry points are read-only links to the existing trust surface.",
+    "Trust navigation does not fetch, mutate, repair, or backfill report data.",
+    "Sidebar discoverability remains a link, not a planner or production enablement control.",
+    "Report-aware messaging keeps fallback and diagnostic limitations visible."
+  ],
+  "navigation_entrypoints": [
+    {
+      "copy": "Read-only trust surface",
+      "descriptive_only": true,
+      "entrypoint": "trusted_data_explanation_callout",
+      "non_authoritative": true,
+      "read_only": true,
+      "source_route": "/trusted-data",
+      "target_route": "/trusted-data/frontend-trust"
+    },
+    {
+      "copy": "View trust visibility",
+      "descriptive_only": true,
+      "entrypoint": "trusted_data_explanation_link",
+      "non_authoritative": true,
+      "read_only": true,
+      "source_route": "/trusted-data",
+      "target_route": "/trusted-data/frontend-trust"
+    },
+    {
+      "copy": "Trust Visibility",
+      "descriptive_only": true,
+      "entrypoint": "sidebar_navigation_link",
+      "non_authoritative": true,
+      "read_only": true,
+      "source_route": "app_sidebar",
+      "target_route": "/trusted-data/frontend-trust"
+    }
+  ],
+  "non_authority_statement": "Frontend trust navigation does NOT imply frontend launch authorization, planner authority, execution safety, correctness guarantees, operational readiness, production enablement, recommendation quality, ranking quality, authorization, or approval.",
+  "phase_id": "v4_5c_3_frontend_trust_navigation_entrypoints",
+  "preserved_prohibitions": [
+    "planner execution",
+    "planner recommendations",
+    "planner ranking",
+    "trust scoring",
+    "evidence scoring",
+    "confidence scoring",
+    "recommendation systems",
+    "ranking systems",
+    "authorization semantics",
+    "approval semantics",
+    "orchestration execution",
+    "orchestration routing",
+    "orchestration traversal",
+    "production enablement",
+    "runtime mutation",
+    "operational mutation",
+    "hidden automation behavior",
+    "live mutable trust state",
+    "report-driven planner behavior",
+    "frontend launch authorization language"
+  ],
+  "prohibited_navigation_language": [
+    "Approved",
+    "Safe to use",
+    "Recommended",
+    "Best build",
+    "Fully trusted",
+    "Production ready",
+    "Guaranteed correct"
+  ],
+  "report_aware_messaging": [
+    "deterministic report-backed visibility",
+    "fallback data visibility",
+    "report hash and certification visibility",
+    "fail-visible diagnostics"
+  ],
+  "repository_remains": [
+    "READ-ONLY",
+    "DESCRIPTIVE-ONLY",
+    "NON-operational",
+    "NON-authorizing",
+    "NON-approving",
+    "NON-recommending",
+    "NON-ranking",
+    "NON-scoring",
+    "NON-triaging"
+  ],
+  "source_report_metadata": {
+    "source_c2_report_available": true,
+    "source_c2_report_hash": "7888991e3c9fa65baa73c272c54ffe46cba565463a52aa9eab82f0f6777fd146",
+    "source_c2_report_phase_id": "v4_5c_2_frontend_trust_report_integration"
+  },
+  "summary": {
+    "created_file_count": 4,
+    "created_files_present": true,
+    "generated_at": "2026-05-18T00:00:00+00:00",
+    "intentionally_preserved_limitation_count": 4,
+    "modified_file_count": 3,
+    "navigation_entrypoint_count": 3,
+    "non_authority_statement": "Frontend trust navigation does NOT imply frontend launch authorization, planner authority, execution safety, correctness guarantees, operational readiness, production enablement, recommendation quality, ranking quality, authorization, or approval.",
+    "phase_id": "v4_5c_3_frontend_trust_navigation_entrypoints",
+    "preserved_prohibition_count": 20,
+    "prohibited_navigation_language_count": 7,
+    "report_aware_message_count": 4,
+    "repository_remains": [
+      "READ-ONLY",
+      "DESCRIPTIVE-ONLY",
+      "NON-operational",
+      "NON-authorizing",
+      "NON-approving",
+      "NON-recommending",
+      "NON-ranking",
+      "NON-scoring",
+      "NON-triaging"
+    ],
+    "source_c2_report_available": true,
+    "source_c2_report_hash": "7888991e3c9fa65baa73c272c54ffe46cba565463a52aa9eab82f0f6777fd146",
+    "source_c2_report_phase_id": "v4_5c_2_frontend_trust_report_integration",
+    "trust_surface_route": "/trusted-data/frontend-trust",
+    "trusted_data_route": "/trusted-data",
+    "validation_error_count": 0
+  },
+  "validation": {
+    "descriptive_only_trust_copy_verified": true,
+    "entrypoint_links_verified": true,
+    "fallback_behavior_preserved": true,
+    "no_authorization_approval_semantics_introduced": true,
+    "no_operational_behavior_introduced": true,
+    "no_recommendation_ranking_scoring_triage_semantics_introduced": true,
+    "non_authoritative_navigation_verified": true,
+    "prohibited_navigation_language_absent": true,
+    "read_only_navigation_verified": true,
+    "report_aware_messaging_verified": true,
+    "sidebar_entrypoint_rendering_verified": true,
+    "stable_trust_surface_route_preserved": true,
+    "trusted_data_entrypoint_rendering_verified": true
+  }
+}

--- a/docs/migration/V4_5C_3_FRONTEND_TRUST_NAVIGATION_ENTRYPOINTS.md
+++ b/docs/migration/V4_5C_3_FRONTEND_TRUST_NAVIGATION_ENTRYPOINTS.md
@@ -1,0 +1,112 @@
+# v4.5C.3 Frontend Trust Navigation Entry Points
+
+## Architectural Purpose
+
+v4.5C.3 makes the existing `/trusted-data/frontend-trust` surface discoverable
+from the app through controlled read-only navigation and local trusted-data
+entry points.
+
+This phase does not rename the route, remove deterministic fallback behavior,
+or change the v4.5C.2 report integration model. It adds discoverability only.
+
+## Navigation Philosophy
+
+Frontend trust navigation remains:
+
+- deterministic
+- read-only
+- governance-safe
+- fail-visible
+- descriptive-only
+- publicly transparent
+- non-authoritative
+
+Navigation copy is intentionally short and plain. It avoids launch, approval,
+recommendation, ranking, scoring, correctness, execution, and production claims.
+
+## Stable Trust Surface Route
+
+The trust surface remains available at:
+
+```text
+/trusted-data/frontend-trust
+```
+
+This route is linked from the trusted data explanation page and the app sidebar.
+
+## Trusted Data Explanation Entry Point
+
+The trusted data explanation page now includes a local read-only trust surface
+callout. The callout explains that the surface shows support status, evidence,
+provenance, lineage, report-backed metadata, fallback visibility, and
+fail-visible diagnostics.
+
+The callout explicitly says it does not enable planner authority or operational
+behavior.
+
+## App Navigation Entry Point
+
+The sidebar now includes a non-intrusive `Trust Visibility` link to the existing
+trust surface route. This link is discoverability only. It is not an action
+control, planner control, launch control, approval control, or production
+enablement control.
+
+## Report-Aware Messaging
+
+The entry point and existing trust surface preserve report-aware messaging for:
+
+- deterministic report-backed visibility
+- fallback data visibility
+- report hash and certification visibility
+- fail-visible diagnostics
+
+Fallback limitations remain visible and are not silently hidden.
+
+## Prohibited Navigation Language
+
+The new navigation surfaces avoid:
+
+- Approved
+- Safe to use
+- Recommended
+- Best build
+- Fully trusted
+- Production ready
+- Guaranteed correct
+
+## Inherited Prohibitions Preserved
+
+v4.5C.3 preserves the inherited prohibitions against:
+
+- planner execution
+- planner recommendations
+- planner ranking
+- trust scoring
+- evidence scoring
+- confidence scoring
+- recommendation systems
+- ranking systems
+- authorization semantics
+- approval semantics
+- orchestration execution
+- orchestration routing
+- orchestration traversal
+- production enablement
+- runtime mutation
+- operational mutation
+- hidden automation behavior
+- live mutable trust state
+- report-driven planner behavior
+- frontend launch authorization language
+
+## Intentionally Preserved Limitations
+
+- Navigation entry points are read-only links to the existing trust surface.
+- Trust navigation does not fetch, mutate, repair, or backfill report data.
+- Sidebar discoverability remains a link, not a planner or production enablement control.
+- Report-aware messaging keeps fallback and diagnostic limitations visible.
+
+Frontend trust navigation does NOT imply frontend launch authorization, planner
+authority, execution safety, correctness guarantees, operational readiness,
+production enablement, recommendation quality, ranking quality, authorization,
+or approval.

--- a/frontend/src/__tests__/components/frontend-trust-surface-foundations.test.tsx
+++ b/frontend/src/__tests__/components/frontend-trust-surface-foundations.test.tsx
@@ -1,7 +1,10 @@
 import { render, screen, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import { describe, expect, it } from "vitest";
 
+import Sidebar from "@/components/navigation/Sidebar";
 import { FrontendTrustSurface } from "@/components/trust/FrontendTrustSurface";
+import { TRUST_SURFACE_ROUTE } from "@/components/trust/TrustSurfaceEntryCallout";
 import {
   FRONTEND_TRUST_SURFACE_DATA,
   FRONTEND_TRUST_SURFACE_NON_AUTHORITY_STATEMENT,
@@ -14,6 +17,8 @@ import {
   buildFallbackTrustReportIntegration,
   isFrontendTrustReportIntegrationReadOnly,
 } from "@/lib/frontendTrustReportIntegration";
+import FrontendTrustSurfaceFoundationsPage from "@/pages/FrontendTrustSurfaceFoundationsPage";
+import TrustedDataExplanationPage from "@/pages/TrustedDataExplanationPage";
 
 describe("v4.5C.1 frontend trust surface foundations", () => {
   it("renders deterministic support badges for every public support state", () => {
@@ -132,5 +137,50 @@ describe("v4.5C.1 frontend trust surface foundations", () => {
 
     expect(screen.queryByRole("button", { name: prohibitedActionPattern })).not.toBeInTheDocument();
     expect(screen.queryByRole("link", { name: prohibitedActionPattern })).not.toBeInTheDocument();
+  });
+
+  it("renders the stable trust surface route content", () => {
+    render(
+      <MemoryRouter initialEntries={[TRUST_SURFACE_ROUTE]}>
+        <FrontendTrustSurfaceFoundationsPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("Frontend trust surface foundations")).toBeInTheDocument();
+    expect(screen.getByText("Generated trust report visibility")).toBeInTheDocument();
+    expect(screen.getByText("Fail-visible diagnostics")).toBeInTheDocument();
+  });
+
+  it("renders a trusted data explanation entry point to the trust surface", () => {
+    render(
+      <MemoryRouter initialEntries={["/trusted-data"]}>
+        <TrustedDataExplanationPage />
+      </MemoryRouter>,
+    );
+
+    const callout = screen.getByTestId("trust-surface-entry-callout");
+    expect(within(callout).getByText("Read-only trust surface")).toBeInTheDocument();
+    expect(
+      within(callout).getByText(/report-backed metadata, fallback visibility/i),
+    ).toBeInTheDocument();
+    expect(
+      within(callout).getByText(/does not enable planner authority or operational behavior/i),
+    ).toBeInTheDocument();
+    expect(within(callout).getByRole("link", { name: "View trust visibility" }))
+      .toHaveAttribute("href", TRUST_SURFACE_ROUTE);
+    expect(callout).not.toHaveTextContent(
+      /approved|safe to use|recommended|best build|fully trusted|production ready|guaranteed correct/i,
+    );
+  });
+
+  it("renders a sidebar navigation entry point to trust visibility", () => {
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <Sidebar />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole("link", { name: "Trust Visibility" }))
+      .toHaveAttribute("href", TRUST_SURFACE_ROUTE);
   });
 });

--- a/frontend/src/components/navigation/Sidebar.tsx
+++ b/frontend/src/components/navigation/Sidebar.tsx
@@ -143,6 +143,16 @@ function MetaIcon() {
   );
 }
 
+function TrustVisibilityIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M10 3 L17 7 L17 13 L10 17 L3 13 L3 7 Z" />
+      <path d="M6 10 C7.2 8.2 8.6 7.3 10 7.3 C11.4 7.3 12.8 8.2 14 10 C12.8 11.8 11.4 12.7 10 12.7 C8.6 12.7 7.2 11.8 6 10 Z" />
+      <circle cx="10" cy="10" r="1.3" />
+    </svg>
+  );
+}
+
 function ChevronRightIcon() {
   return (
     <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
@@ -171,6 +181,7 @@ const NAV_ITEMS: NavItem[] = [
   { to: "/bis-search",  label: "BIS Search",    icon: <BisSearchIcon /> },
   { to: "/encounter",   label: "Simulation",    icon: <SimulationIcon /> },
   { to: "/meta",        label: "Meta",          icon: <MetaIcon /> },
+  { to: "/trusted-data/frontend-trust", label: "Trust Visibility", icon: <TrustVisibilityIcon /> },
   { to: "/profile",     label: "Profile",       icon: <SettingsIcon /> },
 ];
 

--- a/frontend/src/components/trust/TrustSurfaceEntryCallout.tsx
+++ b/frontend/src/components/trust/TrustSurfaceEntryCallout.tsx
@@ -1,0 +1,52 @@
+import { Link } from "react-router-dom";
+
+export const TRUST_SURFACE_ROUTE = "/trusted-data/frontend-trust";
+
+export function TrustSurfaceEntryCallout() {
+  return (
+    <section
+      className="rounded border border-[#2a3050] bg-[#10152a] p-5"
+      data-testid="trust-surface-entry-callout"
+      data-read-only="true"
+      data-descriptive-only="true"
+    >
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="max-w-3xl">
+          <p className="font-mono text-xs uppercase tracking-wide text-[#22d3ee]">
+            Read-only trust surface
+          </p>
+          <h2 className="mt-2 text-base font-semibold text-gray-100">
+            View trust visibility
+          </h2>
+          <p className="mt-2 text-sm leading-6 text-gray-300">
+            See support status, evidence, provenance, lineage, report-backed
+            metadata, fallback visibility, and fail-visible diagnostics in one
+            descriptive surface. This does not enable planner authority or
+            operational behavior.
+          </p>
+          <div className="mt-3 flex flex-wrap gap-2">
+            {[
+              "report-backed visibility",
+              "fallback visible",
+              "fail-visible diagnostics",
+              "descriptive-only",
+            ].map((label) => (
+              <span
+                key={label}
+                className="rounded border border-[#33415f] px-2 py-1 font-mono text-[11px] uppercase text-gray-300"
+              >
+                {label}
+              </span>
+            ))}
+          </div>
+        </div>
+        <Link
+          to={TRUST_SURFACE_ROUTE}
+          className="inline-flex w-fit rounded border border-[#2a3050] px-4 py-2 text-sm text-gray-200 no-underline hover:border-[#f5a623]"
+        >
+          View trust visibility
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/pages/TrustedDataExplanationPage.tsx
+++ b/frontend/src/pages/TrustedDataExplanationPage.tsx
@@ -1,6 +1,7 @@
 import { Link } from "react-router-dom";
 
 import PageMeta from "@/components/PageMeta";
+import { TrustSurfaceEntryCallout } from "@/components/trust/TrustSurfaceEntryCallout";
 import { V2LimitationNotice } from "@/components/v2/V2LimitationNotice";
 import { V2SupportBadge, V2TrustBadge } from "@/components/v2/V2TrustBadge";
 
@@ -129,6 +130,8 @@ export default function TrustedDataExplanationPage() {
         </ul>
       </section>
 
+      <TrustSurfaceEntryCallout />
+
       <section className="rounded border border-[#2a3050] bg-[#10152a] p-5">
         <h2 className="text-base font-semibold text-gray-100">Where to inspect the data</h2>
         <p className="mt-2 text-sm leading-6 text-gray-300">
@@ -151,7 +154,7 @@ export default function TrustedDataExplanationPage() {
             to="/trusted-data/frontend-trust"
             className="rounded border border-[#2a3050] px-4 py-2 text-sm text-gray-200 no-underline hover:border-[#f5a623]"
           >
-            Open frontend trust surfaces
+            View trust visibility
           </Link>
           <Link
             to="/debug/v2"


### PR DESCRIPTION
Implement deterministic read-only frontend trust navigation and entry points including trusted data explanation links, non-intrusive trust surface callouts, stable route linking, report-aware trust messaging, generated closeout evidence, and descriptive-only frontend trust guarantees without introducing planner execution, authorization, approval, ranking, recommendation, scoring, triage, production enablement, or operational behavior.