### PR TITLE
docs: align data dependency governance

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4,7 +4,7 @@
 
 ## System Overview
 
-The Forge is a simulation-driven analysis platform for Last Epoch. The backend is the single source of truth for all calculations -- the frontend sends input, receives results, and renders UI.
+The Forge is a simulation-driven analysis platform for Last Epoch. The backend is the single source of truth for all **calculations** -- the frontend sends input, receives results, and renders UI. For **game data**, the canonical source of truth is the upstream `last-epoch-data` extraction repo, which The Forge consumes (see [`docs/DATA_DEPENDENCY.md`](docs/DATA_DEPENDENCY.md)).
 
 The system follows a layered architecture:
 
@@ -105,12 +105,15 @@ Services orchestrate between engines, database, and external systems.
 
 ### Data Pipeline
 
-Game data flows from extraction to engines:
+Game data is **extracted upstream** in the `last-epoch-data` repo (the canonical
+source of truth); The Forge ingests and normalizes the upstream-generated exports
+rather than being the authoritative extractor (see [`docs/DATA_DEPENDENCY.md`](docs/DATA_DEPENDENCY.md)).
+Data then flows to engines:
 
 ```
-Last Epoch game files
-  --> scripts/sync_game_data.py (extraction + normalization)
-    --> /data/ directory (canonical JSON files)
+last-epoch-data (upstream extraction / generation — source of truth)
+  --> scripts/sync_game_data.py (ingest + normalization in le-the-forge)
+    --> /data/ directory (synced JSON files)
       --> app/game_data/ loader (startup)
         --> AffixRegistry, SkillRegistry, EnemyRegistry
           --> Engines (pure calculation)
@@ -250,7 +253,11 @@ data/
 
 ### Data Sync Pipeline
 
-`scripts/sync_game_data.py` transforms raw exports from `last-epoch-data/` into normalized JSON files in `/data/`. It handles:
+`last-epoch-data` is the upstream extraction/generation source of truth.
+`scripts/sync_game_data.py` **ingests** its generated exports and normalizes them
+into JSON files in `/data/` — The Forge consumes trusted generated artifacts
+rather than authoring the extraction (see [`docs/DATA_DEPENDENCY.md`](docs/DATA_DEPENDENCY.md)).
+It handles:
 - Affix normalization (1,160+ equipment + idol affixes with tier conversion)
 - Passive tree node generation with namespaced IDs and layout coordinates
 - Skill metadata extraction

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 - **Live at** [epochforge.gg](https://epochforge.gg) since 2026-04-21
 - **Game data synced to:** patch 1.4.3, Season 4 (last sync 2026-04-21)
 - **Tests:** 10,865 passing / 377 skipped
-- **Upstream data foundation:** trusted Last Epoch game data is sourced from the companion `last-epoch-data` extraction/compiler repo (the canonical source of truth). The trusted-data rebuild and its current coverage state are tracked in [`docs/migration/TRUSTED_GAMEPLAY_DATA_COVERAGE_AUDIT.md`](docs/migration/TRUSTED_GAMEPLAY_DATA_COVERAGE_AUDIT.md).
+- **Upstream data foundation:** trusted Last Epoch game data is sourced from the companion `last-epoch-data` extraction/compiler repo (the canonical source of truth). The Forge is a downstream consumer — see [`docs/DATA_DEPENDENCY.md`](docs/DATA_DEPENDENCY.md) for the dependency chain, and [`docs/migration/TRUSTED_GAMEPLAY_DATA_COVERAGE_AUDIT.md`](docs/migration/TRUSTED_GAMEPLAY_DATA_COVERAGE_AUDIT.md) for the current (partial) coverage state.
 - **[See known limitations →](docs/KNOWN_LIMITATIONS.md)**
 
 <p align="center">
@@ -24,15 +24,22 @@
 
 ## What Is The Forge
 
-The Forge is a build analysis platform for Last Epoch. It takes a character build — class, mastery, passive tree, skill specializations, and gear — and runs it through a deterministic simulation engine to produce DPS numbers, survivability scores, crafting probability curves, and upgrade recommendations. If you have ever wondered whether swapping an affix or reallocating a passive node actually makes your build stronger, The Forge gives you a concrete answer.
+The Forge is a build analysis platform for Last Epoch. It takes a character build — class, mastery, passive tree, skill specializations, and gear — and runs it through a deterministic simulation engine to produce DPS numbers, survivability scores, crafting probability curves, and upgrade suggestions. If you have ever wondered whether swapping an affix or reallocating a passive node actually makes your build stronger, The Forge gives you a deterministic, inspectable answer for the game data it currently has.
 
-Unlike build planners that stop at showing stat totals, The Forge simulates the full combat loop: skill execution, crit weighting, Monte Carlo damage variance, boss encounter phases, mana gating, and enemy-specific resistance and armour mitigation. The goal is mechanical accuracy — every number traces back to a formula you can inspect, and the engine runs the same calculation every time for the same inputs.
+Unlike build planners that stop at showing stat totals, The Forge simulates the full combat loop: skill execution, crit weighting, Monte Carlo damage variance, boss encounter phases, mana gating, and enemy-specific resistance and armour mitigation. The engine is deterministic — every number traces back to a formula you can inspect, and the same inputs always produce the same result. Accuracy, however, is bounded by the trust of the underlying game data, which is **partial** and is being rebuilt upstream in `last-epoch-data` (see [`docs/DATA_DEPENDENCY.md`](docs/DATA_DEPENDENCY.md)).
 
-The project is currently at **v0.8.0** and went live at [epochforge.gg](https://epochforge.gg) on 2026-04-21. The core simulation pipeline is stable and backed by 10,865 tests, but some input data — particularly skill base damage values and enemy armour profiles — are benchmarked approximations rather than verified game extracts. These are noted honestly throughout the tool, in the [Known Limitations](#known-limitations-beta) section below, and in the dedicated [transparency document](docs/KNOWN_LIMITATIONS.md). Community validation of these values is actively sought and is one of the most impactful ways to contribute.
+The project is currently at **v0.8.0** and went live at [epochforge.gg](https://epochforge.gg) on 2026-04-21. The simulation pipeline is deterministic and backed by 10,865 tests, but mechanical coverage is **not complete** and trusted-data certification is in progress: some input data — particularly skill base damage values and enemy armour profiles — are benchmarked approximations rather than verified game extracts. Optimization, upgrade, and ranking outputs are **advisory** and bounded by that data confidence; they are not yet certified against trusted upstream data. These limits are noted honestly throughout the tool, in the [Known Limitations](#known-limitations-beta) section below, and in the dedicated [transparency document](docs/KNOWN_LIMITATIONS.md). The full dependency and trust model lives in [`docs/DATA_DEPENDENCY.md`](docs/DATA_DEPENDENCY.md). Community validation of these values is actively sought and is one of the most impactful ways to contribute.
 
 ---
 
 ## Features
+
+> The features below describe the deterministic engine surface. Their accuracy is
+> bounded by the confidence of the underlying game data (see [Data Confidence](#data-confidence)
+> and [`docs/DATA_DEPENDENCY.md`](docs/DATA_DEPENDENCY.md)). Optimization, upgrade,
+> ranking, and recommendation outputs are **advisory** and are not yet certified
+> against trusted upstream `last-epoch-data` artifacts. Mechanical coverage across
+> Last Epoch systems is **partial** — see [Known Limitations](#known-limitations-beta).
 
 ### Core Analysis
 
@@ -215,7 +222,7 @@ le-the-forge/
 
 ### Data Sources
 
-The `data/` directory contains canonical game data extracted from Last Epoch and normalized into JSON:
+Game data originates upstream in the `last-epoch-data` extraction/compiler repo (the canonical source of truth); The Forge **ingests** it rather than being the authoritative extractor. The local `data/` directory holds the synced, normalized JSON consumed by the backend (see [`docs/DATA_DEPENDENCY.md`](docs/DATA_DEPENDENCY.md)):
 
 - **`data/classes/`** — class definitions with base stats, passive tree nodes with layout coordinates, skill metadata, and skill specialization trees
 - **`data/items/`** — 1,160+ affixes with tier ranges, base items, uniques, crafting rules, implicit stats, and rarity definitions
@@ -224,7 +231,7 @@ The `data/` directory contains canonical game data extracted from Last Epoch and
 
 ### Versioning and Updates
 
-Game data is synced from Last Epoch exports using `scripts/sync_game_data.py`, which normalizes raw data into the `/data/` JSON schema. The current data tracks **patch 1.4.3, Season 4**. After a game patch, re-run the sync script and validate:
+Game data is synced from upstream `last-epoch-data` exports using `scripts/sync_game_data.py`, which normalizes the upstream-generated data into the `/data/` JSON schema. The current data tracks **patch 1.4.3, Season 4**. After a game patch, re-sync from upstream and validate:
 
 ```bash
 cd backend
