### PR TITLE
docs: define version signal policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - **Game data synced to:** patch 1.4.3, Season 4 (last sync 2026-04-21)
 - **Tests:** 10,865 passing / 377 skipped
 - **Upstream data foundation:** trusted Last Epoch game data is sourced from the companion `last-epoch-data` extraction/compiler repo (the canonical source of truth). The Forge is a downstream consumer — see [`docs/DATA_DEPENDENCY.md`](docs/DATA_DEPENDENCY.md) for the dependency chain, and [`docs/migration/TRUSTED_GAMEPLAY_DATA_COVERAGE_AUDIT.md`](docs/migration/TRUSTED_GAMEPLAY_DATA_COVERAGE_AUDIT.md) for the current (partial) coverage state.
+- **Version signals:** the product release version (`v0.8.0`, above) is separate from the Node package version (`package.json`), the internal roadmap phases, the V2.5→V4.x governance phases, and historical git tags (e.g. `v2.5.0`). They describe different things and are not meant to match — see [`docs/VERSIONING_POLICY.md`](docs/VERSIONING_POLICY.md). A version number does not imply data trust or capability completion.
 - **[See known limitations →](docs/KNOWN_LIMITATIONS.md)**
 
 <p align="center">

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,6 +13,12 @@
 > See [`docs/DATA_DEPENDENCY.md`](docs/DATA_DEPENDENCY.md) and
 > [`docs/migration/TRUSTED_GAMEPLAY_DATA_COVERAGE_AUDIT.md`](docs/migration/TRUSTED_GAMEPLAY_DATA_COVERAGE_AUDIT.md).
 
+> **Phase labels are not version numbers.** Roadmap phases ("Phase 9", etc.) are
+> internal product planning/governance labels — they are **not** the package
+> version (`package.json`), the public product release version (`VERSION`), or the
+> V2.5→V4.x governance phases under `docs/migration/`. These signals are allowed to
+> differ; see [`docs/VERSIONING_POLICY.md`](docs/VERSIONING_POLICY.md).
+
 ## Completed (feature implementation)
 
 ### Phase 1 -- Core Foundation (v0.1.0)

--- a/docs/DATA_DEPENDENCY.md
+++ b/docs/DATA_DEPENDENCY.md
@@ -151,6 +151,12 @@ Public wording — README, UI copy, and anything on
 Honest disclosure of approximations and limitations (e.g.
 [`KNOWN_LIMITATIONS.md`](KNOWN_LIMITATIONS.md)) is required and must be preserved.
 
+**Version labels do not override trust state.** A product, package, git-tag, or
+governance-phase version number never implies more trusted data, more mechanical
+coverage, or any certification. If a version label and the certified trust state
+appear to disagree, the trust state wins and public wording follows it. See
+[`VERSIONING_POLICY.md`](VERSIONING_POLICY.md).
+
 ---
 
 ## 7. Relationship to Existing Trust Docs

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,7 @@ The Forge is a simulation-driven analysis platform for Last Epoch, designed to e
 **Data & Trust**
 
 - [DATA_DEPENDENCY.md](DATA_DEPENDENCY.md) -- **Canonical** explanation of how `le-the-forge` depends on the upstream `last-epoch-data` repo: dependency chain, data trust rules, required upstream domains, downstream behavior, and public-claims policy (start here)
+- [VERSIONING_POLICY.md](VERSIONING_POLICY.md) -- What each version signal means (product, package, roadmap phase, governance phase, deployment, git tags) and why they are allowed to differ; version labels do not imply data trust or capability completion
 - [FORGE_SYSTEM_PILLARS.md](FORGE_SYSTEM_PILLARS.md) -- Product/system direction and why The Forge depends on the upstream `last-epoch-data` extraction repo (where `FORGE_DATA_CONTRACT.md` and `DATA_BUNDLE_SPEC.md` live)
 - [FORGE_DATA_CONSUMER_AUDIT.md](FORGE_DATA_CONSUMER_AUDIT.md) -- How `le-the-forge` consumes game data, with `last-epoch-data` treated as the canonical extraction/compiler/source-of-truth repo
 - [migration/TRUSTED_GAMEPLAY_DATA_COVERAGE_AUDIT.md](migration/TRUSTED_GAMEPLAY_DATA_COVERAGE_AUDIT.md) -- Current trusted gameplay data coverage state (partial / fail-visible) and what remains blocked

