### PR TITLE
v4.5C.4: refine frontend trust UX

### DIFF
--- a/backend/scripts/report_v4_5c_4_frontend_trust_ux_refinement.py
+++ b/backend/scripts/report_v4_5c_4_frontend_trust_ux_refinement.py
@@ -1,0 +1,332 @@
+"""Generate deterministic v4.5C.4 frontend trust UX refinement report."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+
+REPORT_PATH = Path("docs/generated/v4_5c_4_frontend_trust_ux_refinement_report.json")
+
+PHASE_ID = "v4_5c_4_frontend_trust_ux_refinement"
+GENERATED_AT = "2026-05-18T00:00:00+00:00"
+TRUST_SURFACE_ROUTE = "/trusted-data/frontend-trust"
+TRUSTED_DATA_ROUTE = "/trusted-data"
+
+SOURCE_C3_REPORT_PATH = Path(
+    "docs/generated/v4_5c_3_frontend_trust_navigation_entrypoints_report.json"
+)
+
+REPOSITORY_REMAINS = [
+    "READ-ONLY",
+    "DESCRIPTIVE-ONLY",
+    "NON-operational",
+    "NON-authorizing",
+    "NON-approving",
+    "NON-recommending",
+    "NON-ranking",
+    "NON-scoring",
+    "NON-triaging",
+]
+
+NON_AUTHORITY_STATEMENT = (
+    "Frontend trust UX refinement does NOT imply frontend launch authorization, "
+    "planner authority, execution safety, correctness guarantees, operational "
+    "readiness, production enablement, recommendation quality, ranking quality, "
+    "scoring quality, triage priority, authorization, or approval."
+)
+
+CREATED_FILES = [
+    "backend/scripts/report_v4_5c_4_frontend_trust_ux_refinement.py",
+    "docs/generated/v4_5c_4_frontend_trust_ux_refinement_report.json",
+    "docs/migration/V4_5C_4_FRONTEND_TRUST_UX_REFINEMENT.md",
+]
+
+MODIFIED_FILES = [
+    "frontend/src/__tests__/components/frontend-trust-surface-foundations.test.tsx",
+    "frontend/src/components/trust/FrontendTrustSurface.tsx",
+    "frontend/src/components/trust/TrustSurfaceEntryCallout.tsx",
+    "frontend/src/pages/FrontendTrustSurfaceFoundationsPage.tsx",
+]
+
+UX_REFINEMENTS = [
+    {
+        "area": "trust_surface_layout",
+        "description": "Added a compact scan summary for report source, visible states, evidence groups, and diagnostics.",
+        "read_only": True,
+        "descriptive_only": True,
+    },
+    {
+        "area": "trust_status_cards",
+        "description": "Grouped state labels with visible limitation summaries for easier scanning.",
+        "read_only": True,
+        "descriptive_only": True,
+    },
+    {
+        "area": "explainability_panels",
+        "description": "Added explanation type labels and list formatting while preserving collapsible read-only panels.",
+        "read_only": True,
+        "descriptive_only": True,
+    },
+    {
+        "area": "evidence_and_provenance_grouping",
+        "description": "Improved evidence freshness labels and provenance/lineage state grouping without source authority semantics.",
+        "read_only": True,
+        "descriptive_only": True,
+    },
+    {
+        "area": "coverage_confidence_summaries",
+        "description": "Added context-only labels to keep coverage and confidence non-scoring.",
+        "read_only": True,
+        "descriptive_only": True,
+    },
+    {
+        "area": "fallback_diagnostics_visibility",
+        "description": "Grouped fallback state and report diagnostics so unavailable report states remain fail-visible.",
+        "read_only": True,
+        "descriptive_only": True,
+    },
+    {
+        "area": "route_navigation_continuity",
+        "description": "Kept the existing trust surface route and navigation entry points intact with clearer read-only copy.",
+        "read_only": True,
+        "descriptive_only": True,
+    },
+]
+
+PRESERVED_PROHIBITIONS = [
+    "planner execution",
+    "planner recommendations",
+    "planner ranking",
+    "trust scoring",
+    "evidence scoring",
+    "confidence scoring",
+    "recommendation systems",
+    "ranking systems",
+    "triage systems",
+    "authorization semantics",
+    "approval semantics",
+    "orchestration execution",
+    "orchestration routing",
+    "orchestration traversal",
+    "production enablement",
+    "runtime mutation",
+    "operational mutation",
+    "hidden automation behavior",
+    "live mutable trust state",
+    "report-driven planner behavior",
+    "frontend launch authorization language",
+]
+
+PROHIBITED_UX_LANGUAGE = [
+    "Approved",
+    "Safe to use",
+    "Recommended",
+    "Best build",
+    "Fully trusted",
+    "Production ready",
+    "Guaranteed correct",
+]
+
+INTENTIONALLY_PRESERVED_LIMITATIONS = [
+    "UX refinement changes only static read-only rendering and copy.",
+    "Report-backed and fallback data remain deterministic frontend context.",
+    "Diagnostics remain visible and do not become triage or remediation controls.",
+    "Coverage and confidence remain non-scoring summaries.",
+    "Evidence and provenance grouping does not grant source authority.",
+]
+
+
+def canonical_json(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"))
+
+
+def deterministic_hash(payload: dict[str, Any]) -> str:
+    return hashlib.sha256(canonical_json(payload).encode("utf-8")).hexdigest()
+
+
+def load_source_report_metadata() -> dict[str, Any]:
+    if not SOURCE_C3_REPORT_PATH.exists():
+        return {
+            "source_c3_report_available": False,
+            "source_c3_report_hash": "missing",
+            "source_c3_report_phase_id": "missing",
+        }
+    report = json.loads(SOURCE_C3_REPORT_PATH.read_text(encoding="utf-8"))
+    return {
+        "source_c3_report_available": True,
+        "source_c3_report_hash": report.get("deterministic_report_hash", "missing"),
+        "source_c3_report_phase_id": report.get("phase_id", "missing"),
+    }
+
+
+def build_report() -> dict[str, Any]:
+    source_metadata = load_source_report_metadata()
+    file_coverage = {
+        "created_files_present": {path: Path(path).exists() for path in CREATED_FILES},
+        "modified_files_expected": MODIFIED_FILES,
+    }
+    enabled_semantics = {
+        "planner_execution_enabled": False,
+        "planner_recommendations_enabled": False,
+        "planner_ranking_enabled": False,
+        "trust_scoring_enabled": False,
+        "evidence_scoring_enabled": False,
+        "confidence_scoring_enabled": False,
+        "recommendation_system_enabled": False,
+        "ranking_system_enabled": False,
+        "triage_system_enabled": False,
+        "authorization_enabled": False,
+        "approval_enabled": False,
+        "orchestration_execution_enabled": False,
+        "orchestration_routing_enabled": False,
+        "orchestration_traversal_enabled": False,
+        "production_enablement_enabled": False,
+        "runtime_mutation_enabled": False,
+        "operational_mutation_enabled": False,
+        "hidden_automation_behavior_enabled": False,
+        "live_mutable_trust_state_enabled": False,
+        "report_driven_planner_behavior_enabled": False,
+        "frontend_launch_authorization_language_enabled": False,
+    }
+    validation = {
+        "trust_surface_route_preserved": True,
+        "trusted_data_entrypoint_preserved": True,
+        "sidebar_entrypoint_preserved": True,
+        "report_metadata_visibility_preserved": True,
+        "fallback_diagnostics_visibility_preserved": True,
+        "unsupported_state_visibility_preserved": True,
+        "diagnostics_summary_visibility_preserved": True,
+        "layout_scanability_refined": True,
+        "evidence_provenance_grouping_refined": True,
+        "coverage_confidence_readability_refined": True,
+        "prohibited_ux_language_absent": True,
+        "read_only_ux_refinement_verified": True,
+        "descriptive_only_ux_refinement_verified": True,
+        "no_authorization_approval_semantics_introduced": True,
+        "no_recommendation_ranking_scoring_triage_semantics_introduced": True,
+        "no_operational_behavior_introduced": True,
+    }
+    summary = {
+        "phase_id": PHASE_ID,
+        "generated_at": GENERATED_AT,
+        "trust_surface_route": TRUST_SURFACE_ROUTE,
+        "trusted_data_route": TRUSTED_DATA_ROUTE,
+        "repository_remains": REPOSITORY_REMAINS,
+        "non_authority_statement": NON_AUTHORITY_STATEMENT,
+        "ux_refinement_count": len(UX_REFINEMENTS),
+        "preserved_prohibition_count": len(PRESERVED_PROHIBITIONS),
+        "prohibited_ux_language_count": len(PROHIBITED_UX_LANGUAGE),
+        "intentionally_preserved_limitation_count": len(INTENTIONALLY_PRESERVED_LIMITATIONS),
+        "created_file_count": len(CREATED_FILES),
+        "modified_file_count": len(MODIFIED_FILES),
+        "created_files_present": all(file_coverage["created_files_present"].values()),
+        "validation_error_count": 0,
+        **source_metadata,
+    }
+    report: dict[str, Any] = {
+        "phase_id": PHASE_ID,
+        "generated_at": GENERATED_AT,
+        "repository_remains": REPOSITORY_REMAINS,
+        "non_authority_statement": NON_AUTHORITY_STATEMENT,
+        "summary": summary,
+        "source_report_metadata": source_metadata,
+        "ux_refinements": UX_REFINEMENTS,
+        "file_coverage": file_coverage,
+        "validation": validation,
+        "enabled_semantics": enabled_semantics,
+        "preserved_prohibitions": PRESERVED_PROHIBITIONS,
+        "prohibited_ux_language": PROHIBITED_UX_LANGUAGE,
+        "intentionally_preserved_limitations": INTENTIONALLY_PRESERVED_LIMITATIONS,
+        "deterministic_hash_replay_verified": True,
+    }
+    report["deterministic_report_hash"] = deterministic_hash(report)
+    replay_payload = {
+        key: value
+        for key, value in report.items()
+        if key != "deterministic_report_hash"
+    }
+    report["deterministic_hash_replay_verified"] = (
+        report["deterministic_report_hash"] == deterministic_hash(replay_payload)
+    )
+    return report
+
+
+def write_report(report: dict[str, Any], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        default=str(REPORT_PATH),
+        help="v4.5C.4 frontend trust UX refinement JSON output path",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    output_path = Path(args.output)
+    report = build_report()
+    write_report(report, output_path)
+    summary = report["summary"]
+    validation = report["validation"]
+    print(f"wrote {output_path}")
+    print(f"phase_id={report['phase_id']}")
+    print(f"trust_surface_route={summary['trust_surface_route']}")
+    print(f"ux_refinement_count={summary['ux_refinement_count']}")
+    print(f"source_c3_report_available={summary['source_c3_report_available']}")
+    print(f"source_c3_report_hash={summary['source_c3_report_hash']}")
+    print(f"trust_surface_route_preserved={validation['trust_surface_route_preserved']}")
+    print(f"trusted_data_entrypoint_preserved={validation['trusted_data_entrypoint_preserved']}")
+    print(f"sidebar_entrypoint_preserved={validation['sidebar_entrypoint_preserved']}")
+    print(
+        "report_metadata_visibility_preserved="
+        f"{validation['report_metadata_visibility_preserved']}"
+    )
+    print(
+        "fallback_diagnostics_visibility_preserved="
+        f"{validation['fallback_diagnostics_visibility_preserved']}"
+    )
+    print(
+        "unsupported_state_visibility_preserved="
+        f"{validation['unsupported_state_visibility_preserved']}"
+    )
+    print(
+        "diagnostics_summary_visibility_preserved="
+        f"{validation['diagnostics_summary_visibility_preserved']}"
+    )
+    print(f"layout_scanability_refined={validation['layout_scanability_refined']}")
+    print(
+        "evidence_provenance_grouping_refined="
+        f"{validation['evidence_provenance_grouping_refined']}"
+    )
+    print(
+        "coverage_confidence_readability_refined="
+        f"{validation['coverage_confidence_readability_refined']}"
+    )
+    print(f"prohibited_ux_language_absent={validation['prohibited_ux_language_absent']}")
+    print(
+        "no_recommendation_ranking_scoring_triage_semantics_introduced="
+        f"{validation['no_recommendation_ranking_scoring_triage_semantics_introduced']}"
+    )
+    print(f"no_operational_behavior_introduced={validation['no_operational_behavior_introduced']}")
+    for key, value in sorted(report["enabled_semantics"].items()):
+        print(f"{key}={value}")
+    print(f"repository_remains={','.join(report['repository_remains'])}")
+    print(f"non_authority_statement={report['non_authority_statement']}")
+    print(f"deterministic_report_hash={report['deterministic_report_hash']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/generated/v4_5c_4_frontend_trust_ux_refinement_report.json
+++ b/docs/generated/v4_5c_4_frontend_trust_ux_refinement_report.json
@@ -1,0 +1,189 @@
+{
+  "deterministic_hash_replay_verified": true,
+  "deterministic_report_hash": "db098d64aee534f978c84e49c3b06f840124d9a9b108ae4fb8cc8b962dded634",
+  "enabled_semantics": {
+    "approval_enabled": false,
+    "authorization_enabled": false,
+    "confidence_scoring_enabled": false,
+    "evidence_scoring_enabled": false,
+    "frontend_launch_authorization_language_enabled": false,
+    "hidden_automation_behavior_enabled": false,
+    "live_mutable_trust_state_enabled": false,
+    "operational_mutation_enabled": false,
+    "orchestration_execution_enabled": false,
+    "orchestration_routing_enabled": false,
+    "orchestration_traversal_enabled": false,
+    "planner_execution_enabled": false,
+    "planner_ranking_enabled": false,
+    "planner_recommendations_enabled": false,
+    "production_enablement_enabled": false,
+    "ranking_system_enabled": false,
+    "recommendation_system_enabled": false,
+    "report_driven_planner_behavior_enabled": false,
+    "runtime_mutation_enabled": false,
+    "triage_system_enabled": false,
+    "trust_scoring_enabled": false
+  },
+  "file_coverage": {
+    "created_files_present": {
+      "backend/scripts/report_v4_5c_4_frontend_trust_ux_refinement.py": true,
+      "docs/generated/v4_5c_4_frontend_trust_ux_refinement_report.json": true,
+      "docs/migration/V4_5C_4_FRONTEND_TRUST_UX_REFINEMENT.md": true
+    },
+    "modified_files_expected": [
+      "frontend/src/__tests__/components/frontend-trust-surface-foundations.test.tsx",
+      "frontend/src/components/trust/FrontendTrustSurface.tsx",
+      "frontend/src/components/trust/TrustSurfaceEntryCallout.tsx",
+      "frontend/src/pages/FrontendTrustSurfaceFoundationsPage.tsx"
+    ]
+  },
+  "generated_at": "2026-05-18T00:00:00+00:00",
+  "intentionally_preserved_limitations": [
+    "UX refinement changes only static read-only rendering and copy.",
+    "Report-backed and fallback data remain deterministic frontend context.",
+    "Diagnostics remain visible and do not become triage or remediation controls.",
+    "Coverage and confidence remain non-scoring summaries.",
+    "Evidence and provenance grouping does not grant source authority."
+  ],
+  "non_authority_statement": "Frontend trust UX refinement does NOT imply frontend launch authorization, planner authority, execution safety, correctness guarantees, operational readiness, production enablement, recommendation quality, ranking quality, scoring quality, triage priority, authorization, or approval.",
+  "phase_id": "v4_5c_4_frontend_trust_ux_refinement",
+  "preserved_prohibitions": [
+    "planner execution",
+    "planner recommendations",
+    "planner ranking",
+    "trust scoring",
+    "evidence scoring",
+    "confidence scoring",
+    "recommendation systems",
+    "ranking systems",
+    "triage systems",
+    "authorization semantics",
+    "approval semantics",
+    "orchestration execution",
+    "orchestration routing",
+    "orchestration traversal",
+    "production enablement",
+    "runtime mutation",
+    "operational mutation",
+    "hidden automation behavior",
+    "live mutable trust state",
+    "report-driven planner behavior",
+    "frontend launch authorization language"
+  ],
+  "prohibited_ux_language": [
+    "Approved",
+    "Safe to use",
+    "Recommended",
+    "Best build",
+    "Fully trusted",
+    "Production ready",
+    "Guaranteed correct"
+  ],
+  "repository_remains": [
+    "READ-ONLY",
+    "DESCRIPTIVE-ONLY",
+    "NON-operational",
+    "NON-authorizing",
+    "NON-approving",
+    "NON-recommending",
+    "NON-ranking",
+    "NON-scoring",
+    "NON-triaging"
+  ],
+  "source_report_metadata": {
+    "source_c3_report_available": true,
+    "source_c3_report_hash": "543f43dd9e5128a1032f13b68863d497be9338f65f55b047445a6392ca1f90c7",
+    "source_c3_report_phase_id": "v4_5c_3_frontend_trust_navigation_entrypoints"
+  },
+  "summary": {
+    "created_file_count": 3,
+    "created_files_present": true,
+    "generated_at": "2026-05-18T00:00:00+00:00",
+    "intentionally_preserved_limitation_count": 5,
+    "modified_file_count": 4,
+    "non_authority_statement": "Frontend trust UX refinement does NOT imply frontend launch authorization, planner authority, execution safety, correctness guarantees, operational readiness, production enablement, recommendation quality, ranking quality, scoring quality, triage priority, authorization, or approval.",
+    "phase_id": "v4_5c_4_frontend_trust_ux_refinement",
+    "preserved_prohibition_count": 21,
+    "prohibited_ux_language_count": 7,
+    "repository_remains": [
+      "READ-ONLY",
+      "DESCRIPTIVE-ONLY",
+      "NON-operational",
+      "NON-authorizing",
+      "NON-approving",
+      "NON-recommending",
+      "NON-ranking",
+      "NON-scoring",
+      "NON-triaging"
+    ],
+    "source_c3_report_available": true,
+    "source_c3_report_hash": "543f43dd9e5128a1032f13b68863d497be9338f65f55b047445a6392ca1f90c7",
+    "source_c3_report_phase_id": "v4_5c_3_frontend_trust_navigation_entrypoints",
+    "trust_surface_route": "/trusted-data/frontend-trust",
+    "trusted_data_route": "/trusted-data",
+    "ux_refinement_count": 7,
+    "validation_error_count": 0
+  },
+  "ux_refinements": [
+    {
+      "area": "trust_surface_layout",
+      "description": "Added a compact scan summary for report source, visible states, evidence groups, and diagnostics.",
+      "descriptive_only": true,
+      "read_only": true
+    },
+    {
+      "area": "trust_status_cards",
+      "description": "Grouped state labels with visible limitation summaries for easier scanning.",
+      "descriptive_only": true,
+      "read_only": true
+    },
+    {
+      "area": "explainability_panels",
+      "description": "Added explanation type labels and list formatting while preserving collapsible read-only panels.",
+      "descriptive_only": true,
+      "read_only": true
+    },
+    {
+      "area": "evidence_and_provenance_grouping",
+      "description": "Improved evidence freshness labels and provenance/lineage state grouping without source authority semantics.",
+      "descriptive_only": true,
+      "read_only": true
+    },
+    {
+      "area": "coverage_confidence_summaries",
+      "description": "Added context-only labels to keep coverage and confidence non-scoring.",
+      "descriptive_only": true,
+      "read_only": true
+    },
+    {
+      "area": "fallback_diagnostics_visibility",
+      "description": "Grouped fallback state and report diagnostics so unavailable report states remain fail-visible.",
+      "descriptive_only": true,
+      "read_only": true
+    },
+    {
+      "area": "route_navigation_continuity",
+      "description": "Kept the existing trust surface route and navigation entry points intact with clearer read-only copy.",
+      "descriptive_only": true,
+      "read_only": true
+    }
+  ],
+  "validation": {
+    "coverage_confidence_readability_refined": true,
+    "descriptive_only_ux_refinement_verified": true,
+    "diagnostics_summary_visibility_preserved": true,
+    "evidence_provenance_grouping_refined": true,
+    "fallback_diagnostics_visibility_preserved": true,
+    "layout_scanability_refined": true,
+    "no_authorization_approval_semantics_introduced": true,
+    "no_operational_behavior_introduced": true,
+    "no_recommendation_ranking_scoring_triage_semantics_introduced": true,
+    "prohibited_ux_language_absent": true,
+    "read_only_ux_refinement_verified": true,
+    "report_metadata_visibility_preserved": true,
+    "sidebar_entrypoint_preserved": true,
+    "trust_surface_route_preserved": true,
+    "trusted_data_entrypoint_preserved": true,
+    "unsupported_state_visibility_preserved": true
+  }
+}

--- a/docs/migration/V4_5C_4_FRONTEND_TRUST_UX_REFINEMENT.md
+++ b/docs/migration/V4_5C_4_FRONTEND_TRUST_UX_REFINEMENT.md
@@ -1,0 +1,137 @@
+# v4.5C.4 Frontend Trust UX Refinement
+
+## Architectural Purpose
+
+v4.5C.4 refines the existing frontend trust surface at `/trusted-data/frontend-trust` so public trust information is easier to scan, group, and understand.
+
+This phase is UX refinement only. It does not change planner behavior, report authority, trust data mutability, or operational readiness.
+
+## UX Refinement Philosophy
+
+The trust surface remains:
+
+```text
+deterministic
+read-only
+governance-safe
+fail-visible
+descriptive-only
+publicly transparent
+non-authoritative
+```
+
+The refinement improves layout clarity, diagnostics scanability, evidence grouping, provenance and lineage grouping, fallback visibility, and copy clarity without adding execution, scoring, ranking, recommendation, authorization, approval, or triage behavior.
+
+## Trust Surface Layout
+
+The trust surface now includes a compact scan summary for:
+
+- report source
+- visible support states
+- evidence groups
+- diagnostics visibility
+
+This summary is a navigation and comprehension aid only. It does not classify readiness, score trust, prioritize action, or authorize planner behavior.
+
+## Readability And Copy
+
+Copy is tightened around what the surface shows:
+
+- support and unsupported states
+- report-backed metadata
+- explicit fallback data
+- fail-visible diagnostics
+- evidence freshness
+- provenance and lineage continuity
+- coverage and confidence context
+
+The copy intentionally avoids approval, production readiness, recommendation, ranking, scoring, and execution language.
+
+## Diagnostics Scanability
+
+Diagnostics remain visible and grouped for scanning. Report diagnostics, fallback diagnostics, warnings, blockers, unsupported states, continuity gaps, evidence gaps, and explainability gaps are preserved.
+
+Diagnostics do not become triage priority, remediation priority, automated repair, or operational response.
+
+## Evidence And Provenance Grouping
+
+Evidence panels now expose freshness labels and grouped source, provenance, and lineage fields with clearer spacing.
+
+Provenance and lineage panels expose source, provenance state, and lineage state without implying source authority, correctness guarantee, or trust score.
+
+## Empty And Fallback States
+
+Fallback states remain explicit:
+
+- report unavailable states remain visible
+- fallback data active states remain visible
+- missing report metadata remains fail-visible
+- unsupported states remain visible
+
+No silent fallback behavior is introduced.
+
+## Accessibility And Responsiveness
+
+The refinement keeps semantic headings, visible labels, responsive grids, and collapsible read-only explanation panels. The route remains stable and keyboard-accessible through the existing links.
+
+## Inherited Prohibitions
+
+This phase preserves prohibitions against:
+
+- planner execution
+- planner recommendations
+- planner ranking
+- trust scoring
+- evidence scoring
+- confidence scoring
+- recommendation systems
+- ranking systems
+- triage systems
+- authorization semantics
+- approval semantics
+- orchestration execution
+- orchestration routing
+- orchestration traversal
+- production enablement
+- runtime mutation
+- operational mutation
+- hidden automation behavior
+- live mutable trust state
+- report-driven planner behavior
+- frontend launch authorization language
+
+## Generated Evidence
+
+The deterministic report is generated at:
+
+```text
+docs/generated/v4_5c_4_frontend_trust_ux_refinement_report.json
+```
+
+The report certifies:
+
+```text
+READ-ONLY
+DESCRIPTIVE-ONLY
+NON-operational
+NON-authorizing
+NON-approving
+NON-recommending
+NON-ranking
+NON-scoring
+NON-triaging
+```
+
+It also states:
+
+```text
+Frontend trust UX refinement does NOT imply frontend launch authorization, planner authority, execution safety, correctness guarantees, operational readiness, production enablement, recommendation quality, ranking quality, scoring quality, triage priority, authorization, or approval.
+```
+
+## Intentionally Preserved Limitations
+
+- UX refinement changes only static read-only rendering and copy.
+- Report-backed and fallback data remain deterministic frontend context.
+- Diagnostics remain visible and do not become triage or remediation controls.
+- Coverage and confidence remain non-scoring summaries.
+- Evidence and provenance grouping does not grant source authority.

--- a/frontend/src/__tests__/components/frontend-trust-surface-foundations.test.tsx
+++ b/frontend/src/__tests__/components/frontend-trust-surface-foundations.test.tsx
@@ -74,7 +74,7 @@ describe("v4.5C.1 frontend trust surface foundations", () => {
     expect(
       screen.getByText("read_only_descriptive_frontend_trust_surface_certified"),
     ).toBeInTheDocument();
-    expect(screen.getByText("report_backed")).toBeInTheDocument();
+    expect(screen.getAllByText("report backed").length).toBeGreaterThan(0);
     expect(screen.getByText("Report metadata present")).toBeInTheDocument();
     expect(screen.getByText("Report hash visible")).toBeInTheDocument();
   });
@@ -110,6 +110,17 @@ describe("v4.5C.1 frontend trust surface foundations", () => {
     expect(screen.getByText("Public warning")).toBeInTheDocument();
     expect(screen.getByText("Evidence gap")).toBeInTheDocument();
     expect(screen.getByText("Explainability gap")).toBeInTheDocument();
+  });
+
+  it("renders refined scan groups, limitation labels, and context-only summaries", () => {
+    render(<FrontendTrustSurface />);
+
+    expect(screen.getByLabelText("Trust surface scan summary")).toBeInTheDocument();
+    expect(screen.getByText("Report source")).toBeInTheDocument();
+    expect(screen.getByText("Evidence groups")).toBeInTheDocument();
+    expect(screen.getAllByText(/limitation remains visible/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText("context only").length).toBeGreaterThan(0);
+    expect(screen.getByText(/fail-visible report diagnostics/i)).toBeInTheDocument();
   });
 
   it("preserves explicit read-only and descriptive-only guarantees", () => {
@@ -161,10 +172,10 @@ describe("v4.5C.1 frontend trust surface foundations", () => {
     const callout = screen.getByTestId("trust-surface-entry-callout");
     expect(within(callout).getByText("Read-only trust surface")).toBeInTheDocument();
     expect(
-      within(callout).getByText(/report-backed metadata, fallback visibility/i),
+      within(callout).getByText(/report metadata, fallback visibility/i),
     ).toBeInTheDocument();
     expect(
-      within(callout).getByText(/does not enable planner authority or operational behavior/i),
+      within(callout).getByText(/stays read-only and does not enable planner authority/i),
     ).toBeInTheDocument();
     expect(within(callout).getByRole("link", { name: "View trust visibility" }))
       .toHaveAttribute("href", TRUST_SURFACE_ROUTE);

--- a/frontend/src/components/trust/FrontendTrustSurface.tsx
+++ b/frontend/src/components/trust/FrontendTrustSurface.tsx
@@ -43,8 +43,20 @@ const reportDiagnosticToneClasses: Record<TrustReportDiagnostic["state"], string
   unsupported: "border-violet-400/30 bg-violet-500/10 text-violet-100",
 };
 
+const freshnessToneClasses: Record<TrustEvidencePanelData["items"][number]["freshness"], string> = {
+  current: "border-emerald-400/30 bg-emerald-500/10 text-emerald-100",
+  stale: "border-amber-400/30 bg-amber-500/10 text-amber-100",
+  unknown: "border-gray-400/30 bg-gray-500/10 text-gray-100",
+  missing: "border-rose-400/30 bg-rose-500/10 text-rose-100",
+  unsupported: "border-violet-400/30 bg-violet-500/10 text-violet-100",
+};
+
 function ordered<T extends { deterministicOrder: number }>(items: readonly T[]): readonly T[] {
   return [...items].sort((left, right) => left.deterministicOrder - right.deterministicOrder);
+}
+
+function formatToken(value: string): string {
+  return value.replace(/_/g, " ");
 }
 
 export function SupportStatusBadge({
@@ -67,12 +79,73 @@ export function SupportStatusBadge({
   );
 }
 
-function SectionHeading({ eyebrow, title }: { eyebrow: string; title: string }) {
+function SectionHeading({
+  eyebrow,
+  title,
+  description,
+}: {
+  eyebrow: string;
+  title: string;
+  description?: string;
+}) {
   return (
-    <div>
+    <div className="max-w-3xl">
       <p className="font-mono text-xs uppercase tracking-wide text-[#22d3ee]">{eyebrow}</p>
       <h2 className="mt-2 text-xl font-semibold text-gray-100">{title}</h2>
+      {description ? (
+        <p className="mt-2 text-sm leading-6 text-gray-300">{description}</p>
+      ) : null}
     </div>
+  );
+}
+
+function TrustSurfaceOverview({
+  data,
+  integration,
+}: {
+  data: FrontendTrustSurfaceData;
+  integration: FrontendTrustReportIntegrationData;
+}) {
+  const items = [
+    {
+      label: "Report source",
+      value: formatToken(integration.sourceStatus),
+      note: "Report metadata and fallback state are shown together.",
+    },
+    {
+      label: "Visible states",
+      value: `${data.trustStatusCards.length} support states`,
+      note: "Supported, unsupported, blocked, and unknown states remain visible.",
+    },
+    {
+      label: "Evidence groups",
+      value: `${data.evidencePanels.length} groups`,
+      note: "Evidence is grouped by source, freshness, provenance, and lineage.",
+    },
+    {
+      label: "Diagnostics",
+      value: `${data.diagnosticsSummaries.length + integration.diagnostics.length} visible`,
+      note: "Warnings, blockers, gaps, and fallback diagnostics stay fail-visible.",
+    },
+  ];
+
+  return (
+    <section className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4" aria-label="Trust surface scan summary">
+      {items.map((item) => (
+        <article
+          key={item.label}
+          className="rounded border border-[#24304f] bg-[#0c1124] p-4"
+          data-read-only="true"
+          data-descriptive-only="true"
+        >
+          <p className="font-mono text-[11px] uppercase tracking-wide text-gray-400">
+            {item.label}
+          </p>
+          <p className="mt-2 text-base font-semibold text-gray-100">{item.value}</p>
+          <p className="mt-2 text-xs leading-5 text-gray-300">{item.note}</p>
+        </article>
+      ))}
+    </section>
   );
 }
 
@@ -84,13 +157,21 @@ export function TrustStatusCard({ card }: { card: TrustStatusCardData }) {
       data-descriptive-only={card.descriptiveOnly}
     >
       <div className="flex flex-wrap items-start justify-between gap-2">
-        <h3 className="text-sm font-semibold text-gray-100">{card.title}</h3>
+        <div>
+          <h3 className="text-sm font-semibold text-gray-100">{card.title}</h3>
+          <p className="mt-1 font-mono text-[11px] uppercase text-gray-400">
+            read-only state
+          </p>
+        </div>
         <SupportStatusBadge status={card.status} />
       </div>
       <p className="mt-3 text-sm leading-6 text-gray-300">{card.summary}</p>
-      <p className="mt-3 rounded border border-amber-400/20 bg-amber-500/5 p-3 text-xs leading-5 text-amber-100">
-        {card.limitation}
-      </p>
+      <div className="mt-3 rounded border border-amber-400/20 bg-amber-500/5 p-3">
+        <p className="font-mono text-[11px] uppercase tracking-wide text-amber-100">
+          limitation remains visible
+        </p>
+        <p className="mt-1 text-xs leading-5 text-amber-100">{card.limitation}</p>
+      </div>
     </article>
   );
 }
@@ -102,11 +183,14 @@ export function ExplainabilityPanel({ panel }: { panel: TrustExplanationPanelDat
       data-read-only={panel.readOnly}
       data-descriptive-only={panel.descriptiveOnly}
     >
-      <summary className="cursor-pointer text-sm font-semibold text-gray-100">
-        {panel.title}
+      <summary className="cursor-pointer text-sm font-semibold text-gray-100 marker:text-[#22d3ee]">
+        <span>{panel.title}</span>
+        <span className="ml-2 rounded border border-[#33415f] px-2 py-0.5 font-mono text-[10px] uppercase text-gray-300">
+          {formatToken(panel.explanationType)}
+        </span>
       </summary>
       <p className="mt-3 text-sm leading-6 text-gray-300">{panel.summary}</p>
-      <ul className="mt-3 space-y-2 text-sm leading-6 text-gray-300">
+      <ul className="mt-3 list-disc space-y-2 pl-5 text-sm leading-6 text-gray-300">
         {panel.details.map((detail) => (
           <li key={detail}>{detail}</li>
         ))}
@@ -125,9 +209,12 @@ export function EvidencePanel({ panel }: { panel: TrustEvidencePanelData }) {
       <div className="flex flex-wrap items-center justify-between gap-2">
         <h3 className="text-sm font-semibold text-gray-100">{panel.title}</h3>
         <span className="rounded border border-[#33415f] px-2 py-1 font-mono text-[11px] uppercase text-gray-300">
-          {panel.group.replace("_", " ")}
+          {formatToken(panel.group)}
         </span>
       </div>
+      <p className="mt-2 text-xs leading-5 text-gray-400">
+        {panel.items.length} evidence item{panel.items.length === 1 ? "" : "s"} shown without scoring or ranking.
+      </p>
       <div className="mt-4 space-y-3">
         {panel.items.map((item) => (
           <div
@@ -138,11 +225,11 @@ export function EvidencePanel({ panel }: { panel: TrustEvidencePanelData }) {
           >
             <div className="flex flex-wrap items-center justify-between gap-2">
               <p className="text-sm font-medium text-gray-100">{item.label}</p>
-              <span className="rounded border border-[#33415f] px-2 py-1 font-mono text-[11px] uppercase text-gray-300">
+              <span className={`rounded border px-2 py-1 font-mono text-[11px] uppercase ${freshnessToneClasses[item.freshness]}`}>
                 {item.freshness}
               </span>
             </div>
-            <dl className="mt-3 grid gap-2 text-xs leading-5 text-gray-300">
+            <dl className="mt-3 grid gap-3 text-xs leading-5 text-gray-300 sm:grid-cols-3">
               <div>
                 <dt className="font-semibold text-gray-100">Source</dt>
                 <dd>{item.source}</dd>
@@ -170,7 +257,17 @@ export function ProvenanceLineagePanel({ panel }: { panel: TrustProvenanceLineag
       data-read-only={panel.readOnly}
       data-descriptive-only={panel.descriptiveOnly}
     >
-      <h3 className="text-sm font-semibold text-gray-100">{panel.title}</h3>
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <h3 className="text-sm font-semibold text-gray-100">{panel.title}</h3>
+        <div className="flex flex-wrap gap-2">
+          <span className="rounded border border-[#33415f] px-2 py-1 font-mono text-[11px] uppercase text-gray-300">
+            provenance: {panel.provenanceState}
+          </span>
+          <span className="rounded border border-[#33415f] px-2 py-1 font-mono text-[11px] uppercase text-gray-300">
+            lineage: {panel.lineageState}
+          </span>
+        </div>
+      </div>
       <dl className="mt-3 grid gap-2 text-xs leading-5 text-gray-300">
         <div>
           <dt className="font-semibold text-gray-100">Source reference</dt>
@@ -209,6 +306,9 @@ export function CoverageConfidenceSummary({ summary }: { summary: TrustMetricSum
       <h3 className="text-sm font-semibold text-gray-100">{summary.label}</h3>
       <p className="mt-2 font-mono text-xs uppercase text-[#22d3ee]">{summary.state}</p>
       <p className="mt-3 text-sm leading-6 text-gray-300">{summary.visibilityNote}</p>
+      <p className="mt-3 rounded border border-[#33415f] px-2 py-1 font-mono text-[11px] uppercase text-gray-300">
+        context only
+      </p>
     </article>
   );
 }
@@ -248,7 +348,7 @@ export function TrustReportIntegrationPanel({
           </h2>
         </div>
         <span className="rounded border border-[#33415f] px-2.5 py-1 font-mono text-[11px] uppercase text-gray-200">
-          {integration.sourceStatus.replace("_", " ")}
+          {formatToken(integration.sourceStatus)}
         </span>
       </div>
 
@@ -306,20 +406,37 @@ export function TrustReportIntegrationPanel({
         </article>
       </div>
 
-      <article className="mt-4 rounded border border-amber-400/20 bg-amber-500/5 p-4">
-        <h3 className="text-sm font-semibold text-amber-100">
-          {integration.fallbackState.fallbackLabel}
-        </h3>
-        <p className="mt-2 text-sm leading-6 text-amber-100/90">
-          {integration.fallbackState.fallbackReason}
-        </p>
-        <p className="mt-2 text-sm leading-6 text-amber-100/90">
-          {integration.fallbackState.fallbackVisibilityNote}
-        </p>
-        <p className="mt-2 font-mono text-xs uppercase text-amber-100">
-          fallback_active={String(integration.fallbackState.fallbackActive)}
-        </p>
-      </article>
+      <div className="mt-4 grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+        <article className="rounded border border-amber-400/20 bg-amber-500/5 p-4">
+          <p className="font-mono text-[11px] uppercase tracking-wide text-amber-100">
+            fallback state
+          </p>
+          <h3 className="mt-2 text-sm font-semibold text-amber-100">
+            {integration.fallbackState.fallbackLabel}
+          </h3>
+          <p className="mt-2 text-sm leading-6 text-amber-100/90">
+            {integration.fallbackState.fallbackReason}
+          </p>
+          <p className="mt-2 text-sm leading-6 text-amber-100/90">
+            {integration.fallbackState.fallbackVisibilityNote}
+          </p>
+          <p className="mt-2 font-mono text-xs uppercase text-amber-100">
+            fallback_active={String(integration.fallbackState.fallbackActive)}
+          </p>
+        </article>
+
+        <article className="rounded border border-[#24304f] bg-[#0c1124] p-4">
+          <p className="font-mono text-[11px] uppercase tracking-wide text-gray-400">
+            report diagnostics
+          </p>
+          <h3 className="mt-2 text-sm font-semibold text-gray-100">
+            {integration.diagnostics.length} fail-visible report diagnostic{integration.diagnostics.length === 1 ? "" : "s"}
+          </h3>
+          <p className="mt-2 text-sm leading-6 text-gray-300">
+            Report-backed and fallback states stay visible together; missing metadata does not trigger recovery behavior.
+          </p>
+        </article>
+      </div>
 
       <div className="mt-5 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
         {integration.certificationSummaries.map((summary) => (
@@ -330,7 +447,7 @@ export function TrustReportIntegrationPanel({
             data-descriptive-only={summary.descriptiveOnly}
           >
             <h3 className="text-sm font-semibold text-gray-100">{summary.label}</h3>
-            <ul className="mt-3 space-y-2 text-xs leading-5 text-gray-300">
+            <ul className="mt-3 list-disc space-y-2 pl-5 text-xs leading-5 text-gray-300">
               {summary.values.map((value) => (
                 <li key={value}>{value}</li>
               ))}
@@ -393,10 +510,16 @@ export function FrontendTrustSurface({
         </div>
       </section>
 
+      <TrustSurfaceOverview data={data} integration={reportIntegration} />
+
       <TrustReportIntegrationPanel integration={reportIntegration} />
 
       <section className="space-y-4">
-        <SectionHeading eyebrow="Trust status cards" title="State visibility" />
+        <SectionHeading
+          eyebrow="Trust status cards"
+          title="State visibility"
+          description="Each state is labeled for inspection only, with limitations kept next to the status."
+        />
         <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
           {ordered(data.trustStatusCards).map((card) => (
             <TrustStatusCard key={card.id} card={card} />
@@ -405,7 +528,11 @@ export function FrontendTrustSurface({
       </section>
 
       <section className="space-y-4">
-        <SectionHeading eyebrow="Support status badges" title="Deterministic labels" />
+        <SectionHeading
+          eyebrow="Support status badges"
+          title="Deterministic labels"
+          description="Badge labels are descriptive public trust states, not approvals or operational signals."
+        />
         <div className="rounded border border-[#2a3050] bg-[#10152a] p-4">
           <div className="flex flex-wrap gap-2">
             {data.supportBadges.map((badge) => (
@@ -416,7 +543,11 @@ export function FrontendTrustSurface({
       </section>
 
       <section className="space-y-4">
-        <SectionHeading eyebrow="Explainability panels" title="Read-only explanations" />
+        <SectionHeading
+          eyebrow="Explainability panels"
+          title="Read-only explanations"
+          description="Panels open in place so support, limitation, continuity, trust, and diagnostic explanations stay close to their context."
+        />
         <div className="grid gap-4 md:grid-cols-2">
           {ordered(data.explainabilityPanels).map((panel) => (
             <ExplainabilityPanel key={panel.id} panel={panel} />
@@ -425,7 +556,11 @@ export function FrontendTrustSurface({
       </section>
 
       <section className="space-y-4">
-        <SectionHeading eyebrow="Evidence panels" title="Grouped public evidence" />
+        <SectionHeading
+          eyebrow="Evidence panels"
+          title="Grouped public evidence"
+          description="Evidence is grouped by visible surface and freshness without scoring source quality."
+        />
         <div className="grid gap-4 lg:grid-cols-2">
           {ordered(data.evidencePanels).map((panel) => (
             <EvidencePanel key={panel.id} panel={panel} />
@@ -434,7 +569,11 @@ export function FrontendTrustSurface({
       </section>
 
       <section className="space-y-4">
-        <SectionHeading eyebrow="Provenance and lineage" title="Source continuity" />
+        <SectionHeading
+          eyebrow="Provenance and lineage"
+          title="Source continuity"
+          description="Source, provenance, and lineage states are shown as continuity context without source authority."
+        />
         <div className="grid gap-4 md:grid-cols-2">
           {ordered(data.provenanceLineagePanels).map((panel) => (
             <ProvenanceLineagePanel key={panel.id} panel={panel} />
@@ -443,7 +582,11 @@ export function FrontendTrustSurface({
       </section>
 
       <section className="space-y-4">
-        <SectionHeading eyebrow="Coverage and confidence" title="Non-scoring summaries" />
+        <SectionHeading
+          eyebrow="Coverage and confidence"
+          title="Non-scoring summaries"
+          description="Coverage and confidence are displayed as context only; incomplete and unknown states remain explicit."
+        />
         <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
           {[...ordered(data.coverageSummaries), ...ordered(data.confidenceSummaries)].map(
             (summary) => (
@@ -454,7 +597,11 @@ export function FrontendTrustSurface({
       </section>
 
       <section className="space-y-4">
-        <SectionHeading eyebrow="Diagnostics summaries" title="Fail-visible diagnostics" />
+        <SectionHeading
+          eyebrow="Diagnostics summaries"
+          title="Fail-visible diagnostics"
+          description="Warnings, blockers, unsupported states, and gaps remain visible as descriptive diagnostics."
+        />
         <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
           {ordered(data.diagnosticsSummaries).map((summary) => (
             <DiagnosticsSummary key={summary.id} summary={summary} />

--- a/frontend/src/components/trust/TrustSurfaceEntryCallout.tsx
+++ b/frontend/src/components/trust/TrustSurfaceEntryCallout.tsx
@@ -19,9 +19,9 @@ export function TrustSurfaceEntryCallout() {
             View trust visibility
           </h2>
           <p className="mt-2 text-sm leading-6 text-gray-300">
-            See support status, evidence, provenance, lineage, report-backed
-            metadata, fallback visibility, and fail-visible diagnostics in one
-            descriptive surface. This does not enable planner authority or
+            See support status, evidence, provenance, lineage, report metadata,
+            fallback visibility, and fail-visible diagnostics in one descriptive
+            surface. It stays read-only and does not enable planner authority or
             operational behavior.
           </p>
           <div className="mt-3 flex flex-wrap gap-2">

--- a/frontend/src/pages/FrontendTrustSurfaceFoundationsPage.tsx
+++ b/frontend/src/pages/FrontendTrustSurfaceFoundationsPage.tsx
@@ -12,19 +12,29 @@ export default function FrontendTrustSurfaceFoundationsPage() {
         path="/trusted-data/frontend-trust"
       />
 
-      <nav className="flex flex-wrap gap-3 text-sm">
-        <Link
-          to="/trusted-data"
-          className="rounded border border-[#2a3050] px-4 py-2 text-gray-200 no-underline hover:border-[#f5a623]"
-        >
-          Trusted data guide
-        </Link>
-        <Link
-          to="/trusted-data/support"
-          className="rounded border border-[#2a3050] px-4 py-2 text-gray-200 no-underline hover:border-[#f5a623]"
-        >
-          Support matrix
-        </Link>
+      <nav
+        className="rounded border border-[#2a3050] bg-[#10152a] p-4 text-sm"
+        aria-label="Trust surface related views"
+      >
+        <p className="mb-3 text-sm leading-6 text-gray-300">
+          Trust visibility is read-only context for support, evidence, provenance,
+          lineage, coverage, confidence, and diagnostics. It does not enable
+          planner authority.
+        </p>
+        <div className="flex flex-wrap gap-3">
+          <Link
+            to="/trusted-data"
+            className="rounded border border-[#2a3050] px-4 py-2 text-gray-200 no-underline hover:border-[#f5a623]"
+          >
+            Trusted data guide
+          </Link>
+          <Link
+            to="/trusted-data/support"
+            className="rounded border border-[#2a3050] px-4 py-2 text-gray-200 no-underline hover:border-[#f5a623]"
+          >
+            Support matrix
+          </Link>
+        </div>
       </nav>
 
       <FrontendTrustSurface />


### PR DESCRIPTION
Refine deterministic read-only frontend trust UX including layout clarity, trust copy, diagnostics scanability, evidence and provenance grouping, fallback and empty-state visibility, route continuity, generated closeout evidence, and descriptive-only frontend trust guarantees without introducing planner execution, authorization, approval, ranking, recommendation, scoring, triage, production enablement, or operational behavior.