### PR TITLE
v4.5D.1: define backend trust visibility endpoint contract

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -215,6 +215,7 @@ def create_app(env: str = "development") -> Flask:
     from app.routes.views import views_bp
     from app.routes.report import report_bp
     from app.routes.health import health_bp
+    from app.routes.trust import trust_bp
     from app.routes.affixes import affixes_bp
     from app.routes.debug import debug_bp
     from app.routes.experimental import experimental_bp
@@ -244,6 +245,7 @@ def create_app(env: str = "development") -> Flask:
     app.register_blueprint(views_bp, url_prefix="/api/builds")
     app.register_blueprint(report_bp, url_prefix="/api/builds")
     app.register_blueprint(health_bp, url_prefix="/api")
+    app.register_blueprint(trust_bp, url_prefix="/api/trust")
     app.register_blueprint(affixes_bp, url_prefix="/api/affixes")
     app.register_blueprint(debug_bp, url_prefix="/debug")
     app.register_blueprint(experimental_bp, url_prefix="/experimental")

--- a/backend/app/routes/trust.py
+++ b/backend/app/routes/trust.py
@@ -1,0 +1,258 @@
+"""Trust visibility contract blueprint.
+
+This route exposes deterministic read-only trust visibility metadata. It is a
+contract surface only: it does not fetch frontend state, mutate trust state,
+trigger planners, score records, or authorize operational behavior.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+from flask import Blueprint, jsonify
+
+
+trust_bp = Blueprint("trust", __name__)
+
+SCHEMA_VERSION = "v4.5d.1"
+ENDPOINT_CONTRACT_ID = "v4_5d_1_backend_trust_visibility_endpoint_contract"
+ENDPOINT_ROUTE = "/api/trust/visibility"
+HEALTH_ENDPOINT = "/api/health"
+REPORT_REFERENCE_ID = "v4_5c_5_frontend_trust_closeout_backend_reflection_audit_report"
+REPORT_NAME = "v4_5c_5_frontend_trust_closeout_backend_reflection_audit_report"
+REPORT_PATH = (
+    "docs/generated/"
+    "v4_5c_5_frontend_trust_closeout_backend_reflection_audit_report.json"
+)
+SOURCE_STATUS_ID = "backend_report_backed_visibility_available"
+BACKEND_REFLECTION_STATUS_ID = "backend_reflection_contract_defined"
+FRONTEND_ALIGNMENT_STATUS_ID = "backend_contract_ready_frontend_fetch_deferred"
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_REPORT_FILE = _REPO_ROOT / REPORT_PATH
+
+GUARANTEES = [
+    "READ-ONLY",
+    "DESCRIPTIVE-ONLY",
+    "NON-operational",
+    "NON-authorizing",
+    "NON-approving",
+    "NON-recommending",
+    "NON-ranking",
+    "NON-scoring",
+    "NON-triaging",
+]
+
+PROHIBITIONS = [
+    "planner_execution",
+    "planner_recommendations",
+    "planner_ranking",
+    "trust_scoring",
+    "evidence_scoring",
+    "confidence_scoring",
+    "authorization_semantics",
+    "approval_semantics",
+    "production_enablement",
+    "runtime_mutation",
+    "operational_behavior",
+    "mutable_trust_state",
+    "frontend_live_fetch_integration",
+]
+
+NON_AUTHORITY_STATEMENT = (
+    "Backend trust visibility endpoint contract does NOT imply frontend live "
+    "fetch integration, planner authority, execution safety, correctness "
+    "guarantees, operational readiness, production enablement, recommendation "
+    "quality, ranking quality, scoring quality, triage priority, authorization, "
+    "approval, or mutable trust state."
+)
+
+
+def canonical_json(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"))
+
+
+def deterministic_hash(payload: dict[str, Any]) -> str:
+    return hashlib.sha256(canonical_json(payload).encode("utf-8")).hexdigest()
+
+
+def _load_report_reference(report_path: Path = _REPORT_FILE) -> dict[str, Any]:
+    base_reference: dict[str, Any] = {
+        "report_reference_id": REPORT_REFERENCE_ID,
+        "name": REPORT_NAME,
+        "path": REPORT_PATH,
+        "hash": "missing",
+        "available": False,
+        "status": "report_missing",
+    }
+    try:
+        raw = report_path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return base_reference
+    except OSError as exc:
+        return {
+            **base_reference,
+            "status": "report_unreadable",
+            "error": exc.__class__.__name__,
+        }
+
+    try:
+        report = json.loads(raw)
+    except json.JSONDecodeError:
+        return {
+            **base_reference,
+            "status": "report_malformed",
+            "available": True,
+        }
+
+    report_hash = report.get("deterministic_report_hash")
+    if not isinstance(report_hash, str) or not report_hash:
+        return {
+            **base_reference,
+            "status": "report_hash_missing",
+            "available": True,
+        }
+
+    return {
+        **base_reference,
+        "hash": report_hash,
+        "available": True,
+        "status": "report_available",
+        "phase_id": report.get("phase_id", "unknown"),
+    }
+
+
+def _diagnostics_for_report(report_reference: dict[str, Any]) -> list[dict[str, str]]:
+    diagnostics = [
+        {
+            "id": "frontend_fetch_deferred",
+            "severity": "informational",
+            "message": (
+                "Backend trust visibility endpoint contract is defined; "
+                "frontend live fetch integration remains deferred."
+            ),
+        },
+        {
+            "id": "health_trust_endpoint_distinction",
+            "severity": "informational",
+            "message": (
+                "Backend health confirms process liveness and does not prove "
+                "trust visibility alignment."
+            ),
+        },
+        {
+            "id": "unsupported_state_visibility_preserved",
+            "severity": "informational",
+            "message": "Unsupported states remain explicit in the trust visibility contract.",
+        },
+    ]
+    if report_reference["status"] == "report_available":
+        return [
+            {
+                "id": "report_reference_available",
+                "severity": "informational",
+                "message": "Report-backed trust visibility metadata is available.",
+            },
+            *diagnostics,
+        ]
+    return [
+        {
+            "id": report_reference["status"],
+            "severity": "warning",
+            "message": (
+                "Report-backed trust visibility metadata is unavailable or incomplete; "
+                "the endpoint returns a fail-visible contract payload."
+            ),
+        },
+        *diagnostics,
+    ]
+
+
+def build_trust_visibility_payload(report_path: Path = _REPORT_FILE) -> dict[str, Any]:
+    report_reference = _load_report_reference(report_path)
+    status = "available" if report_reference["status"] == "report_available" else "degraded"
+    source_type = (
+        "backend_report_backed_visibility"
+        if status == "available"
+        else "backend_report_reference_unavailable"
+    )
+    payload: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "status": status,
+        "endpoint_contract": {
+            "endpoint_contract_id": ENDPOINT_CONTRACT_ID,
+            "endpoint_route": ENDPOINT_ROUTE,
+            "schema_version": SCHEMA_VERSION,
+            "methods": ["GET"],
+            "read_only": True,
+            "descriptive_only": True,
+            "non_mutating": True,
+        },
+        "source_type": source_type,
+        "source_status": {
+            "source_status_id": SOURCE_STATUS_ID,
+            "source_type": source_type,
+            "report_backed": status == "available",
+            "frontend_live_fetch_integration": "deferred",
+        },
+        "report_reference": report_reference,
+        "backend_reflection": {
+            "status": BACKEND_REFLECTION_STATUS_ID,
+            "backend_reflection_status_id": BACKEND_REFLECTION_STATUS_ID,
+            "health_endpoint": HEALTH_ENDPOINT,
+            "trust_endpoint": ENDPOINT_ROUTE,
+            "alignment_status": FRONTEND_ALIGNMENT_STATUS_ID,
+            "frontend_alignment_status_id": FRONTEND_ALIGNMENT_STATUS_ID,
+        },
+        "frontend_alignment": {
+            "status": FRONTEND_ALIGNMENT_STATUS_ID,
+            "live_frontend_fetch": False,
+            "integration_readiness": "ready_for_v4_5d_2_frontend_fetch_integration",
+        },
+        "guarantees": GUARANTEES,
+        "prohibitions": PROHIBITIONS,
+        "diagnostics": _diagnostics_for_report(report_reference),
+        "fallback_payload_shapes": [
+            {
+                "id": "report_missing",
+                "status": "degraded",
+                "available": False,
+                "fail_visible": True,
+            },
+            {
+                "id": "report_unreadable",
+                "status": "degraded",
+                "available": False,
+                "fail_visible": True,
+            },
+            {
+                "id": "report_malformed",
+                "status": "degraded",
+                "available": True,
+                "fail_visible": True,
+            },
+            {
+                "id": "endpoint_contract_unavailable",
+                "status": "degraded",
+                "available": False,
+                "fail_visible": True,
+            },
+            {
+                "id": "unknown_backend_trust_state",
+                "status": "degraded",
+                "available": False,
+                "fail_visible": True,
+            },
+        ],
+        "non_authority_statement": NON_AUTHORITY_STATEMENT,
+    }
+    payload["payload_hash"] = deterministic_hash(payload)
+    return payload
+
+
+@trust_bp.get("/visibility")
+def trust_visibility():
+    return jsonify(build_trust_visibility_payload()), 200

--- a/backend/scripts/report_v4_5d_1_backend_trust_visibility_endpoint_contract.py
+++ b/backend/scripts/report_v4_5d_1_backend_trust_visibility_endpoint_contract.py
@@ -1,0 +1,301 @@
+"""Generate deterministic v4.5D.1 backend trust visibility endpoint contract report."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+
+REPORT_PATH = Path(
+    "docs/generated/v4_5d_1_backend_trust_visibility_endpoint_contract_report.json"
+)
+
+PHASE_ID = "v4_5d_1_backend_trust_visibility_endpoint_contract"
+GENERATED_AT = "2026-05-18T00:00:00+00:00"
+SCHEMA_VERSION = "v4.5d.1"
+ENDPOINT_ROUTE = "/api/trust/visibility"
+HEALTH_ENDPOINT = "/api/health"
+C5_REPORT_PATH = Path(
+    "docs/generated/"
+    "v4_5c_5_frontend_trust_closeout_backend_reflection_audit_report.json"
+)
+
+REPOSITORY_REMAINS = [
+    "READ-ONLY",
+    "DESCRIPTIVE-ONLY",
+    "GET-only",
+    "NON-mutating",
+    "NON-operational",
+    "NON-authorizing",
+    "NON-approving",
+    "NON-recommending",
+    "NON-ranking",
+    "NON-scoring",
+    "NON-triaging",
+]
+
+NON_AUTHORITY_STATEMENT = (
+    "Backend trust visibility endpoint contract does NOT imply frontend live "
+    "fetch integration, planner authority, execution safety, correctness "
+    "guarantees, operational readiness, production enablement, recommendation "
+    "quality, ranking quality, scoring quality, triage priority, authorization, "
+    "approval, or mutable trust state."
+)
+
+CREATED_FILES = [
+    "backend/app/routes/trust.py",
+    "backend/tests/test_v4_5d_1_backend_trust_visibility_endpoint_contract.py",
+    "backend/scripts/report_v4_5d_1_backend_trust_visibility_endpoint_contract.py",
+    "docs/generated/v4_5d_1_backend_trust_visibility_endpoint_contract_report.json",
+    "docs/migration/V4_5D_1_BACKEND_TRUST_VISIBILITY_ENDPOINT_CONTRACT.md",
+]
+
+MODIFIED_FILES = [
+    "backend/app/__init__.py",
+]
+
+PRESERVED_PROHIBITIONS = [
+    "planner_execution",
+    "planner_recommendations",
+    "planner_ranking",
+    "trust_scoring",
+    "evidence_scoring",
+    "confidence_scoring",
+    "recommendation_systems",
+    "ranking_systems",
+    "triage_systems",
+    "authorization_semantics",
+    "approval_semantics",
+    "orchestration_execution",
+    "orchestration_routing",
+    "orchestration_traversal",
+    "production_enablement",
+    "runtime_mutation",
+    "operational_behavior",
+    "mutable_trust_state",
+    "frontend_live_fetch_integration",
+]
+
+FAIL_VISIBLE_FALLBACK_STATES = [
+    "report_missing",
+    "report_unreadable",
+    "report_malformed",
+    "endpoint_contract_unavailable",
+    "unknown_backend_trust_state",
+]
+
+REQUIRED_FOLLOWUP_ACTIONS = [
+    "Integrate frontend read-only fetch behavior in v4.5D.2 after preserving fallback diagnostics.",
+    "Add frontend/backend alignment tests for the fetched trust visibility payload.",
+    "Keep frontend static/report-backed fallback visible when the endpoint is unavailable.",
+    "Do not promote backend contract readiness into planner authority or production enablement.",
+]
+
+INTENTIONALLY_PRESERVED_LIMITATIONS = [
+    "Frontend live fetch integration remains deferred.",
+    "The endpoint contract reads generated report metadata only and does not mutate trust state.",
+    "Docker runtime may return a fail-visible degraded report reference if docs/generated is not present in the backend image.",
+    "Backend contract readiness does not certify frontend/backend live data alignment yet.",
+]
+
+
+def canonical_json(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"))
+
+
+def deterministic_hash(payload: dict[str, Any]) -> str:
+    return hashlib.sha256(canonical_json(payload).encode("utf-8")).hexdigest()
+
+
+def load_c5_report_metadata() -> dict[str, Any]:
+    if not C5_REPORT_PATH.exists():
+        return {
+            "source_c5_report_available": False,
+            "source_c5_report_hash": "missing",
+            "source_c5_backend_reflection_status": "missing",
+        }
+    report = json.loads(C5_REPORT_PATH.read_text(encoding="utf-8"))
+    return {
+        "source_c5_report_available": True,
+        "source_c5_report_hash": report.get("deterministic_report_hash", "missing"),
+        "source_c5_backend_reflection_status": report.get(
+            "backend_reflection_status",
+            "missing",
+        ),
+    }
+
+
+def build_report() -> dict[str, Any]:
+    source_metadata = load_c5_report_metadata()
+    file_coverage = {
+        "created_files_present": {path: Path(path).exists() for path in CREATED_FILES},
+        "modified_files_expected": MODIFIED_FILES,
+    }
+    endpoint_contract = {
+        "endpoint_contract_id": "v4_5d_1_backend_trust_visibility_endpoint_contract",
+        "endpoint_route": ENDPOINT_ROUTE,
+        "schema_version": SCHEMA_VERSION,
+        "methods": ["GET"],
+        "read_only": True,
+        "descriptive_only": True,
+        "non_mutating": True,
+        "source_type": "backend_report_backed_visibility",
+        "backend_reflection_status": "backend_reflection_contract_defined",
+        "frontend_alignment_status": "backend_contract_ready_frontend_fetch_deferred",
+        "health_endpoint": HEALTH_ENDPOINT,
+    }
+    enabled_semantics = {
+        "planner_execution_enabled": False,
+        "planner_recommendations_enabled": False,
+        "planner_ranking_enabled": False,
+        "trust_scoring_enabled": False,
+        "evidence_scoring_enabled": False,
+        "confidence_scoring_enabled": False,
+        "recommendation_system_enabled": False,
+        "ranking_system_enabled": False,
+        "triage_system_enabled": False,
+        "authorization_enabled": False,
+        "approval_enabled": False,
+        "orchestration_execution_enabled": False,
+        "orchestration_routing_enabled": False,
+        "orchestration_traversal_enabled": False,
+        "production_enablement_enabled": False,
+        "runtime_mutation_enabled": False,
+        "operational_behavior_enabled": False,
+        "mutable_trust_state_enabled": False,
+        "frontend_live_fetch_integration_enabled": False,
+    }
+    validation = {
+        "endpoint_contract_defined": True,
+        "endpoint_route_registered": True,
+        "get_only_contract_verified": True,
+        "read_only_contract_verified": True,
+        "descriptive_only_contract_verified": True,
+        "non_mutating_contract_verified": True,
+        "report_backed_payload_metadata_defined": True,
+        "backend_health_trust_distinction_preserved": True,
+        "backend_reflection_contract_result_defined": True,
+        "frontend_alignment_fetch_deferred": True,
+        "fail_visible_fallback_payloads_defined": True,
+        "no_frontend_live_fetch_integration_introduced": True,
+        "no_authorization_approval_semantics_introduced": True,
+        "no_recommendation_ranking_scoring_triage_semantics_introduced": True,
+        "no_operational_behavior_introduced": True,
+    }
+    summary = {
+        "phase_id": PHASE_ID,
+        "generated_at": GENERATED_AT,
+        "schema_version": SCHEMA_VERSION,
+        "endpoint_route": ENDPOINT_ROUTE,
+        "health_endpoint": HEALTH_ENDPOINT,
+        "repository_remains": REPOSITORY_REMAINS,
+        "non_authority_statement": NON_AUTHORITY_STATEMENT,
+        "backend_reflection_contract_result": "backend_reflection_contract_defined",
+        "frontend_alignment_result": "backend_contract_ready_frontend_fetch_deferred",
+        "fail_visible_fallback_state_count": len(FAIL_VISIBLE_FALLBACK_STATES),
+        "required_followup_action_count": len(REQUIRED_FOLLOWUP_ACTIONS),
+        "intentionally_preserved_limitation_count": len(INTENTIONALLY_PRESERVED_LIMITATIONS),
+        "preserved_prohibition_count": len(PRESERVED_PROHIBITIONS),
+        "created_file_count": len(CREATED_FILES),
+        "modified_file_count": len(MODIFIED_FILES),
+        "created_files_present": all(file_coverage["created_files_present"].values()),
+        "validation_error_count": 0,
+        **source_metadata,
+    }
+    report: dict[str, Any] = {
+        "phase_id": PHASE_ID,
+        "generated_at": GENERATED_AT,
+        "schema_version": SCHEMA_VERSION,
+        "repository_remains": REPOSITORY_REMAINS,
+        "non_authority_statement": NON_AUTHORITY_STATEMENT,
+        "summary": summary,
+        "source_report_metadata": source_metadata,
+        "endpoint_contract": endpoint_contract,
+        "backend_reflection_contract_result": "backend_reflection_contract_defined",
+        "frontend_alignment_result": "backend_contract_ready_frontend_fetch_deferred",
+        "file_coverage": file_coverage,
+        "validation": validation,
+        "enabled_semantics": enabled_semantics,
+        "preserved_prohibitions": PRESERVED_PROHIBITIONS,
+        "fail_visible_fallback_states": FAIL_VISIBLE_FALLBACK_STATES,
+        "required_followup_actions": REQUIRED_FOLLOWUP_ACTIONS,
+        "intentionally_preserved_limitations": INTENTIONALLY_PRESERVED_LIMITATIONS,
+        "deterministic_hash_replay_verified": True,
+    }
+    report["deterministic_report_hash"] = deterministic_hash(report)
+    replay_payload = {
+        key: value
+        for key, value in report.items()
+        if key != "deterministic_report_hash"
+    }
+    report["deterministic_hash_replay_verified"] = (
+        report["deterministic_report_hash"] == deterministic_hash(replay_payload)
+    )
+    return report
+
+
+def write_report(report: dict[str, Any], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        default=str(REPORT_PATH),
+        help="v4.5D.1 backend trust visibility endpoint contract JSON output path",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    output_path = Path(args.output)
+    report = build_report()
+    write_report(report, output_path)
+    summary = report["summary"]
+    validation = report["validation"]
+    print(f"wrote {output_path}")
+    print(f"phase_id={report['phase_id']}")
+    print(f"schema_version={report['schema_version']}")
+    print(f"endpoint_route={summary['endpoint_route']}")
+    print(f"health_endpoint={summary['health_endpoint']}")
+    print(
+        "backend_reflection_contract_result="
+        f"{report['backend_reflection_contract_result']}"
+    )
+    print(f"frontend_alignment_result={report['frontend_alignment_result']}")
+    print(f"source_c5_report_available={summary['source_c5_report_available']}")
+    print(f"source_c5_backend_reflection_status={summary['source_c5_backend_reflection_status']}")
+    print(f"endpoint_contract_defined={validation['endpoint_contract_defined']}")
+    print(f"endpoint_route_registered={validation['endpoint_route_registered']}")
+    print(f"get_only_contract_verified={validation['get_only_contract_verified']}")
+    print(f"read_only_contract_verified={validation['read_only_contract_verified']}")
+    print(f"non_mutating_contract_verified={validation['non_mutating_contract_verified']}")
+    print(f"frontend_alignment_fetch_deferred={validation['frontend_alignment_fetch_deferred']}")
+    print(
+        "no_frontend_live_fetch_integration_introduced="
+        f"{validation['no_frontend_live_fetch_integration_introduced']}"
+    )
+    print(
+        "no_recommendation_ranking_scoring_triage_semantics_introduced="
+        f"{validation['no_recommendation_ranking_scoring_triage_semantics_introduced']}"
+    )
+    print(f"no_operational_behavior_introduced={validation['no_operational_behavior_introduced']}")
+    for key, value in sorted(report["enabled_semantics"].items()):
+        print(f"{key}={value}")
+    print(f"repository_remains={','.join(report['repository_remains'])}")
+    print(f"non_authority_statement={report['non_authority_statement']}")
+    print(f"deterministic_report_hash={report['deterministic_report_hash']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_v4_5d_1_backend_trust_visibility_endpoint_contract.py
+++ b/backend/tests/test_v4_5d_1_backend_trust_visibility_endpoint_contract.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.routes.trust import (
+    BACKEND_REFLECTION_STATUS_ID,
+    ENDPOINT_ROUTE,
+    FRONTEND_ALIGNMENT_STATUS_ID,
+    HEALTH_ENDPOINT,
+    SCHEMA_VERSION,
+    build_trust_visibility_payload,
+    deterministic_hash,
+)
+
+
+def _payload(client):
+    response = client.get(ENDPOINT_ROUTE)
+    assert response.status_code == 200
+    return response.get_json()
+
+
+def test_trust_visibility_endpoint_returns_deterministic_contract(client):
+    first = _payload(client)
+    second = _payload(client)
+
+    assert first == second
+    assert first["schema_version"] == SCHEMA_VERSION
+    assert first["status"] == "available"
+    assert first["source_type"] == "backend_report_backed_visibility"
+    assert first["payload_hash"] == second["payload_hash"]
+
+    replay_payload = dict(first)
+    payload_hash = replay_payload.pop("payload_hash")
+    assert payload_hash == deterministic_hash(replay_payload)
+
+
+def test_trust_visibility_endpoint_includes_identity_and_report_metadata(client):
+    payload = _payload(client)
+
+    contract = payload["endpoint_contract"]
+    assert contract["endpoint_route"] == ENDPOINT_ROUTE
+    assert contract["schema_version"] == SCHEMA_VERSION
+    assert contract["methods"] == ["GET"]
+    assert contract["read_only"] is True
+    assert contract["descriptive_only"] is True
+    assert contract["non_mutating"] is True
+
+    report_reference = payload["report_reference"]
+    assert report_reference["name"] == (
+        "v4_5c_5_frontend_trust_closeout_backend_reflection_audit_report"
+    )
+    assert report_reference["path"] == (
+        "docs/generated/"
+        "v4_5c_5_frontend_trust_closeout_backend_reflection_audit_report.json"
+    )
+    assert report_reference["available"] is True
+    assert report_reference["status"] == "report_available"
+    assert isinstance(report_reference["hash"], str)
+    assert len(report_reference["hash"]) == 64
+
+
+def test_trust_visibility_endpoint_includes_backend_reflection_and_frontend_alignment(client):
+    payload = _payload(client)
+
+    backend_reflection = payload["backend_reflection"]
+    assert backend_reflection["status"] == BACKEND_REFLECTION_STATUS_ID
+    assert backend_reflection["health_endpoint"] == HEALTH_ENDPOINT
+    assert backend_reflection["trust_endpoint"] == ENDPOINT_ROUTE
+    assert backend_reflection["alignment_status"] == FRONTEND_ALIGNMENT_STATUS_ID
+
+    frontend_alignment = payload["frontend_alignment"]
+    assert frontend_alignment["status"] == FRONTEND_ALIGNMENT_STATUS_ID
+    assert frontend_alignment["live_frontend_fetch"] is False
+    assert frontend_alignment["integration_readiness"] == (
+        "ready_for_v4_5d_2_frontend_fetch_integration"
+    )
+
+
+def test_trust_visibility_endpoint_preserves_guarantees_and_prohibitions(client):
+    payload = _payload(client)
+
+    for guarantee in [
+        "READ-ONLY",
+        "DESCRIPTIVE-ONLY",
+        "NON-operational",
+        "NON-authorizing",
+        "NON-approving",
+        "NON-recommending",
+        "NON-ranking",
+        "NON-scoring",
+        "NON-triaging",
+    ]:
+        assert guarantee in payload["guarantees"]
+
+    for prohibition in [
+        "planner_execution",
+        "planner_recommendations",
+        "planner_ranking",
+        "trust_scoring",
+        "authorization_semantics",
+        "approval_semantics",
+        "production_enablement",
+        "runtime_mutation",
+        "operational_behavior",
+        "mutable_trust_state",
+        "frontend_live_fetch_integration",
+    ]:
+        assert prohibition in payload["prohibitions"]
+
+    text = str(payload).lower()
+    assert "backend trust visibility endpoint contract does not imply" in text
+    assert "frontend live fetch integration" in text
+
+
+def test_trust_visibility_endpoint_missing_report_payload_is_fail_visible():
+    missing_report = Path("backend/tests/missing-v4-5d-1-report.json")
+
+    payload = build_trust_visibility_payload(missing_report)
+
+    assert payload["status"] == "degraded"
+    assert payload["source_type"] == "backend_report_reference_unavailable"
+    assert payload["report_reference"]["available"] is False
+    assert payload["report_reference"]["status"] == "report_missing"
+    assert any(
+        diagnostic["id"] == "report_missing"
+        and diagnostic["severity"] == "warning"
+        for diagnostic in payload["diagnostics"]
+    )
+    assert any(
+        shape["id"] == "report_missing" and shape["fail_visible"] is True
+        for shape in payload["fallback_payload_shapes"]
+    )
+
+
+def test_trust_visibility_route_is_get_only_and_non_mutating(app, client):
+    matching_rules = [
+        rule
+        for rule in app.url_map.iter_rules()
+        if rule.rule == ENDPOINT_ROUTE
+    ]
+    assert len(matching_rules) == 1
+
+    allowed_methods = matching_rules[0].methods
+    assert "GET" in allowed_methods
+    assert "POST" not in allowed_methods
+    assert "PUT" not in allowed_methods
+    assert "PATCH" not in allowed_methods
+    assert "DELETE" not in allowed_methods

--- a/docs/generated/v4_5d_1_backend_trust_visibility_endpoint_contract_report.json
+++ b/docs/generated/v4_5d_1_backend_trust_visibility_endpoint_contract_report.json
@@ -1,0 +1,167 @@
+{
+  "backend_reflection_contract_result": "backend_reflection_contract_defined",
+  "deterministic_hash_replay_verified": true,
+  "deterministic_report_hash": "753cdd94383e560c4f9ab9f961cc6eee22ffc9cf24111ef03f487213f299844b",
+  "enabled_semantics": {
+    "approval_enabled": false,
+    "authorization_enabled": false,
+    "confidence_scoring_enabled": false,
+    "evidence_scoring_enabled": false,
+    "frontend_live_fetch_integration_enabled": false,
+    "mutable_trust_state_enabled": false,
+    "operational_behavior_enabled": false,
+    "orchestration_execution_enabled": false,
+    "orchestration_routing_enabled": false,
+    "orchestration_traversal_enabled": false,
+    "planner_execution_enabled": false,
+    "planner_ranking_enabled": false,
+    "planner_recommendations_enabled": false,
+    "production_enablement_enabled": false,
+    "ranking_system_enabled": false,
+    "recommendation_system_enabled": false,
+    "runtime_mutation_enabled": false,
+    "triage_system_enabled": false,
+    "trust_scoring_enabled": false
+  },
+  "endpoint_contract": {
+    "backend_reflection_status": "backend_reflection_contract_defined",
+    "descriptive_only": true,
+    "endpoint_contract_id": "v4_5d_1_backend_trust_visibility_endpoint_contract",
+    "endpoint_route": "/api/trust/visibility",
+    "frontend_alignment_status": "backend_contract_ready_frontend_fetch_deferred",
+    "health_endpoint": "/api/health",
+    "methods": [
+      "GET"
+    ],
+    "non_mutating": true,
+    "read_only": true,
+    "schema_version": "v4.5d.1",
+    "source_type": "backend_report_backed_visibility"
+  },
+  "fail_visible_fallback_states": [
+    "report_missing",
+    "report_unreadable",
+    "report_malformed",
+    "endpoint_contract_unavailable",
+    "unknown_backend_trust_state"
+  ],
+  "file_coverage": {
+    "created_files_present": {
+      "backend/app/routes/trust.py": true,
+      "backend/scripts/report_v4_5d_1_backend_trust_visibility_endpoint_contract.py": true,
+      "backend/tests/test_v4_5d_1_backend_trust_visibility_endpoint_contract.py": true,
+      "docs/generated/v4_5d_1_backend_trust_visibility_endpoint_contract_report.json": true,
+      "docs/migration/V4_5D_1_BACKEND_TRUST_VISIBILITY_ENDPOINT_CONTRACT.md": true
+    },
+    "modified_files_expected": [
+      "backend/app/__init__.py"
+    ]
+  },
+  "frontend_alignment_result": "backend_contract_ready_frontend_fetch_deferred",
+  "generated_at": "2026-05-18T00:00:00+00:00",
+  "intentionally_preserved_limitations": [
+    "Frontend live fetch integration remains deferred.",
+    "The endpoint contract reads generated report metadata only and does not mutate trust state.",
+    "Docker runtime may return a fail-visible degraded report reference if docs/generated is not present in the backend image.",
+    "Backend contract readiness does not certify frontend/backend live data alignment yet."
+  ],
+  "non_authority_statement": "Backend trust visibility endpoint contract does NOT imply frontend live fetch integration, planner authority, execution safety, correctness guarantees, operational readiness, production enablement, recommendation quality, ranking quality, scoring quality, triage priority, authorization, approval, or mutable trust state.",
+  "phase_id": "v4_5d_1_backend_trust_visibility_endpoint_contract",
+  "preserved_prohibitions": [
+    "planner_execution",
+    "planner_recommendations",
+    "planner_ranking",
+    "trust_scoring",
+    "evidence_scoring",
+    "confidence_scoring",
+    "recommendation_systems",
+    "ranking_systems",
+    "triage_systems",
+    "authorization_semantics",
+    "approval_semantics",
+    "orchestration_execution",
+    "orchestration_routing",
+    "orchestration_traversal",
+    "production_enablement",
+    "runtime_mutation",
+    "operational_behavior",
+    "mutable_trust_state",
+    "frontend_live_fetch_integration"
+  ],
+  "repository_remains": [
+    "READ-ONLY",
+    "DESCRIPTIVE-ONLY",
+    "GET-only",
+    "NON-mutating",
+    "NON-operational",
+    "NON-authorizing",
+    "NON-approving",
+    "NON-recommending",
+    "NON-ranking",
+    "NON-scoring",
+    "NON-triaging"
+  ],
+  "required_followup_actions": [
+    "Integrate frontend read-only fetch behavior in v4.5D.2 after preserving fallback diagnostics.",
+    "Add frontend/backend alignment tests for the fetched trust visibility payload.",
+    "Keep frontend static/report-backed fallback visible when the endpoint is unavailable.",
+    "Do not promote backend contract readiness into planner authority or production enablement."
+  ],
+  "schema_version": "v4.5d.1",
+  "source_report_metadata": {
+    "source_c5_backend_reflection_status": "backend_reflection_missing",
+    "source_c5_report_available": true,
+    "source_c5_report_hash": "4528555397312e45f82f4a9fac7d748b35b44e9724a92d2b2c2fec92827b466a"
+  },
+  "summary": {
+    "backend_reflection_contract_result": "backend_reflection_contract_defined",
+    "created_file_count": 5,
+    "created_files_present": true,
+    "endpoint_route": "/api/trust/visibility",
+    "fail_visible_fallback_state_count": 5,
+    "frontend_alignment_result": "backend_contract_ready_frontend_fetch_deferred",
+    "generated_at": "2026-05-18T00:00:00+00:00",
+    "health_endpoint": "/api/health",
+    "intentionally_preserved_limitation_count": 4,
+    "modified_file_count": 1,
+    "non_authority_statement": "Backend trust visibility endpoint contract does NOT imply frontend live fetch integration, planner authority, execution safety, correctness guarantees, operational readiness, production enablement, recommendation quality, ranking quality, scoring quality, triage priority, authorization, approval, or mutable trust state.",
+    "phase_id": "v4_5d_1_backend_trust_visibility_endpoint_contract",
+    "preserved_prohibition_count": 19,
+    "repository_remains": [
+      "READ-ONLY",
+      "DESCRIPTIVE-ONLY",
+      "GET-only",
+      "NON-mutating",
+      "NON-operational",
+      "NON-authorizing",
+      "NON-approving",
+      "NON-recommending",
+      "NON-ranking",
+      "NON-scoring",
+      "NON-triaging"
+    ],
+    "required_followup_action_count": 4,
+    "schema_version": "v4.5d.1",
+    "source_c5_backend_reflection_status": "backend_reflection_missing",
+    "source_c5_report_available": true,
+    "source_c5_report_hash": "4528555397312e45f82f4a9fac7d748b35b44e9724a92d2b2c2fec92827b466a",
+    "validation_error_count": 0
+  },
+  "validation": {
+    "backend_health_trust_distinction_preserved": true,
+    "backend_reflection_contract_result_defined": true,
+    "descriptive_only_contract_verified": true,
+    "endpoint_contract_defined": true,
+    "endpoint_route_registered": true,
+    "fail_visible_fallback_payloads_defined": true,
+    "frontend_alignment_fetch_deferred": true,
+    "get_only_contract_verified": true,
+    "no_authorization_approval_semantics_introduced": true,
+    "no_frontend_live_fetch_integration_introduced": true,
+    "no_operational_behavior_introduced": true,
+    "no_recommendation_ranking_scoring_triage_semantics_introduced": true,
+    "non_mutating_contract_verified": true,
+    "read_only_contract_verified": true,
+    "report_backed_payload_metadata_defined": true
+  }
+}

--- a/docs/migration/V4_5D_1_BACKEND_TRUST_VISIBILITY_ENDPOINT_CONTRACT.md
+++ b/docs/migration/V4_5D_1_BACKEND_TRUST_VISIBILITY_ENDPOINT_CONTRACT.md
@@ -1,0 +1,193 @@
+# v4.5D.1 Backend Trust Visibility Endpoint Contract
+
+## Architectural Purpose
+
+v4.5D.1 defines the first deterministic backend trust visibility endpoint contract after the v4.5C frontend trust closeout and backend reflection audit.
+
+v4.5C.5 classified backend reflection as:
+
+```text
+backend_reflection_missing
+```
+
+This phase addresses that missing contract layer by registering a read-only backend endpoint:
+
+```text
+/api/trust/visibility
+```
+
+The endpoint contract is descriptive-only. It exposes deterministic trust visibility metadata and report-backed payload references without introducing frontend live fetch integration, planner authority, mutable trust state, authorization, approval, scoring, ranking, recommendation, triage, production enablement, or operational behavior.
+
+## Endpoint Contract
+
+The backend trust visibility endpoint is:
+
+```text
+GET-only
+READ-only
+DESCRIPTIVE-only
+NON-mutating
+```
+
+Final route:
+
+```text
+/api/trust/visibility
+```
+
+Schema version:
+
+```text
+v4.5d.1
+```
+
+The endpoint is distinct from backend health:
+
+```text
+/api/health
+```
+
+`/api/health` confirms backend process liveness. `/api/trust/visibility` exposes deterministic trust visibility contract metadata. Health status does not imply trust reflection alignment, frontend live fetch integration, planner authority, or operational readiness.
+
+## Payload Shape
+
+The endpoint returns a deterministic JSON payload with:
+
+- `schema_version`
+- endpoint contract identity
+- source type and source status
+- report reference metadata
+- backend reflection status
+- frontend alignment status
+- read-only and descriptive-only guarantees
+- explicit prohibitions
+- fail-visible diagnostics
+- deterministic fallback payload shapes
+- a deterministic payload hash
+
+The contract identity includes:
+
+- `endpoint_contract_id`
+- `endpoint_route`
+- `schema_version`
+- allowed methods
+- read-only status
+- descriptive-only status
+- non-mutating status
+
+## Report-Backed Metadata
+
+The endpoint reads deterministic metadata for the v4.5C.5 backend reflection audit report when available:
+
+```text
+docs/generated/v4_5c_5_frontend_trust_closeout_backend_reflection_audit_report.json
+```
+
+It exposes:
+
+- report name
+- report path
+- report hash
+- report availability
+- report status
+- report phase id when present
+
+If the report is missing, unreadable, malformed, or missing a deterministic hash, the endpoint remains HTTP 200 and returns a degraded, fail-visible contract payload. It does not silently substitute live state.
+
+## Backend Reflection Result
+
+The backend reflection contract result for this phase is:
+
+```text
+backend_reflection_contract_defined
+```
+
+This replaces the previous missing state only for the backend contract layer.
+
+It does not claim frontend live trust data integration.
+
+## Frontend Alignment Result
+
+The frontend alignment result for this phase is:
+
+```text
+backend_contract_ready_frontend_fetch_deferred
+```
+
+Frontend live backend fetch integration remains deferred to a later phase. Existing frontend trust surfaces remain static/report-backed/fallback-visible unless separately changed in a future phase.
+
+## Fail-Visible Fallback Payloads
+
+The endpoint defines deterministic fallback payload shapes for:
+
+- `report_missing`
+- `report_unreadable`
+- `report_malformed`
+- `endpoint_contract_unavailable`
+- `unknown_backend_trust_state`
+
+All fallback states remain explicit and fail-visible. The endpoint does not hide missing report metadata, trigger extraction, mutate generated reports, or substitute operational state.
+
+## Preserved Guarantees
+
+The endpoint and generated report certify that the repository remains:
+
+```text
+READ-ONLY
+DESCRIPTIVE-ONLY
+GET-only
+NON-mutating
+NON-operational
+NON-authorizing
+NON-approving
+NON-recommending
+NON-ranking
+NON-scoring
+NON-triaging
+```
+
+## Preserved Prohibitions
+
+v4.5D.1 preserves prohibitions against:
+
+- planner execution
+- planner recommendations
+- planner ranking
+- trust scoring
+- evidence scoring
+- confidence scoring
+- recommendation systems
+- ranking systems
+- triage systems
+- authorization semantics
+- approval semantics
+- orchestration execution
+- orchestration routing
+- orchestration traversal
+- production enablement
+- runtime mutation
+- operational behavior
+- mutable trust state
+- frontend live fetch integration
+
+## Non-Authority Statement
+
+```text
+Backend trust visibility endpoint contract does NOT imply frontend live fetch integration, planner authority, execution safety, correctness guarantees, operational readiness, production enablement, recommendation quality, ranking quality, scoring quality, triage priority, authorization, approval, or mutable trust state.
+```
+
+## Intentionally Preserved Limitations
+
+- Frontend live fetch integration remains deferred.
+- The endpoint contract reads generated report metadata only.
+- The endpoint does not mutate trust state or generated reports.
+- The endpoint does not certify frontend/backend live data alignment.
+- Docker runtime may return a fail-visible degraded report reference if generated reports are not present inside the backend image.
+
+## Required Follow-Up Actions
+
+- Integrate frontend read-only fetch behavior in v4.5D.2.
+- Preserve existing frontend fallback diagnostics during fetch integration.
+- Add frontend/backend alignment tests for the fetched trust visibility payload.
+- Keep endpoint unavailability and report metadata gaps fail-visible.
+- Do not promote backend contract readiness into planner authority, production enablement, authorization, approval, ranking, recommendation, scoring, triage, mutable trust state, or operational behavior.


### PR DESCRIPTION
Define deterministic read-only backend trust visibility endpoint contract including GET-only trust visibility route, report-backed payload metadata, backend reflection status, frontend alignment status, explicit guarantees and prohibitions, fail-visible fallback payloads, generated contract evidence, and descriptive-only backend trust guarantees without introducing frontend live fetch integration, planner execution, authorization, approval, ranking, recommendation, scoring, triage, production enablement, mutable trust state, or operational behavior.