--- a/docs/VERSIONING_POLICY.md
+++ b/docs/VERSIONING_POLICY.md
@@ -1,0 +1,168 @@
+# Versioning Policy — What Each Version Signal Means
+
+> This repository carries several independent version-like signals. They are
+> **not** the same number and are **not meant to match**. This document defines
+> what each one means, which file owns it, and when it changes, so the repo does
+> not look contradictory to contributors or AI agents.
+>
+> Policy/documentation only. It does not change runtime behavior, package
+> versions, the `VERSION` file, git tags, or any code.
+
+---
+
+## 1. Purpose
+
+The Forge has evolved along **two parallel tracks** plus several supporting
+metadata signals:
+
+- a **product / feature track** (the deployed v0.x application), and
+- a **trust / governance track** (the V2.5 → V4.x data-trust and governance
+  program).
+
+Because these tracks advance independently — and because packages, deployments,
+data syncs, and git tags each carry their own version metadata — the repo
+contains multiple numbers that look like "the version" but describe different
+things. Conflating them creates false impressions (e.g. reading a `v4.x`
+governance phase as a "version 4 product", or a package version as proof of
+release maturity). This policy keeps them distinct.
+
+---
+
+## 2. Version Signal Definitions
+
+| # | Signal | What it describes |
+|---|---|---|
+| 1 | **Product / public release version** | The user-facing release line of the deployed application (v0.x). |
+| 2 | **Package / application version** | Node package metadata for build/tooling (`package.json`). Not a release-maturity claim. |
+| 3 | **Internal roadmap phase** | Product feature-development phases (e.g. "Phase 9"). Planning labels, not release numbers. |
+| 4 | **Migration / governance phase** | Trust/data-governance program phases (V2.5 → V4.x). Historical and ongoing governance milestones. |
+| 5 | **Public deployment / site version** | The version string the running service reports (`/api/version`, `/api/health`), sourced from the `VERSION` file. |
+| 6 | **Historical Git tags / releases** | Snapshots cut at a point in time (e.g. `v2.5.0`, the trust-foundation release). |
+
+Supporting metadata signals (related but distinct):
+
+- **Data / patch sync state** — `data/version.json` (`patch_version`, `synced_at`)
+  and the README "Game data synced to" line; tracks the Last Epoch patch the data
+  reflects, not the application version.
+- **Internal schema / contract version identifiers** — strings such as
+  `v3_8.coordination_*` in backend modules; these version individual
+  schemas/contracts, not the product.
+
+---
+
+## 3. Current Observed Version Signals
+
+Recorded as observed on this branch. Values not verifiable are marked **unknown**.
+No values were invented or changed by this document.
+
+| Signal | Observed value | Source |
+|---|---|---|
+| Product / public release version | `v0.8.0` | `README.md` badge + prose |
+| Latest changelog entry | `0.8.1` (2026-04-21) | `CHANGELOG.md` (top entry) |
+| Package / application version (root) | `0.3.0` (name `the-forge`, private) | `package.json` |
+| Package version (frontend) | `0.1.0` (name `the-forge-frontend`) | `frontend/package.json` |
+| Public deployment / site version | `0.8.0` (reads `VERSION`) | `VERSION` → `backend/app/__init__.py` `__version__` → `/api/version`, `/api/health` |
+| Internal roadmap phase | Phases 1–9 complete; 10–16 future | `ROADMAP.md` |
+| Migration / governance phase | `V2.5` → `V4.5` series | `docs/migration/` |
+| Historical Git tags | `v2.5.0` only — "ship v2.5 trust foundation" (2026-05-14) | `git tag` |
+| Data / patch sync state | `patch_version = "unknown"`; README states patch `1.4.3`, Season 4 | `data/version.json`, `README.md` |
+| Internal schema/contract IDs | e.g. `v3_8.coordination_*` | backend modules (code) |
+
+Observed timeline nuance (not a defect, but the source of apparent contradiction):
+the `v2.5.0` **git tag** (2026-05-14) is both numerically higher and later than
+the **product** `v0.8.x` line (2026-04-21). They are different tracks — the tag
+belongs to the trust-foundation/governance line, the v0.8.x line is the product
+release line. See §5.
+
+---
+
+## 4. Authoritative Source Rules
+
+Each signal has exactly one owning source. Other places that mention it are
+**reflections** and should defer to the owner.
+
+| Signal | Authoritative owner |
+|---|---|
+| Public deployment / runtime app version | **`VERSION`** (read at runtime by `backend/app/__init__.py`; surfaced at `/api/version`, `/api/health`) |
+| Product / public release version (human-facing) | **`VERSION`** is the canonical number; `README.md` and the version badge reflect it; `CHANGELOG.md` owns the release **history** |
+| Package / application (Node) version | **`package.json`** (root) and **`frontend/package.json`** (frontend) — tooling metadata only |
+| Internal roadmap (product) phases | **`ROADMAP.md`** |
+| Migration / governance phases | **`docs/migration/`** documents (historical labels are immutable) |
+| Historical release snapshots | **Git tags** (e.g. `v2.5.0`) |
+| Data / patch sync state | **`data/version.json`** (and the README "synced to" line as a reflection) |
+| Internal schema/contract versions | the **backend module** that defines each schema constant |
+
+> Note: the runtime app version is owned by the `VERSION` file, **not** by
+> `package.json`. The root `package.json` version (`0.3.0`) is build/tooling
+> metadata and is not the deployed application version.
+
+---
+
+## 5. Non-Conflict Rule
+
+These values are **allowed to differ** because they describe different concepts.
+
+- A `package.json` version of `0.3.0` and a `VERSION` of `0.8.0` is **not** a
+  conflict — one is Node tooling metadata, the other is the runtime app version.
+- A `v2.5.0` git tag and a `v0.8.0` product version are **not** a conflict — the
+  tag belongs to the trust-foundation/governance line; the product line is v0.x.
+- A `V4.5` migration phase and a `v0.8.0` product version are **not** a conflict —
+  one is a governance-program milestone, the other a product release.
+
+Do not "fix" these by forcing them equal. The fix for apparent contradiction is
+**clarity of meaning** (this policy), not numeric normalization.
+
+---
+
+## 6. Update Policy
+
+When each signal changes:
+
+- **`VERSION` / runtime app version** — only when a new application build/release
+  is cut for deployment.
+- **`package.json` / `frontend/package.json`** — only on a package/tooling
+  release change; independent of product release maturity.
+- **`CHANGELOG.md`** — appended whenever a release is documented; existing entries
+  are historical and not rewritten.
+- **Roadmap phases (`ROADMAP.md`)** — only when a product feature phase actually
+  advances.
+- **Migration/governance phases (`docs/migration/`)** — a new phase adds new
+  documents; **historical phase documents and names are retained as-is**.
+- **Git tags** — only when a release snapshot is cut; tags are immutable history.
+- **`data/version.json` / patch line** — only when game data is re-synced from
+  upstream `last-epoch-data` for a new patch.
+
+---
+
+## 7. AI / Contributor Guardrails
+
+Explicitly:
+
+- **Do not** "normalize" all version numbers to match.
+- **Do not** rename historical migration docs (e.g. the `V4_*` files) to match the
+  current phase.
+- **Do not** treat a `V4.x` governance phase as equivalent to a public **product**
+  version.
+- **Do not** treat the `package.json` version as proof of public release maturity.
+- **Do not** infer capability completion, coverage, or certification from any
+  version label. Capability is governed by trusted-data evidence, not by a number.
+- **Do not** change `VERSION` or `package.json` solely to reduce visual mismatch;
+  change them only per §6, with a real release reason.
+
+---
+
+## 8. Relationship to Data Dependency Governance
+
+Version labels are orthogonal to data trust. A higher version number — product,
+package, tag, or governance phase — does **not** imply more trusted data, more
+mechanical coverage, or any certification.
+
+- [`DATA_DEPENDENCY.md`](DATA_DEPENDENCY.md) — the canonical dependency chain and
+  data-trust rules. Trust comes from upstream `last-epoch-data` evidence, not from
+  version numbers.
+- [`migration/DATA_DEPENDENCY_GOVERNANCE_ALIGNMENT.md`](migration/DATA_DEPENDENCY_GOVERNANCE_ALIGNMENT.md)
+  — the governance alignment that scoped capability claims to proven support.
+
+If a version label and the certified trust state ever appear to disagree, the
+trust state (per the coverage audit) wins, and public wording must follow the
+trust state — never the version number.