@@ -338,7 +345,7 @@ The Forge is live in beta and is honest about what is not yet complete. The full
 
 ## Roadmap
 
-Phases 1–9 are complete. Phase 9 (Deploy & Launch) landed on 2026-04-21 with production live at [epochforge.gg](https://epochforge.gg) on Render + Cloudflare.
+Phases 1–9 (engine and feature **implementation**) are complete; Phase 9 (Deploy & Launch) landed on 2026-04-21 with production live at [epochforge.gg](https://epochforge.gg) on Render + Cloudflare. Implementation-complete is distinct from **trusted mechanical coverage**, which is a separate in-progress track gated on upstream `last-epoch-data` certification (see [`ROADMAP.md`](ROADMAP.md) and [`docs/DATA_DEPENDENCY.md`](docs/DATA_DEPENDENCY.md)). The optimization, encounter-optimization, and AI recommendation phases below are gated behind upstream trusted data and downstream consumption certification.
 
 **Post-launch priorities:**
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,18 @@
 
 ---
 
-## Completed
+> **Trust-first framing.** The "Completed" phases below describe **engine and
+> feature implementation** in the deployed v0.8 build. Implementation-complete is
+> distinct from **trusted mechanical coverage**: game data originates upstream in
+> the `last-epoch-data` extraction repo, and trusted/certified coverage is a
+> separate in-progress track (the V2.5 → V4.5 trusted-data rebuild). Optimization,
+> recommendation, ranking, scoring, and simulation outputs are **advisory** and
+> bounded by upstream data confidence — they are not certified ground truth until
+> upstream trusted data **and** downstream consumption certification support them.
+> See [`docs/DATA_DEPENDENCY.md`](docs/DATA_DEPENDENCY.md) and
+> [`docs/migration/TRUSTED_GAMEPLAY_DATA_COVERAGE_AUDIT.md`](docs/migration/TRUSTED_GAMEPLAY_DATA_COVERAGE_AUDIT.md).
+
+## Completed (feature implementation)
 
 ### Phase 1 -- Core Foundation (v0.1.0)
 Character data model, stat calculation engine, base damage simulation, defensive stat modeling, crafting simulator with Monte Carlo, community builds browser, Discord OAuth2, Docker Compose environment.
@@ -60,8 +71,14 @@ Ordered by impact on simulation accuracy and user-visible behaviour.
 
 ## Future Phases
 
+> The optimization, recommendation, and AI phases below are **gated** behind
+> upstream trusted data (`last-epoch-data` certification) and downstream
+> consumption certification. They must not be presented as complete or certified
+> capability until that evidence exists — see [`docs/DATA_DEPENDENCY.md`](docs/DATA_DEPENDENCY.md).
+
+- **Trusted-data foundation (prerequisite track)** -- complete the V2.5 → V4.5 upstream trusted-data rebuild, schema/provenance governance, and downstream consumption certification that gate the capability work below
 - **Native desktop packaging** -- Electron wrapper already scaffolded in `electron/`, needs production bundling with PyInstaller for the backend
-- **Advanced crafting prediction models** -- machine learning or probabilistic models for craft outcome prediction beyond Monte Carlo
-- **Encounter-specific optimization** -- recommend stat changes targeting specific boss fights
-- **Patch auto-sync pipeline** -- GitHub Actions workflow to automatically sync game data when new patches release
-- **"Ask The Forge" AI-powered build Q&A** -- natural language build analysis and recommendations
+- **Advanced crafting prediction models** *(gated on trusted crafting data)* -- machine learning or probabilistic models for craft outcome prediction beyond Monte Carlo
+- **Encounter-specific optimization** *(gated on trusted data + consumption certification)* -- advisory stat-change suggestions targeting specific boss fights
+- **Patch auto-sync pipeline** -- GitHub Actions workflow to automatically sync game data from `last-epoch-data` when new patches release
+- **"Ask The Forge" AI-powered build Q&A** *(gated on trusted data + consumption certification)* -- natural language build analysis and advisory suggestions

--- a/docs/DATA_DEPENDENCY.md
+++ b/docs/DATA_DEPENDENCY.md
@@ -1,0 +1,172 @@
+# Data Dependency — How The Forge Depends on `last-epoch-data`
+
+> Canonical explanation of the data dependency between `le-the-forge` (this repo,
+> the consumer / analysis application behind [epochforge.gg](https://epochforge.gg))
+> and `last-epoch-data` (the upstream extraction / data-generation repo).
+>
+> This is a governance/documentation reference. It does not change runtime,
+> planner, simulator, backend, frontend, ingestion, extraction, or generated
+> data behavior. It defines the trust rules those layers are expected to honor.
+
+---
+
+## 1. Purpose
+
+`le-the-forge` is **downstream** of `last-epoch-data`.
+
+- `last-epoch-data` is the canonical extraction / compiler / source-of-truth repo
+  for Last Epoch game data. The cross-repo data architecture contracts
+  (`FORGE_DATA_CONTRACT.md`, `DATA_BUNDLE_SPEC.md`) live there, not here
+  (see [`FORGE_SYSTEM_PILLARS.md`](FORGE_SYSTEM_PILLARS.md)).
+- `le-the-forge` is a **consumer**: it ingests generated artifacts, exposes them
+  through visibility/debug layers, and — only where proven — uses them in scoped
+  planner/runtime behavior and public-facing capability claims.
+
+Trusted data must come from **upstream generated artifacts and certification
+evidence**, not from self-asserted confidence inside this repo. When `le-the-forge`
+hardcodes, approximates, or falls back to legacy data, that data is **not** trusted
+just because it ships — it is trusted only when upstream provenance and
+certification support it.
+
+---
+
+## 2. Dependency Chain
+
+```
+last-epoch-data
+  → generated artifacts (bundles, normalized JSON)
+    → schema / provenance / certification reports
+      → le-the-forge ingestion (data pipeline, registries, DB seed)
+        → visibility / debug layers (trust surfaces, coverage reports)
+          → scoped planner / runtime behavior (only where certified)
+            → public-facing capability claims (README / epochforge.gg)
+```
+
+Each arrow is a **trust boundary**. A capability may only be claimed at a later
+stage if every earlier stage supports it. Concretely:
+
+- A planner/runtime feature may not be promoted to "supported" unless ingestion +
+  schema/provenance + upstream certification cover the data it depends on.
+- A public claim (README, marketing, `epochforge.gg`) may not exceed the proven
+  scoped-support state.
+
+Current state of the chain is tracked in
+[`migration/TRUSTED_GAMEPLAY_DATA_COVERAGE_AUDIT.md`](migration/TRUSTED_GAMEPLAY_DATA_COVERAGE_AUDIT.md),
+which presently certifies coverage as `trusted_gameplay_coverage_partial_fail_visible`
+(generated trusted assets exist, but planner completeness is **not** certified).
+
+---
+
+## 3. Data Trust Rules
+
+These rules apply to every data domain consumed by `le-the-forge`:
+
+1. **Trusted only with upstream evidence.** A domain is "trusted" only when backed
+   by upstream generated artifacts plus provenance/schema/certification evidence.
+   Self-asserted confidence inside this repo is not trust.
+2. **Partial stays partial.** Partially covered domains must remain classified as
+   partial. Partial is a first-class state and must not be rounded up to "complete".
+3. **Unknown stays unknown.** Unknown-source or unknown-trust data must remain
+   labeled unknown, not silently treated as verified.
+4. **Quarantined data is not silently promoted.** Data isolated for review or
+   excluded from production paths must stay isolated until upstream evidence
+   clears it.
+5. **Diagnostic-only is not production-safe.** Values produced by diagnostic /
+   dry-run / audit-only tooling must not be treated as production-certified.
+6. **Public wording must not exceed proven certification.** No README, UI, or
+   `epochforge.gg` statement may claim more than the proven scoped-support state.
+
+These rules are deliberately conservative: when in doubt, a domain is *less*
+trusted, not more. Limitation, warning, quarantine, and diagnostic-only language
+must be preserved unless it is directly proven obsolete.
+
+---
+
+## 4. Required Upstream Data Domains
+
+`le-the-forge` depends on the following domains being supplied — and, for deeper
+functionality, **certified** — by `last-epoch-data`:
+
+- **Items & item bases** — base items, item types, implicits, rarities
+- **Affixes** — affix definitions, tiers, eligibility, value ranges
+- **Uniques** — unique item definitions and their mechanical text/effects
+- **Set items** — set definitions and set bonuses
+- **Idols** — idol affixes and slot rules
+- **Skills** — skill metadata, base damage, skill trees, skill nodes
+- **Passives** — passive trees, nodes, node stat payloads, layout coordinates
+- **Crafting data** — crafting rules, materials, forging-potential model inputs
+- **Modifiers / stat mappings** — modifier registry, stat identity, value
+  normalization, stat-key mappings
+- **Relationships between game objects** — skill ownership, class/mastery links,
+  node→stat resolution, item→affix eligibility
+- **Provenance & schema metadata** — source-kind, trust state, schema versions,
+  patch/version manifests
+- **Trust / certification reports** — coverage, support-matrix, schema-alignment,
+  and extraction-gap reports
+
+Domains with known **missing** or **incomplete** upstream coverage (per the
+coverage audit) include blessings, crafting materials, monolith/echo systems,
+bosses, ailments, damage types, and planner-facing gameplay contracts. These must
+not be presented as fully supported.
+
+---
+
+## 5. Downstream Behavior Expectations
+
+How `le-the-forge` is expected to behave by data state:
+
+| Data state | Expected downstream behavior |
+|---|---|
+| **Trusted** (upstream-certified) | May be consumed by visibility and, where the chain supports it, scoped planner/runtime. May back a public capability claim. |
+| **Partial** | Consume what is covered; keep the partial classification visible. Do not infer the uncovered remainder. No "complete coverage" claim. |
+| **Unsupported** | Surface as a reportable, visible unsupported state. Do not silently substitute a guess or treat as failure. |
+| **Quarantined** | Keep isolated from production/planner paths until upstream evidence clears it. Visible, not promoted. |
+| **Diagnostic-only** | Use for inspection/debug only. Never treat as production-certified or as the basis of a public claim. |
+| **Missing** | Report the gap explicitly. Do not fabricate a value to fill it. |
+| **Stale after a patch** | Treat as suspect until re-synced/re-certified upstream. Patch/version manifests should make staleness visible rather than presenting old data as current. |
+
+The governing principle: **unsupported / unknown data must remain visible, never
+silently treated as trusted.**
+
+---
+
+## 6. Public-Facing Claims Policy
+
+Public wording — README, UI copy, and anything on
+[epochforge.gg](https://epochforge.gg) — must be scoped to proven support.
+
+- The Forge may describe itself as a **deterministic** analysis engine: for a
+  given input and a given data set, it produces the same inspectable result. That
+  is provable today.
+- The Forge **may not** claim **complete** simulation, optimization, upgrade
+  recommendation, ranking, scoring, or production planner authority over Last
+  Epoch mechanics until upstream trust **and** downstream consumption
+  certification support those claims.
+- Optimization, upgrade, ranking, and recommendation outputs are **advisory** and
+  bounded by the confidence of the underlying data. They must be presented as
+  such, not as certified ground truth.
+- No public claim may outrun the certification state reported by
+  [`migration/TRUSTED_GAMEPLAY_DATA_COVERAGE_AUDIT.md`](migration/TRUSTED_GAMEPLAY_DATA_COVERAGE_AUDIT.md).
+
+Honest disclosure of approximations and limitations (e.g.
+[`KNOWN_LIMITATIONS.md`](KNOWN_LIMITATIONS.md)) is required and must be preserved.
+
+---
+
+## 7. Relationship to Existing Trust Docs
+
+This document is the canonical entry point for the data dependency. It sits above
+and links to the existing trust/governance material:
+
+- [`migration/LAST_EPOCH_DATA_DEPENDENCY_DOCUMENTATION_AUDIT.md`](migration/LAST_EPOCH_DATA_DEPENDENCY_DOCUMENTATION_AUDIT.md)
+  — the audit that motivated this document.
+- [`migration/DATA_DEPENDENCY_GOVERNANCE_ALIGNMENT.md`](migration/DATA_DEPENDENCY_GOVERNANCE_ALIGNMENT.md)
+  — the follow-up record of corrections made in response to the audit.
+- [`migration/TRUSTED_GAMEPLAY_DATA_COVERAGE_AUDIT.md`](migration/TRUSTED_GAMEPLAY_DATA_COVERAGE_AUDIT.md)
+  — current trusted gameplay data coverage state and what remains blocked.
+- [`FORGE_SYSTEM_PILLARS.md`](FORGE_SYSTEM_PILLARS.md) — product/system direction
+  and why upstream extraction priorities matter.
+- [`FORGE_DATA_CONSUMER_AUDIT.md`](FORGE_DATA_CONSUMER_AUDIT.md) — how this repo
+  consumes game data, with `last-epoch-data` as canonical source of truth.
+- [`migration/`](migration/) — the full trusted-data rebuild, schema/provenance
+  governance, and dependency-chain migration series.

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@ The Forge is a simulation-driven analysis platform for Last Epoch, designed to e
 
 **Data & Trust**
 
+- [DATA_DEPENDENCY.md](DATA_DEPENDENCY.md) -- **Canonical** explanation of how `le-the-forge` depends on the upstream `last-epoch-data` repo: dependency chain, data trust rules, required upstream domains, downstream behavior, and public-claims policy (start here)
 - [FORGE_SYSTEM_PILLARS.md](FORGE_SYSTEM_PILLARS.md) -- Product/system direction and why The Forge depends on the upstream `last-epoch-data` extraction repo (where `FORGE_DATA_CONTRACT.md` and `DATA_BUNDLE_SPEC.md` live)
 - [FORGE_DATA_CONSUMER_AUDIT.md](FORGE_DATA_CONSUMER_AUDIT.md) -- How `le-the-forge` consumes game data, with `last-epoch-data` treated as the canonical extraction/compiler/source-of-truth repo
 - [migration/TRUSTED_GAMEPLAY_DATA_COVERAGE_AUDIT.md](migration/TRUSTED_GAMEPLAY_DATA_COVERAGE_AUDIT.md) -- Current trusted gameplay data coverage state (partial / fail-visible) and what remains blocked
@@ -45,7 +46,7 @@ The Forge is built around:
 
 - **Deterministic calculations** -- reproducible results for any given input
 - **Monte Carlo simulations** -- statistical analysis across thousands of runs
-- **Data-driven recommendations** -- insights derived from game data, not opinions
+- **Data-driven, advisory insights** -- derived from available game data, not opinions; scoped to proven trusted coverage and bounded by upstream data confidence (see **Data & Trust**)
 
 ---
 

--- a/docs/migration/DATA_DEPENDENCY_GOVERNANCE_ALIGNMENT.md
+++ b/docs/migration/DATA_DEPENDENCY_GOVERNANCE_ALIGNMENT.md
@@ -1,0 +1,144 @@
+# Data Dependency Governance Alignment
+
+> Follow-up to the Last Epoch data dependency documentation audit. Records the
+> documentation corrections made to resolve the overclaim and dependency-chain
+> issues the audit identified.
+>
+> Documentation/governance only. No runtime, planner, simulator, backend,
+> frontend, ingestion, extraction, or generated-JSON logic was changed. No
+> certification status was fabricated. No limitation/warning/quarantine/
+> diagnostic-only language was removed.
+
+- **Date:** 2026-05-29
+- **Branch:** `docs/data-dependency-governance-alignment` (cut from `dev`)
+- **Predecessor audit:** [`LAST_EPOCH_DATA_DEPENDENCY_DOCUMENTATION_AUDIT.md`](LAST_EPOCH_DATA_DEPENDENCY_DOCUMENTATION_AUDIT.md)
+  (classification: `documentation_partially_aligned_with_last_epoch_data_dependency`)
+- **Canonical reference produced:** [`../DATA_DEPENDENCY.md`](../DATA_DEPENDENCY.md)
+
+---
+
+## 1. What Was Corrected
+
+1. **Created the canonical dependency document** `docs/DATA_DEPENDENCY.md`,
+   documenting the chain `last-epoch-data → generated artifacts →
+   schema/provenance/certification → ingestion → visibility/debug → scoped
+   planner/runtime → public claims`, the data trust rules, required upstream
+   domains, downstream behavior by data state, and the public-claims policy.
+2. **README opening + intro scoped.** The product description now states the
+   engine is deterministic but that accuracy is bounded by **partial** game-data
+   trust being rebuilt upstream; "concrete answer" → "deterministic, inspectable
+   answer for the game data it currently has"; mechanical coverage explicitly
+   marked **not complete**; optimization/upgrade/ranking outputs marked
+   **advisory** and not yet certified.
+3. **README Features scoping banner** added: feature accuracy is bounded by data
+   confidence; optimization/upgrade/ranking/recommendation outputs are advisory
+   and not certified against trusted upstream data; mechanical coverage is partial.
+4. **README data-ownership wording corrected.** "Data Sources" and "Versioning"
+   now state game data originates upstream in `last-epoch-data` and that The Forge
+   **ingests** it rather than being the authoritative extractor.
+5. **README roadmap section scoped.** "Phases 1–9 complete" reframed as
+   implementation-complete vs. trusted mechanical coverage; future
+   optimization/AI phases explicitly gated on upstream + downstream certification.
+6. **`docs/README.md` index** now lists `DATA_DEPENDENCY.md` as the canonical
+   "start here" entry in **Data & Trust**, and the "Data-driven recommendations"
+   philosophy line was scoped to "advisory … bounded by upstream data confidence".
+7. **`ROADMAP.md`** gained a trust-first preamble, the "Completed" header is now
+   "Completed (feature implementation)", and the Future Phases gate
+   optimization/encounter-optimization/AI work behind trusted data + consumption
+   certification, plus an explicit trusted-data prerequisite track.
+8. **`ARCHITECTURE.md`** reworded so `last-epoch-data` is named as the upstream
+   extraction/generation source of truth and `scripts/sync_game_data.py` is
+   described as **ingest + normalization**, not extraction; the System Overview
+   distinguishes calculation source-of-truth (backend) from game-data
+   source-of-truth (upstream).
+
+---
+
+## 2. Audit Findings Addressed
+
+| Audit finding | Status now |
+|---|---|
+| **F1** — README did not disclose the `last-epoch-data` dependency | **Resolved** — Status bullet + intro + canonical `DATA_DEPENDENCY.md` link. |
+| **F2** — README presented simulation/optimization/recommendations as complete/authoritative | **Resolved (wording)** — claims scoped to deterministic + advisory + partial coverage; not deleted, since the deployed engine does compute them. |
+| **F3** — ROADMAP omitted dependency chain / trust-rebuild and ungated future capability | **Resolved** — trust-first preamble, implementation-vs-coverage distinction, gated future phases, prerequisite trusted-data track. |
+| **F4** — docs index hid the trust/dependency program | **Resolved** — `DATA_DEPENDENCY.md` added as canonical index entry (audit had already added the Data & Trust group). |
+| **F5** — ARCHITECTURE framed The Forge as the extractor/normalizer | **Resolved** — reworded to upstream extraction + downstream ingestion. |
+| **F7** — README "Data Confidence" not tied to upstream provenance | **Partially addressed** — intro + Features banner now tie confidence to upstream trust and `DATA_DEPENDENCY.md`; the confidence **table** itself was preserved verbatim (see §5). |
+| **F8** — governance/migration layer already aligned | **No change needed** — preserved. |
+
+---
+
+## 3. Findings That Remain Open
+
+- **F6 — Inconsistent version signals** (`VERSION` = 0.8.0, `package.json` = 0.3.0,
+  git tag `v2.5.0`, migration series at V4.5). **Open.** Reconciling these
+  requires owner intent on the authoritative versioning scheme (product line vs.
+  data-trust program line) and touches non-doc files; left as a recommendation.
+- **F7 (residual)** — A provenance/certification column or note inside the README
+  "Data Confidence" table itself was intentionally **not** added, to avoid
+  asserting per-row upstream certification states that are not yet proven. The
+  surrounding scoping text now carries the qualification instead.
+- **Deployed-runtime reconciliation** — Wording was scoped conservatively rather
+  than asserting the deployed product's exact runtime enablement state, which is
+  not verifiable from documentation alone (the `*_enabled=false` boundaries are
+  governance-layer prohibitions for the trusted-consumption path).
+
+---
+
+## 4. Files Changed
+
+**Created**
+- `docs/DATA_DEPENDENCY.md` (canonical dependency reference)
+- `docs/migration/DATA_DEPENDENCY_GOVERNANCE_ALIGNMENT.md` (this document)
+
+**Modified**
+- `README.md` — Status bullet; "What Is The Forge" intro; Features scoping banner;
+  Data Sources / Versioning ingestion wording; Roadmap section scoping.
+- `docs/README.md` — `DATA_DEPENDENCY.md` canonical index entry; scoped philosophy
+  line.
+- `ROADMAP.md` — trust-first preamble; Completed header; gated Future Phases.
+- `ARCHITECTURE.md` — System Overview source-of-truth split; Data Pipeline and
+  Data Sync Pipeline ingestion wording.
+
+---
+
+## 5. Intentionally Left Unchanged (and Why)
+
+- **All `KNOWN_LIMITATIONS.md` and README "Known Limitations" entries** — these are
+  honest, specific disclosures and must be preserved (not proven obsolete).
+- **README "Data Confidence" table rows** — accurate per-value confidence labels;
+  preserved verbatim. No fabricated certification was added.
+- **Governance/migration layer docs** (`TRUSTED_GAMEPLAY_DATA_COVERAGE_AUDIT.md`,
+  `MACBOOK_TRANSITION_SAFETY_AUDIT.md`, `FORGE_*`, V2.5–V4.5 series) — already
+  aligned; left as-is, only linked.
+- **Generated reports under `docs/generated/`** — not hand-edited; no generator was
+  run as part of this documentation phase.
+- **Version files** — see F6; left for an owner decision.
+- **The product vision / tagline** — retained; only the completeness/authority
+  implications around it were scoped.
+
+---
+
+## 6. Final Classification
+
+```text
+data_dependency_documentation_partially_aligned
+```
+
+Rationale: the dependency chain, data-ownership framing, and capability-claim
+scoping are now consistent across the entry-point docs (README, docs index,
+ROADMAP, ARCHITECTURE) and anchored to a canonical `DATA_DEPENDENCY.md`. Full
+alignment is held back only by the open version-signal reconciliation (F6) and by
+the deliberate decision not to assert upstream certification states that are not
+yet proven — i.e., remaining gaps are bounded by **missing upstream certification
+evidence**, not by documentation wording.
+
+---
+
+## Next Recommended Step
+
+Reconcile version signals (F6) under an explicit versioning policy, then — once
+`last-epoch-data` trusted-bundle ingestion is production-consumed and certified —
+revisit README/ROADMAP capability language to promote specific domains from
+"advisory/partial" to "trusted" strictly in step with the certification state
+reported by `TRUSTED_GAMEPLAY_DATA_COVERAGE_AUDIT.md`.


### PR DESCRIPTION
## Summary

This PR adds canonical documentation for the `last-epoch-data` → `le-the-forge` dependency chain and aligns entry-point documentation so public/project capability claims remain scoped to proven trusted data, provenance, schema governance, and downstream consumption certification.

## Created

- `docs/DATA_DEPENDENCY.md`
- `docs/migration/DATA_DEPENDENCY_GOVERNANCE_ALIGNMENT.md`

## Modified

- `README.md`
- `docs/README.md`
- `ROADMAP.md`
- `ARCHITECTURE.md`

## Audit findings addressed

- F1: upstream `last-epoch-data` dependency now named and linked
- F2: simulation/optimization/recommendation wording scoped to deterministic/advisory behavior
- F3: roadmap now reflects trust-first dependency chain and gated future work
- F4: docs index now exposes canonical Data & Trust entry
- F5: architecture no longer frames `le-the-forge` as the authoritative extractor
- F7: partially addressed by tying confidence language to scoped trust/provenance expectations

## Remaining findings

- F6: version signal mismatch requires owner decision
- F7 residual: no fabricated per-row certification added to the Data Confidence table
- Runtime/deployed enablement state was not asserted because this task was documentation-only

## Validation

- `git diff --check` passed
- Dependency links verified
- `last-epoch-data` references verified in entry docs
- Advisory/scoped language verified
- Relative links and README anchors verified
- No generated files edited
- No runtime/planner/simulator/backend/frontend/ingestion/extraction logic changed

## Final classification

`data_dependency_documentation_partially_aligned`

## Notes

This PR intentionally preserves honest limitation language and does not promote any domain from partial/advisory to trusted without upstream certification evidence.