--- a/docs/migration/VERSION_SIGNAL_RECONCILIATION_AUDIT.md
+++ b/docs/migration/VERSION_SIGNAL_RECONCILIATION_AUDIT.md
@@ -1,0 +1,165 @@
+# Version Signal Reconciliation Audit
+
+> Focused audit resolving finding **F6** (inconsistent version signals) from the
+> Last Epoch data dependency documentation audit. Versioning policy and
+> documentation alignment only — no runtime code, `package.json`, `VERSION`, git
+> tags, or generated JSON were changed.
+
+- **Date:** 2026-05-29
+- **Branch:** `docs/version-signal-reconciliation` (cut from `dev`)
+- **Predecessor:** [`DATA_DEPENDENCY_GOVERNANCE_ALIGNMENT.md`](DATA_DEPENDENCY_GOVERNANCE_ALIGNMENT.md)
+  (left F6 open as an owner decision)
+- **Policy produced:** [`../VERSIONING_POLICY.md`](../VERSIONING_POLICY.md)
+
+---
+
+## 1. Executive Summary
+
+The repo carries multiple version-like signals that previously looked
+contradictory (e.g. `VERSION` 0.8.0 vs `package.json` 0.3.0 vs git tag `v2.5.0`
+vs `V4.5` migration phases). Investigation confirmed these are **not** a single
+mis-set number — they describe **different concepts across two parallel tracks**
+(a product/feature line and a trust/governance line) plus supporting metadata.
+
+The reconciliation does **not** force the numbers equal. Instead it introduces a
+canonical [`VERSIONING_POLICY.md`](../VERSIONING_POLICY.md) that defines each
+signal, names its authoritative owner, states a non-conflict rule, and adds
+contributor/AI guardrails. Entry-point docs now point to that policy. No version
+value was changed, because no existing policy authorized a change and doing so
+would risk fabricating release history or breaking the runtime version surfaced
+by `/api/version` and `/api/health`.
+
+Key clarifying fact established: the **runtime/app version is owned by the
+`VERSION` file** (read by `backend/app/__init__.py`, surfaced at `/api/version`
+and `/api/health`), **not** by `package.json`. The root `package.json` version is
+Node tooling metadata.
+
+---
+
+## 2. Files Reviewed
+
+- `VERSION`
+- `package.json`, `frontend/package.json`
+- `README.md`, `CHANGELOG.md`, `ROADMAP.md`
+- `docs/README.md`, `docs/DATA_DEPENDENCY.md`, `ARCHITECTURE.md`
+- `backend/app/__init__.py` (version reader), `backend/app/routes/version.py`,
+  `backend/app/routes/health.py`
+- `data/version.json`
+- `docs/migration/` phase labels (V2.5 → V4.5), git tags
+- backend schema-version constants (e.g. `v3_8.coordination_*`) — observed only
+
+---
+
+## 3. Observed Version Signals
+
+| Signal | Observed value | Source |
+|---|---|---|
+| Product / public release version | `v0.8.0` | `README.md` badge + prose |
+| Latest changelog entry | `0.8.1` (2026-04-21) | `CHANGELOG.md` |
+| Package version (root) | `0.3.0` (`the-forge`, private) | `package.json` |
+| Package version (frontend) | `0.1.0` (`the-forge-frontend`) | `frontend/package.json` |
+| Deployment / runtime app version | `0.8.0` (reads `VERSION`) | `VERSION` → `backend/app/__init__.py` → `/api/version`, `/api/health` |
+| Internal roadmap phase | Phases 1–9 done; 10–16 future | `ROADMAP.md` |
+| Migration / governance phase | `V2.5` → `V4.5` | `docs/migration/` |
+| Historical git tag | `v2.5.0` — "ship v2.5 trust foundation" (2026-05-14) | `git tag` |
+| Data / patch sync state | `patch_version="unknown"`; README states `1.4.3`, S4 | `data/version.json`, `README.md` |
+| Internal schema/contract IDs | e.g. `v3_8.coordination_*` | backend modules |
+
+---
+
+## 4. Conflicts / Misleading Areas Found
+
+1. **Apparent track collision** — git tag `v2.5.0` (2026-05-14) is higher and
+   later than the product `v0.8.x` line (2026-04-21). Without context this reads
+   as a contradiction; in fact the tag is on the trust-foundation/governance line.
+   *(Now explained by policy §3/§5.)*
+2. **Package vs runtime version mismatch** — `package.json` `0.3.0` vs `VERSION`
+   `0.8.0`. Looks wrong; actually two different concepts (Node metadata vs runtime
+   app version). *(Now explained by policy §4/§5.)*
+3. **Changelog vs badge drift** — `CHANGELOG.md` top is `0.8.1` while the badge and
+   prose say `v0.8.0`. Minor product-line lag within one owner. *(Recorded; left
+   for owner — see §7.)*
+4. **Governance phase mistaken for product version** — `V4.5` could be read as
+   "version 4". *(Now explicitly guarded against in policy §7.)*
+5. **Data patch signal mismatch** — `data/version.json` `patch_version="unknown"`
+   vs README `1.4.3`. Distinct data/patch signal, not an app version. *(Recorded;
+   data-sync owner decision — §7.)*
+6. **Code docstring example** — `backend/app/routes/version.py` docstring shows an
+   illustrative `"1.0.0-beta"` / `data_version "1.0.0"` example that matches no
+   real signal. *(Left unchanged — code file; see §6.)*
+
+---
+
+## 5. Corrections Made
+
+- **Created `docs/VERSIONING_POLICY.md`** — canonical definitions, current
+  observed values, authoritative-source rules, non-conflict rule, update policy,
+  AI/contributor guardrails, and the link to data-dependency governance.
+- **`README.md`** — added a "Version signals" Status bullet linking the policy and
+  stating the signals are separate and that a version number does not imply data
+  trust or capability completion.
+- **`docs/README.md`** — added `VERSIONING_POLICY.md` to the Data & Trust index.
+- **`ROADMAP.md`** — added a note that roadmap phase labels are internal
+  planning/governance labels, not package/public-release/governance versions.
+- **`docs/DATA_DEPENDENCY.md`** — added a cross-reference that version labels do
+  not override trust/certification state (trust state wins).
+
+No numeric version value was changed in any file.
+
+---
+
+## 6. Items Intentionally Left Unchanged
+
+- **`VERSION` (0.8.0)** — it is the authoritative runtime/app version consumed by
+  `/api/version` and `/api/health`; changing it would alter the deployed version
+  surface with no release reason. Not stale.
+- **`package.json` / `frontend/package.json`** — Node tooling metadata; no policy
+  authorized a bump, and changing it would not be a real release event.
+- **Git tag `v2.5.0`** — immutable historical release snapshot; not renamed.
+- **`docs/migration/` phase docs and names (V2.5 → V4.5)** — historical governance
+  labels are retained as-is; not renamed.
+- **`CHANGELOG.md`** — historical entries left intact (the 0.8.0/0.8.1 drift is a
+  product-owner reconciliation, not a docs rewrite).
+- **`backend/app/routes/version.py` docstring** — code file; example value left
+  untouched to avoid modifying code (recorded as an owner decision).
+- **`data/version.json`** — generated/sync artifact; not hand-edited.
+- **`ARCHITECTURE.md`** — its only version references are factual endpoint
+  descriptions; nothing misleading, so no edit.
+
+---
+
+## 7. Remaining Owner Decisions
+
+- Whether to reconcile the **CHANGELOG `0.8.1` vs badge/`VERSION` `0.8.0`** drift
+  (cut a release or align the badge).
+- Whether to **bump `VERSION`/`package.json`** under a defined release event (the
+  policy now defines the rules; the trigger is an owner call).
+- Whether to refresh `data/version.json` `patch_version` from "unknown" to the
+  tracked patch on the next upstream sync.
+- Whether to update the illustrative example value in the
+  `backend/app/routes/version.py` docstring (code change, out of scope here).
+
+None of these block the policy; they are deferred product/release decisions.
+
+---
+
+## 8. Final Classification
+
+```text
+version_signals_partially_aligned_pending_owner_decision
+```
+
+Rationale: the signals are now **explained and governed by an authoritative
+policy**, and entry-point docs point to it, so the repo no longer reads as
+contradictory. Full numeric alignment (where desired) and the changelog/patch
+drifts remain **owner decisions** with real release triggers, deliberately not
+forced by this documentation phase.
+
+---
+
+## Recommended Next Step
+
+Have the owner action the §7 decisions under the new policy — at minimum
+reconciling the CHANGELOG/badge drift and refreshing the data patch version on the
+next `last-epoch-data` sync — then keep `VERSIONING_POLICY.md`'s "current observed
+signals" table updated whenever a signal legitimately changes.


### PR DESCRIPTION
## Summary

This PR adds a canonical versioning policy and reconciliation audit so `le-the-forge` no longer appears contradictory when different version-like signals are present.

The policy distinguishes:

- product/public release version
- package/application version
- runtime/deployment version
- roadmap phase
- migration/governance phase
- historical Git tags/releases
- data patch/sync version
- internal schema/contract identifiers

## Created

- `docs/VERSIONING_POLICY.md`
- `docs/migration/VERSION_SIGNAL_RECONCILIATION_AUDIT.md`

## Modified

- `README.md`
- `docs/README.md`
- `ROADMAP.md`
- `docs/DATA_DEPENDENCY.md`

## Observed version signals

- product/public release: `v0.8.0`
- latest changelog entry: `0.8.1`
- root package: `0.3.0`
- frontend package: `0.1.0`
- runtime app version: `0.8.0`
- roadmap phase: Phases 1–9 complete, 10–16 future
- migration/governance phase: `V2.5` → `V4.5`
- historical Git tag: `v2.5.0`
- data patch sync: `patch_version="unknown"` / README `1.4.3/S4`
- internal schema/contract IDs: examples such as `v3_8.coordination_*`

## Corrections made

- Added canonical `docs/VERSIONING_POLICY.md`
- Added follow-up audit record
- Linked version policy from README and docs index
- Clarified that roadmap phases are internal planning/governance labels, not package or public release versions
- Clarified that version labels do not override data trust/certification state
- Preserved existing numeric values rather than forcing an artificial match

## Intentionally left unchanged

- `VERSION`
- root `package.json`
- `frontend/package.json`
- historical Git tag `v2.5.0`
- `docs/migration/` V4.x names
- `CHANGELOG.md`
- `data/version.json`
- generated files
- runtime code

## Remaining owner decisions

- reconcile `CHANGELOG` `0.8.1` vs badge/runtime `0.8.0`
- decide whether/when to bump `VERSION`
- decide whether/when to bump package versions
- refresh `data/version.json` patch version on next upstream sync
- decide whether to update `version.py` docstring example in a future code/documentation pass

## Validation

- `git diff --check` passed
- `docs/VERSIONING_POLICY.md` exists
- README links to version policy
- docs index links to version policy
- `docs/DATA_DEPENDENCY.md` references version policy
- ROADMAP clarifies phases are not versions
- relative links resolved
- no markdown linter configured
- `git status` showed exactly intended files

## Final classification

`version_signals_partially_aligned_pending_owner_decision`

## Notes

This PR does not assert new capability, release maturity, production readiness, or trust certification. It only defines how version signals should be interpreted and maintained.